### PR TITLE
Removed second monitor mode banner message

### DIFF
--- a/code/components/citizen-server-monitor/src/MonitorInstance.cpp
+++ b/code/components/citizen-server-monitor/src/MonitorInstance.cpp
@@ -174,13 +174,6 @@ namespace fx
 				consoleCtx->ExecuteSingleCommandDirect(bit);
 			}
 
-			trace(R"(
-^3--------------------------------------------
-FXServerMonitor is watching over the servers
---------------------------------------------^7
-
-)");
-
 			// execute config
 			consoleCtx->ExecuteSingleCommandDirect(ProgramArguments{ "exec", "monitor_autoexec.cfg" });
 		}


### PR DESCRIPTION
This is necessary due to the fact that `trace()` is async and its possible for resources to send sync messages, effectively cutting this message in half.