### PR TITLE
An ability to override isPlayerTalking value

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -331,6 +331,9 @@ static void Mumble_RunFrame()
 	}
 }
 
+static std::bitset<256> g_talkers;
+static std::bitset<256> o_talkers;
+
 static InitFunction initFunction([]()
 {
 	g_mumbleClient = CreateMumbleClient();
@@ -346,6 +349,7 @@ static InitFunction initFunction([]()
 		g_mumbleClient->SetAudioDistance(FLT_MAX);
 
 		Mumble_Disconnect();
+		o_talkers.reset();
 	});
 });
 
@@ -357,8 +361,6 @@ static bool _isAnyoneTalking(void* mgr)
 }
 
 static bool(*g_origIsPlayerTalking)(void*, void*);
-
-static std::bitset<256> g_talkers;
 
 static bool _isPlayerTalking(void* mgr, char* playerData)
 {
@@ -382,7 +384,7 @@ static bool _isPlayerTalking(void* mgr, char* playerData)
 			// actually: netobj owner
 			auto index = netObj[73];
 
-			if (g_talkers.test(index))
+			if (g_talkers.test(index) || o_talkers.test(index))
 			{
 				return true;
 			}
@@ -505,6 +507,29 @@ static HookFunction hookFunction([]()
 					if (talkerSet.find(name) != talkerSet.end())
 					{
 						g_talkers.set(i);
+					}
+				}
+			}
+		});
+
+		fx::ScriptEngine::RegisterNativeHandler("OVERRIDE_PLAYER_TALKING", [](fx::ScriptContext& context)
+		{
+			auto isPlayerActive = fx::ScriptEngine::GetNativeHandler(0xB8DFD30D6973E135);
+
+			int playerId = context.GetArgument<int>(0);
+			int state = context.GetArgument<bool>(1);
+
+			if (playerId <= o_talkers.size() && playerId >= 0)
+			{
+				if (FxNativeInvoke::Invoke<bool>(isPlayerActive, playerId))
+				{
+					if (state)
+					{
+						o_talkers.set(playerId);
+					}
+					else
+					{
+						o_talkers.reset(playerId);
 					}
 				}
 			}

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -1731,6 +1731,14 @@ native 'SET_VEHICLE_WHEEL_X_OFFSET'
 	</summary>
 ]]
 
+native 'OVERRIDE_PLAYER_TALKING'
+	arguments {
+		Player 'player',
+		BOOL 'state'
+	}
+	apiset 'client'
+	returns 'void'
+
 native 'SEND_LOADING_SCREEN_MESSAGE'
 	arguments {
 		charPtr 'jsonString'


### PR DESCRIPTION
This function can be very useful for custom voip systems. It affects on other default voip natives and also plays mp_facial animation without affecting on other anims.
`void OVERRIDE_PLAYER_TALKING(Player player, BOOL state)`

Demonstration: https://gfycat.com/EmbellishedForkedAdmiralbutterfly