### PR TITLE
Improvements in rotation/heading serverside natives

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1479,7 +1479,21 @@ struct CPedHealthDataNode
 struct CPedMovementGroupDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedAIDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedAppearanceDataNode { bool Parse(SyncParseState& state) { return true; } };
-struct CPedOrientationDataNode { bool Parse(SyncParseState& state) { return true; } };
+
+struct CPedOrientationDataNode
+{
+	bool Parse(SyncParseState& state)
+	{
+		auto currentHeading = state.buffer.ReadSignedFloat(8, 6.28318548f);
+		auto desiredHeading = state.buffer.ReadSignedFloat(8, 6.28318548f);
+
+		state.entity->data["currentHeading"] = currentHeading;
+		state.entity->data["desiredHeading"] = desiredHeading;
+
+		return true;
+	}
+};
+
 struct CPedMovementDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedTaskTreeDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPedTaskSpecificDataNode { bool Parse(SyncParseState& state) { return true; } };

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -167,16 +167,37 @@ static InitFunction initFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_ROTATION", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
 		scrVector resultVec = { 0 };
-		resultVec.x = entity->GetData("rotX", 0.0f) * 180.0 / pi;
-		resultVec.y = entity->GetData("rotY", 0.0f) * 180.0 / pi;
-		resultVec.z = entity->GetData("rotZ", 0.0f) * 180.0 / pi;
+
+		if (entity->type == fx::sync::NetObjEntityType::Player || entity->type == fx::sync::NetObjEntityType::Ped)
+		{
+			resultVec.x = 0.0f;
+			resultVec.y = 0.0f;
+			resultVec.z = entity->GetData("currentHeading", 0.0f) * 180.0 / pi;
+		}
+		else
+		{
+			resultVec.x = entity->GetData("rotX", 0.0f) * 180.0 / pi;
+			resultVec.y = entity->GetData("rotY", 0.0f) * 180.0 / pi;
+			resultVec.z = entity->GetData("rotZ", 0.0f) * 180.0 / pi;
+		}
 
 		return resultVec;
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_HEADING", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
-		return entity->GetData("angVelZ", 0.0f) * 180.0 / pi;
+		float heading;
+
+		if (entity->type == fx::sync::NetObjEntityType::Player || entity->type == fx::sync::NetObjEntityType::Ped)
+		{
+			heading = entity->GetData("currentHeading", 0.0f) * 180.0 / pi;
+		}
+		else
+		{
+			heading = entity->GetData("rotZ", 0.0f) * 180.0 / pi;
+		}
+
+		return (heading < 0) ? 360.0f + heading : heading;
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_POPULATION_TYPE", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
@@ -429,6 +450,17 @@ static InitFunction initFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("GET_PED_CAUSE_OF_DEATH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
 	{
 		return entity->GetData("causeOfDeath", 0);
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_DESIRED_HEADING", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)
+	{
+		if (entity->type == fx::sync::NetObjEntityType::Player || entity->type == fx::sync::NetObjEntityType::Ped)
+		{
+			float heading = entity->GetData("desiredHeading", 0.0f) * 180.0 / pi;
+			return (heading < 0) ? 360.0f + heading : heading;
+		}
+
+		return 0.0f;
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_MAX_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const std::shared_ptr<fx::sync::SyncEntityState>& entity)


### PR DESCRIPTION
1) Fixed `GET_ENTITY_ROTATION` and `GET_ENTITY_HEADING` when target entity is a ped/player. (https://forum.cfx.re/t/getentityheading-doesnt-work-on-server-side/1056285)
2) Changed `GET_ENTITY_HEADING` bounds from `-180f -> 180f` to `0f -> 360f` since clientside native uses that.
3) Added `GET_PED_DESIRED_HEADING` native.