### PR TITLE
Fix Unhandled TypeError error (add ability to pass arguments to setImmediate and setTimeout callbacks)

### DIFF
--- a/data/shared/citizen/scripting/v8/timer.js
+++ b/data/shared/citizen/scripting/v8/timer.js
@@ -64,8 +64,8 @@
         return id;
     }
 
-    function setImmediate(callback) {
-        return setTimeout(callback, 0);
+    function setImmediate(callback, ...argsForCallback) {
+        return setTimeout(callback, 0,...argsForCallback);
     }
 
     function onTick() {

--- a/data/shared/citizen/scripting/v8/timer.js
+++ b/data/shared/citizen/scripting/v8/timer.js
@@ -46,14 +46,14 @@
         return id;
     }
 
-    function setTimeout(callback, timeout) {
+    function setTimeout(callback, timeout, ...argsForCallback) {
         const id = nextId();
 
         setTimer(
             id,
             function() {
 				try {
-					callback();
+					callback(...argsForCallback);
 				} finally {
 					clearTimer(id);
 				}
@@ -65,7 +65,7 @@
     }
 
     function setImmediate(callback, ...argsForCallback) {
-        return setTimeout(callback, 0,...argsForCallback);
+        return setTimeout(callback, 0, ...argsForCallback);
     }
 
     function onTick() {


### PR DESCRIPTION
this fixes errors like `Unhandled error TypeError: Cannot read property '_destroySSL' of undefined`, this error was being thrown because https://github.com/citizenfx/node/blob/93ebc8f2c1af6818bc7c94bdb65671a55ae523e5/lib/_tls_wrap.js#L407
was passing "this" as an argument to setImmediate, but setImmediate wasn't passing the argument along to the destroySSL function.
