### PR TITLE
Add possibility to detach current thread

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -9,12 +9,6 @@ function Citizen.CreateThread(threadFunction)
 	})
 end
 
-function Citizen.DetachCurrentThread()
-	table.remove(threads, curThreadIndex)
-
-	return curThread
-end
-
 function Citizen.Wait(msec)
 	curThread.wakeTime = GetGameTimer() + msec
 
@@ -24,6 +18,41 @@ end
 -- legacy alias (and to prevent people from calling the game's function)
 Wait = Citizen.Wait
 CreateThread = Citizen.CreateThread
+
+-- Transform an async function with callback (last parameter) to sync api style
+function Citizen.Await(awaitFunction, ...)
+	if not curThread then
+		error("Current execution context is not in the scheduler, you should use CreateThread / SetTimeout or Event system (AddEventHandler) to be able to Await")
+	end
+
+	-- Remove current thread from the pool (avoid resume from the loop)
+	if curThreadIndex then
+		table.remove(threads, curThreadIndex)
+	end
+
+	curThreadIndex = nil
+	local resumableThread = curThread
+	local args = {...}
+
+	table.insert(args, function (...)
+		-- Reattach thread
+		table.insert(threads, resumableThread)
+
+		curThread = resumableThread
+		curThreadIndex = #threads
+
+		local result, err = coroutine.resume(resumableThread.coroutine, ...)
+
+		if err then
+			error('Failed to resume thread: ' .. debug.traceback(resumableThread.coroutine, err))
+		end
+	end)
+
+	awaitFunction(table.unpack(args))
+
+	curThread = nil
+	return coroutine.yield()
+end
 
 function Citizen.CreateThreadNow(threadFunction)
 	local coro = coroutine.create(threadFunction)
@@ -39,6 +68,8 @@ function Citizen.CreateThreadNow(threadFunction)
 
 	local result, err = coroutine.resume(coro)
 
+	-- Get current thread, can be nil and so should not be added to the pool
+	local resumedThread = curThread
 	-- restore last thread
 	curThread = oldThread
 
@@ -46,7 +77,7 @@ function Citizen.CreateThreadNow(threadFunction)
 		error('Failed to execute thread: ' .. debug.traceback(coro, err))
 	end
 
-	if coroutine.status(coro) ~= 'dead' then
+	if resumedThread and coroutine.status(coro) ~= 'dead' then
 		table.insert(threads, t)
 	end
 end
@@ -88,6 +119,9 @@ Citizen.SetTickRoutine(function()
 			end
 		end
 	end
+
+	curThread = nil
+	curThreadIndex = nil
 end)
 
 local alwaysSafeEvents = {

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -1,11 +1,18 @@
 local threads = {}
 local curThread
+local curThreadIndex
 
 function Citizen.CreateThread(threadFunction)
 	table.insert(threads, {
 		coroutine = coroutine.create(threadFunction),
 		wakeTime = 0
 	})
+end
+
+function Citizen.DetachCurrentThread()
+	table.remove(threads, curThreadIndex)
+
+	return curThread
 end
 
 function Citizen.Wait(msec)
@@ -64,6 +71,7 @@ Citizen.SetTickRoutine(function()
 
 		if curTime >= thread.wakeTime then
 			curThread = thread
+			curThreadIndex = i
 
 			local status = coroutine.status(thread.coroutine)
 


### PR DESCRIPTION
This will allow to allow some mods to have "transparent" async.

Like in MySQL, would allow to have async call while using a sync api

```
local dbResult = MySQL.execute(...)
```

The execute method would then call in async the query, then pause the current thread and resume it. It should be detached as i don't want the scheduler to resume it if async call is too slow.

Also having this detached may ensure that if someone use this function it doesn't fucked up the scheduler.

I feel like, there is more safeguard to add here, would just bring this as a first shot will certainly add some more commits.