### PR TITLE
Mumble volume override by server ID

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -670,6 +670,17 @@ static HookFunction hookFunction([]()
 			}
 		});
 
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_VOLUME_OVERRIDE_BY_SERVER_ID", [](fx::ScriptContext& context)
+		{
+			int serverId = context.GetArgument<int>(0);
+			float volume = context.GetArgument<float>(1);
+
+			if (g_mumble.connected)
+			{
+				g_mumbleClient->SetClientVolumeOverrideByServerId(serverId, volume);
+			}
+		});
+
 		static VoiceTargetConfig vtConfigs[31];
 
 		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_CLEAR_VOICE_TARGET", [](fx::ScriptContext& context)

--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -89,6 +89,8 @@ public:
 
 	virtual void SetClientVolumeOverride(const std::string& clientName, float volume) = 0;
 
+	virtual void SetClientVolumeOverrideByServerId(uint32_t serverId, float volume) = 0;
+
 	virtual void GetTalkers(std::vector<std::string>* names) = 0;
 
 	virtual void SetPositionHook(const TPositionHook& hook) = 0;

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -100,6 +100,8 @@ public:
 
 	virtual void SetClientVolumeOverride(const std::string& clientName, float volume) override;
 
+	virtual void SetClientVolumeOverrideByServerId(uint32_t serverId, float volume) override;
+
 	virtual void GetTalkers(std::vector<std::string>* referenceIds) override;
 
 	virtual void SetPositionHook(const TPositionHook& hook) override;

--- a/code/components/voip-mumble/include/MumbleClientState.h
+++ b/code/components/voip-mumble/include/MumbleClientState.h
@@ -50,6 +50,8 @@ private:
 
 	uint32_t m_session;
 
+	uint32_t m_serverId;
+
 	std::wstring m_name;
 
 	uint32_t m_currentChannelId;
@@ -73,6 +75,8 @@ public:
 	}
 
 	inline uint32_t GetSessionId() const { return m_session; }
+
+	inline uint32_t GetServerId() const { return m_serverId; }
 
 	inline std::wstring GetName() const { return m_name; }
 

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -446,6 +446,17 @@ void MumbleClient::SetClientVolumeOverride(const std::string& clientName, float 
 	});
 }
 
+void MumbleClient::SetClientVolumeOverrideByServerId(uint32_t serverId, float volume)
+{
+	m_state.ForAllUsers([this, serverId, volume](const std::shared_ptr<MumbleUser>& user)
+	{
+		if (user->GetServerId() == serverId)
+		{
+			GetOutput().HandleClientVolumeOverride(*user, volume);
+		}
+	});
+}
+
 void MumbleClient::GetTalkers(std::vector<std::string>* referenceIds)
 {
 	referenceIds->clear();

--- a/code/components/voip-mumble/src/MumbleClientState_User.cpp
+++ b/code/components/voip-mumble/src/MumbleClientState_User.cpp
@@ -35,7 +35,16 @@ void MumbleUser::UpdateUser(MumbleProto::UserState& state)
 
 	if (state.has_name())
 	{
-		m_name = ConvertFromUTF8(state.name());
+		std::string name = state.name();
+		m_name = ConvertFromUTF8(name);
+		if (name.length() >= 2)
+		{
+			m_serverId = atoi(name.substr(1, name.length() - 1).c_str());
+		} 
+		else
+		{
+			m_serverId = 0;
+		}
 	}
 
 	if (state.has_mute())


### PR DESCRIPTION
Re-referenced to https://github.com/citizenfx/fivem/pull/404 with the requested changes. 
Couldn't get it to rebase properly.