### PR TITLE
v8: fix console failing on undefined values

### DIFF
--- a/data/shared/citizen/scripting/v8/console.js
+++ b/data/shared/citizen/scripting/v8/console.js
@@ -93,7 +93,7 @@
             case arg === null:
                 return 'null';
                 
-            case typeof arg === 'undefined';
+            case arg === undefined || arg === void 0;
                 return 'undefined'
 
             case arg instanceof WeakMap:

--- a/data/shared/citizen/scripting/v8/console.js
+++ b/data/shared/citizen/scripting/v8/console.js
@@ -93,7 +93,7 @@
             case arg === null:
                 return 'null';
                 
-            case arg === undefined || arg === void 0;
+            case arg === undefined:
                 return 'undefined'
 
             case arg instanceof WeakMap:

--- a/data/shared/citizen/scripting/v8/console.js
+++ b/data/shared/citizen/scripting/v8/console.js
@@ -92,6 +92,9 @@
         switch (true) {
             case arg === null:
                 return 'null';
+                
+            case typeof arg === 'undefined';
+                return 'undefined'
 
             case arg instanceof WeakMap:
                 return 'WeakMap {}';


### PR DESCRIPTION
this didnt seem to be fixed with commit 15fd5d3eeaf687544ed5c64e1dc721bab6c04914 which was fixed only null values, leaving undefined values unhandled.