### PR TITLE
Fix event handling, allow termination of threads.

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -3,10 +3,12 @@ local curThread
 local curThreadIndex
 
 function Citizen.CreateThread(threadFunction)
-	table.insert(threads, {
+	local thread = {
 		coroutine = coroutine.create(threadFunction),
 		wakeTime = 0
-	})
+	}
+	table.insert(threads,thread)
+	return thread
 end
 
 function Citizen.Wait(msec)
@@ -38,15 +40,16 @@ function Citizen.CreateThreadNow(threadFunction)
 	curThread = oldThread
 
 	if err then
-		error('Failed to execute thread: ' .. debug.traceback(coro, err))
-	end
-
-	if resumedThread and coroutine.status(coro) ~= 'dead' then
+		-- only print, rather than cause an error stopping the thread creator.
+		Citizen.Trace('Failed to execute thread: ' .. debug.traceback(coro, err))
+	elseif resumedThread and coroutine.status(coro) ~= 'dead' then
 		table.insert(threads, t)
+		return t
 	end
-
-	return coroutine.status(coro) ~= 'dead'
 end
+
+-- for consistency with CreateThread
+CreateThreadNow = Citizen.CreateThreadNow
 
 local inNext
 
@@ -133,21 +136,36 @@ end
 local timeouts = {}
 
 function Citizen.SetTimeout(msec, callback)
-	table.insert(threads, {
-		coroutine = coroutine.create(callback),
-		wakeTime = GetGameTimer() + msec
-	})
+	local thread = CreateThread(callback)
+	thread.wakeTime = GetGameTimer() + msec
+	return thread
 end
 
 SetTimeout = Citizen.SetTimeout
