### PR TITLE
Workaround for Native calls not working in threaded server environment

### DIFF
--- a/code/client/clrcore/InternalManager.cs
+++ b/code/client/clrcore/InternalManager.cs
@@ -18,6 +18,7 @@ namespace CitizenFX.Core
 		private static int ms_instanceId;
 
 		public static IScriptHost ScriptHost { get; private set; }
+		public static int ScriptHostThreadID { get; private set; }
 
 		[SecuritySafeCritical]
 		public InternalManager()
@@ -39,6 +40,7 @@ namespace CitizenFX.Core
 		{
 			ScriptHost = host;
 			ms_instanceId = instanceId;
+			ScriptHostThreadID = Thread.CurrentThread.ManagedThreadId;
 		}
 
 		[SecuritySafeCritical]


### PR DESCRIPTION
Calling `Function.Call` inside of a thread would normally fail on `ResourceManager::GetCurrent()` (ResourceManager.cpp). Another interesting side effect is that `Function.Call` will get called twice: Once by the main (ScriptHost) thread, and once by the background thread. This can be abused to create a workaround for the (previously) failed assertion by only allowing the main thread to perform this task. The native call will be performed by the 'main' thread, but its value returned to the background thread like in this demo:
```
public class Test : BaseScript
{
	public Test()
	{
		ThreadPool.QueueUserWorkItem( ( state ) => {
			string hostname = Function.Call<string>( Hash.GET_CONVAR, "sv_hostname", "" );
			Debug.WriteLine( "sv_hostname: {0}", hostname );
		} );
	}
}

// prints: sv_hostname: Dev server
```
It's ugly but in my opinion reasonable as a temporary solution for those who wish to use natives in threads.