### PR TITLE
Implement Get/SetVehicleWheelXOffset.

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -151,6 +151,7 @@ const int CanWheelsBreakOffset = 0x893;
 const int BlinkerState = 0x899;
 
 // Wheel class
+const int WheelTrackWidthOffset = 0x030;
 const int WheelTyreRadiusOffset = 0x110;
 const int WheelRimRadiusOffset = 0x114;
 const int WheelTyreWidthOffset = 0x118;
@@ -352,4 +353,14 @@ static HookFunction initFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_INTERIOR_LIGHT_ON", readVehicleMemoryBit<IsInteriorLightOnOffset, 6>);
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_INDICATOR_LIGHTS", readVehicleMemory<unsigned char, BlinkerState>);
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_WHEEL_TRACK_WIDTH", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	{
+		context.SetResult<float>(*reinterpret_cast<float *>(wheelAddr + WheelTrackWidthOffset));
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_WHEEL_TRACK_WIDTH", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	{
+		*reinterpret_cast<float *>(wheelAddr + WheelTrackWidthOffset) = context.GetArgument<float>(2);
+	}));
 });

--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -151,7 +151,7 @@ const int CanWheelsBreakOffset = 0x893;
 const int BlinkerState = 0x899;
 
 // Wheel class
-const int WheelTrackWidthOffset = 0x030;
+const int WheelXOffsetOffset = 0x030;
 const int WheelTyreRadiusOffset = 0x110;
 const int WheelRimRadiusOffset = 0x114;
 const int WheelTyreWidthOffset = 0x118;
@@ -354,13 +354,13 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_INDICATOR_LIGHTS", readVehicleMemory<unsigned char, BlinkerState>);
 
-	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_WHEEL_TRACK_WIDTH", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_WHEEL_X_OFFSET", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
 	{
-		context.SetResult<float>(*reinterpret_cast<float *>(wheelAddr + WheelTrackWidthOffset));
+		context.SetResult<float>(*reinterpret_cast<float *>(wheelAddr + WheelXOffsetOffset));
 	}));
 
-	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_WHEEL_TRACK_WIDTH", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_WHEEL_X_OFFSET", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
 	{
-		*reinterpret_cast<float *>(wheelAddr + WheelTrackWidthOffset) = context.GetArgument<float>(2);
+		*reinterpret_cast<float *>(wheelAddr + WheelXOffsetOffset) = context.GetArgument<float>(2);
 	}));
 });

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -1299,6 +1299,34 @@ native 'SET_VEHICLE_WHEEL_XROT'
 	apiset 'client'
 	returns 'void'
 
+native 'GET_VEHICLE_WHEEL_TRACK_WIDTH'
+	arguments {
+		Vehicle 'vehicle',
+		int 'wheelIndex'
+	}
+	apiset 'client'
+	returns 'float'
+	doc [[
+	<summary>
+	Returns the offset of the specified wheel relative to the wheel's axle center.
+	</summary>
+]]
+
+native 'SET_VEHICLE_WHEEL_TRACK_WIDTH'
+	arguments {
+		Vehicle 'vehicle',
+		int 'wheelIndex',
+		float 'offset'
+	}
+	apiset 'client'
+	returns 'void'
+	doc [[
+	<summary>
+	Adjusts the offset of the specified wheel relative to the wheel's axle center.
+	Needs to be called every frame in order to function properly, as GTA will reset the track width otherwise.
+	</summary>
+]]
+
 native 'SEND_LOADING_SCREEN_MESSAGE'
 	arguments {
 		charPtr 'jsonString'

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -1299,7 +1299,7 @@ native 'SET_VEHICLE_WHEEL_XROT'
 	apiset 'client'
 	returns 'void'
 
-native 'GET_VEHICLE_WHEEL_TRACK_WIDTH'
+native 'GET_VEHICLE_WHEEL_X_OFFSET'
 	arguments {
 		Vehicle 'vehicle',
 		int 'wheelIndex'
@@ -1312,7 +1312,7 @@ native 'GET_VEHICLE_WHEEL_TRACK_WIDTH'
 	</summary>
 ]]
 
-native 'SET_VEHICLE_WHEEL_TRACK_WIDTH'
+native 'SET_VEHICLE_WHEEL_X_OFFSET'
 	arguments {
 		Vehicle 'vehicle',
 		int 'wheelIndex',
@@ -1323,7 +1323,15 @@ native 'SET_VEHICLE_WHEEL_TRACK_WIDTH'
 	doc [[
 	<summary>
 	Adjusts the offset of the specified wheel relative to the wheel's axle center.
-	Needs to be called every frame in order to function properly, as GTA will reset the track width otherwise.
+	Needs to be called every frame in order to function properly, as GTA will reset the offset otherwise.
+
+	This function can be especially useful to set the track width of a vehicle, for example:
+	```
+	function SetVehicleFrontTrackWidth(vehicle, width)
+		SetVehicleWheelXOffset(vehicle, 0, -width/2)
+		SetVehicleWheelXOffset(vehicle, 1, width/2)
+	end
+	```
 	</summary>
 ]]
 


### PR DESCRIPTION
Continuation of https://github.com/citizenfx/fivem/pull/90, fixing commented issues.

Some notes:

`Get/SetVehicleWheelCamber` was removed in favor of `Get/SetVehicleWheelXrot`. An alias can be added in the future. At that point, I suggest to also alias `Get/SetVehicleWheelXrot` to `*WheelXRot` due to capitalization.

`Get/SetVehicleWheelTrackWidth` was renamed to `Get/SetVehicleWheelXOffset`. While `TrackWidth` is a friendly and familiar name, it is technically not correct as it implies the distance between both wheels on a single axle. Instead, track width can be correctly applied like so:
```lua
function SetVehicleFrontTrackWidth(vehicle, width)
  SetVehicleWheelXOffset(vehicle, 0, -width/2)
  SetVehicleWheelXOffset(vehicle, 1, width/2)
end
```

Also added a short doc on the natives, including a note to call the setter every frame as this may not necessarily be clear to everyone. Not sure if examples can contains triple backticks here.  Let me know if that needs to change.

Might work on a more generic `Get/SetVehicleWheelOffset` later, but the Y and Z axis seem to be a bit more funky than X axis so that needs additional work. 