### PR TITLE
Open tweet, server refresh button, small improvements.

### DIFF
--- a/ext/cfx-ui/src/app/home/home.component.html
+++ b/ext/cfx-ui/src/app/home/home.component.html
@@ -8,7 +8,7 @@
 					<small>@{{tweet.user_screenname}}</small>
 					<small>
 						{{tweet.date | amTimeAgo}}
-						<span class="additional">{{tweet.date | date:'MM/dd/yyyy @ h:mma'}}</span>
+						<span class="additional" data-balloon="Open tweet in browser." data-balloon-pos="right" (click)="openTweet(tweet.id)">{{tweet.date | date:'MM/dd/yyyy @ h:mma'}}</span>
 					</small>	
 				</div>
 				<div class="message-body">

--- a/ext/cfx-ui/src/app/home/home.component.scss
+++ b/ext/cfx-ui/src/app/home/home.component.scss
@@ -33,6 +33,10 @@
 				opacity: 0;
 				padding-left: 0;
 				transition: all .2s ease;
+
+				&:hover {
+					color: #fff;
+				}				
 			}
 			
 			&:hover {

--- a/ext/cfx-ui/src/app/home/home.component.ts
+++ b/ext/cfx-ui/src/app/home/home.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 
 import { Tweet, TweetService } from './tweet.service';
 
+import { GameService } from '../game.service';
+
 @Component({
     moduleId: module.id,
     selector: 'app-home',
@@ -12,7 +14,7 @@ import { Tweet, TweetService } from './tweet.service';
 export class HomeComponent implements OnInit {
     tweets: Tweet[];
 
-    constructor(private tweetService: TweetService) { }
+    constructor(private tweetService: TweetService, private gameService: GameService) { }
 
     ngOnInit() {
         this.fetchTweets();
@@ -22,5 +24,9 @@ export class HomeComponent implements OnInit {
         this.tweetService
             .getTweets('https://runtime.fivem.net/tweets.json')
             .then(tweets => this.tweets = tweets);
+    }
+
+    openTweet(id) {
+        this.gameService.openUrl('https://twitter.com/_FiveM/status/' + id);
     }
 }

--- a/ext/cfx-ui/src/app/home/tweet.service.ts
+++ b/ext/cfx-ui/src/app/home/tweet.service.ts
@@ -10,6 +10,7 @@ export class Tweet {
     readonly content: string;
     readonly date: Date;
     readonly avatar: string;
+    readonly id: string;
 
     image: string;
 
@@ -21,6 +22,7 @@ export class Tweet {
 
         this.date = new Date(json.created_at);
         this.avatar = json.user.profile_image_url_https;
+        this.id = json.id_str;
     }
 
     // based on https://gist.github.com/darul75/88fc42a21f6113708a0b

--- a/ext/cfx-ui/src/app/servers/components/servers-detail.component.html
+++ b/ext/cfx-ui/src/app/servers/components/servers-detail.component.html
@@ -51,6 +51,9 @@
 			<button class="unimportant favorite" (click)="removeFavorite()" *ngIf="isFavorite()" translate>
 				#ServerDetail_DelFavorite
 			</button>
+			<button class="unimportant refresh" (click)="refreshServer()" [class.disabled]="!canRefresh" translate>
+				#ServerDetail_Refresh
+			</button>
 			<button class="unimportant back" (click)="goBack()" translate>
 				#ServerDetail_Back
 			</button>
@@ -59,7 +62,7 @@
 
 	<div class="info player-list" *ngIf="this.server">
 		<h1 translate>#ServerDetail_Players</h1>
-
+		<span *ngIf="server.data.players.length == 0" translate>#ServerDetail_PlayersEmpty</span>
 		<ul>
 			<li *ngFor="let player of server.data.players"><figure><img [src]="getPlayerUrl(player)"></figure>
 				<span>

--- a/ext/cfx-ui/src/app/servers/components/servers-detail.component.scss
+++ b/ext/cfx-ui/src/app/servers/components/servers-detail.component.scss
@@ -79,7 +79,7 @@
             }
 
             .title {
-                font-size: 2.5rem;
+                font-size: 4vh;
                 line-height: 1;
             }
 
@@ -98,6 +98,11 @@
 
             .connect {
                 margin-top: $padding;
+            }
+
+            .disabled {
+                opacity: .5;
+                transition: opacity .4s;
             }
 
             &.player-list {

--- a/ext/cfx-ui/src/app/servers/components/servers-detail.component.ts
+++ b/ext/cfx-ui/src/app/servers/components/servers-detail.component.ts
@@ -35,6 +35,7 @@ export class ServersDetailComponent extends Translation implements OnInit, OnDes
     filterFuncs: {[key: string]: (pair: VariablePair) => VariablePair} = {};
     resourceString = '';
     error = '';
+    canRefresh = true;
 
     interval: number;
 
@@ -45,7 +46,7 @@ export class ServersDetailComponent extends Translation implements OnInit, OnDes
     addrEvent = new Subject<[string, number]>();
 
     disallowedVars = ['sv_enhancedHostSupport', 'sv_licenseKeyToken', 'sv_lan', 'sv_maxClients'];
-
+    
     @Language()
     lang: string;
 
@@ -84,6 +85,17 @@ export class ServersDetailComponent extends Translation implements OnInit, OnDes
                     .filter(({ key }) => this.disallowedVars.indexOf(key) < 0)
                     .map(pair => this.filterFuncs[pair.key] ? this.filterFuncs[pair.key](pair) : pair);
             });
+    }
+
+    refreshServer() {
+        if (this.canRefresh) {
+            this.updateServer();
+
+            this.canRefresh = false;
+            window.setTimeout(() => {
+                this.canRefresh = true;
+            }, 2000);
+        }
     }
 
     getPlayerUrl(player: any) {

--- a/ext/cfx-ui/src/app/servers/components/servers-list-item.component.scss
+++ b/ext/cfx-ui/src/app/servers/components/servers-list-item.component.scss
@@ -101,6 +101,7 @@
 			padding-top: 0.5vh;
 			height: $appServersItemHeight;
 			opacity: 0;
+			font-size: 0;
 
 			transition: all .2s ease-out;
 

--- a/ext/cfx-ui/src/assets/locale-en.json
+++ b/ext/cfx-ui/src/assets/locale-en.json
@@ -31,9 +31,11 @@
     "#DirectConnect_IPPort": "IP:Port",
     "#DirectConnect_Connect": "Connect",
     "#ServerDetail_Players": "Players",
+    "#ServerDetail_PlayersEmpty": "No online players on this server.",
     "#ServerDetail_Back": "Back",
     "#ServerDetail_AddFavorite": "Favorite",
     "#ServerDetail_DelFavorite": "Unfavorite",
+    "#ServerDetail_Refresh": "Refresh",
     "#ServerDetail_ScriptHook": "Client scripts allowed",
     "#Yes": "Yes",
     "#No": "No"


### PR DESCRIPTION
Preview: https://imgur.com/a/Dd9dS

An ability to open tweets by clicking detailed date label.

Server refresh button was added to detail page, have 2s timeout to prevent possible spam.

Fixed "favourite" svg button position, now it's looks right on any resolution.

Big server names on server detail page could use ~30% of page on small resolutions. Changed font-size to vh to prevent it.

"Players" panel looks too empty when no players online. Added description text when server is empty to make it looks a bit better