### PR TITLE
Fix bad cache when restarting a mod

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -377,14 +377,11 @@ AddEventHandler(('on%sResourceStart'):format(IsDuplicityVersion() and 'Server' o
 			end)
 		end
 	end
-
-	-- Init cache on resource start (allow to detect if resource or function does not exist)
-	exportsCallbackCache[resource] = {}
 end)
 
 -- Remove cache when resource stop to avoid calling unexisting exports
 AddEventHandler(('on%sResourceStop'):format(IsDuplicityVersion() and 'Server' or 'Client'), function(resource)
-	exportsCallbackCache[resource] = nil
+	exportsCallbackCache[resource] = {}
 end)
 
 -- invocation bit
@@ -397,7 +394,7 @@ setmetatable(exports, {
 		return setmetatable({}, {
 			__index = function(t, k)
 				if not exportsCallbackCache[resource] then
-					error('No such resource ' .. resource)
+					exportsCallbackCache[resource] = {}
 				end
 
 				if not exportsCallbackCache[resource][k] then


### PR DESCRIPTION
Previously when restarting all this exports were reset to nil since the start for others resources were not called.

So i removed the detection of the resource on the cache and only trust the result of the event.