### PR TITLE
Ability to use specific port for localhost connect

### DIFF
--- a/ext/cfx-ui/src/app/app-nav.component.ts
+++ b/ext/cfx-ui/src/app/app-nav.component.ts
@@ -43,7 +43,6 @@ export class AppNavComponent extends Translation {
 	}
 
 	connectToLocal() {
-		console.log(this.localhostPort);
 		(<any>window).invokeNative('connectTo', (typeof this.localhostPort === 'undefined') ? '127.0.0.1:30120' : '127.0.0.1:' + this.localhostPort );
 	}
 

--- a/ext/cfx-ui/src/app/app-nav.component.ts
+++ b/ext/cfx-ui/src/app/app-nav.component.ts
@@ -14,6 +14,7 @@ import { Translation, TranslationService } from 'angular-l10n';
 export class AppNavComponent extends Translation {
 	nickname = '';
 	devMode = false;
+	localhostPort = '';
 	hasSubNav = false;
 
 	constructor(
@@ -26,6 +27,8 @@ export class AppNavComponent extends Translation {
 
 		this.nickname = gameService.nickname;
 		this.devMode = gameService.devMode;
+		this.localhostPort = gameService.localhostPort;
+		
 
 		router.events.subscribe(event => {
 			if ((<NavigationEnd>event).url) {
@@ -36,10 +39,12 @@ export class AppNavComponent extends Translation {
 		gameService.signinChange.subscribe(value => this.nickname = value.name);
 		gameService.nicknameChange.subscribe(value => this.nickname = value);
 		gameService.devModeChange.subscribe(value => this.devMode = value);
+		gameService.localhostPortChange.subscribe(value => this.localhostPort = value);
 	}
 
 	connectToLocal() {
-		(<any>window).invokeNative('connectTo', '127.0.0.1:30120');
+		console.log(this.localhostPort);
+		(<any>window).invokeNative('connectTo', (typeof this.localhostPort === 'undefined') ? '127.0.0.1:30120' : '127.0.0.1:' + this.localhostPort );
 	}
 
 	exitGame() {

--- a/ext/cfx-ui/src/app/game.service.ts
+++ b/ext/cfx-ui/src/app/game.service.ts
@@ -36,6 +36,7 @@ export abstract class GameService {
 
 	devModeChange = new EventEmitter<boolean>();
 	nicknameChange = new EventEmitter<string>();
+	localhostPortChange = new EventEmitter<string>();
 
 	signinChange = new EventEmitter<Profile>();
 
@@ -57,6 +58,14 @@ export abstract class GameService {
 
 	}
 
+	get localhostPort(): string {
+		return '30120';
+	}
+
+	set localhostPort(name: string) {
+
+	}	
+	
 	abstract init(): void;
 
 	abstract connectTo(server: Server): void;
@@ -117,6 +126,10 @@ export abstract class GameService {
 	protected invokeDevModeChanged(value: boolean) {
 		this.devModeChange.emit(value);
 	}
+	
+	protected invokeLocalhostPortChanged(port: string) {
+		this.localhostPortChange.emit(port);
+	}	
 }
 
 @Injectable()
@@ -134,7 +147,9 @@ export class CfxGameService extends GameService {
 	private history: string[] = [];
 
 	private realNickname: string;
-
+	
+	private _localhostPort: string;
+	
 	private inConnecting = false;
 
 	constructor(private sanitizer: DomSanitizer, private zone: NgZone) {
@@ -210,6 +225,10 @@ export class CfxGameService extends GameService {
 			this._devMode = localStorage.getItem('devMode') === 'yes';
 		}
 
+		if (localStorage.getItem('localhostPort')) {
+			this._localhostPort = localStorage.getItem('localhostPort');
+		}		
+		
 		this.connecting.subscribe(server => {
 			this.inConnecting = false;
 		});
@@ -239,6 +258,16 @@ export class CfxGameService extends GameService {
 		this.invokeDevModeChanged(value);
 	}
 
+	get localhostPort(): string {
+		return this._localhostPort;
+	}
+
+	set localhostPort(port: string) {
+		this._localhostPort = port;
+		localStorage.setItem('localhostPort', port);
+		this.invokeLocalhostPortChanged(port);
+	}
+	
 	private saveHistory() {
 		localStorage.setItem('history', JSON.stringify(this.history));
 	}
@@ -362,6 +391,7 @@ export class CfxGameService extends GameService {
 @Injectable()
 export class DummyGameService extends GameService {
 	private _devMode = false;
+	private _localhostPort = '';
 
 	constructor() {
 		super();
@@ -430,6 +460,15 @@ export class DummyGameService extends GameService {
 		this.invokeNicknameChanged(name);
 	}
 
+	get localhostPort(): string {
+		return this._localhostPort;
+	}
+
+	set localhostPort(port: string) {
+		localStorage.setItem('localhostPort', port);
+		this.invokeLocalhostPortChanged(port);
+	}	
+	
 	get devMode(): boolean {
 		return this._devMode;
 	}

--- a/ext/cfx-ui/src/app/settings/settings.component.html
+++ b/ext/cfx-ui/src/app/settings/settings.component.html
@@ -33,3 +33,20 @@
 		</div>
 	</div>
 </section>
+
+<section class="setting" *ngIf="devMode">
+	<div class="key">
+		Localhost port
+	</div>
+	<div class="value">
+		<input
+			#input
+			class="text"
+			type="text"
+			placeholder="{{'#Settings_LocalhostPort'|translate}}"
+			spellcheck="false"
+			[(ngModel)]="localhostPort"
+			(ngModelChange)="localhostPortChanged($event)"		
+		>
+	</div>
+</section>

--- a/ext/cfx-ui/src/app/settings/settings.component.ts
+++ b/ext/cfx-ui/src/app/settings/settings.component.ts
@@ -10,16 +10,19 @@ import { GameService } from '../game.service';
 
 export class SettingsComponent implements OnInit {
     nickname = '';
+    localhostPort = '30120';
     devMode = false;
 
     constructor(private gameService: GameService) {
         gameService.nicknameChange.subscribe(value => this.nickname = value);
         gameService.devModeChange.subscribe(value => this.devMode = value);
+        gameService.localhostPortChange.subscribe(value => this.localhostPort = value);
     }
 
     ngOnInit() {
         this.nickname = this.gameService.nickname;
         this.devMode = this.gameService.devMode;
+        this.localhostPort = this.gameService.localhostPort;
     }
 
     nameChanged(newName) {
@@ -28,5 +31,9 @@ export class SettingsComponent implements OnInit {
 
     toggleDevMode() {
         this.gameService.devMode = !this.devMode;
+    }
+	
+    localhostPortChanged(newPort) {
+        this.gameService.localhostPort = newPort;
     }
 }

--- a/ext/cfx-ui/src/assets/locale-en.json
+++ b/ext/cfx-ui/src/assets/locale-en.json
@@ -25,6 +25,7 @@
     "#ServerList_AddFavorite": "Add Favorite",
     "#ServerList_RemoveFavorite": "Remove Favorite",
     "#Settings_Nickname": "Player name",
+    "#Settings_LocalhostPort": "Custom port",
     "#DirectConnect_ServerInvalid": "Server could not be found",
     "#DirectConnect_ServerInvalid_SubTitle": "Make sure you've entered the correct address.",
     "#DirectConnect_IPPort": "IP:Port",


### PR DESCRIPTION
A little update that allow developers use different port. I'm using 33333 port on my local server, so I forced to use Direct connect or console to connect. If "Custom port" is empty, it will use 30120. Also this setting support saving. I don't know can it be useful someone besides me, but still decided to share.
![preview](https://user-images.githubusercontent.com/10367215/33068042-12cc94d6-cec1-11e7-89ce-93961e028326.gif)
