### PR TITLE
handling-loader-five: fix vehicle handling memleak

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -530,6 +530,11 @@ static HookFunction initFunction([]()
 		static void CleanupVehicle(fwEntity* VehPointer)
 		{
 			g_skipRepairVehicles.erase(VehPointer);
+
+			// Delete the handling if it has been set to hooked.
+			void* handling = readValue<void*>(VehPointer, 0x918);
+			if (*((char*)handling + 28) == 1)
+				delete handling;
 		}
 		virtual void InternalMain() override
 		{

--- a/code/components/handling-loader-five/include/HandlingLoader.h
+++ b/code/components/handling-loader-five/include/HandlingLoader.h
@@ -131,6 +131,8 @@ public:
 
 	inline void SetHandlingData(CHandlingData* ptr)
 	{
+		// Use an alignment byte within CHandlingDataMgr to represent the handling as hooked.
+		*((char*)ptr + 28) = 1;
 		m_handlingData = ptr;
 	}
 };


### PR DESCRIPTION
Commit has only been tested locally, and may be programmed a bit too
defensively.