### PR TITLE
citizen:scripting:v8 add generator function to supported tickers

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -27,7 +27,7 @@ type InputArgument =
 
 interface CitizenInterface {
     trace(...args: string[]): void
-    setTickFunction(callback: Function): void
+    setTickFunction(callback: Function | GeneratorFunction): void
     setEventFunction(callback: Function): void
 
     setCallRefFunction(callback: Function): void
@@ -77,6 +77,6 @@ declare function TriggerClientEvent(eventName: string, target: number|string, ..
 
 declare function removeEventListener(eventName: string, callback: Function): void
 
-declare function setTick(callback: Function): void
+declare function setTick(callback: Function | GeneratorFunction): void
 
 declare var exports: any;


### PR DESCRIPTION
The preface of this PR is to add support for yielding execution back to the timer without returning from your tick handler.

For example:
```javascript
let modelRequested = false;
setTick(() => {
  if (!modelRequested) {
    RequestModel('...');
    modelRequested = true;
    return;
  } else if (!HasModelLoaded('...')) {
    return;
  }

  ...
});
```

Can be simplified to:
```javascript
setTick(function* () {
  ...

  RequestModel('...')
  while (!HasModelLoaded('...')) {
    yield;
  }

  ...
});
```