### PR TITLE
build: fix node prebuild command

### DIFF
--- a/code/vendor/node.lua
+++ b/code/vendor/node.lua
@@ -136,15 +136,24 @@ return {
 			'http_parser.c'
 		}
 
-		prebuildcommands {
-			('python %s %s'):format(
-				path.getabsolute('vendor/node_js2c.py'),
-				path.getabsolute('../vendor/node/')
-			)
+		files_project 'vendor/' {
+			'node_js2c.py'
 		}
+
+		filter 'files:vendor/node_js2c.py'
+			buildcommands {
+				('python %s %s'):format(
+					path.getabsolute('vendor/node_js2c.py'),
+					path.getabsolute('../vendor/node/')
+				)
+			}
+			buildoutputs { '../vendor/node/src/node_javascript.cc' }
+
+		filter {}
 
 		if os.istarget('windows') then
 			files_project '../vendor/node/' {
+				'src/node_javascript.cc', -- with msc, commands that output C/C++ source files are not fed into the build process yet
 				'src/backtrace_win32.cc'
 			}
 		else
@@ -154,7 +163,6 @@ return {
 		end
 
 		files_project '../vendor/node/' {
-			'src/node_javascript.cc',
 			'src/async_wrap.cc',
 			'src/bootstrapper.cc',
 	        'src/cares_wrap.cc',


### PR DESCRIPTION
~It's better to have a slow build for a while rather than nothing~

Edit: fixed the issue with a premake filter

Generated Makefile part:
```makefile
../../../../vendor/node/src/node_javascript.cc: ../../../vendor/node_js2c.py
        $(SILENT) python /src/code/vendor/node_js2c.py /src/vendor/node
$(OBJDIR)/node_javascript.o: ../../../../vendor/node/src/node_javascript.cc
        @echo $(notdir $<)
        $(SILENT) $(CXX) $(ALL_CXXFLAGS) $(FORCE_INCLUDE) -o "$@" -MF "$(@:%.o=%.d)" -c "$<"
```

Generated vcxproj:
```vcxproj
  <ItemGroup>
    <ClCompile Include="..\..\..\..\vendor\node\src\node_javascript.cc" />
  </ItemGroup>
  <ItemGroup>
    <CustomBuild Include="..\..\..\vendor\node_js2c.py">
      <FileType>Document</FileType>
      <Command>python /src/code/vendor/node_js2c.py /src/vendor/node</Command>
      <Outputs>../../../../vendor/node/src/node_javascript.cc</Outputs>
    </CustomBuild>
  </ItemGroup>
```