### PR TITLE
Update SteamComponent.cpp (replacing Source SDK Base 2007 with Grand Theft Auto V)

### DIFF
--- a/code/components/steam/src/SteamComponent.cpp
+++ b/code/components/steam/src/SteamComponent.cpp
@@ -277,11 +277,11 @@ void SteamComponent::RemoveSteamCallback(int registeredID)
 #define PARENT_APP_ID 204100
 #define PRODUCT_DISPLAY_NAME "CitizenPayne \xF0\x9F\x92\x8A"
 #elif defined(GTA_FIVE)
-#define PARENT_APP_ID 218
+#define PARENT_APP_ID 271590
 #define PRODUCT_DISPLAY_NAME "FiveM \xF0\x9F\x90\x8C" // snail
 #else
-#define PARENT_APP_ID 218
-#define PRODUCT_DISPLAY_NAME "Unknown CitizenFX product"
+#define PARENT_APP_ID 271590
+#define PRODUCT_DISPLAY_NAME "FiveM \xF0\x9F\x90\x8C" // snail
 #endif
 
 static int SehRoutine(PEXCEPTION_POINTERS exception)


### PR DESCRIPTION
In an attempt to replace Source SDK Base 2007 app ID with the actual Grand Theft Auto V app ID, to perhaps show "Playing FiveM" when friends look at what you are playing.

I am not sure whether this even works (and if it does) if it is anything useful.