### PR TITLE
d-typing: declare source as global

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -80,3 +80,4 @@ declare function removeEventListener(eventName: string, callback: Function): voi
 declare function setTick(callback: Function): void
 
 declare var exports: any;
+declare var source: string;


### PR DESCRIPTION
Just add `declare var source: string;` so it's accessible from server without typescript error.