### PR TITLE
clrcore: Change GetDistance method from native call to Vector3 euclidean distance method

### DIFF
--- a/code/client/clrcore/External/World.cs
+++ b/code/client/clrcore/External/World.cs
@@ -535,7 +535,7 @@ namespace CitizenFX.Core
 		/// <returns>The distance</returns>
 		public static float GetDistance(Vector3 origin, Vector3 destination)
 		{
-			return Function.Call<float>(Hash.GET_DISTANCE_BETWEEN_COORDS, origin.X, origin.Y, origin.Z, destination.X, destination.Y, destination.Z, 1);
+			return (float) Math.Sqrt(destination.DistanceToSquared(origin));
 		}
 		/// <summary>
 		/// Calculates the travel distance using roads and paths between 2 positions.


### PR DESCRIPTION
- Reduces the amount of native calls
- Higher Accuracy:
```C#
var pointA = new Vector3(0f, 0f, 0f);
var pointB = new Vector3(1000f, 1000f, 1000f);


GET_DISTANCE_BETWEEN_COORDS(pointA.X, pointA.Y, pointA.Z, pointB.X, pointB.Y, pointB.Z, 1):
1732.051

Math.Sqrt(pointB.DistanceToSquared(pointA)):
1732.05080756888
```