### PR TITLE
Fix typescript clearTick reference

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -78,5 +78,6 @@ declare function TriggerClientEvent(eventName: string, target: number|string, ..
 declare function removeEventListener(eventName: string, callback: Function): void
 
 declare function setTick(callback: Function): void
+declare function clearTick(id: number): void
 
 declare var exports: any;

--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -77,7 +77,7 @@ declare function TriggerClientEvent(eventName: string, target: number|string, ..
 
 declare function removeEventListener(eventName: string, callback: Function): void
 
-declare function setTick(callback: Function): void
+declare function setTick(callback: Function): number
 declare function clearTick(id: number): void
 
 declare var exports: any;


### PR DESCRIPTION
Typescript definition misses clearTick function declaration, which doesn't allow the code to be compiled in strict mode.