### PR TITLE
shared: fix fwPlatformString narrowing on linux

### DIFF
--- a/code/client/shared/Utils.cpp
+++ b/code/client/shared/Utils.cpp
@@ -363,6 +363,13 @@ std::string ToNarrow(const std::wstring& wide)
 	return std::string(outVec.begin(), outVec.end());
 }
 
+#ifndef _WIN32
+std::string ToNarrow(const fwPlatformString& wide)
+{
+	return (std::string) wide;
+}
+#endif
+
 std::wstring ToWide(const std::string& narrow)
 {
 	std::vector<uint8_t> cleanVec;

--- a/code/client/shared/Utils.h
+++ b/code/client/shared/Utils.h
@@ -275,6 +275,9 @@ void SetThreadName(int threadId, const char* threadName);
 
 std::wstring ToWide(const std::string& narrow);
 std::string ToNarrow(const std::wstring& wide);
+#ifndef _WIN32
+std::string ToNarrow(const fwPlatformString& wide);
+#endif
 
 #ifdef COMPILING_CORE
 extern "C" bool DLL_EXPORT CoreIsDebuggerPresent();


### PR DESCRIPTION
On linux `fwPlatformString` is a basic `std::string` instead of a `std::wstring`.