### PR TITLE
Added NUI's cursor position getter

### DIFF
--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -148,4 +148,14 @@ static InitFunction initFunction([] ()
 			}
 		}
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_NUI_CURSOR_POSITION", [](fx::ScriptContext& context)
+	{
+		POINT cursorPos;
+		GetCursorPos(&cursorPos);
+		ScreenToClient(FindWindow(L"grcWindow", nullptr), &cursorPos);
+
+		*context.GetArgument<int*>(0) = cursorPos.x;
+		*context.GetArgument<int*>(1) = cursorPos.y;
+	});
 });

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -244,6 +244,14 @@ native 'SET_NUI_FOCUS'
 	apiset 'client'
 	returns 'void'
 
+native 'GET_NUI_CURSOR_POSITION'
+	arguments {
+		intPtr 'x',
+		intPtr 'y'
+	}
+	apiset 'client'
+	returns 'void'
+
 native 'SET_TEXT_CHAT_ENABLED'
 	arguments {
 		BOOL 'enabled'


### PR DESCRIPTION
With this function you can get NUI's cursor position (x, y) from client scripts.
`void GET_NUI_CURSOR_POSITION(int *x, int *y)`

Usage example: https://hastebin.com/ikepijohux
Demonstration: https://gfycat.com/HonoredAmbitiousDwarfrabbit