### PR TITLE
scripting:v8: add missing methods

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -151,6 +151,17 @@ const EXT_LOCALFUNCREF = 11;
 		};
 
 		global.TriggerClientEvent = global.emitNet;
+		
+		function GetPlayerIdentifiers(player) {
+    			var numIds = GetNumPlayerIdentifiers(player);
+    			var t = [];
+
+    			for (let i = 0; i < numIds; i++) {
+        			t.push(GetPlayerIdentifier(player, i))
+    			}
+
+    			return t;
+		}
 	} else {
 		global.emitNet = (name, ...args) => {
 			const dataSerialized = pack(args);

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -163,7 +163,7 @@ const EXT_LOCALFUNCREF = 11;
     			return t;
 		}
 		
-		function GetPlayers(player) {
+		function GetPlayers() {
     			var num = GetNumPlayerIndices();
     			var t = [];
 

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -162,6 +162,17 @@ const EXT_LOCALFUNCREF = 11;
 
     			return t;
 		}
+		
+		function GetPlayers(player) {
+    			var num = GetNumPlayerIndices();
+    			var t = [];
+
+    			for (let i = 0; i < num; i++) {
+        			t.push(GetPlayerFromIndex(i))
+    			}
+
+    			return t;
+		}
 	} else {
 		global.emitNet = (name, ...args) => {
 			const dataSerialized = pack(args);


### PR DESCRIPTION
GetPlayerIdentifiers and GetPlayers() were missing on the v8 runtime, this PR adds them.