### PR TITLE
clrcore: Fixes remote function index out of bounds exception

### DIFF
--- a/code/client/clrcore/RemoteFunctionReference.cs
+++ b/code/client/clrcore/RemoteFunctionReference.cs
@@ -95,7 +95,7 @@ namespace CitizenFX.Core
 				{
 					var repId = args[0].ToString();
 					var arg = args[1] as List<object>;
-					var err = args[2];
+					var err = args.Length > 2 ? args[2] : null;
 
 					if (m_rpcList.TryGetValue(repId, out var tcs))
 					{


### PR DESCRIPTION
* The error parameter will be missing from the array when there is no error.

This fix allows you to use networked callbacks in C#. You just need the lua sessionmanager resource running. Also for the example below you also need an empty lua client_script inside the sessionmanager. Since the callbacks are handled via scheduler.lua when the resource name is sessionmanager.

```
class ClientScript : BaseScript
{
    public ClientScript()
    {
        TriggerServerEvent("SomeEvent", new Func<int, int>((arg) =>
        {
            return arg * 2;
        }));
    }
}
class ServerScript : BaseScript
{
    public ServerScript()
    {
        this.EventHandlers.Add("SomeEvent", new Action<dynamic>(OnSomeEvent));
    }

    private async void OnSomeEvent(dynamic cb)
    {
        var val = await cb(10);
        Debug.WriteLine("new val: " + val);
    }
}
```