### PR TITLE
Rename vehicle extra-native which somehow has the same name of a native

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -269,7 +269,7 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_DASHBOARD_SPEED", readVehicleMemory<float, DashSpeedOffset>);
 
-	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_ACCELERATION", readVehicleMemory<float, AccelerationOffset>);
+	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_CURRENT_ACCELERATION", readVehicleMemory<float, AccelerationOffset>);
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_GRAVITY", readVehicleMemory<float, AccelerationOffset>);
 


### PR DESCRIPTION
Both CFX and VEHICLES namespaces have a native called GET_VEHICLE_ACCELERATION so I've changed the name for the extra-native and on purpose didn't add an alias.