### PR TITLE
gameconfig: increase FragmentStore

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -270,7 +270,7 @@
 						</Item>
 						<Item>
 							<PoolName>FragmentStore</PoolName>
-							<PoolSize value="24000"/>
+							<PoolSize value="48000"/>
 						</Item>
 						<Item>
 							<PoolName>GamePlayerBroadcastDataHandler_Remote</PoolName>


### PR DESCRIPTION
This increases FragmentStore from 24000 to 48000 so more vehicle modkits can be streamed.