### PR TITLE
rage:input/gta:core: fixes SetCursorLocation native by temporarily re-enabling SetCursorPos during native invocation

### DIFF
--- a/code/components/gta-core-five/component.json
+++ b/code/components/gta-core-five/component.json
@@ -6,6 +6,7 @@
 		"rage:allocator:five",
 		"rage:nutsnbolts:five",
 		"rage:scripting:five",
+		"rage:input:five",
 		"vendor:minhook"
 	],
 	"provides": []

--- a/code/components/gta-core-five/src/SetCursorLocation.cpp
+++ b/code/components/gta-core-five/src/SetCursorLocation.cpp
@@ -1,0 +1,21 @@
+#include "StdInc.h"
+
+#include "scrEngine.h"
+#include "InputHook.h"
+
+rage::scrEngine::NativeHandler m_origSetCursorLocation;
+static HookFunction hookFunction([]()
+{
+	//_SET_CURSOR_LOCATION
+	rage::scrEngine::OnScriptInit.Connect([]()
+	{
+		m_origSetCursorLocation = rage::scrEngine::GetNativeHandler(0xFC695459D4D0E219);
+		rage::scrEngine::RegisterNativeHandler(0xFC695459D4D0E219, [](rage::scrNativeCallContext* context)
+		{
+			InputHook::EnableSetCursorPos(true);
+			(*m_origSetCursorLocation)(context);
+			InputHook::EnableSetCursorPos(false);
+		});
+	});
+
+});

--- a/code/components/rage-input-five/include/InputHook.h
+++ b/code/components/rage-input-five/include/InputHook.h
@@ -13,4 +13,6 @@ namespace InputHook
 	extern INPUT_DECL fwEvent<int&> QueryMayLockCursor;
 
 	INPUT_DECL void SetGameMouseFocus(bool focus);
+
+	INPUT_DECL void EnableSetCursorPos(bool enabled);
 }

--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -6,6 +6,7 @@
 static WNDPROC origWndProc;
 
 static bool g_isFocused = true;
+static bool g_enableSetCursorPos = false;
 static bool g_isFocusStolen = false;
 
 static void(*disableFocus)();
@@ -33,6 +34,10 @@ void InputHook::SetGameMouseFocus(bool focus)
 	g_isFocusStolen = !focus;
 
 	return (focus) ? enableFocus() : disableFocus();
+}
+
+void InputHook::EnableSetCursorPos(bool enabled) {
+	g_enableSetCursorPos = enabled;
 }
 
 static char* g_gameKeyArray;
@@ -121,13 +126,15 @@ HKL WINAPI ActivateKeyboardLayoutWrap(IN HKL hkl, IN UINT flags)
 
 BOOL WINAPI SetCursorPosWrap(int X, int Y)
 {
-	if (!g_isFocused)
+	if (!g_isFocused || g_enableSetCursorPos)
 	{
 		return SetCursorPos(X, Y);
 	}
 
 	return TRUE;
 }
+
+
 
 static HookFunction hookFunction([] ()
 {


### PR DESCRIPTION
Wasn't sure the best place to put the native override, so let me know if it should be placed elsewhere or if another approach should be taken to fix SetCursorLocation.