### PR TITLE
Suggestion for alternative hook, for easier pool management

### DIFF
--- a/code/components/gta-core-five/src/PoolManagementAlternativeHook.cpp
+++ b/code/components/gta-core-five/src/PoolManagementAlternativeHook.cpp
@@ -1,0 +1,39 @@
+LPVOID allocatePoolMemory_ori;
+
+// #include "memmath.h"
+// Hook(Scan("48 83 ec 28 83 3d ?? ?? ?? ?? 00 75 23")
+//         .add(0x20)
+//         .rip(4)
+//         .as<void*>(), 
+//     allocatePoolMemory, 
+//     &allocatePoolMemory_ori
+// );
+
+int allocatePoolMemory(UINT_PTR a1, unsigned int hash, int size) {
+    // Obviously in FiveM, you would do a map lookup rather that using a switch statement.
+    switch (hash) {
+        case JOAAT("CGameScriptHandler"):
+            trace("Resized ScriptHandler Pool");
+            return std::max(256, size);
+
+        case JOAAT("atDScriptObjectNode"):
+            trace("Resized ScriptObject Pool");
+            return 3072;
+
+        case JOAAT("fwScriptGuid"): // EntityPool
+            trace("Resized Entity Pool");
+            return 3072;
+
+        case JOAAT("CScriptEntityExtension"): // MissionPool
+            trace("Resized Mission Pool");
+            return 3072;
+
+        case 0xf2e37be0:
+            // The function is called continuously throughout the game with this 1 single hash. 
+            // Avoid wasting time processing it. The function is otherwise uncalled except on 
+            // initial creation of a pool.
+        default:
+            return reinterpret_cast<decltype(&allocatePoolMemory)>
+                (allocatePoolMemory_ori)(a1, hash, size);
+    }
+}

