### PR TITLE
Update vehicle natives

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -263,7 +263,6 @@ static HookFunction initFunction([]()
 		{
 			unsigned char numWheels = readValue<unsigned char>(vehicle, NumWheelsOffset);
 			if (wheelIndex >= numWheels) {
-				context.SetResult<float>(0.0f);
 				return;
 			}
 			auto wheelsAddress = readValue<uint64_t>(vehicle, WheelsPtrOffset);

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -743,6 +743,13 @@ native 'GET_VEHICLE_WHEEL_SPEED'
 	}
 	apiset 'client'
 	returns 'float'
+	doc [[
+	<summary>
+	Gets speed of a wheel at the tyre. 
+	Max number of wheels can be retrieved with the native GET_VEHICLE_NUMBER_OF_WHEELS.
+	</summary>
+	<returns>An integer.</returns>
+]]
 	
 native 'GET_VEHICLE_DASHBOARD_SPEED'
 	arguments {
@@ -941,18 +948,34 @@ native 'GET_VEHICLE_NUMBER_OF_WHEELS'
 	apiset 'client'
 	returns 'int'
 
-native 'IS_VEHICLE_LEFT_BLINKER_ACTIVE'
+native 'GET_VEHICLE_INDICATOR_LIGHTS'
 	arguments {
 		Vehicle 'vehicle'
 	}
 	apiset 'client'
-	returns 'BOOL'
-	
-native 'IS_VEHICLE_RIGHT_BLINKER_ACTIVE'
+	returns 'int'	
+	doc [[
+	<summary>
+	Gets the vehicle indicator light state. 0 = off, 1 = left, 2 = right, 3 = both
+	</summary>
+	<returns>An integer.</returns>
+]]
+
+native 'GET_VEHICLE_WHEEL_HEALTH'
 	arguments {
-		Vehicle 'vehicle'
+		Vehicle 'vehicle',
+		int 'wheelIndex',
 	}
 	apiset 'client'
-	returns 'BOOL'	
+	returns 'float'
 	
+native 'SET_VEHICLE_WHEEL_HEALTH'
+	arguments {
+		Vehicle 'vehicle',
+		int 'wheelIndex',
+		float 'health'
+	}
+	apiset 'client'
+	returns 'void'
+
 -- TODO: handling field natives


### PR DESCRIPTION
Renamed `IsVehicleLeftBlinkerActive` and `IsVehicleRightBlinkerActive` to `GetVehicleIndicatorLights`, to match the original native `SetVehicleIndicatorLights` more. Sorry for the quick change, I should've looked that up.

Added `Get/SetVehicleWheelHealth`. 