### PR TITLE
Addition of "Error" in brackets next to "Ошибка"

### DIFF
--- a/ext/cfx-ui/src/assets/locale-en.json
+++ b/ext/cfx-ui/src/assets/locale-en.json
@@ -18,7 +18,7 @@
     "#Servers_Connecting": "Connecting",
     "#Servers_ConnectingTo": "Connecting to {{ serverName }}...",
     "#Servers_ConnectFailed": "Connection failed",
-    "#Servers_Error": "Ошибка",
+    "#Servers_Error": "Ошибка (Error)",
     "#Servers_CloseOverlay": "Close",
     "#Servers_CancelOverlay": "Cancel",
     "#Servers_Message": "{{ message }}",


### PR DESCRIPTION
As mentioned in #98, you don't want to remove the "Ошибка". And that's OK. But on the other hand it decreases the usability of this statement. So I thought that a good way will be not touching the word "Ошибка" and leaving it as it is, and adding next to it an English "Error" in brackets.

Case 1: Someone understands the meaning of "Ошибка", so he reads it and moves his eyes below, to the description. Without paying attention to what is in brackets.

Case 2: Someone doesn't understand the meaning of "Ошибка", so he reads it and thinks "What's this?? Idk. Maybe it's a mistake in translation. Anyway, let's continue reading.", then he moves his eyes to the next word, which is in brackets – "Error". He understands it, so he moves his eyes below, to the description.

I think this is a good solution for the problem "nostalgia vs usability".