### PR TITLE
fix: return proper rotation

### DIFF
--- a/code/client/clrcore/Server/Entity.cs
+++ b/code/client/clrcore/Server/Entity.cs
@@ -38,7 +38,7 @@ namespace CitizenFX.Core
 		{
 			get
 			{
-				return API.GetEntityRotation(this.Handle);
+				return API.GetEntityRotation(this.Handle, 4);
 			}
 			set
 			{


### PR DESCRIPTION
So I was messing around with entity rotation. I couldn't figure out which order to use, so I messed around with API.GetEntityRotation and this fixed my rotation issues. It returns local rotation of the entity.