### PR TITLE
Add more MP character data structs

### DIFF
--- a/code/client/clrcore/External/Game.cs
+++ b/code/client/clrcore/External/Game.cs
@@ -859,7 +859,7 @@ namespace CitizenFX.Core
 
 			int maxVariations = API.N_0xd40aac51e8e4c663(propHashName);
 
-			AltPropVariationData[] items;
+			AltPropVariationData[] items = new AltPropVariationData[maxVariations];
 			if (maxVariations > 0)
 			{
 				items = new AltPropVariationData[maxVariations];

--- a/code/client/clrcore/External/Game.cs
+++ b/code/client/clrcore/External/Game.cs
@@ -803,7 +803,12 @@ namespace CitizenFX.Core
 
 
 
-
+		/// <summary>
+		/// Private unsafe version of <see cref="GetTattooCollectionData(int, int)"/>
+		/// </summary>
+		/// <param name="characterType"></param>
+		/// <param name="decorationIndex"></param>
+		/// <returns></returns>
 		[SecuritySafeCritical]
 		private static TattooCollectionData _GetTattooCollectionData(int characterType, int decorationIndex)
 		{
@@ -831,6 +836,61 @@ namespace CitizenFX.Core
 				return _GetTattooCollectionData(characterType, decorationIndex);
 			}
 			return new TattooCollectionData();
+		}
+
+
+
+		/// <summary>
+		/// Private (unsafe) version of <see cref="GetAltPropVariationData(int, int)"/>
+		/// </summary>
+		/// <param name="ped"></param>
+		/// <param name="propIndex"></param>
+		/// <returns></returns>
+		[SecuritySafeCritical]
+		private static AltPropVariationData[] _GetAltPropVariationData(int ped, int propIndex)
+		{
+			int prop = API.GetPedPropIndex(ped, propIndex);
+			int propTexture = API.GetPedPropTextureIndex(ped, propIndex);
+			uint propHashName = (uint)API.GetHashNameForProp(ped, propIndex, prop, propTexture);
+
+			uint someHash = 0;
+			int unk1 = 0;
+			int unk2 = 0;
+
+			int maxVariations = API.N_0xd40aac51e8e4c663(propHashName);
+
+			AltPropVariationData[] items;
+			if (maxVariations > 0)
+			{
+				items = new AltPropVariationData[maxVariations];
+				for (var i = 0; i < maxVariations; i++)
+				{
+					UnsafeAltPropVariationData data = new UnsafeAltPropVariationData();
+					unsafe
+					{
+						Function.Call((Hash)0xD81B7F27BC773E66, propHashName, i, &someHash, &unk1, &unk2);
+					}
+					unsafe
+					{
+						Function.Call((Hash)0x5D5CAFF661DDF6FC, someHash, &data);
+					}
+					items[i] = data.GetData(someHash, unk1, unk2);
+				}
+				return items;
+			}
+			return null;
+		}
+
+		/// <summary>
+		/// Gets the alternate prop index data for a specific prop on a specific ped.
+		/// This is used to check for the 'alternate' version of a helmet with a visor for example (open/closed visor variants).
+		/// </summary>
+		/// <param name="ped"></param>
+		/// <param name="propIndex"></param>
+		/// <returns></returns>
+		public static AltPropVariationData[] GetAltPropVariationData(int ped, int propIndex)
+		{
+			return _GetAltPropVariationData(ped, propIndex);
 		}
 	}
 }

--- a/code/client/clrcore/External/MpPedDataStructs.cs
+++ b/code/client/clrcore/External/MpPedDataStructs.cs
@@ -133,4 +133,52 @@ namespace CitizenFX.Core
 		}
 	}
 
+	[StructLayout(LayoutKind.Explicit, Size = 0x30)]
+	[SecuritySafeCritical]
+	internal unsafe struct UnsafeAltPropVariationData
+	{
+		[FieldOffset(0x00)] private uint unkHash1;
+
+		[FieldOffset(0x08)] private uint unkHash2;
+
+		[FieldOffset(0x10)] private int unkInt1;
+
+		[FieldOffset(0x18)] private int altPropIndex;
+
+		[FieldOffset(0x20)] private int altPropTextureIndex;
+
+		[FieldOffset(0x28)] private int unkInt2;
+
+		public AltPropVariationData GetData(uint unk1, int unk2, int unk3)
+		{
+			return new AltPropVariationData(unkHash1, unkHash2, unkInt1, altPropIndex, altPropTextureIndex, unkInt2, unk1, unk2, unk3);
+		}
+	}
+
+	public struct AltPropVariationData
+	{
+		public uint unknownHash1;
+		public uint unknownHash2;
+		public uint unknownHash3;
+		public int unknownInt1;
+		public int unknownInt2;
+		public int unknownInt3;
+		public int unknownInt4;
+		public int altPropVariationIndex;
+		public int altPropVariationTexture;
+
+		public AltPropVariationData(uint unknownHash1, uint unknownHash2, int unknownInt1, int altPropVariationIndex, int altPropVariationTexture, int unknownInt2, uint unknownHash3, int unknownInt3, int unknownInt4)
+		{
+			this.unknownHash1 = unknownHash1;
+			this.unknownHash2 = unknownHash2;
+			this.unknownInt1 = unknownInt1;
+			this.altPropVariationIndex = altPropVariationIndex;
+			this.altPropVariationTexture = altPropVariationTexture;
+			this.unknownInt2 = unknownInt2;
+			this.unknownHash3 = unknownHash3;
+			this.unknownInt3 = unknownInt3;
+			this.unknownInt4 = unknownInt4;
+		}
+	}
+
 }


### PR DESCRIPTION
Add a `AltPropVariationData` struct, and `Game.GetAltPropVariationData()` function.

These are used to get the alternate component for things like helmets with goggles/visors. One being the toggled up version, and the other being the toggled down version. Including prop texture variant.