### PR TITLE
GetParentResourceName function for NUI frames

### DIFF
--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -46,6 +46,11 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		{
 			frame.style.visibility = 'visible';
 		}, true);
+
+		frame.contentWindow.GetParentResourceName = function()
+		{
+			return frameName;
+		}
 	}
 	else if (msg == "destroyFrame")
 	{


### PR DESCRIPTION
With this function you can get frame's parent resource. This can be useful for resources that sending data from NUI to client. Without it you will be forced to hardcode resource name in post's url.

Example code:
`const name = GetParentResourceName();
$.post("http://" + name + "/test", JSON.stringify(data));`

Tested with vrp, wk_actionmenu and few other resources from the forum.