+
+-- Terminate threads.
+function TerminateThread(thread)
+	if not thread then
+		-- CreateThreadNow might not always return a thread, so we'll just ignore it.
+		return
+	end
+	for i,t in ipairs(threads) do
+		if t == thread then
+			threads[i] = false
+		end
+	end
+end
+ClearTimeout = TerminateThread
 
 Citizen.SetTickRoutine(function()
 	local curTime = GetGameTimer()
 
 	for i = #threads, 1, -1 do
 		local thread = threads[i]
-
-		if curTime >= thread.wakeTime then
+		
+		if not thread then
+			table.remove(threads, i)
+		elseif curTime >= thread.wakeTime then
 			curThread = thread
 			curThreadIndex = i
 
@@ -178,6 +196,14 @@ local alwaysSafeEvents = {
 
 local eventHandlers = {}
 local deserializingNetEvent = false
+local handlingEvent
+local removedCurrentEvent = false
+
+local function runEventHandler(handler,args)
+	CreateThreadNow(function()
+		handler(table.unpack(args))
+	end)
+end
 
 Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 	-- set the event source
@@ -185,15 +211,15 @@ Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 	_G.source = eventSource
 
 	-- try finding an event handler for the event
-	local eventHandlerEntry = eventHandlers[eventName]
+	local event = eventHandlers[eventName]
 	
 	-- deserialize the event structure (so that we end up adding references to delete later on)
 	local data = msgpack.unpack(eventPayload)
 
-	if eventHandlerEntry and eventHandlerEntry.handlers then
+	if event and event.handlers then
 		-- if this is a net event and we don't allow this event to be triggered from the network, return
 		if eventSource:sub(1, 3) == 'net' then
-			if not eventHandlerEntry.safeForNet and not alwaysSafeEvents[eventName] then
+			if not event.safeForNet and not alwaysSafeEvents[eventName] then
 				Citizen.Trace('event ' .. eventName .. " was not safe for net\n")
 
 				return
@@ -214,60 +240,121 @@ Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 		-- if this is a table...
 		if type(data) == 'table' then
 			-- loop through all the event handlers
-			for k, handler in pairs(eventHandlerEntry.handlers) do
-				Citizen.CreateThreadNow(function()
-					handler(table.unpack(data))
-				end)
+			handlingEvent = eventName
+			if event.reversed then
+				-- in reverse order (default).
+				event.index = event.count
+				while event.index ~= 0 do
+					runEventHandler(event.handlers[event.index].routine,data)
+					removedCurrentEvent = false
+					event.index = event.index - 1
+				end
+			else
+				-- in order.
+				event.index = 1
+				while event.index <= event.count do
+					runEventHandler(event.handlers[event.index].routine,data)
+					removedCurrentEvent = false
+					event.index = event.index + 1
+				end
 			end
+			event.index = false
+			handlingEvent = nil
 		end
 	end
 
 	_G.source = lastSource
 end)
 
-local eventKey = 10
-
-function AddEventHandler(eventName, eventRoutine)
-	local tableEntry = eventHandlers[eventName]
-
-	if not tableEntry then
-		tableEntry = { }
-
-		eventHandlers[eventName] = tableEntry
+local function getEventHandler(eventName)
+	-- there used to be multiple places event handler tables were created, now only here.
+	if not eventHandlers[eventName] then
+		eventHandlers[eventName] = {
+			count = 0,
+			index = false, -- if being handled, the current handler index.
+			handlers = {},
+			reversed = true,
+			safeForNet = false,
+		}
 	end
-
-	if not tableEntry.handlers then
-		tableEntry.handlers = { }
-	end
-
-	eventKey = eventKey + 1
-	tableEntry.handlers[eventKey] = eventRoutine
-
-	return {
-		key = eventKey,
-		name = eventName
-	}
+	return eventHandlers[eventName]
 end
 
-function RemoveEventHandler(eventData)
-	if not eventData.key and not eventData.name then
-		error('Invalid event data passed to RemoveEventHandler()')
+function GetCurrentEvent()
+	return handlingEvent
+end
+
+function SetEventReversed(eventName, yes) -- controls the order of event callbacks, on by default.
+	getEventHandler(eventName).reversed = yes and true or false
+end
+
+function AddEventHandler(eventName, eventRoutine)
+	local tableEntry = getEventHandler(eventName)
+	local eventData = {
+		name = eventName,
+		routine = eventRoutine,
+	}
+
+	tableEntry.count = tableEntry.count + 1
+	tableEntry.handlers[tableEntry.count] = eventData
+
+	return eventData
+end
+
+function RemoveEventHandler(eventData,eventIndex) -- eventIndex is used internally, dont specify
+	local event = eventHandlers[eventData.name]
+	if not event then
+		error('Invalid event data passed to RemoveEventHandler()',2)
+	end
+
+	-- find the entry
+	if eventIndex then
+		if eventData ~= event.handlers[eventIndex] then
+			error('Index for RemoveEventHandler is wrong',2)
+		end
+	else
+		for i,v in ipairs(event.handlers) do
+			if v == eventData then
+				eventIndex = i
+				break
+			end
+		end
+	end
+	if not eventIndex then
+		return
 	end
 
 	-- remove the entry
-	eventHandlers[eventData.name].handlers[eventData.key] = nil
+	table.remove(event.handlers,eventIndex)
+	event.count = event.count - 1
+
+	-- adjust the event handling index if active
+	if event.index then
+		if event.reversed then
+			if eventIndex < event.index then
+				event.index = event.index - 1
+			end
+		elseif eventIndex <= event.index then
+			event.index = event.index - 1
+		end
+	end
+end
+
+function RemoveCurrentEventHandler()
+	local event = eventHandlers[handlingEvent]
+	if not event.index then
+		error('Tried to remove current event handler while no event was being handled',2)
+	end
+	if removedCurrentEvent then
+		return
+	end
+	
+	removedCurrentEvent = true
+	RemoveEventHandler(event.handlers[event.index],event.index)
 end
 
 function RegisterNetEvent(eventName)
-	local tableEntry = eventHandlers[eventName]
-
-	if not tableEntry then
-		tableEntry = { }
-
-		eventHandlers[eventName] = tableEntry
-	end
-
-	tableEntry.safeForNet = true
+	getEventHandler(eventName).safeForNet = true
 end
 
 function TriggerEvent(eventName, ...)


### PR DESCRIPTION
This little patch aims to fix quite a bit of event handling w/ the scheduler, a tiny bit with CreateThreadNow, and allows you to terminate threads.

1. Make event handlers run in order (they didn't before).
2. Made a function to let you change the order they run in, SetEventReversed. They are reversed by default.
3. Made GetCurrentEvent which simply gives back the name of the currently running event.
4. Made RemoveCurrentEventHandler which is also pretty self explanatory.
5. Removing an event handler will not screw up the event handling order (if you removed a handler for the current event before, it would).
6. For neatness sake, event handler tables are now created in one place, getEventHandler.
7. Made runEventHandler simply for the sake of creating an event handler thread w/ less upvalues.
8. Made CreateThreadNow an alias for Citizen.CreateThreadNow for consistency w/ other common functions.
9. Made CreateThreadNow not cause an error, but rather just print the error as to not interrupt whatever created the thread.
10. Made TerminateThread (and ClearTimeout), which will mark a thread for removal.

I'm not sure if I should be uploading this test somewhere different, but if you want to see a test script for these proposed changes, I put it on pastebin. https://pastebin.com/wtAH0uLq