### PR TITLE
js: Callbacks queued by process.nextTick weren't being called reliably

### DIFF
--- a/data/shared/citizen/scripting/v8/timer.js
+++ b/data/shared/citizen/scripting/v8/timer.js
@@ -116,6 +116,11 @@
         }
 
         gameTime = localGameTime;
+				
+        //Manually fire the callbacks that were enqueued by process.nextTick.
+        //Since we override setImmediate/etc, this doesn't happen automatically.
+        if (global.process && typeof global.process._tickCallback === "function")
+          global.process._tickCallback();
     }
 
     global.setTimeout = setTimeout;


### PR DESCRIPTION
* This issue was causing some libraries (E.g. mongodb) to have a long delay since the nextTick callbacks weren't firing until a nodejs callback happened(E.g. io callback like fs.stat). Specifically a query in mongodb would take 30 seconds due to the query callback, queued using process.nextTick, not firing until the socket connection timed out.

* Here is a minimal repro that works in nodejs but didn't work in fivem.

```javascript
setImmediate(() => {
  process.nextTick(() => {
    console.log("didn't get called in fivem");
  });
});```