### PR TITLE
Fix open handles when nothing is found.

### DIFF
--- a/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
+++ b/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
@@ -154,6 +154,7 @@ static void FindFirstHandler(fx::ScriptContext& context)
 			context.SetResult(handle - g_handles);
 			return;
 		}
+		handle->pool = nullptr;
 	}
 
 	context.SetResult(-1);


### PR DESCRIPTION
When a find handle was made but couldn't find any entities, it left the handle open but returned an invalid handle. Now it simply sets the pool back to nullptr when it fails to get the first entity.