### PR TITLE
build/linux: set the number of job slots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ script:
   - curl -O -L https://github.com/grammarly/rocker/releases/download/1.3.0/rocker_linux_amd64.tar.gz
   - tar xvf rocker_linux_amd64.tar.gz
   - cd code/
-  - 'if [ -z "$TRAVIS_TAG" ]; then ../rocker build; fi'
-  - 'if [ ! -z "$TRAVIS_TAG" ]; then ../rocker build --build-arg CI_BRANCH=${GIT_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_TAG} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'
+  - 'if [ -z "$TRAVIS_TAG" ]; then ../rocker build --build-arg JOB_SLOTS=$(nproc); fi'
+  - 'if [ ! -z "$TRAVIS_TAG" ]; then ../rocker build --build-arg JOB_SLOTS=$(nproc) --build-arg CI_BRANCH=${GIT_BRANCH} --build-arg CI_BUILD_NUMBER=${TRAVIS_TAG} --auth $DOCKER_USER:$DOCKER_PASS --push; fi'

--- a/code/Rockerfile
+++ b/code/Rockerfile
@@ -2,9 +2,11 @@
 FROM alpine:3.8
 ARG CI_BRANCH
 ARG CI_BUILD_NUMBER
+ARG JOB_SLOTS
 MOUNT ..:/src
 RUN echo 'export CI_BRANCH='$CI_BRANCH > /src/.env
 RUN echo 'export CI_BUILD_NUMBER='$CI_BUILD_NUMBER >> /src/.env
+RUN echo 'export JOB_SLOTS='$JOB_SLOTS >> /src/.env
 
 # build system resources
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine3.9

--- a/code/tools/ci/build_server_2.sh
+++ b/code/tools/ci/build_server_2.sh
@@ -3,6 +3,9 @@
 # fail on error
 set -e
 
+# set the number of job slots
+JOB_SLOTS=${JOB_SLOTS:-24}
+
 # upgrade to edge
 echo http://dl-cdn.alpinelinux.org/alpine/edge/main > /etc/apk/repositories
 echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
@@ -46,7 +49,7 @@ rm premake.zip
 cd premake-*
 
 cd build/gmake.unix/
-make -j24
+make -j${JOB_SLOTS}
 cd ../../
 
 mv bin/release/premake5 /usr/local/bin
@@ -114,7 +117,7 @@ fi
 
 make clean
 make clean config=release
-make -j24 config=release
+make -j${JOB_SLOTS} config=release
 
 cd ../../../
 


### PR DESCRIPTION
Using 24 job slots for Travis is inefficient and uses too much RAM.