### PR TITLE
breakpad: fix submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	url = https://github.com/google/protobuf.git
 [submodule "vendor/breakpad"]
 	path = vendor/breakpad
-	url = https://chromium.googlesource.com/breakpad/breakpad
+	url = https://github.com/citizenfx/breakpad.git
 [submodule "vendor/udis86"]
 	path = vendor/udis86
 	url = https://github.com/vmt/udis86.git


### PR DESCRIPTION
This fixed submodule breakpad not loading correctly for me. Because the target commit (4897624beec8cdd6020d231fdc60106c31b5c39c) does not exist on the original repo, only on the fork.