### PR TITLE
http-client: fixes crash when closing the connection failed, failed handshake dialog

### DIFF
--- a/code/components/http-client/src/HttpClient.cpp
+++ b/code/components/http-client/src/HttpClient.cpp
@@ -367,6 +367,10 @@ public:
 			auto curl = request->curlHandle;
 			auto impl = request->impl;
 
+			//Request has completed and curl has been cleaned up.
+			if (curl == nullptr)
+				return;
+
 			// delete the data pointer
 			char* dataPtr;
 			curl_easy_getinfo(curl, CURLINFO_PRIVATE, &dataPtr);


### PR DESCRIPTION
* This specifically would happen when closing the dialog after trying to connect to a server that isn't online.

This fixes the si-680d1ad23f4a42eca4195bac5be60f3b crash.