### PR TITLE
handling-loader-five: Fix for fDriveBiasFront get/set

### DIFF
--- a/code/components/handling-loader-five/src/HandlingLoader.cpp
+++ b/code/components/handling-loader-five/src/HandlingLoader.cpp
@@ -79,7 +79,21 @@ static float getFloatField(char* handlingChar, uint32_t offset, const char* fiel
 {
 	auto hash = HashRageString(fieldName);
 
-	if (hash == HashRageString("fDriveBiasFront") || hash == HashRageString("fBrakeBiasFront") || hash == HashRageString("fSuspensionBiasFront") ||
+	if (hash == HashRageString("fDriveBiasFront"))
+	{
+		float fDriveBiasFront = *(float*)(handlingChar + offset);
+		float fDriveBiasRear = *(float*)(handlingChar + offset + 4);
+		
+		if ((fDriveBiasFront == 1.0f && fDriveBiasRear == 0.0f) || (fDriveBiasFront == 0.0f && fDriveBiasRear == 1.0f))
+		{
+			return fDriveBiasFront;
+		}
+		else
+		{
+			return fDriveBiasFront / 2.0f;
+		}
+	}
+	else if (hash == HashRageString("fBrakeBiasFront") || hash == HashRageString("fSuspensionBiasFront") ||
 		hash == HashRageString("fTractionBiasFront") || hash == HashRageString("fAntiRollBarBiasFront"))
 	{
 		return *(float*)(handlingChar + offset) / 2.0f;
@@ -147,7 +161,7 @@ static void setFloatField(char* handlingChar, uint32_t offset, float value, cons
 			*(float*)(handlingChar + offset) = 0.0f;
 			*(float*)(handlingChar + offset + 4) = 1.0f; // rear
 		}
-		else if (value >= 0.9f)
+		else if (value > 0.9f)
 		{
 			*(float*)(handlingChar + offset) = 1.0f;
 			*(float*)(handlingChar + offset + 4) = 0.0f; // rear


### PR DESCRIPTION
set: Fixed condition that wouldn't have allowed to set 0.9f as value
get: Changed logic to match the one used for the set
fDriveBiasFront and +4 (fDriveBiasRear) are either one 1.0f and the other 0.0f or both are a value among 0 and 1 (whose sum is 1.0f) but stored doubled 