### PR TITLE
clrcore: Updated MarkerType enum to reflect changes to natives documentation

### DIFF
--- a/code/client/clrcore/External/World.cs
+++ b/code/client/clrcore/External/World.cs
@@ -200,7 +200,20 @@ namespace CitizenFX.Core
 		HorizontalCircleSkinny,
 		HorizontalCircleSkinnyArrow,
 		HorizontalSplitArrowCircle,
-		DebugSphere
+		DebugSphere,
+		DollarSign,
+		HorizontalBars,
+		WolfHead,
+		QuestionMark,
+		PlaneSymbol,
+		HelicopterSymbol,
+		BoatSymbol,
+		CarSymbol,
+		MotorcycleSymbol,
+		BikeSymbol,
+		TruckSymbol,
+		ParachuteSymbol,
+		SawbladeSymbol
 	}
 	public enum ExplosionType
 	{


### PR DESCRIPTION
I realized that clrcore was missing marker types after the natives documentation was updated. 
See https://github.com/citizenfx/natives/commit/dce7ff110d194c961720632ba6488ab63e5aa3f0

This adds the missing marker types to the `MarkerType` enum of clrcore.

Added types:
* DollarSign
* HorizontalBars
* WolfHead
* QuestionMark
* PlaneSymbol
* HelicopterSymbol
* BoatSymbol
* CarSymbol
* MotorcycleSymbol
* BikeSymbol
* TruckSymbol
* ParachuteSymbol
* SawbladeSymbol