### PR TITLE
Add compat for v8/node to Docker builds

### DIFF
--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 MOUNT ..:/src
 RUN /bin/sh /src/code/tools/ci/build_server_2.sh
 WORKDIR /opt/cfx-server

--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 MOUNT ..:/src
 RUN /bin/sh /src/code/tools/ci/build_server_2.sh
+ENV LD_LIBRARY_PATH /usr/lib/v8/:/lib:/usr/lib/
 WORKDIR /opt/cfx-server
 CMD ["/bin/sh", "/opt/cfx-server/run.sh"]
 PUSH citizenfx/server:dev

--- a/code/tools/ci/build_server_2.sh
+++ b/code/tools/ci/build_server_2.sh
@@ -11,7 +11,7 @@ apk --no-cache update
 apk --no-cache upgrade
 
 # install runtime dependencies
-apk add libc++ curl libssl1.0 libunwind libstdc++ zlib c-ares
+apk add libc++ curl libssl1.0 libunwind libstdc++ zlib c-ares icu-libs
 
 # add fivem repositories
 curl -sLo /etc/apk/keys/peachypies@protonmail.ch-5adb3818.rsa.pub https://runtime.fivem.net/client/alpine/peachypies@protonmail.ch-5adb3818.rsa.pub


### PR DESCRIPTION
It fixes docker builds:
* Alpine 3.7 is needed to use the cfx repo (added for v8)
* icu-libs is needed by libv8