### PR TITLE
Fix oversight in acceleration and current rpm offsets

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -335,8 +335,8 @@ static HookFunction initFunction([]()
 	{
 		auto location = hook::get_pattern<char>("F6 83 ? ? ? ? 07 75 ? 44 0F");
 
-		AccelerationOffset = *(uint32_t*)(location - 42);
-		CurrentRPMOffset = *(uint32_t*)(location + 2);
+		CurrentRPMOffset = *(uint32_t*)(location - 42);
+		AccelerationOffset = CurrentRPMOffset + 16;
 	}
 
 	{


### PR DESCRIPTION
Fixes regressions introduced in https://github.com/citizenfx/fivem/pull/397
https://forum.cfx.re/t/getvehiclecurrentrpm-not-working-since-last-client-update/1093214

Related natives:
```cpp
GET_VEHICLE_CURRENT_ACCELERATION
GET_VEHICLE_CURRENT_RPM
SET_VEHICLE_CURRENT_RPM
```