### PR TITLE
clrcore: Add Flags attribute to IntersectOptions

### DIFF
--- a/code/client/clrcore/External/World.cs
+++ b/code/client/clrcore/External/World.cs
@@ -177,6 +177,7 @@ namespace CitizenFX.Core
 		Wispy
 	}
 
+	[Flags]
 	public enum IntersectOptions
 	{
 		Everything = -1,
@@ -190,6 +191,7 @@ namespace CitizenFX.Core
 		Vegetation = 256,
 		Unk4 = 512
 	}
+
 	public enum MarkerType
 	{
 		UpsideDownCone,


### PR DESCRIPTION
`IntersectOptions` is considered a bit flag according to the [documentation](https://runtime.fivem.net/doc/natives/#_0x377906D8A31E5586). This change just properly adds the `Flags` attribute to the enum so it could have bit operations done on it without warnings.