--- a/code/components/gta-core-five/src/memmath.h
+++ b/code/components/gta-core-five/src/memmath.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <type_traits>
+#include <cstdint>
+#include <cstddef>
+
+namespace mem {
+    class pointer {
+    protected:
+        uintptr_t value_;
+
+    public:
+        pointer()                                                       noexcept;
+        pointer(const std::nullptr_t null)                              noexcept;
+        pointer(const uintptr_t value)                                  noexcept;
+        pointer(const void* const value)                                noexcept;
+
+        bool null()                                               const noexcept;
+
+        pointer add(const pointer value)                          const noexcept;
+        pointer sub(const pointer value)                          const noexcept;
+
+        size_t dist(const pointer value)                          const noexcept;
+
+        pointer shift(const pointer from, const pointer to)       const noexcept;
+
+        pointer rip(const ptrdiff_t offset)                       const;
+
+        pointer& deref()                                          const noexcept;
+
+        pointer operator+(const pointer value)                    const noexcept;
+        pointer operator-(const pointer value)                    const noexcept;
+
+        pointer& operator+=(const pointer value)                        noexcept;
+        pointer& operator-=(const pointer value)                        noexcept;
+
+        pointer& operator++()                                           noexcept;
+        pointer& operator--()                                           noexcept;
+
+        pointer operator++(int)                                         noexcept;
+        pointer operator--(int)                                         noexcept;
+
+        bool operator==(const pointer value)                      const noexcept;
+        bool operator!=(const pointer value)                      const noexcept;
+
+        bool operator<(const pointer value)                       const noexcept;
+        bool operator>(const pointer value)                       const noexcept;
+
+        bool operator<=(const pointer value)                      const noexcept;
+        bool operator>=(const pointer value)                      const noexcept;
+
+        template <typename T>
+        std::enable_if_t<std::is_same<T, pointer>::value, T> as() const noexcept;
+
+        template <typename T>
+        std::enable_if_t<std::is_integral<T>::value, T>      as() const noexcept;
+
+        template <typename T>
+        std::enable_if_t<std::is_pointer<T>::value, T>       as() const noexcept;
+
+        template <typename T>
+        std::enable_if_t<
+            std::is_lvalue_reference<T>::value, T>           as() const noexcept;
+
+        template <typename T>
+        std::enable_if_t<std::is_array<T>::value,
+            std::add_lvalue_reference_t<T>>                  as() const noexcept;
+    };
+
+    inline pointer::pointer() noexcept
+        : value_()
+    { }
+
+    inline pointer::pointer(std::nullptr_t) noexcept
+        : value_()
+    { }
+
+    inline pointer::pointer(const uintptr_t p) noexcept
+        : value_(p)
+    { }
+
+    inline pointer::pointer(const void* const p) noexcept
+        : value_(reinterpret_cast<uintptr_t>(p))
+    { }
+
+    inline bool pointer::null() const noexcept {
+        return !value_;
+    }
+
+    inline pointer pointer::add(const pointer value) const noexcept {
+        return value_ + value.value_;
+    }
+
+    inline pointer pointer::sub(const pointer value) const noexcept {
+        return value_ - value.value_;
+    }
+
+    inline size_t pointer::dist(const pointer value) const noexcept {
+        return value.sub(*this).as<size_t>();
+    }
+
+    inline pointer pointer::shift(const pointer from, const pointer to) const noexcept {
+        return sub(from).add(to);
+    }
+
+    inline pointer pointer::rip(const ptrdiff_t offset) const
+    {
+        return add(offset).add(as<int32_t&>());
+    }
+
+    inline pointer& pointer::deref() const noexcept {
+        return as<pointer&>();
+    }
+
+    inline pointer pointer::operator+(const pointer value) const noexcept {
+        return add(value);
+    }
+
+    inline pointer pointer::operator-(const pointer value) const noexcept {
+        return sub(value);
+    }
+
+    inline pointer& pointer::operator+=(const pointer value) noexcept {
+        return (*this) = (*this) + value;
+    }
+
+    inline pointer& pointer::operator-=(const pointer value) noexcept {
+        return (*this) = (*this) - value;
+    }
+
+    inline pointer& pointer::operator++() noexcept {
+        return (*this) = (*this) + 1;
+    }
+
+    inline pointer& pointer::operator--() noexcept {
+        return (*this) = (*this) - 1;
+    }
+
+    inline pointer pointer::operator++(int) noexcept {
+        pointer result = (*this);
+
+        ++(*this);
+
+        return result;
+    }
+
+    inline pointer pointer::operator--(int) noexcept {
+        pointer result = (*this);
+
+        ++(*this);
+
+        return result;
+    }
+
+    inline bool pointer::operator==(const pointer value) const noexcept {
+        return value_ == value.value_;
+    }
+
+    inline bool pointer::operator!=(const pointer value) const noexcept {
+        return value_ != value.value_;
+    }
+
+    inline bool pointer::operator<(const pointer value) const noexcept {
+        return value_ < value.value_;
+    }
+
+    inline bool pointer::operator>(const pointer value) const noexcept {
+        return value_ > value.value_;
+    }
+
+    inline bool pointer::operator<=(const pointer value) const noexcept {
+        return value_ <= value.value_;
+    }
+
+    inline bool pointer::operator>=(const pointer value) const noexcept {
+        return value_ >= value.value_;
+    }
+
+    template <typename T>
+    inline std::enable_if_t<std::is_same<T, pointer>::value, T> pointer::as() const noexcept {
+        return (*this);
+    }
+
+    template <typename T>
+    inline std::enable_if_t<std::is_integral<T>::value, T> pointer::as() const noexcept {
+        static_assert(std::is_same<std::make_unsigned_t<T>, uintptr_t>::value, "Invalid Integer Type");
+
+        return static_cast<T>(value_);
+    }
+
+    template <typename T>
+    inline std::enable_if_t<std::is_pointer<T>::value, T> pointer::as() const noexcept {
+        return reinterpret_cast<T>(value_);
+    }
+
+    template <typename T>
+    inline std::enable_if_t<std::is_lvalue_reference<T>::value, T> pointer::as() const noexcept {
+        return *as<std::add_pointer_t<T>>();
+    }
+
+    template <typename T>
+    inline std::enable_if_t<std::is_array<T>::value, std::add_lvalue_reference_t<T>> pointer::as() const noexcept {
+        return as<std::add_lvalue_reference_t<T>>();
+    }
+}


### PR DESCRIPTION
This is the function I hook to increase pool sizes, and it has always worked flawlessly. 

It seems a lot simpler than the multiple patterns you are using at the moment, though I could be missing something.

I've added it as a separate .cpp file, for your perusal, and also included a handy little pointer-match library which I much prefer 

```cpp
    var = mem::pointer(location).rip(4).as<uint32_t>();
```

to 

```cpp
    var = (uint32_t*)(*(int32_t*)location + location + 4);
```

and other things like:

```cpp
    mem::pointer(location).add(3).rip(4).as<uint32_t&> = var;
```

your `get_call()` and `set_call()` functions could be expressed by new methods:

```cpp
    inline pointer pointer::call() const { 
        return offset(1).rip(4); 
    }

    inline pointer pointer::call(const uintptr_t func) {
        as<uint8_t&>() = 0xe8;
        offset(1).as<int&>() = func - value_ - 5;
    }
```

not that there is any reason to switch from your existing `get_call()` etc, I only use them as an example.

_n.b., all my work and testing has been performed in the single-player (offline) and is not intended for online play. (Gena disclaimer)_