### PR TITLE
clrcore: Add missing parameter in HAS_PED_GOT_WEAPON calls

### DIFF
--- a/code/client/clrcore/External/Weapon.cs
+++ b/code/client/clrcore/External/Weapon.cs
@@ -149,7 +149,7 @@ namespace CitizenFX.Core
 					return true;
 				}
 
-				return Function.Call<bool>(Native.Hash.HAS_PED_GOT_WEAPON, _owner.Handle, Hash);
+				return Function.Call<bool>(Native.Hash.HAS_PED_GOT_WEAPON, _owner.Handle, Hash, 0);
 			}
 		}
 		public string DisplayName

--- a/code/client/clrcore/External/WeaponCollection.cs
+++ b/code/client/clrcore/External/WeaponCollection.cs
@@ -108,7 +108,7 @@ namespace CitizenFX.Core
 
 		public bool HasWeapon(WeaponHash weaponHash)
 		{
-			return Function.Call<bool>(Hash.HAS_PED_GOT_WEAPON, _owner.Handle, weaponHash);
+			return Function.Call<bool>(Hash.HAS_PED_GOT_WEAPON, _owner.Handle, weaponHash, 0);
 		}
 		public bool IsWeaponValid(WeaponHash hash)
 		{
@@ -153,7 +153,7 @@ namespace CitizenFX.Core
 		}
 		public bool Select(WeaponHash weaponHash, bool equipNow)
 		{
-			if (!Function.Call<bool>(Hash.HAS_PED_GOT_WEAPON, _owner.Handle, weaponHash))
+			if (!Function.Call<bool>(Hash.HAS_PED_GOT_WEAPON, _owner.Handle, weaponHash, 0))
 			{
 				return false;
 			}


### PR DESCRIPTION
`HAS_PED_GOT_WEAPON` has 3 parameters: `Ped`, `WeaponHash`, `bool`. The 3rd parameter is always false. This should fix `WeaponCollection#HasWeapon(WeaponHash)` from always returning false.