### PR TITLE
Fix Rocker build for the latest FXServer

### DIFF
--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 MOUNT ..:/src
 RUN /bin/sh /src/code/tools/ci/build_server_2.sh
-WORKDIR /data
+WORKDIR /opt/cfx-server
 CMD ["/bin/sh", "/opt/cfx-server/run.sh"]
 PUSH citizenfx/server:dev

--- a/code/tools/ci/build_server_2.sh
+++ b/code/tools/ci/build_server_2.sh
@@ -69,6 +69,8 @@ cp -a ../data/server/* /opt/cfx-server
 cp -a bin/server/linux/release/FXServer /opt/cfx-server
 cp -a bin/server/linux/release/*.so /opt/cfx-server
 cp -a bin/server/linux/release/*.json /opt/cfx-server
+cp tools/ci/run.sh /opt/cfx-server
+chmod +x /opt/cfx-server/run.sh
 
 # strip output files
 strip --strip-unneeded /opt/cfx-server/*.so

--- a/code/tools/ci/run.sh
+++ b/code/tools/ci/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd /opt/cfx-server
+[ -d cache ] || mkdir cache
+
+exec /opt/cfx-server/FXServer $SERVER_ARGS $*


### PR DESCRIPTION
It adds `run.sh` shell script to properly start the FXServer on the Docker built image.