### PR TITLE
Fix DPI scale issue in UpdateUI

### DIFF
--- a/code/client/launcher/UpdaterUI.cpp
+++ b/code/client/launcher/UpdaterUI.cpp
@@ -10,6 +10,38 @@
 #include <CommCtrl.h>
 #include <shobjidl.h>
 
+#include <ShellScalingApi.h>
+
+static class DPIScaler
+{
+public:
+	DPIScaler()
+	{
+		// Default DPI is 96 (100%)
+		dpiX = 96;
+		dpiY = 96;
+	}
+
+	void SetScale(UINT dpiX, UINT dpiY)
+	{
+		this->dpiX = dpiX;
+		this->dpiY = dpiY;
+	}
+
+	int ScaleX(int x)
+	{
+		return MulDiv(x, dpiX, 96);
+	}
+
+	int ScaleY(int y)
+	{
+		return MulDiv(y, dpiY, 96);
+	}
+
+private:
+	UINT dpiX, dpiY;
+} g_dpi;
+
 static struct  
 {
 	HWND rootWindow;
@@ -33,31 +65,55 @@ HWND UI_GetWindowHandle()
 	return g_uui.rootWindow;
 }
 
+HFONT UI_CreateScaledFont(int cHeight, int cWidth, int cEscapement, int cOrientation, int cWeight, DWORD bItalic,
+	DWORD bUnderline, DWORD bStrikeOut, DWORD iCharSet, DWORD iOutPrecision, DWORD iClipPrecision,
+	DWORD iQuality, DWORD iPitchAndFamily, LPCWSTR pszFaceName)
+{
+	LOGFONT logFont;
+	
+	memset(&logFont, 0, sizeof(LOGFONT));
+	logFont.lfHeight = g_dpi.ScaleY(cHeight);
+	logFont.lfWidth = cWidth;
+	logFont.lfEscapement = cEscapement;
+	logFont.lfOrientation = cOrientation;
+	logFont.lfWeight = cWeight;
+	logFont.lfItalic = bItalic;
+	logFont.lfUnderline = bUnderline;
+	logFont.lfStrikeOut = bStrikeOut;
+	logFont.lfCharSet = iCharSet;
+	logFont.lfOutPrecision = 8;
+	logFont.lfClipPrecision = iClipPrecision;
+	logFont.lfQuality = iQuality;
+	logFont.lfPitchAndFamily = iPitchAndFamily;
+	wcscpy_s(logFont.lfFaceName, pszFaceName);
+	return CreateFontIndirect(&logFont);
+}
+
 void UI_CreateWindow()
 {
 	g_uui.taskbarMsg = RegisterWindowMessage(L"TaskbarButtonCreated");
 
-	HWND rootWindow = CreateWindowEx(0, L"NotSteamAtAll", L"Updating " PRODUCT_NAME, 13238272 /* lol */, 0x80000000, 0, 500, 129, NULL, NULL, GetModuleHandle(NULL), 0);
+	HWND rootWindow = CreateWindowEx(0, L"NotSteamAtAll", L"Updating " PRODUCT_NAME, 13238272 /* lol */, 0x80000000, 0, g_dpi.ScaleX(500), g_dpi.ScaleY(129), NULL, NULL, GetModuleHandle(NULL), 0);
 
 	INITCOMMONCONTROLSEX controlSex;
 	controlSex.dwSize = sizeof(controlSex);
 	controlSex.dwICC = 16416; // lazy bum
 	InitCommonControlsEx(&controlSex);
 
-	HFONT font = CreateFont(-12, 0, 0, 0, 0, 0, 0, 0, 1, 8, 0, 5, 2, L"Tahoma");
+	HFONT font = UI_CreateScaledFont(-12, 0, 0, 0, 0, 0, 0, 0, 1, 8, 0, 5, 2, L"Tahoma");
 
 	// TODO: figure out which static is placed where
-	HWND static1 = CreateWindowEx(0x20, L"static", L"static1", 0x50000000, 15, 15, 455, 25, rootWindow, 0, GetModuleHandle(NULL) /* what?! */, 0);
+	HWND static1 = CreateWindowEx(0x20, L"static", L"static1", 0x50000000, g_dpi.ScaleX(15), g_dpi.ScaleY(15), g_dpi.ScaleX(455), g_dpi.ScaleY(25), rootWindow, 0, GetModuleHandle(NULL) /* what?! */, 0);
 
 	SendMessage(static1, WM_SETFONT, (WPARAM)font, 0);
 
-	HWND cancelButton = CreateWindowEx(0, L"button", L"Cancel", 0x50000000, 395, 64, 75, 25, rootWindow, 0, GetModuleHandle(NULL), 0);
+	HWND cancelButton = CreateWindowEx(0, L"button", L"Cancel", 0x50000000, g_dpi.ScaleX(395), g_dpi.ScaleY(64), g_dpi.ScaleX(75), g_dpi.ScaleY(25), rootWindow, 0, GetModuleHandle(NULL), 0);
 	SendMessage(cancelButton, WM_SETFONT, (WPARAM)font, 0);
 
-	HWND progressBar = CreateWindowEx(0, L"msctls_progress32", 0, 0x50000000, 15, 40, 455, 15, rootWindow, 0, GetModuleHandle(NULL), 0);
+	HWND progressBar = CreateWindowEx(0, L"msctls_progress32", 0, 0x50000000, g_dpi.ScaleX(15), g_dpi.ScaleY(40), g_dpi.ScaleX(455), g_dpi.ScaleY(15), rootWindow, 0, GetModuleHandle(NULL), 0);
 	SendMessage(progressBar, PBM_SETRANGE32, 0, 10000);
 
-	HWND static2 = CreateWindowEx(0x20, L"static", L"static2", 0x50000000, 15, 68, 370, 25, rootWindow, 0, GetModuleHandle(NULL) /* what?! */, 0);
+	HWND static2 = CreateWindowEx(0x20, L"static", L"static2", 0x50000000, g_dpi.ScaleX(15), g_dpi.ScaleY(68), g_dpi.ScaleX(370), g_dpi.ScaleY(25), rootWindow, 0, GetModuleHandle(NULL) /* what?! */, 0);
 	SendMessage(static2, WM_SETFONT, (WPARAM)font, 0);
 
 	g_uui.cancelButton = cancelButton;
@@ -69,8 +125,8 @@ void UI_CreateWindow()
 	RECT wndRect;
 	wndRect.left = 0;
 	wndRect.top = 0;
-	wndRect.right = 500;
-	wndRect.bottom = 139;
+	wndRect.right = g_dpi.ScaleX(500);
+	wndRect.bottom = g_dpi.ScaleY(139);
 
 	HWND desktop = GetDesktopWindow();
 	HDC dc = GetDC(desktop);
@@ -81,7 +137,7 @@ void UI_CreateWindow()
 
 	SetTimer(rootWindow, 0, 20, NULL);
 
-	MoveWindow(rootWindow, (width - 500) / 2, (height - 139) / 2, wndRect.right - wndRect.left + 1, wndRect.bottom - wndRect.top + 1, TRUE);
+	MoveWindow(rootWindow, (width - g_dpi.ScaleX(500)) / 2, (height - g_dpi.ScaleY(139)) / 2, wndRect.right - wndRect.left + 1, wndRect.bottom - wndRect.top + 1, TRUE);
 
 	ShowWindow(rootWindow, TRUE);
 }
