### PR TITLE
ci: fix travis git env variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ script:
   - curl -O -L https://github.com/grammarly/rocker/releases/download/1.3.0/rocker_linux_amd64.tar.gz
   - tar xvf rocker_linux_amd64.tar.gz
   - cd code/
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ../rocker build; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ../rocker build --build-arg CI_BRANCH=${GIT_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_TAG} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'
+  - 'if [ -z "$TRAVIS_TAG" ]; then ../rocker build; fi'
+  - 'if [ ! -z "$TRAVIS_TAG" ]; then ../rocker build --build-arg CI_BRANCH=${GIT_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_TAG} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - secure: "EcQUC0ttoRmJHZC6fpH5NqfTne/ZusCQi8JZNfAdXPTNF3ftxz0DPqVkmm9CMltYIOedM+xFwr9anFZB/zLGx21qxQuRHaHPMWq5/sd2QI8DnYgN+HpUYpCVBsGBLjO6TgIFq+y70Anvfs5Zn8D/1BZJ8whuQwWNKhPg+zHSDjQ/vkKLlcAtseSjvvX9fIubBrp+ZDkqSOn6gwgssmUaPbA5k/+G/LZU8GFoIUNLQPKxYn9KTraNxSWQqfPIUrT7vWKgATA9BrF0B5+OUvByy68hY7HKuIFbJBOryOOST3TOIjeuhv8QWF0IensT8pgHBCiduj+jZoFzXGR+vt63nACJWei9RFDiyjm5VQvZrLwJURDLMP1kn5jsjTUHNPfElUhwdX17sK6dG4QfSo9+KQjmFTSdBIr1hzIntrqlO1st1f8Yqc0a2gPdSXwSDe/kqs0LGzE58iAsfikoU8P1GEq/p9VlfDYL4Xajhr0H2FAyQg2JmteXrCqC6jYWsjWsLGS3OZstcSAFNxGR5b6/gPcsN33zjKTVskp7922JVr5WuA3FMl2f9pHCPna31Ypacl+pP2lidEKHIjgAfI/Hak3gBPeWG6by+QgYsTsvaeRjE/Lg814D3bEIoNoa9lcp8eeiigUbbB7SDAZXbZ20tppwAt9jjwv4P2CrGuGwbmg="
     # DOCKER_PASS
     - secure: "iJ7lEEj/Cub2st1Q7of7y7Diz4KXgXsHgKxZ20v19y5SolQ3W0E/nugcGKqz1mznryFPVxKH/SwG17TMqhFrgIaaDF90Rjs79PqwMuJ7MCNOTeYIXwWVVvpIWCBwzZ65yCcHQtwRS35LWw6+BbsqvZakrrwOpMBhRGIZVUHRsEtZSaOZpnLwJymzDnCJrrlE3r1zu4L3WjYYwAkQ4bz4BPH3os0pbJAHXaPaRJuVVPB4fyvIshFAF6aqz60x2mzpS7y8erZ+IOh0urUyzxR7H6RuntyL84+ATZyGweYpfuQPNyD7pZjHCVDabQSvK+/n5VrsWAIX5RheCYGv+a6HtJsX8L6RXPFMk8N82Feo97YiqcFhxSKKL+8rrQ51j9My0Odkx3z39l0j2PP0Z4rDLy8QwPmGqtDZOX/iXCOTMcPHq4Zlb4X/yS6mfHmyO/wigKfYPmrGEVqFT5JhQctgSsUlWSbHvw1vPrZk7g7YBdUbBb2Xd9RCwzuBmuC8ytq0bKnabqlJhIOB4027DmtZA70ECdEEUxE5a8w8hutuW9UWiCnZzpIcbG2s662Qy6/AdpGzxHUBxwHoHAP+P0Qa7u6JhErsqt5DIdzAezqKQrDS/fi4TPcYCYusGeaVjMlVuzZycwO8EOvrV2WNKlPRNc8MMyvj7g7KVibEKer8bwk="
+    - GIT_BRANCH=$(git ls-remote origin | sed -n "\|$TRAVIS_COMMIT\s\+refs/heads/|{s///p}")
 
 script:
   - git submodule update --init
@@ -20,4 +21,4 @@ script:
   - tar xvf rocker_linux_amd64.tar.gz
   - cd code/
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ../rocker build; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ../rocker build --build-arg CI_BRANCH=${TRAVIS_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ../rocker build --build-arg CI_BRANCH=${GIT_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_TAG} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'


### PR DESCRIPTION
Travis builds are triggered by tag and git does not store the branch from which a commit was tagged.
This finally fix the FXS version for travis builds.

Old (wrong) version:
```json
"server": "FXServer-v1.0.0.750 940 linux"
```
new one:
```
"server": "FXServer-master v1.0.0.750 linux"
```