### PR TITLE
add SET_PLAYER_NAME native (server)

### DIFF
--- a/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
@@ -187,4 +187,16 @@ static InitFunction initFunction([]()
 			return 0;
 		}
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_NAME", MakeClientFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::Client>& client)
+	{
+		const char* str = context.GetArgument<const char*>(1);
+
+		if (str)
+		{
+			client->SetName(str);
+		}
+
+		return true;
+	}));
 });

--- a/ext/natives/codegen_cfx_natives.lua
+++ b/ext/natives/codegen_cfx_natives.lua
@@ -2026,3 +2026,11 @@ native "SET_DISCORD_RICH_PRESENCE_ASSET"
 </summary>
 <param name="assetName">The name of a valid asset registered on Discordapp's developer dashboard. note that the asset has to be registered under the same discord API application set using the SET_DISCORD_APP_ID native.</param>
 	]]
+
+native 'SET_PLAYER_NAME'
+	arguments {
+		charPtr 'playerSrc',
+		charPtr 'name'
+	}
+	apiset 'server'
+	returns 'void'


### PR DESCRIPTION
An useful native for people that do not necessary use steam usernames. It will also replace the name in players.json but will not be synced with the client.
It could also be used with adaptive card to "choose" your username for example.