### PR TITLE
Add 2 new weapon struct native wrappers

### DIFF
--- a/code/client/clrcore/External/Game.cs
+++ b/code/client/clrcore/External/Game.cs
@@ -897,7 +897,7 @@ namespace CitizenFX.Core
 
 		[StructLayout(LayoutKind.Explicit, Size = 0x28)]
 		[SecuritySafeCritical]
-		private struct UnsafeWeaponHudStats
+		internal struct UnsafeWeaponHudStats
 		{
 			[FieldOffset(0x00)] private int hudDamage;
 
@@ -973,7 +973,7 @@ namespace CitizenFX.Core
 
 		[StructLayout(LayoutKind.Explicit, Size = 0x28)]
 		[SecuritySafeCritical]
-		private struct UnsafeWeaponComponentHudStats
+		internal struct UnsafeWeaponComponentHudStats
 		{
 			[FieldOffset(0x00)] private int hudDamage;
 
@@ -1053,18 +1053,18 @@ namespace CitizenFX.Core
 			UnsafeWeaponHudStats unsafeStats = new UnsafeWeaponHudStats();
 			unsafe
 			{
-				Function.Call(Hash.GET_WEAPON_HUD_STATS, &unsafeStats);
+				Function.Call(Hash.GET_WEAPON_HUD_STATS, weaponHash, &unsafeStats);
 			}
 			return unsafeStats.GetSafeStats();
 		}
 
 		[SecuritySafeCritical]
-		private static WeaponComponentHudStats _GetWeaponComponentHudStats(uint weaponHash)
+		private static WeaponComponentHudStats _GetWeaponComponentHudStats(uint weaponComponentHash)
 		{
 			UnsafeWeaponComponentHudStats unsafeStats = new UnsafeWeaponComponentHudStats();
 			unsafe
 			{
-				Function.Call(Hash.GET_WEAPON_COMPONENT_HUD_STATS, &unsafeStats);
+				Function.Call(Hash.GET_WEAPON_COMPONENT_HUD_STATS, weaponComponentHash, &unsafeStats);
 			}
 			return unsafeStats.GetSafeStats();
 		}

--- a/code/client/clrcore/External/Game.cs
+++ b/code/client/clrcore/External/Game.cs
@@ -3,6 +3,7 @@ using CitizenFX.Core.Native;
 using System.Threading.Tasks;
 using CitizenFX.Core;
 using System.Security;
+using System.Runtime.InteropServices;
 
 namespace CitizenFX.Core
 {
@@ -891,6 +892,207 @@ namespace CitizenFX.Core
 		public static AltPropVariationData[] GetAltPropVariationData(int ped, int propIndex)
 		{
 			return _GetAltPropVariationData(ped, propIndex);
+		}
+
+
+		[StructLayout(LayoutKind.Explicit, Size = 0x28)]
+		[SecuritySafeCritical]
+		private struct UnsafeWeaponHudStats
+		{
+			[FieldOffset(0x00)] private int hudDamage;
+
+			[FieldOffset(0x08)] private int hudSpeed;
+
+			[FieldOffset(0x10)] private int hudCapacity;
+
+			[FieldOffset(0x18)] private int hudAccuracy;
+
+			[FieldOffset(0x20)] private int hudRange;
+
+
+			public WeaponHudStats GetSafeStats()
+			{
+				return new WeaponHudStats(hudDamage, hudSpeed, hudCapacity, hudAccuracy, hudRange);
+			}
+		}
+
+		public struct WeaponHudStats
+		{
+			public int hudDamage;
+			public int hudSpeed;
+			public int hudCapacity;
+			public int hudAccuracy;
+			public int hudRange;
+
+			public WeaponHudStats(int hudDamage, int hudSpeed, int hudCapacity, int hudAccuracy, int hudRange)
+			{
+				this.hudDamage = hudDamage;
+				this.hudSpeed = hudSpeed;
+				this.hudCapacity = hudCapacity;
+				this.hudAccuracy = hudAccuracy;
+				this.hudRange = hudRange;
+			}
+
+			public override bool Equals(object obj)
+			{
+				if (obj is WeaponHudStats stat)
+				{
+					return stat.hudDamage == hudDamage &&
+						stat.hudSpeed == hudSpeed &&
+						stat.hudCapacity == hudCapacity &&
+						stat.hudAccuracy == hudAccuracy &&
+						stat.hudRange == hudRange;
+				}
+				return false;
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					int hash = 13;
+					hash = (hash * 7) + hudDamage.GetHashCode();
+					hash = (hash * 7) + hudSpeed.GetHashCode();
+					hash = (hash * 7) + hudCapacity.GetHashCode();
+					hash = (hash * 7) + hudAccuracy.GetHashCode();
+					hash = (hash * 7) + hudRange.GetHashCode();
+					return hash;
+				}
+			}
+
+			public static bool operator ==(WeaponHudStats left, WeaponHudStats right)
+			{
+				return left.Equals(right);
+			}
+
+			public static bool operator !=(WeaponHudStats left, WeaponHudStats right)
+			{
+				return !(left == right);
+			}
+		}
+
+		[StructLayout(LayoutKind.Explicit, Size = 0x28)]
+		[SecuritySafeCritical]
+		private struct UnsafeWeaponComponentHudStats
+		{
+			[FieldOffset(0x00)] private int hudDamage;
+
+			[FieldOffset(0x08)] private int hudSpeed;
+
+			[FieldOffset(0x10)] private int hudCapacity;
+
+			[FieldOffset(0x18)] private int hudAccuracy;
+
+			[FieldOffset(0x20)] private int hudRange;
+
+
+			public WeaponComponentHudStats GetSafeStats()
+			{
+				return new WeaponComponentHudStats(hudDamage, hudSpeed, hudCapacity, hudAccuracy, hudRange);
+			}
+		}
+
+		public struct WeaponComponentHudStats
+		{
+			public int hudDamage;
+			public int hudSpeed;
+			public int hudCapacity;
+			public int hudAccuracy;
+			public int hudRange;
+
+			public WeaponComponentHudStats(int hudDamage, int hudSpeed, int hudCapacity, int hudAccuracy, int hudRange)
+			{
+				this.hudDamage = hudDamage;
+				this.hudSpeed = hudSpeed;
+				this.hudCapacity = hudCapacity;
+				this.hudAccuracy = hudAccuracy;
+				this.hudRange = hudRange;
+			}
+
+			public override bool Equals(object obj)
+			{
+				if (obj is WeaponComponentHudStats stat)
+				{
+					return stat.hudDamage == hudDamage &&
+						stat.hudSpeed == hudSpeed &&
+						stat.hudCapacity == hudCapacity &&
+						stat.hudAccuracy == hudAccuracy &&
+						stat.hudRange == hudRange;
+				}
+				return false;
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					int hash = 13;
+					hash = (hash * 7) + hudDamage.GetHashCode();
+					hash = (hash * 7) + hudSpeed.GetHashCode();
+					hash = (hash * 7) + hudCapacity.GetHashCode();
+					hash = (hash * 7) + hudAccuracy.GetHashCode();
+					hash = (hash * 7) + hudRange.GetHashCode();
+					return hash;
+				}
+			}
+
+			public static bool operator ==(WeaponComponentHudStats left, WeaponComponentHudStats right)
+			{
+				return left.Equals(right);
+			}
+
+			public static bool operator !=(WeaponComponentHudStats left, WeaponComponentHudStats right)
+			{
+				return !(left == right);
+			}
+		}
+
+		[SecuritySafeCritical]
+		private static WeaponHudStats _GetWeaponHudStats(uint weaponHash)
+		{
+			UnsafeWeaponHudStats unsafeStats = new UnsafeWeaponHudStats();
+			unsafe
+			{
+				Function.Call(Hash.GET_WEAPON_HUD_STATS, &unsafeStats);
+			}
+			return unsafeStats.GetSafeStats();
+		}
+
+		[SecuritySafeCritical]
+		private static WeaponComponentHudStats _GetWeaponComponentHudStats(uint weaponHash)
+		{
+			UnsafeWeaponComponentHudStats unsafeStats = new UnsafeWeaponComponentHudStats();
+			unsafe
+			{
+				Function.Call(Hash.GET_WEAPON_COMPONENT_HUD_STATS, &unsafeStats);
+			}
+			return unsafeStats.GetSafeStats();
+		}
+
+		/// <summary>
+		/// Get the hud stats for this weapon.
+		/// </summary>
+		/// <param name="weaponHash"></param>
+		/// <param name="weaponStats"></param>
+		/// <returns></returns>
+		public static bool GetWeaponHudStats(uint weaponHash, ref WeaponHudStats weaponStats)
+		{
+			if (!API.IsWeaponValid(weaponHash))
+				return false;
+			weaponStats = _GetWeaponHudStats(weaponHash);
+			return true;
+		}
+
+		/// <summary>
+		/// Get the hud stats for this weapon component.
+		/// </summary>
+		/// <param name="weaponHash"></param>
+		/// <param name="weaponComponentStats"></param>
+		/// <returns></returns>
+		public static bool GetWeaponComponentHudStats(uint weaponHash, ref WeaponComponentHudStats weaponComponentStats)
+		{
+			weaponComponentStats = _GetWeaponComponentHudStats(weaponHash);
+			return true;
 		}
 	}
 }

