### PR TITLE
Avoid keeping callback in registry on error

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -216,8 +216,9 @@ if IsDuplicityVersion() then
 	local httpDispatch = {}
 	AddEventHandler('__cfx_internal:httpResponse', function(token, status, body, headers)
 		if httpDispatch[token] then
-			httpDispatch[token](status, body, headers)
+			local userCallback = httpDispatch[token]
 			httpDispatch[token] = nil
+			userCallback(status, body, headers)
 		end
 	end)
 


### PR DESCRIPTION
Before when the user callback was failing with an error it was keep in the registry,

Not sure if we should do this this way ? or use pcall ?