### PR TITLE
Bring back stability to Rocker build

### DIFF
--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.6
 MOUNT ..:/src
 RUN /bin/sh /src/code/tools/ci/build_server_2.sh
 WORKDIR /opt/cfx-server


### PR DESCRIPTION
It fixes the automated build, however, we still can't remove the testing repository (`edge/testing`) because of `libc++`.

Side note: proot build already use Alpine `3.6`.