--- a/code/client/clrcore/External/Weapon.cs
+++ b/code/client/clrcore/External/Weapon.cs
@@ -504,5 +504,20 @@ namespace CitizenFX.Core
 			return "WT_INVALID";
 		}
 
+		/// <summary>
+		/// Gets the <see cref="Game.WeaponHudStats"/> data from this <see cref="Weapon"/>.
+		/// </summary>
+		public Game.WeaponHudStats HudStats
+		{
+			get
+			{
+				Game.WeaponHudStats stats = new Game.WeaponHudStats();
+				if (Game.GetWeaponHudStats((uint)this.Hash, ref stats))
+				{
+					return stats;
+				}
+				return new Game.WeaponHudStats();
+			}
+		}
 	}
 }

--- a/code/client/clrcore/External/WeaponComponent.cs
+++ b/code/client/clrcore/External/WeaponComponent.cs
@@ -1180,6 +1180,22 @@ namespace CitizenFX.Core
 			}
 			return ComponentAttachmentPoint.Invalid;
 		}
+
+		/// <summary>
+		/// Gets the <see cref="Game.WeaponComponentHudStats"/> data from this <see cref="WeaponComponent"/>.
+		/// </summary>
+		public Game.WeaponComponentHudStats HudStats
+		{
+			get
+			{
+				Game.WeaponComponentHudStats stats = new Game.WeaponComponentHudStats();
+				if (Game.GetWeaponComponentHudStats((uint)this.ComponentHash, ref stats))
+				{
+					return stats;
+				}
+				return new Game.WeaponComponentHudStats();
+			}
+		}
 	}
 
 	public class InvalidWeaponComponent : WeaponComponent
@@ -1221,6 +1237,7 @@ namespace CitizenFX.Core
 			get { return ComponentAttachmentPoint.Invalid; }
 		}
 	}
+
 
 
 }


### PR DESCRIPTION
Add 2 new weapon struct native wrappers
- `Game.GetWeaponHudStats()`
- `Game.GetWeaponComponentHudStats()`

Struct info: 
```cs
int hudDamage, int hudSpeed, int hudCapacity, int hudAccuracy, int hudRange
```

Used for things like [this](https://d.fivem.dev/2019-03-24_23-54_9eb75_976.gif).