### PR TITLE
Label docker container with CI_BUILD_NUMBER

### DIFF
--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -18,6 +18,7 @@ RUN source /src/.env && /bin/sh /src/code/tools/ci/build_server_2.sh
 RUN mkdir -p /opt/cfx-server/citizen/system_resources/
 RUN cp -a /src/ext/system-resources/data/* /opt/cfx-server/citizen/system_resources/
 ENV LD_LIBRARY_PATH /usr/lib/v8/:/lib:/usr/lib/
+LABEL CI_BUILD_NUMBER=$CI_BUILD_NUMBER
 WORKDIR /opt/cfx-server
 CMD ["/bin/sh", "/opt/cfx-server/run.sh"]
 PUSH citizenfx/server:dev


### PR DESCRIPTION
This used to be a label and was useful for identifying a pulled docker container's version. Can we add this back or explain an alternative way to get the version of a stopped fivem docker container?