### PR TITLE
clrcore: fix to ChangeModel and CreatePed always failing

### DIFF
--- a/code/client/clrcore/External/Player.cs
+++ b/code/client/clrcore/External/Player.cs
@@ -1,4 +1,4 @@
-using CitizenFX.Core.Native;
+﻿using CitizenFX.Core.Native;
 using System;
 using System.Drawing;
 using System.Security;
@@ -474,7 +474,8 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if the change was sucessful; otherwise, <c>false</c>.</returns>
 		public async Task<bool> ChangeModel(Model model)
 		{
-			if (!model.IsInCdImage || !model.IsPed || !await model.Request(1000))
+			// TODO: Implement IsPed
+			if (!model.IsInCdImage /*|| !model.IsPed*/ || !await model.Request(1000))
 			{
 				return false;
 			}

--- a/code/client/clrcore/External/World.cs
+++ b/code/client/clrcore/External/World.cs
@@ -1,4 +1,4 @@
-using CitizenFX.Core.Native;
+﻿using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -1089,7 +1089,8 @@ namespace CitizenFX.Core
 		/// <remarks>returns <c>null</c> if the <see cref="Ped"/> could not be spawned</remarks>
 		public static async Task<Ped> CreatePed(Model model, Vector3 position, float heading = 0f)
 		{
-			if (!model.IsPed || !await model.Request(1000))
+			// TODO: Implement IsPed
+			if (/*!model.IsPed ||*/ !await model.Request(1000))
 			{
 				return null;
 			}


### PR DESCRIPTION
IsPed is not yet fully implemented (and currently returns false at all times.)
This temporarily disables its use where it's causing issues.