@@ -90,6 +146,29 @@ LRESULT CALLBACK UI_WndProc(HWND hWnd, UINT uMsg, WPARAM wparam, LPARAM lparam)
 {
 	switch (uMsg)
 	{
+		case WM_NCCREATE:
+			{
+				// Only Windows 10+ supports EnableNonClientDpiScaling
+				if (IsWindows10OrGreater())
+				{
+					HMODULE user32 = LoadLibrary(L"user32.dll");
+
+					if (user32)
+					{
+						auto EnableNonClientDpiScaling = (decltype(&::EnableNonClientDpiScaling))GetProcAddress(user32, "EnableNonClientDpiScaling");
+
+						if (EnableNonClientDpiScaling)
+						{
+							EnableNonClientDpiScaling(hWnd);
+						}
+
+						FreeLibrary(user32);
+					}
+				}
+
+				return DefWindowProc(hWnd, uMsg, wparam, lparam);
+			}
+		
 		case WM_CTLCOLORSTATIC:
 			SetBkMode((HDC)wparam, TRANSPARENT);
 			SetTextColor((HDC)wparam, COLORREF(GetSysColor(COLOR_WINDOWTEXT)));
@@ -112,6 +191,31 @@ LRESULT CALLBACK UI_WndProc(HWND hWnd, UINT uMsg, WPARAM wparam, LPARAM lparam)
 				HDC dc = BeginPaint(hWnd, &ps);
 			
 				EndPaint(hWnd, &ps);
+				break;
+			}
+		case WM_DPICHANGED:
+			{
+				// Set the new DPI
+				g_dpi.SetScale(LOWORD(wparam), HIWORD(wparam));
+
+				// Resize the window
+				LPRECT newScale = (LPRECT)lparam;
+				SetWindowPos(hWnd, HWND_TOP, newScale->left, newScale->top, newScale->right - newScale->left, newScale->bottom - newScale->top, SWP_NOZORDER | SWP_NOACTIVATE);
+
+				// Recreate the font
+				HFONT newFont = UI_CreateScaledFont(-12, 0, 0, 0, 0, 0, 0, 0, 1, 8, 0, 5, 2, L"Tahoma");
+
+				// Resize all components
+				SetWindowPos(g_uui.topStatic, HWND_TOP, g_dpi.ScaleX(15), g_dpi.ScaleY(15), g_dpi.ScaleX(455), g_dpi.ScaleY(25), SWP_SHOWWINDOW);
+				SendMessage(g_uui.topStatic, WM_SETFONT, (WPARAM)newFont, 0);
+
+				SetWindowPos(g_uui.cancelButton, HWND_TOP, g_dpi.ScaleX(395), g_dpi.ScaleY(64), g_dpi.ScaleX(75), g_dpi.ScaleY(25), SWP_SHOWWINDOW);
+				SendMessage(g_uui.cancelButton, WM_SETFONT, (WPARAM)newFont, 0);
+
+				SetWindowPos(g_uui.progressBar, HWND_TOP, g_dpi.ScaleX(15), g_dpi.ScaleY(40), g_dpi.ScaleX(455), g_dpi.ScaleY(15), SWP_SHOWWINDOW);
+
+				SetWindowPos(g_uui.bottomStatic, HWND_TOP, g_dpi.ScaleX(15), g_dpi.ScaleY(68), g_dpi.ScaleX(370), g_dpi.ScaleY(25), SWP_SHOWWINDOW);
+				SendMessage(g_uui.bottomStatic, WM_SETFONT, (WPARAM)newFont, 0);
 				break;
 			}
 		default:
@@ -155,6 +259,33 @@ void UI_DoCreation()
 	{
 		CoCreateInstance(CLSID_TaskbarList, 
 			NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&g_uui.tbList));
+	}
+
+	// Only Windows 8.1+ supports per-monitor DPI awareness
+	if (IsWindows8Point1OrGreater())
+	{
+		HMODULE shCore = LoadLibrary(L"shcore.dll");
+
+		if (shCore)
+		{
+			auto GetDpiForMonitor = (decltype(&::GetDpiForMonitor))GetProcAddress(shCore, "GetDpiForMonitor");
+
+			if (GetDpiForMonitor)
+			{
+				UINT dpiX, dpiY;
+
+				POINT point;
+				point.x = 1;
+				point.y = 1;
+
+				// Get DPI for the main monitor
+				HMONITOR monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+				GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+				g_dpi.SetScale(dpiX, dpiY);
+			}
+
+			FreeLibrary(shCore);
+		}
 	}
 
 	UI_RegisterClass();


### PR DESCRIPTION
The UpdateUI is not correctly scaled by the DPI setting, so the window may be clipped and the text is too small in the HiDPI environment (mine is 200%), looking like:
![2019-04-14 (6)](https://user-images.githubusercontent.com/1834970/56119067-2ff9c100-5f20-11e9-9d4c-ec63a1ed8ac0.png)

My patch fixes this problem, making both non-client and client area scaled properly:
![2019-04-15](https://user-images.githubusercontent.com/1834970/56119111-4869db80-5f20-11e9-8cab-de2987b2f481.png)

This patch also responds to WM_DPICHANGED message, so the window and the text and button on it will be correspondingly scaled once the DPI is changed.

What it looks like under 200%:
![200%](https://user-images.githubusercontent.com/1834970/56119302-b9a98e80-5f20-11e9-81d7-8ce708f4c0e3.png)

... and what it looks like under 150% after WM_DPICHANGED is processed:
![150%](https://user-images.githubusercontent.com/1834970/56119337-cb8b3180-5f20-11e9-86b0-f1b71fd17d61.png)
