### PR TITLE
discord: add ability to use custom applications for Rich Presence

### DIFF
--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -61,7 +61,6 @@ static void UpdatePresence()
 			memset(&handlers, 0, sizeof(handlers));
 			Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
 		}
-		
 
 		DiscordRichPresence discordPresence;
 		memset(&discordPresence, 0, sizeof(discordPresence));

--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -1,4 +1,7 @@
 #include <StdInc.h>
+#include <windows.h> 
+#include <tchar.h>
+#include <stdio.h> 
 #include <discord-rpc.h>
 
 #include <nutsnbolts.h>
@@ -16,7 +19,13 @@ static std::string g_richPresenceValues[8];
 
 static std::string g_richPresenceOverride;
 
+static std::string g_richPresenceOverrideAsset;
+
 static time_t g_startTime = time(nullptr);
+
+static std::string DiscordId;
+
+static std::string DiscordImage;
 
 static void UpdatePresence()
 {
@@ -40,13 +49,20 @@ static void UpdatePresence()
 		{
 			line1 = g_richPresenceOverride;
 		}
-
+		
 		DiscordRichPresence discordPresence;
 		memset(&discordPresence, 0, sizeof(discordPresence));
 		discordPresence.state = line1.c_str();
 		discordPresence.details = line2.c_str();
 		discordPresence.startTimestamp = g_startTime;
-		discordPresence.largeImageKey = "fivem_large";
+		if (!g_richPresenceOverrideAsset.empty())
+		{
+		discordPresence.largeImageKey = g_richPresenceOverrideAsset.c_str();
+		}
+		else {
+			discordPresence.largeImageKey = DiscordImage.c_str();
+		}
+		
 		Discord_UpdatePresence(&discordPresence);
 
 		g_richPresenceChanged = false;
@@ -57,7 +73,41 @@ static InitFunction initFunction([]()
 {
 	DiscordEventHandlers handlers;
 	memset(&handlers, 0, sizeof(handlers));
-	Discord_Initialize("382624125287399424", &handlers, 1, nullptr);
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	
+	if (GetFileAttributes(fpath.c_str()) == INVALID_FILE_ATTRIBUTES)
+	{
+		DiscordId = "382624125287399424";
+		DiscordImage = "fivem_large";
+	}
+	else {
+		wchar_t path[512];
+		const wchar_t* pathKey = L"DiscordId";
+		GetPrivateProfileString(L"Game", pathKey, NULL, path, _countof(path), fpath.c_str());
+		if (wcscmp(path, L"") == 0)
+		{
+			DiscordId = "382624125287399424";
+		}
+		else {
+			char DiscordIdS[512];
+			wcstombs(DiscordIdS, path, sizeof(DiscordIdS));
+			DiscordId = DiscordIdS;
+		}
+		
+		pathKey = L"DiscordImage";
+		GetPrivateProfileString(L"Game", pathKey, NULL, path, _countof(path), fpath.c_str());
+		if (wcscmp(path, L"") == 0)
+		{
+			DiscordImage = "fivem_large";
+		}
+		else {
+			char DiscordImageS[512];
+			wcstombs(DiscordImageS, path, sizeof(DiscordImageS));
+			DiscordImage = DiscordImageS;
+		}
+		
+	}
+	Discord_Initialize(DiscordId.c_str(), &handlers, 1, nullptr);
 
 	OnRichPresenceSetTemplate.Connect([](const std::string& text)
 	{
@@ -105,6 +155,42 @@ static InitFunction initFunction([]()
 		{
 			g_richPresenceOverride = "";
 		}
+
+		g_richPresenceChanged = true;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_RICH_PRESENCE_ASSET", [](fx::ScriptContext& context)
+	{
+		const char* str = context.GetArgument<const char*>(0);
+
+		if (str)
+		{
+			g_richPresenceOverrideAsset = str;
+		}
+		else
+		{
+			g_richPresenceOverrideAsset = "";
+		}
+
+		g_richPresenceChanged = true;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_RICH_PRESENCE_ID", [](fx::ScriptContext& context)
+	{
+		const char* str = context.GetArgument<const char*>(0);
+
+		if (str)
+		{
+			DiscordId = str;
+		}
+		else
+		{
+			DiscordId = "382624125287399424";
+		}
+		Discord_Shutdown();
+		DiscordEventHandlers handlers;
+		memset(&handlers, 0, sizeof(handlers));
+		Discord_Initialize(DiscordId.c_str(), &handlers, 1, nullptr);
 
 		g_richPresenceChanged = true;
 	});

--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -7,6 +7,7 @@
 #include <NetLibrary.h>
 
 #include <ScriptEngine.h>
+#include <scrEngine.h>
 
 #define DEFAULT_APP_ID "382624125287399424"
 #define DEFAULT_APP_ASSET "fivem_large"
@@ -75,37 +76,8 @@ static InitFunction initFunction([]()
 {
 	DiscordEventHandlers handlers;
 	memset(&handlers, 0, sizeof(handlers));
-	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
-	
-	if (GetFileAttributes(fpath.c_str()) == INVALID_FILE_ATTRIBUTES)
-	{
-		g_discordAppId = DEFAULT_APP_ID;
-		g_discordAppAsset = DEFAULT_APP_ASSET;
-	}
-	else {
-		wchar_t path[512];
-		const wchar_t* pathKey = L"DiscordId";
-		GetPrivateProfileString(L"Game", pathKey, NULL, path, _countof(path), fpath.c_str());
-		if (wcscmp(path, L"") == 0)
-		{
-			g_discordAppId = DEFAULT_APP_ID;
-		}
-		else {
-			g_discordAppId = ToNarrow(path);
-		}
-		
-		pathKey = L"DiscordImage";
-		GetPrivateProfileString(L"Game", pathKey, NULL, path, _countof(path), fpath.c_str());
-
-		if (wcscmp(path, L"") == 0)
-		{
-			g_discordAppAsset = DEFAULT_APP_ASSET;
-		}
-		else {
-			g_discordAppAsset = ToNarrow(path);
-		}
-		
-	}
+	g_discordAppId = DEFAULT_APP_ID;
+	g_discordAppAsset = DEFAULT_APP_ASSET;
 	
 	Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
 
@@ -139,6 +111,8 @@ static InitFunction initFunction([]()
 	OnKillNetworkDone.Connect([]()
 	{
 		g_richPresenceOverride = "";
+		NativeInvoke::Invoke<HashString("SET_DISCORD_APP_ID"),char*,char*>(DEFAULT_APP_ID);
+		NativeInvoke::Invoke<HashString("SET_DISCORD_RICH_PRESENCE_ASSET"), char*, char*>(DEFAULT_APP_ASSET);
 
 		OnRichPresenceSetTemplate("In the menus\n");
 	});
@@ -187,6 +161,7 @@ static InitFunction initFunction([]()
 		{
 			g_discordAppId = DEFAULT_APP_ID;
 		}
+		
 		Discord_Shutdown();
 		DiscordEventHandlers handlers;
 		memset(&handlers, 0, sizeof(handlers));

--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -26,6 +26,8 @@ static time_t g_startTime = time(nullptr);
 
 static std::string g_discordAppId;
 
+static std::string g_lastDiscordAppId = DEFAULT_APP_ID;
+
 static std::string g_discordAppAsset;
 
 static void UpdatePresence()
@@ -51,6 +53,14 @@ static void UpdatePresence()
 			line1 = g_richPresenceOverride;
 		}
 
+		if (g_discordAppId != g_lastDiscordAppId) 
+		{
+			g_lastDiscordAppId = g_discordAppId;
+			Discord_Shutdown();
+			DiscordEventHandlers handlers;
+			memset(&handlers, 0, sizeof(handlers));
+			Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
+		}
 		
 
 		DiscordRichPresence discordPresence;
@@ -62,7 +72,8 @@ static void UpdatePresence()
 		{
 			discordPresence.largeImageKey = g_richPresenceOverrideAsset.c_str();
 		}
-		else {
+		else 
+		{
 			discordPresence.largeImageKey = g_discordAppAsset.c_str();
 		}
 		
@@ -111,8 +122,9 @@ static InitFunction initFunction([]()
 	OnKillNetworkDone.Connect([]()
 	{
 		g_richPresenceOverride = "";
-		NativeInvoke::Invoke<HashString("SET_DISCORD_APP_ID"),char*,char*>(DEFAULT_APP_ID);
-		NativeInvoke::Invoke<HashString("SET_DISCORD_RICH_PRESENCE_ASSET"), char*, char*>(DEFAULT_APP_ASSET);
+		g_discordAppId = DEFAULT_APP_ID;
+		g_richPresenceOverrideAsset = DEFAULT_APP_ASSET;
+		g_richPresenceChanged = true;
 
 		OnRichPresenceSetTemplate("In the menus\n");
 	});
@@ -161,11 +173,6 @@ static InitFunction initFunction([]()
 		{
 			g_discordAppId = DEFAULT_APP_ID;
 		}
-		
-		Discord_Shutdown();
-		DiscordEventHandlers handlers;
-		memset(&handlers, 0, sizeof(handlers));
-		Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
 
 		g_richPresenceChanged = true;
 	});

--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -94,7 +94,7 @@ static InitFunction initFunction([]()
 			g_discordAppId = ToNarrow(path);
 		}
 		
-		pathKey = L"g_discordAppAsset";
+		pathKey = L"DiscordImage";
 		GetPrivateProfileString(L"Game", pathKey, NULL, path, _countof(path), fpath.c_str());
 
 		if (wcscmp(path, L"") == 0)

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -1947,8 +1947,9 @@ native "SET_DISCORD_APP_ID"
 	returns	"void"
 	doc [[!
 <summary>
-		This native sets the discord app id for the rich presence implementation.
+		This native sets the app id for the discord rich presence implementation.
 </summary>
+<param name="appId">A valid Discord API App Id, can be generated at https://discordapp.com/developers/applications/</param>
 	]]
 
 native "SET_DISCORD_RICH_PRESENCE_ASSET"
@@ -1959,6 +1960,7 @@ native "SET_DISCORD_RICH_PRESENCE_ASSET"
 	returns	"void"
 	doc [[!
 <summary>
-		This native sets the discord image asset for the rich presence implementation.
+		This native sets the image asset for the discord rich presence implementation.
 </summary>
+<param name="assetName">The name of a valid asset registered on Discordapp's developer dashboard. note that the asset has to be registered under the same discord API application set using the SET_DISCORD_APP_ID native.</param>
 	]]

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -1938,3 +1938,27 @@ native "GET_HASH_KEY"
 		This native converts the passed string to a hash.
 </summary>
 	]]
+
+native "SET_DISCORD_APP_ID"
+	arguments {
+		charPtr "appId",
+	}
+	apiset 'client'
+	returns	"void"
+	doc [[!
+<summary>
+		This native sets the discord app id for the rich presence implementation.
+</summary>
+	]]
+
+native "SET_DISCORD_RICH_PRESENCE_ASSET"
+	arguments {
+		charPtr "assetName",
+	}
+	apiset 'client'
+	returns	"void"
+	doc [[!
+<summary>
+		This native sets the discord image asset for the rich presence implementation.
+</summary>
+	]]


### PR DESCRIPTION
this is useful for people who want to change fivem's rich presence image, it can be set from scripts using natives and also from the CitizenFX.ini file (DiscordId and DiscordImage)

P.S. this is my real first time doing anything with cpp, i have probably overcomplicated some things, if you'd like for me to change anything, just review the commit and i will try my best to fix it :)