### PR TITLE
Save last direct connection to localstorage (quick connect)

### DIFF
--- a/ext/cfx-ui/src/app/servers/direct/direct-connect.component.ts
+++ b/ext/cfx-ui/src/app/servers/direct/direct-connect.component.ts
@@ -94,6 +94,7 @@ export class DirectConnectComponent implements OnInit, AfterViewInit {
 
     ngOnInit() {
 		this.addr = localStorage.getItem('directLast');
+		this.addrChanged(localStorage.getItem('directLast'));
 	}
 
     ngAfterViewInit() {

--- a/ext/cfx-ui/src/app/servers/direct/direct-connect.component.ts
+++ b/ext/cfx-ui/src/app/servers/direct/direct-connect.component.ts
@@ -84,6 +84,7 @@ export class DirectConnectComponent implements OnInit, AfterViewInit {
             addrBits[1] = parseInt(match[2], 10);
         }
 
+		localStorage.setItem('directLast', this.addr);
         this.addrEvent.next(addrBits);
     }
 
@@ -91,7 +92,9 @@ export class DirectConnectComponent implements OnInit, AfterViewInit {
         this.gameService.connectTo(this.server);
     }
 
-    ngOnInit() { }
+    ngOnInit() {
+		this.addr = localStorage.getItem('directLast');
+	}
 
     ngAfterViewInit() {
         this.inputBox.first.nativeElement.focus();


### PR DESCRIPTION
On direct connect input update, the address is saved to the user's storage.

When the direct connection screen is opened, the input is pre-filled with the last used address.