### PR TITLE
onesync: complete CPedHealthDataNode

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -974,7 +974,72 @@ struct CPedScriptCreationDataNode { bool Parse(SyncParseState& state) { return t
 struct CPedComponentReservationDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedScriptGameStateDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedAttachDataNode { bool Parse(SyncParseState& state) { return true; } };
-struct CPedHealthDataNode { bool Parse(SyncParseState& state) { return true; } };
+
+struct CPedHealthDataNode
+{
+	bool Parse(SyncParseState& state)
+	{
+		bool isFine = state.buffer.ReadBit();
+		auto maxHealthChanged = state.buffer.ReadBit();
+
+		int maxHealth = 200;
+
+		if (maxHealthChanged)
+		{
+			maxHealth = state.buffer.Read<int>(13);
+		}
+
+		state.entity->data["maxHealth"] = maxHealth;
+
+		if (!isFine)
+		{
+			int pedHealth = state.buffer.Read<int>(13);
+			auto unk4 = state.buffer.ReadBit();
+			auto unk5 = state.buffer.ReadBit();
+
+			state.entity->data["health"] = pedHealth;
+		}
+		else
+		{
+			state.entity->data["health"] = maxHealth;
+		}
+
+		bool noArmour = state.buffer.ReadBit();
+
+		if (!noArmour)
+		{
+			int pedArmour = state.buffer.Read<int>(13);
+			state.entity->data["armour"] = pedArmour;
+		}
+		else
+		{
+			state.entity->data["armour"] = 0;
+		}
+
+		auto unk8 = state.buffer.ReadBit();
+
+		if (unk8) // unk9 != 0
+		{
+			auto unk9 = state.buffer.ReadBit();
+		}
+
+		int causeOfDeath = state.buffer.Read<int>(32);
+		// state.entity->data["causeOfDeath"] = causeOfDeath;
+
+		int unk11 = state.buffer.Read<int>(32);
+		int injuredStatus = state.buffer.Read<int>(2); // Change below 150 HP, injured data?
+
+		auto unk13 = state.buffer.ReadBit();
+
+		if (unk13)
+		{
+			int unk14 = state.buffer.Read<int>(8);
+		}
+
+		return true;
+	}
+};
+
 struct CPedMovementGroupDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedAIDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedAppearanceDataNode { bool Parse(SyncParseState& state) { return true; } };
@@ -1293,7 +1358,7 @@ struct SyncTree : public SyncTreeBase
 
 		return false;
 	}
-
+		
 	virtual void Parse(SyncParseState& state) final override
 	{
 		std::unique_lock<std::mutex> lock(mutex);

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1020,13 +1020,12 @@ struct CPedHealthDataNode
 
 		if (unk8) // unk9 != 0
 		{
-			auto unk9 = state.buffer.ReadBit();
+			auto unk9 = state.buffer.Read<short>(13);
 		}
 
 		int causeOfDeath = state.buffer.Read<int>(32);
-		// state.entity->data["causeOfDeath"] = causeOfDeath;
+		state.entity->data["causeOfDeath"] = causeOfDeath;
 
-		int unk11 = state.buffer.Read<int>(32);
 		int injuredStatus = state.buffer.Read<int>(2); // Change below 150 HP, injured data?
 
 		auto unk13 = state.buffer.ReadBit();

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -397,6 +397,11 @@ static InitFunction initFunction([]()
 		return entity->data["armour"];
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_CAUSE_OF_DEATH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		return entity->data["causeOfDeath"];
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_MAX_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
 		switch (entity->type)

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -386,4 +386,40 @@ static InitFunction initFunction([]()
 
 		return lockedForPlayer;
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_MAX_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		return entity->data["maxHealth"];
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_ARMOUR", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		return entity->data["armour"];
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_MAX_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		switch (entity->type)
+		{
+		case fx::sync::NetObjEntityType::Player:
+			return entity->GetData("maxHealth", 0);
+		case fx::sync::NetObjEntityType::Ped:
+			return entity->GetData("maxHealth", 0);
+		default:
+			return 0;
+		}
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		switch (entity->type)
+		{
+		case fx::sync::NetObjEntityType::Player:
+			return entity->GetData("health", 0);
+		case fx::sync::NetObjEntityType::Ped:
+			return entity->GetData("health", 0);
+		default:
+			return 0;
+		}
+	}));
 });


### PR DESCRIPTION
Tested and working properly.
I did not added `GET_PED_CAUSE_OF_DEATH` because for some unknown reason the returned value in the synctree does not match what should be returned even though the order seems fine.

I get 1891351 instead of 3452007600 for `weapon_fall`