### PR TITLE
ext/natives: js/lua multi-line return types

### DIFF
--- a/ext/natives/codegen_out_js.lua
+++ b/ext/natives/codegen_out_js.lua
@@ -241,6 +241,11 @@ local function printInvocationArguments(native)
 	return table.concat(args, ', ')
 end
 
+local function formatCommentedLine(line, indent)
+	local indentStr = string.rep('\t', indent or 0)
+	return line:gsub('\r\n', '\n'):gsub('\n', '\n * ' .. indentStr)
+end
+
 local function formatDocString(native)
 	local d = parseDocString(native)
 
@@ -267,7 +272,7 @@ local function formatDocString(native)
 	end
 
 	if d.returns then
-		l = l .. ' * @return ' .. d.returns .. '\n'
+		l = l .. ' * @return ' .. formatCommentedLine(d.returns, 2) .. '\n'
 	end
 
 	l = l .. ' */\n'

--- a/ext/natives/codegen_out_lua.lua
+++ b/ext/natives/codegen_out_lua.lua
@@ -172,6 +172,11 @@ local function printInvocationArguments(native)
 	return table.concat(args, ', ')
 end
 
+local function formatCommentedLine(line, indent)
+	local indentStr = string.rep('\t', indent or 0)
+	return line:gsub('\r\n', '\n'):gsub('\n', '\n-- ' .. indentStr)
+end
+
 local function formatDocString(native)
 	local d = parseDocString(native)
 
@@ -198,7 +203,7 @@ local function formatDocString(native)
 	end
 
 	if d.returns then
-		l = l .. '-- @return ' .. d.returns .. '\n'
+		l = l .. '-- @return ' .. formatCommentedLine(d.returns, 2) .. '\n'
 	end
 
 	return l


### PR DESCRIPTION
Example returns:

```js
 * @return 0 = None
 *      1 = Unlocked
 *      2 = Locked
 *      3 = Locked for player
 *      4 = Stick player inside (Doesn't allow players to exit the vehicle with the exit vehicle key.)
 *      7 = Can be broken into (Can be broken into the car. If the glass is broken, the value will be set to 1)
 *      8 = Can be broken into persist
 *      10 = Cannot be tried to enter (Nothing happens when you press the vehicle enter key).
```

```lua
-- @return 0 = None
--      1 = Unlocked
--      2 = Locked
--      3 = Locked for player
--      4 = Stick player inside (Doesn't allow players to exit the vehicle with the exit vehicle key.)
--      7 = Can be broken into (Can be broken into the car. If the glass is broken, the value will be set to 1)
--      8 = Can be broken into persist
--      10 = Cannot be tried to enter (Nothing happens when you press the vehicle enter key).
```