### PR TITLE
Improve DX when an errors happens on a export

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -411,7 +411,13 @@ setmetatable(exports, {
 				end
 
 				return function(self, ...)
-					return exportsCallbackCache[resource][k](...)
+					local status, result = pcall(exportsCallbackCache[resource][k], ...)
+
+					if not status then
+						error('An error happens when calling export ' .. k .. ' of resource ' .. resource .. ' "' .. result .. '", previous log should give you more information')
+					end
+
+					return result
 				end
 			end,
 


### PR DESCRIPTION
This may help avoiding X messages about the MessagePack error when in fact it's an user error when calling an export