### PR TITLE
citizen:scripting:mono: use new profiler API

### DIFF
--- a/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
@@ -143,7 +143,7 @@ static std::shared_mutex g_memoryUsagesMutex;
 
 static bool g_requestedMemoryUsage;
 
-static void gc_event(MonoProfiler *profiler, MonoGCEvent event, int generation)
+static void gc_event(MonoProfiler *profiler, MonoProfilerGCEvent event, int generation)
 {
 	switch (event) {
 	case MONO_GC_EVENT_PRE_START_WORLD:

--- a/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
@@ -143,7 +143,11 @@ static std::shared_mutex g_memoryUsagesMutex;
 
 static bool g_requestedMemoryUsage;
 
+#ifdef _MSC_VER
+static void gc_event(MonoProfiler *profiler, MonoGCEvent event, int generation)
+#else
 static void gc_event(MonoProfiler *profiler, MonoProfilerGCEvent event, int generation)
+#endif
 {
 	switch (event) {
 	case MONO_GC_EVENT_PRE_START_WORLD:


### PR DESCRIPTION
Small PR to fix linux build.

MonoGCEvent was refactored to MonoProfilerGCEvent since mono-5.8.0.103 (https://github.com/mono/mono/commit/ea4e4a9ef6fc42570a23026adbe826cf7248290e)