### PR TITLE
Removing double "Quit:" message

### DIFF
--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -780,7 +780,7 @@ namespace fx
 
 				auto gameServer = instance->GetComponent<fx::GameServer>();
 
-				gameServer->DropClient(client, "Quit: %s", reason.data());
+				gameServer->DropClient(client, "%s", reason.data());
 			}
 
 			inline static constexpr const char* GetPacketId()


### PR DESCRIPTION
As seen here http://upload.boras.org/upload/files/598bd0aeac1b9598bd0aeac257.png