### PR TITLE
Changed v8 console.log() on monitormode to be sync

### DIFF
--- a/data/shared/citizen/scripting/v8/console.js
+++ b/data/shared/citizen/scripting/v8/console.js
@@ -1,8 +1,8 @@
 // Global console
 
 (function (global) {
+    const monitorMode = (GetConvar('monitormode', 'false') == 'true')  && IsDuplicityVersion();
     const percent = '%'.charCodeAt(0);
-
     const stringSpecifier = 's'.charCodeAt(0);
     const decimalSpecifier = 'd'.charCodeAt(0);
     const floatSpecifier = 'f'.charCodeAt(0);
@@ -92,7 +92,7 @@
         switch (true) {
             case arg === null:
                 return 'null';
-                
+
             case arg === undefined:
                 return 'undefined'
 
@@ -154,10 +154,10 @@
 
     /**
      * WHATWG Spec compliant formatter
-     * 
+     *
      * @see https://console.spec.whatwg.org/#formatter
-     * @param {*} message 
-     * @param {*} args 
+     * @param {*} message
+     * @param {*} args
      */
     function format(message = undefined, ...args) {
         if (typeof message === "undefined") {
@@ -204,7 +204,7 @@
             }
 
             result[result.length] = formattedMessage;
-        }        
+        }
 
         return result.concat(args.slice(usedArgs).map(formatValue)).join(' ');
     }
@@ -216,7 +216,8 @@
             this._timers = new Map();
             this._counters = new Map();
 
-            this.log = this.log.bind(this);
+            //TODO: Improve the sync console output.
+            this.log = (monitorMode)? this.logSync.bind(this) : this.log.bind(this);
             this.info = this.info.bind(this);
             this.warn = this.warn.bind(this);
             this.time = this.time.bind(this);
@@ -268,6 +269,10 @@
 
         log(message = undefined, ...optionalParams) {
             this._trace(format(message, ...optionalParams));
+        }
+
+		logSync(message = undefined, ...optionalParams) {
+			process.stdout.write(format(message, ...optionalParams)+"\n");
         }
 
         debug(message = undefined, ...optionalParams) {


### PR DESCRIPTION
This is a temporary fix for issues with node resources not giving all their console output before the process closes when executing `process.exit()`;