### PR TITLE
fixed issue with callback urls having capitals

### DIFF
--- a/code/components/nui-resources/src/ResourceUI.cpp
+++ b/code/components/nui-resources/src/ResourceUI.cpp
@@ -55,7 +55,9 @@ bool ResourceUI::Create()
 	std::string pageName = uiPageData.begin()->second;
 
 	// initialize the page
-	CefRegisterSchemeHandlerFactory("http", m_resource->GetName(), Instance<NUISchemeHandlerFactory>::Get());
+	auto resourceName = m_resource->GetName();
+	std::transform(resourceName.begin(), resourceName.end(), resourceName.begin(), ::ToLower);
+	CefRegisterSchemeHandlerFactory("http", resourceName, Instance<NUISchemeHandlerFactory>::Get());
 
 	// create the NUI frame
 	std::string path = "nui://" + m_resource->GetName() + "/" + pageName;


### PR DESCRIPTION
This is needed when doing a callback from NUI to a script.
The domain name needs to be in all lowercase characters.