### PR TITLE
ext/natives: ensure langwords are handled in docs

### DIFF
--- a/ext/natives/codegen.lua
+++ b/ext/natives/codegen.lua
@@ -314,7 +314,7 @@ function parseDocString(native)
 	end
 
 	local summary = trim(docString:match("<summary>(.+)</summary>"))
-	local params = docString:gmatch("<param name=\"([^\"]+)\">([^<]+)</param>")
+	local params = docString:gmatch("<param name=\"([^\"]+)\">([^<]*)</param>")
 	local returns = docString:match("<returns>(.+)</returns>")
 
 	if not summary then

--- a/ext/natives/codegen_out_cs.lua
+++ b/ext/natives/codegen_out_cs.lua
@@ -148,23 +148,23 @@ local function trimAndNormalize(str)
 	return trim(str):gsub('/%*', ' -- [['):gsub('%*/', ']] '):gsub('&', '&amp;'):gsub('<', '&lt;'):gsub('>', '&gt;')
 end
 
-local function wrapLines(str, openTag, closeTag)
+local function wrapLines(str, openTag, closeTag, allowEmptyTag)
 	local firstLine, nextLines = str:match("([^\n]+)\n?(.*)")
 
-	if not firstLine then
-		return ''
-	end
-	
 	local t = '\t\t'
-
-	local l = t .. '/// ' .. openTag .. '\n'
-	l = l .. t .. '/// ' .. trimAndNormalize(firstLine) .. "\n"
-	for line in nextLines:gmatch("([^\n]+)") do
-		l = l ..t .. '/// ' .. trimAndNormalize(line) .. "\n"
-	end
-	l = l .. t .. '/// ' .. closeTag .. '\n'
-	
-	return l
+	if firstLine then
+		local l = t .. '/// ' .. openTag .. '\n'
+		l = l .. t .. '/// ' .. trimAndNormalize(firstLine) .. "\n"
+		for line in nextLines:gmatch("([^\n]+)") do
+			l = l ..t .. '/// ' .. trimAndNormalize(line) .. "\n"
+		end
+		l = l .. t .. '/// ' .. closeTag .. '\n'
+		return l
+	elseif allowEmptyTag then
+		return t .. '/// ' .. openTag:sub(1, openTag:len() - 1) .. ' />\n'
+	else
+		return ''
+	end	
 end
 
 local function formatDocString(native)
@@ -179,7 +179,7 @@ local function formatDocString(native)
 
 	if d.hasParams then
 		for _, v in ipairs(d.params) do
-			l = l .. wrapLines(v[2], '<param name="' .. (langWords[v[1]] or v[1]) .. '">', '</param>')
+			l = l .. wrapLines(v[2], '<param name="' .. (langWords[v[1]] or v[1]) .. '">', '</param>', true)
 		end
 	end
 

--- a/ext/natives/codegen_out_cs.lua
+++ b/ext/natives/codegen_out_cs.lua
@@ -457,7 +457,7 @@ local function formatImpl(native)
 	
 	appendix = appendix .. t .. '}\n'
 
-	return retType, body .. appendix .. '\t\t}\n'
+	return retType, (body .. appendix .. '\t\t}\n'), hyperDriveSafe
 end
 
 local function printNative(native)
@@ -474,7 +474,7 @@ local function printNative(native)
 	local baseAppendix = appendix
 
 	local doc = formatDocString(native)
-	local retType, def = formatImpl(native)
+	local retType, def, hyperDriveSafe = formatImpl(native)
 	local wrapper = formatWrapper(native, 'Internal' .. nativeName .. baseAppendix)
 
 	local str = string.format("%s\t\t[System.Security.SecuritySafeCritical]\n\t\tpublic static %s %s%s", doc, retType, nativeName .. appendix, wrapper)
@@ -494,9 +494,10 @@ local function printNative(native)
 		end
 	end
 	
-	str = str .. string.format("\t\t[System.Security.SecurityCritical]\n\t\tprivate static unsafe %s Internal%s%s", retType, nativeName .. baseAppendix, def)
-	str = str .. string.format("\n#if USE_HYPERDRIVE\n\t\tprivate static ScriptContext.CallFunc m_invoker%s;\n#endif\n", nativeName);
-
+	str = str .. string.format("\t\t[System.Security.SecurityCritical]\n\t\tprivate static unsafe %s Internal%s%s", retType, nativeName .. baseAppendix, def)	
+	if hyperDriveSafe then
+		str = str .. string.format("\n#if USE_HYPERDRIVE\n\t\tprivate static ScriptContext.CallFunc m_invoker%s;\n#endif\n", nativeName);
+	end	
 	return str
 end
 

--- a/ext/natives/codegen_out_cs.lua
+++ b/ext/natives/codegen_out_cs.lua
@@ -179,7 +179,7 @@ local function formatDocString(native)
 
 	if d.hasParams then
 		for _, v in ipairs(d.params) do
-			l = l .. wrapLines(v[2], '<param name="' .. v[1] .. '">', '</param>')
+			l = l .. wrapLines(v[2], '<param name="' .. (langWords[v[1]] or v[1]) .. '">', '</param>')
 		end
 	end
 


### PR DESCRIPTION
Handles, for example, ``<param name="value">`` while the function is parameterized as ``_value``