### PR TITLE
Revert unsequential packet change and reduce how frequently 0x53FFFA3F is transmitted.

### DIFF
--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -629,7 +629,7 @@ namespace fx
 						outPacket.Write(packetLength);
 						outPacket.Write(packetData.data(), packetLength);
 
-						targetClient->SendPacket(1, outPacket, (ENetPacketFlag)0);
+						targetClient->SendPacket(1, outPacket, ENET_PACKET_FLAG_UNSEQUENCED);
 
 						client->SetHasRouted();
 					}

--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -285,12 +285,14 @@ namespace fx
 		}
 
 		std::vector<std::shared_ptr<fx::Client>> toRemove;
+		auto roundedTime = m_serverTime - m_serverTime % frameTime;
+		auto isSecond = roundedTime % 1000 == 0;
 
 		m_clientRegistry->ForAllClients([&](const std::shared_ptr<fx::Client>& client)
 		{
 			auto peer = client->GetPeer();
 
-			if (peer)
+			if (peer && isSecond)
 			{
 				net::Buffer outMsg;
 				outMsg.Write(0x53FFFA3F);

--- a/code/components/net/src/NetLibraryImplV2.cpp
+++ b/code/components/net/src/NetLibraryImplV2.cpp
@@ -187,7 +187,7 @@ void NetLibraryImplV2::RunFrame()
 
 			msg.Write(packet.payload.c_str(), packet.payload.size());
 
-			enet_peer_send(m_serverPeer, 1, enet_packet_create(msg.GetBuffer(), msg.GetCurLength(), (ENetPacketFlag)0));
+			enet_peer_send(m_serverPeer, 1, enet_packet_create(msg.GetBuffer(), msg.GetCurLength(), ENET_PACKET_FLAG_UNSEQUENCED));
 
 			m_base->GetMetricSink()->OnOutgoingRoutePackets(1);
 		}
@@ -197,7 +197,7 @@ void NetLibraryImplV2::RunFrame()
 			NetBuffer msg(1300);
 			msg.Write(0xCA569E63); // msgEnd
 
-			enet_peer_send(m_serverPeer, 1, enet_packet_create(msg.GetBuffer(), msg.GetCurLength(), (ENetPacketFlag)0));
+			enet_peer_send(m_serverPeer, 1, enet_packet_create(msg.GetBuffer(), msg.GetCurLength(), ENET_PACKET_FLAG_UNSEQUENCED));
 
 			m_lastKeepaliveSent = timeGetTime();
 		}


### PR DESCRIPTION
# 1610d7f
I didn't see the 0x53FFFA3F packet anywhere else in the repository. My only guess is that it's used to keep the ping up-to-date on the server end when there is a lull in reliable server->client packets.

# 1472989
I can't repro unsequential packets being dropped due to poor network conditions(out of order, delayed, etc). However I'm able to easily repro unreliable sequential packets being dropped due to network hiccups.