### PR TITLE
Native for overriding ms per game minute value

### DIFF
--- a/code/components/extra-natives-five/src/TimeExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/TimeExtraNatives.cpp
@@ -1,0 +1,42 @@
+#include "StdInc.h"
+
+#include <Local.h>
+#include <Hooking.h>
+#include <ScriptEngine.h>
+#include <nutsnbolts.h>
+#include <ICoreGameInit.h>
+#include <gameSkeleton.h>
+
+static uint32_t* msPerMinute;
+static uint32_t msPerMinuteDefault = 2000;
+
+static HookFunction initFunction([]()
+{
+	{
+		auto location = hook::get_pattern("8B 0D ? ? ? ? B8 D3 4D 62 10 69 C9 A0 05", 0);
+		msPerMinute = hook::get_address<uint32_t*>((char*)location + 2);
+	}
+
+	rage::OnInitFunctionEnd.Connect([](rage::InitFunctionType type)
+	{
+		if (type == rage::INIT_CORE)
+		{
+			msPerMinuteDefault = *(uint32_t*)msPerMinute;
+		}
+	});
+
+	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]()
+	{
+		*(uint32_t*)msPerMinute = msPerMinuteDefault;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_MILLISECONDS_PER_GAME_MINUTE", [=](fx::ScriptContext& context)
+	{
+		auto value = context.GetArgument<int>(0);
+
+		if (value > 0)
+		{
+			*(uint32_t*)msPerMinute = value;
+		}
+	});
+});


### PR DESCRIPTION
This native is allowing to set what is game minute in real milliseconds. Default is 2000 (real ms) per 1 in-game minute. For example, changing value to 1000 will speed up in-game clock in 2 times.

## Demonstration:
https://gfycat.com/ColdGregariousBrant

https://github.com/citizenfx/natives/pull/175