### PR TITLE
Increased CNetworkRopeWorldStateData limit

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -28,6 +28,10 @@
 							<PoolSize value="256"/>
 						</Item>
 						<Item>
+							<PoolName>CNetworkRopeWorldStateData</PoolName>
+							<PoolSize value="256"/>
+						</Item>
+						<Item>
 							<PoolName>CNetObjPed</PoolName>
 							<PoolSize value="238"/> <!-- 110 + player count -->
 						</Item>


### PR DESCRIPTION
I experienced error messages in log and even crashes due to CNetworkRopeWorldStateData limit (20) and other players reported to me too.
This is not my log, but it shows the problem: https://pastebin.com/9bzRENKD