### PR TITLE
Abstract BaseScript support and stacktrace removed for CreateObjectInstance

### DIFF
--- a/code/client/clrcore/InternalManager.cs
+++ b/code/client/clrcore/InternalManager.cs
@@ -69,24 +69,21 @@ namespace CitizenFX.Core
 			var assembly = Assembly.Load(assemblyData, symbolData);
 			Debug.WriteLine("Loaded {1} into {0}", AppDomain.CurrentDomain.FriendlyName, assembly.FullName);
 
-			var definedTypes = assembly.GetTypes();
+			var definedTypes = assembly.GetTypes().Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(BaseScript)));
 
 			foreach (var type in definedTypes)
 			{
-				if (type.IsSubclassOf(typeof(BaseScript)))
+				try
 				{
-					try
-					{
-						var derivedScript = Activator.CreateInstance(type) as BaseScript;
+					var derivedScript = Activator.CreateInstance(type) as BaseScript;
 
-						Debug.WriteLine("Instantiated instance of script {0}.", type.FullName);
+					Debug.WriteLine("Instantiated instance of script {0}.", type.FullName);
 
-						ms_definedScripts.Add(derivedScript);
-					}
-					catch (Exception e)
-					{
-						Debug.WriteLine("Failed to instantiate instance of script {0}: {1}", type.FullName, e.ToString());
-					}
+					ms_definedScripts.Add(derivedScript);
+				}
+				catch (Exception e)
+				{
+					Debug.WriteLine("Failed to instantiate instance of script {0}: {1}", type.FullName, e.ToString());
 				}
 			}
 

--- a/code/client/clrcore/RuntimeManager.cs
+++ b/code/client/clrcore/RuntimeManager.cs
@@ -49,10 +49,9 @@ namespace CitizenFX.Core
             }
             catch (Exception e)
             {
-                Debug.WriteLine($"Failed to get instance for guid {guid} and iid {iid}: {e}");
-
-                throw;
-            }
+				// Debug.WriteLine($"Failed to get instance for guid {guid} and iid {iid}: {e}");
+				return IntPtr.Zero;
+			}
         }
     }
 }


### PR DESCRIPTION
This pull request prevents several error messages from appearing in the server log. The messages don't seem to make a difference and thus provide no additional information.

I haven't seen anyone else complaing about abstract classes, so I took the liberty to correct this little annoyance. The RuntimeManager would try and create abstract classes, which is not going to work. I added a simple IsAbstract check so this wouldn't happen again. I also merged the if statement to a LINQ statement as this is more neat and reduces nesting.

Plus when starting FXServer one would always see the following exception:
```Failed to get instance for guid a7242855-0350-4cb5-a0fe-61021e7eafaa and iid 567634c6-3bdd-4d0e-af39-7472aed479b7: System.InvalidOperationException: Sequence contains no matching element
  at System.Linq.Enumerable.First[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00011] in <48501e5f32e8491e924f8b8beae3e4f6>:0
  at CitizenFX.Core.RuntimeManager.CreateObjectInstance (System.Guid guid, System.Guid iid) [0x00016] in G:\git\HB2012\fivem\code\client\clrcore\RuntimeManager.cs:39
```
I fixed this by returning IntPtr.Zero in CreateObjectInstance and uncommenting the debug message. I originally wanted to go for a #if DEBUG approach, but it doesn't appear to be defined. I could define it, but it kind of beats the point when there's just 1 chunk of code making use of it. I left the message there so one can uncomment it when more information is required.