### PR TITLE
scheduler.lua: Add debug info for slow server resource threads

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -37,7 +37,7 @@ function Citizen.CreateThreadNow(threadFunction, eventName)
 	local result, err = coroutine.resume(coro)
 	local runTime = GetGameTimer() - startAt
 
-	if runTime > 110 then
+	if runTime > 150 then
 		print("Executing thread in resource " .. t.resource .. " was slow: " .. runTime .. "ms, please verify what you are doing")
 		if eventName then
 			print("in event: " .. eventName)
@@ -172,7 +172,7 @@ Citizen.SetTickRoutine(function()
 				local result, err = coroutine.resume(thread.coroutine)
 				local runTime = GetGameTimer() - startTime
 
-				if runTime > 110 then
+				if runTime > 150 then
 					print("Executing thread in resource " .. thread.resource .. " was slow: " .. runTime .. "ms, please verify what you are doing")
 				end
 

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -147,7 +147,8 @@ local timeouts = {}
 function Citizen.SetTimeout(msec, callback)
 	table.insert(threads, {
 		coroutine = coroutine.create(callback),
-		wakeTime = GetGameTimer() + msec
+		wakeTime = GetGameTimer() + msec,
+		resource = GetCurrentResourceName()
 	})
 end
 

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -38,7 +38,7 @@ function Citizen.CreateThreadNow(threadFunction, eventName)
 	local runTime = GetGameTimer() - startAt
 
 	if runTime > 110 then
-		print("Executing thread in resource " .. t.resource .. " was slow : " .. runTime .. "ms, please verify what your are doing")
+		print("Executing thread in resource " .. t.resource .. " was slow: " .. runTime .. "ms, please verify what you are doing")
 		if eventName then
 			print("in event: " .. eventName)
 		end
@@ -173,7 +173,7 @@ Citizen.SetTickRoutine(function()
 				local runTime = GetGameTimer() - startTime
 
 				if runTime > 110 then
-					print("Executing thread in resource " .. thread.resource .. " was slow : " .. runTime .. "ms, please verify what you are doing")
+					print("Executing thread in resource " .. thread.resource .. " was slow: " .. runTime .. "ms, please verify what you are doing")
 				end
 
 				if not result then


### PR DESCRIPTION
This change to ``scheduler.lua`` helps server owners (or script developers) track down and find the source of hitch frame warnings that are caused by 'slow' code in server sided scripts.

These general idea of these changes were first done a while back by @joelwurtz but it was never put into production. I since modified the scheduler myself to try it out and it has helped me track down which resources and in what events were causing certain hitch frame warnings I was consistently getting but was unsure of where they were coming from exactly. So this change is basically credited to @joelwurtz and I just made some minor changes to his version of the change like adding the event name that triggered the warning.