### PR TITLE
Added null-terminator to end of event name for latent events

### DIFF
--- a/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
+++ b/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
@@ -676,7 +676,7 @@ static InitFunction initFunction([] ()
 			int bps = context.GetArgument<int>(3);
 
 			auto reassembler = Instance<fx::ResourceManager>::Get()->GetComponent<fx::EventReassemblyComponent>();
-			reassembler->TriggerEvent(0, eventName, eventPayload, bps);
+			reassembler->TriggerEvent(0, std::string_view{ eventName.c_str(), eventName.size() + 1 }, eventPayload, bps);
 		});
 
 		netLibrary->OnFinalizeDisconnect.Connect([=](NetAddress)

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -645,7 +645,7 @@ static InitFunction initFunction2([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("TRIGGER_LATENT_CLIENT_EVENT_INTERNAL", [](fx::ScriptContext& context)
 	{
-		std::string_view eventName = context.CheckArgument<const char*>(0);
+		std::string eventName = context.CheckArgument<const char*>(0);
 		auto targetSrcIdx = context.CheckArgument<const char*>(1);
 
 		const void* data = context.GetArgument<const void*>(2);
@@ -659,7 +659,7 @@ static InitFunction initFunction2([]()
 		// get the owning server instance
 		auto rac = resourceManager->GetComponent<fx::EventReassemblyComponent>();
 
-		rac->TriggerEvent(std::stoi(targetSrcIdx), eventName, std::string_view{ reinterpret_cast<const char*>(data), dataLen }, bps);
+		rac->TriggerEvent(std::stoi(targetSrcIdx), std::string_view{ eventName.c_str(), eventName.size() + 1 }, std::string_view{ reinterpret_cast<const char*>(data), dataLen }, bps);
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("START_RESOURCE", [](fx::ScriptContext& context)


### PR DESCRIPTION
This fixed the bug causing latent events' name to stick around after using a longer name