### PR TITLE
Added resource name to process warnings

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -161,6 +161,11 @@ const EXT_LOCALFUNCREF = 11;
 	const rawEmitter = new EventEmitter2();
 	const netSafeEventNames = new Set(['playerDropped', 'playerConnecting']);
 
+	//Process warnings
+	process.on('warning', (warning) => {
+		console.log(`Resource ${GetCurrentResourceName()} warning: ${warning.message}`);
+	});
+
 	// Raw events
 	global.addRawEventListener = rawEmitter.on.bind(rawEmitter);
 	global.addRawEventHandler = global.addRawEventListener;
@@ -297,6 +302,7 @@ const EXT_LOCALFUNCREF = 11;
 		return frames;
 	}
 	
+	Error.stackTraceLimit = 16;
 	Error.prepareStackTrace = prepareStackTrace;
 	
 	class StackDumpError {


### PR DESCRIPTION
This was done to help see the culprit of random deprecation warnings.  
TODO: show the stack.