### PR TITLE
server/onesync: three new 'state' natives

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -433,7 +433,6 @@ struct CVehicleGameStateDataNode
 		bool unk6 = state.buffer.ReadBit();
 		bool unk7 = state.buffer.ReadBit();
 		int unk8 = state.buffer.ReadBit();
-		state.entity->data["unk8"] = unk8;
 
 		if (!unk8)
 		{
@@ -445,6 +444,10 @@ struct CVehicleGameStateDataNode
 				// NOTE: Even if xenon lights are not enabled, this will still work.
 				int headlightsColour = state.buffer.Read<int>(8);
 				state.entity->data["headlightsColour"] = headlightsColour;
+			}
+			else
+			{
+				state.entity->data["headlightsColour"] = 0;
 			}
 
 			int sirenOn = state.buffer.ReadBit();
@@ -459,7 +462,6 @@ struct CVehicleGameStateDataNode
 
 			bool unk14 = state.buffer.ReadBit();
 			int unk15 = state.buffer.ReadBit();
-			state.entity->data["unk15"] = unk15;
 
 			if (unk15)
 			{
@@ -495,6 +497,11 @@ struct CVehicleGameStateDataNode
 					v22++;
 				} while (v22 < 7);
 			}
+			else
+			{
+				state.entity->data["lockStatus"] = 0;
+				state.entity->data["doorsOpen"] = 0;
+			}
 
 			bool anyWindowsOpen = state.buffer.ReadBit();
 
@@ -505,7 +512,8 @@ struct CVehicleGameStateDataNode
 
 			bool unk25 = state.buffer.ReadBit();
 			bool unk26 = state.buffer.ReadBit();
-			bool noLongerNeeded = state.buffer.ReadBit();
+			int noLongerNeeded = state.buffer.ReadBit();
+			state.entity->data["noLongerNeeded"] = noLongerNeeded;
 			bool unk28 = state.buffer.ReadBit();
 			bool unk29 = state.buffer.ReadBit();
 			bool unk30 = state.buffer.ReadBit();
@@ -515,6 +523,15 @@ struct CVehicleGameStateDataNode
 			{
 				float unk32 = state.buffer.ReadFloat(10, 3000);
 			}
+		}
+		else
+		{
+			state.entity->data["noLongerNeeded"] = 0;
+			state.entity->data["defaultHeadlights"] = 1;
+			state.entity->data["headlightsColour"] = 0;
+			state.entity->data["sirenOn"] = 0;
+			state.entity->data["lockStatus"] = 0;
+			state.entity->data["doorsOpen"] = 0;
 		}
 
 		bool unk33 = state.buffer.ReadBit();
@@ -563,7 +580,9 @@ struct CVehicleGameStateDataNode
 		auto unk49 = state.buffer.Read<int>(32);
 		auto unk50 = state.buffer.Read<int>(3);
 		bool unk51 = state.buffer.ReadBit();
-		bool unk52 = state.buffer.ReadBit();
+		int hasBeenOwnedByPlayer = state.buffer.ReadBit();
+		state.entity->data["hasBeenOwnedByPlayer"] = hasBeenOwnedByPlayer;
+
 		bool unk53 = state.buffer.ReadBit();
 		bool unk54 = state.buffer.ReadBit();
 		bool unk55 = state.buffer.ReadBit();

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -564,4 +564,14 @@ static InitFunction initFunction([]()
 	{
 		return entity->data["numberPlateTextIndex"];
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("HAS_VEHICLE_BEEN_OWNED_BY_PLAYER", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		return entity->data["hasBeenOwnedByPlayer"];
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("HAS_ENTITY_BEEN_MARKED_AS_NO_LONGER_NEEDED", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		return entity->data["noLongerNeeded"];
+	}));
 });

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -302,7 +302,7 @@ static InitFunction initFunction([]()
 		int unk8 = entity->GetData("unk8", 0);
 		int defaultHeadlights = entity->GetData("defaultHeadlights", 0);
 		
-		if (unk8 == 0 && defaultHeadlights == 0)
+		if (defaultHeadlights)
 		{
 			headlightsColour = entity->GetData("headlightsColour", 0);
 		}
@@ -312,35 +312,17 @@ static InitFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_SIREN_ON", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
-		int sirenOn = 0;
-		int unk8 = entity->GetData("unk8", 0);
-
-		if (unk8 == 0)
-		{
-			sirenOn = entity->GetData("sirenOn", 0);
-		}
-
-		return sirenOn;
+		return entity->data["sirenOn"];
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_DOOR_STATUS", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
 		int doorStatus = 0;
-		int unk8 = entity->GetData("unk8", 0);
+		int doorsOpen = entity->GetData("doorsOpen", 0);
 
-		if (unk8 == 0 && context.GetArgumentCount() > 1)
+		if (context.GetArgumentCount() > 1 && doorsOpen)
 		{
-			int unk15 = entity->GetData("unk15", 0);
-
-			if (unk15 != 0)
-			{
-				int doorsOpen = entity->GetData("doorsOpen", 0);
-
-				if (doorsOpen != 0)
-				{
-					doorStatus = entity->GetData("doorPosition" + context.GetArgument<int>(1), 0);
-				}
-			}
+			doorStatus = entity->GetData("doorPosition" + context.GetArgument<int>(1), 0);
 		}
 
 		return doorStatus;
@@ -348,20 +330,7 @@ static InitFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_DOOR_LOCK_STATUS", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
-		uint8_t lockStatus = 0;
-		int unk8 = entity->GetData("unk8", 0);
-
-		if (unk8 == 0)
-		{
-			int unk15 = entity->GetData("unk15", 0);
-
-			if (unk15 != 0)
-			{
-				lockStatus = entity->GetData("lockStatus", 0);
-			}
-		}
-
-		return lockStatus;
+		return entity->data["lockStatus"];
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_DOORS_LOCKED_FOR_PLAYER", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
@@ -369,7 +338,7 @@ static InitFunction initFunction([]()
 		int lockedForPlayer = 0;
 		int hasLock = entity->GetData("hasLock", 0);
 
-		if (hasLock != 0)
+		if (hasLock)
 		{
 			int lockedPlayers = entity->GetData("lockedPlayers", 0);
 


### PR DESCRIPTION
Useful for some server/entities stuff.
`HAS_VEHICLE_BEEN_OWNED_BY_PLAYER`
`HAS_ENTITY_BEEN_MARKED_AS_NO_LONGER_NEEDED`
This one only works with vehicle since ped/object game state nodes still need to be made.