### PR TITLE
server: added check if ped exists

### DIFF
--- a/code/client/clrcore/Server/Ped.cs
+++ b/code/client/clrcore/Server/Ped.cs
@@ -20,7 +20,7 @@ namespace CitizenFX.Core
 		{
 			int entityHandle = API.GetPlayerPed(handle);
 
-			if (API.GetEntityType(entityHandle) == 1)
+			if (API.DoesEntityExist(entityHandle) && API.GetEntityType(entityHandle) == 1)
 			{
 				return new Ped(entityHandle);
 			}


### PR DESCRIPTION
If you use `player.Character` e.g. shortly after a player connected, then you have a chance of running into:
```
InvokeNative: execution failed: Tried to access invalid entity: 137485
```

This will check if the entity exists, before calling another native.