### PR TITLE
Removed '\' from Line 164 (DLL)

### DIFF
--- a/code/premake5.lua
+++ b/code/premake5.lua
@@ -161,7 +161,7 @@ function premake.vstudio.cs2005.debugProps(cfg)
 end
 
 local function WriteDocumentationFileXml(_premake, _prj, value)
-    _premake.w('<DocumentationFile>' .. string.gsub(_prj.buildtarget.relpath, "\.dll", ".xml") .. '</DocumentationFile>')
+    _premake.w('<DocumentationFile>' .. string.gsub(_prj.buildtarget.relpath, ".dll", ".xml") .. '</DocumentationFile>')
 end
 
 premake.override(premake.vstudio.cs2005, "compilerProps", function(base, prj)


### PR DESCRIPTION
Results in an error throwing invalid character sequence. Tested fully on 2 systems & edited version works flawlessly.