### PR TITLE
Discord: Add ability to add a small image asset as well as set hover …  …text for small and large image assets.

### DIFF
--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -1,4 +1,4 @@
-#include <StdInc.h>
+﻿#include <StdInc.h>
 #include <discord-rpc.h>
 
 #include <nutsnbolts.h>
@@ -11,6 +11,9 @@
 
 #define DEFAULT_APP_ID "382624125287399424"
 #define DEFAULT_APP_ASSET "fivem_large"
+#define DEFAULT_APP_ASSET_SMALL ""
+#define DEFAULT_APP_ASSET_TEXT ""
+#define DEFAULT_APP_ASSET_SMALL_TEXT ""
 
 static bool g_richPresenceChanged;
 
@@ -22,6 +25,12 @@ static std::string g_richPresenceOverride;
 
 static std::string g_richPresenceOverrideAsset;
 
+static std::string g_richPresenceOverrideAssetSmall;
+
+static std::string g_richPresenceOverrideAssetText;
+
+static std::string g_richPresenceOverrideAssetSmallText;
+
 static time_t g_startTime = time(nullptr);
 
 static std::string g_discordAppId;
@@ -29,6 +38,12 @@ static std::string g_discordAppId;
 static std::string g_lastDiscordAppId = DEFAULT_APP_ID;
 
 static std::string g_discordAppAsset;
+
+static std::string g_discordAppAssetSmall;
+
+static std::string g_discordAppAssetText;
+
+static std::string g_discordAppAssetSmallText;
 
 static void UpdatePresence()
 {
@@ -67,6 +82,7 @@ static void UpdatePresence()
 		discordPresence.state = line1.c_str();
 		discordPresence.details = line2.c_str();
 		discordPresence.startTimestamp = g_startTime;
+
 		if (!g_richPresenceOverrideAsset.empty())
 		{
 			discordPresence.largeImageKey = g_richPresenceOverrideAsset.c_str();
@@ -75,7 +91,34 @@ static void UpdatePresence()
 		{
 			discordPresence.largeImageKey = g_discordAppAsset.c_str();
 		}
-		
+
+		if (!g_richPresenceOverrideAssetSmall.empty())
+		{
+			discordPresence.smallImageKey = g_richPresenceOverrideAssetSmall.c_str();
+		}
+		else
+		{
+			discordPresence.smallImageKey = g_discordAppAssetSmall.c_str();
+		}
+
+		if (!g_richPresenceOverrideAssetText.empty())
+		{
+			discordPresence.largeImageText = g_richPresenceOverrideAssetText.c_str();
+		}
+		else
+		{
+			discordPresence.largeImageText = g_discordAppAssetText.c_str();
+		}
+
+		if (!g_richPresenceOverrideAssetSmallText.empty())
+		{
+			discordPresence.smallImageText = g_richPresenceOverrideAssetSmallText.c_str();
+		}
+		else
+		{
+			discordPresence.smallImageText = g_discordAppAssetSmallText.c_str();
+		}
+
 		Discord_UpdatePresence(&discordPresence);
 
 		g_richPresenceChanged = false;
@@ -88,6 +131,9 @@ static InitFunction initFunction([]()
 	memset(&handlers, 0, sizeof(handlers));
 	g_discordAppId = DEFAULT_APP_ID;
 	g_discordAppAsset = DEFAULT_APP_ASSET;
+	g_discordAppAssetSmall = DEFAULT_APP_ASSET_SMALL;
+	g_discordAppAssetText = DEFAULT_APP_ASSET_TEXT;
+	g_discordAppAssetSmallText = DEFAULT_APP_ASSET_SMALL_TEXT;
 	
 	Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
 
@@ -123,6 +169,9 @@ static InitFunction initFunction([]()
 		g_richPresenceOverride = "";
 		g_discordAppId = DEFAULT_APP_ID;
 		g_richPresenceOverrideAsset = DEFAULT_APP_ASSET;
+		g_richPresenceOverrideAssetSmall = DEFAULT_APP_ASSET_SMALL;
+		g_richPresenceOverrideAssetText = DEFAULT_APP_ASSET_TEXT;
+		g_richPresenceOverrideAssetSmallText = DEFAULT_APP_ASSET_SMALL_TEXT;
 		g_richPresenceChanged = true;
 
 		OnRichPresenceSetTemplate("In the menus\n");
@@ -155,6 +204,54 @@ static InitFunction initFunction([]()
 		else
 		{
 			g_richPresenceOverrideAsset = DEFAULT_APP_ASSET;
+		}
+
+		g_richPresenceChanged = true;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DISCORD_RICH_PRESENCE_ASSET_SMALL", [](fx::ScriptContext& context)
+	{
+		const char* str = context.GetArgument<const char*>(0);
+
+		if (str)
+		{
+			g_richPresenceOverrideAssetSmall = str;
+		}
+		else
+		{
+			g_richPresenceOverrideAssetSmall = DEFAULT_APP_ASSET_SMALL;
+		}
+
+		g_richPresenceChanged = true;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DISCORD_RICH_PRESENCE_ASSET_TEXT", [](fx::ScriptContext& context)
+	{
+		const char* str = context.GetArgument<const char*>(0);
+
+		if (str)
+		{
+			g_richPresenceOverrideAssetText = str;
+		}
+		else
+		{
+			g_richPresenceOverrideAssetText = DEFAULT_APP_ASSET_TEXT;
+		}
+
+		g_richPresenceChanged = true;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DISCORD_RICH_PRESENCE_ASSET_SMALL_TEXT", [](fx::ScriptContext& context)
+	{
+		const char* str = context.GetArgument<const char*>(0);
+
+		if (str)
+		{
+			g_richPresenceOverrideAssetSmallText = str;
+		}
+		else
+		{
+			g_richPresenceOverrideAssetSmallText = DEFAULT_APP_ASSET_SMALL_TEXT;
 		}
 
 		g_richPresenceChanged = true;


### PR DESCRIPTION
This adds more functionality and flexibility for users to use Discord Rich Presence. They can now set a small "badge" as well as hover text for each image. By default, these three additions are empty.

**Small Image Asset**
Native: _SET_DISCORD_RICH_PRESENCE_ASSET_SMALL_
![alt smallimageasset](https://i.imgur.com/FFn5a6a.png)

**Large Image Asset Hover Text**
Native: _SET_DISCORD_RICH_PRESENCE_ASSET_TEXT_
![alt largehovertext](https://i.imgur.com/e4YlUTq.png)

**Small Image Asset Hover Text**
Native: _SET_DISCORD_RICH_PRESENCE_ASSET_SMALL_TEXT_
![alt smallhovertext](https://i.imgur.com/H6gOInQ.png)