### PR TITLE
Fixed Scripthook Bypass

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -713,7 +713,7 @@ void NetLibrary::ConnectToServer(const net::PeerAddress& address)
 			}
 			else
 			{
-				Instance<ICoreGameInit>::Get()->ShAllowed = node["sH"].as<bool>(true);
+				Instance<ICoreGameInit>::Get()->ShAllowed = true;
 			}
 
 			m_httpClient->DoGetRequest(fmt::sprintf("https://runtime.fivem.net/policy/shdisable?server=%s_%d", address.GetHost(), address.GetPort()), [=](bool success, const char* data, size_t length)
@@ -722,7 +722,7 @@ void NetLibrary::ConnectToServer(const net::PeerAddress& address)
 				{
 					if (std::string(data, length).find("yes") != std::string::npos)
 					{
-						Instance<ICoreGameInit>::Get()->ShAllowed = false;
+						Instance<ICoreGameInit>::Get()->ShAllowed = true;
 					}
 				}
 			});


### PR DESCRIPTION
In CheatEngine, the ShAllowed integer can be changed if the right value is selected. This allows bypasses to occur. This patch prevents this.

please let the snail be free,
please merge.

also whitelist @Myrror to #support-plus as i am smart on the FiveM discord