### PR TITLE
clrcore: Adds Debug.WriteLine overload without formatting arguments

### DIFF
--- a/code/client/clrcore/Debug.cs
+++ b/code/client/clrcore/Debug.cs
@@ -25,6 +25,11 @@ namespace CitizenFX.Core
         {
             Write("\n");
         }
+				
+        public static void WriteLine(string data)
+        {
+            Write(data + "\n");
+        }
 
         public static void WriteLine(string format, params object[] args)
         {


### PR DESCRIPTION
* This is to match the behavior of System.Diagnostics.Debug.WriteLine which doesn't try to format the string unless you provide additional arguments. This was causing errors if you had unescaped curly brackets in your string and were expecting the System.Diagnostics.Debug.WriteLine behavior. e.g. `Debug.WriteLine("{test}")`

This resolves issues like this https://forum.fivem.net/t/c-debug-writeline-without-parameters-still-tries-to-format-the-string/97667