### PR TITLE
mumble: implement new natives

### DIFF
--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -51,7 +51,7 @@ struct VoiceTargetConfig
 {
 	struct Target
 	{
-		std::vector<std::string> users;
+		std::vector<std::wstring> users;
 		std::string channel;
 		// ACL is not supported in umurmur, so does not count
 		bool links;
@@ -87,9 +87,11 @@ public:
 
 	virtual void SetChannel(const std::string& channelName) = 0;
 
-	virtual void SetClientVolumeOverride(const std::string& clientName, float volume) = 0;
+	virtual void SetClientVolumeOverride(const std::wstring& clientName, float volume) = 0;
 
 	virtual void SetClientVolumeOverrideByServerId(uint32_t serverId, float volume) = 0;
+
+	virtual std::wstring GetPlayerNameFromServerId(uint32_t serverId) = 0;
 
 	virtual void GetTalkers(std::vector<std::string>* names) = 0;
 

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -98,9 +98,11 @@ public:
 
 	virtual std::shared_ptr<lab::AudioContext> GetAudioContext(const std::string& name) override;
 
-	virtual void SetClientVolumeOverride(const std::string& clientName, float volume) override;
+	virtual void SetClientVolumeOverride(const std::wstring& clientName, float volume) override;
 
 	virtual void SetClientVolumeOverrideByServerId(uint32_t serverId, float volume) override;
+
+	virtual std::wstring GetPlayerNameFromServerId(uint32_t serverId) override;
 
 	virtual void GetTalkers(std::vector<std::string>* referenceIds) override;
 

--- a/code/components/voip-mumble/include/MumbleClientState.h
+++ b/code/components/voip-mumble/include/MumbleClientState.h
@@ -122,6 +122,13 @@ public:
 
 	inline std::map<uint32_t, MumbleChannel>& GetChannels() { return m_channels; }
 
+	inline std::map<uint32_t, std::shared_ptr<MumbleUser>> GetUsers()
+	{
+		std::shared_lock<std::shared_mutex> lock(m_usersMutex);
+
+		return m_users;
+	}
+
 	inline std::shared_ptr<MumbleUser> GetUser(uint32_t id)
 	{
 		std::shared_lock<std::shared_mutex> lock(m_usersMutex);

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -216,7 +216,7 @@ void MumbleClient::Initialize()
 							{
 								m_state.ForAllUsers([this, &userName, &vt](const std::shared_ptr<MumbleUser>& user)
 								{
-									if (user->GetName() == ToWide(userName))
+									if (user->GetName() == userName)
 									{
 										vt->add_session(user->GetSessionId());
 									}
@@ -435,11 +435,11 @@ float MumbleClient::GetInputAudioLevel()
 	return m_audioInput.GetAudioLevel();
 }
 
-void MumbleClient::SetClientVolumeOverride(const std::string& clientName, float volume)
+void MumbleClient::SetClientVolumeOverride(const std::wstring& clientName, float volume)
 {
 	m_state.ForAllUsers([this, &clientName, volume](const std::shared_ptr<MumbleUser>& user)
 	{
-		if (user->GetName() == ToWide(clientName))
+		if (user->GetName() == clientName)
 		{
 			GetOutput().HandleClientVolumeOverride(*user, volume);
 		}
@@ -455,6 +455,17 @@ void MumbleClient::SetClientVolumeOverrideByServerId(uint32_t serverId, float vo
 			GetOutput().HandleClientVolumeOverride(*user, volume);
 		}
 	});
+}
+
+std::wstring MumbleClient::GetPlayerNameFromServerId(uint32_t serverId)
+{
+	for (auto& user : m_state.GetUsers())
+	{
+		if (user.second && user.second->GetServerId() == serverId)
+		{
+			return user.second->GetName();
+;		}
+	}
 }
 
 void MumbleClient::GetTalkers(std::vector<std::string>* referenceIds)

--- a/code/components/voip-server-mumble/component.json
+++ b/code/components/voip-server-mumble/component.json
@@ -6,6 +6,7 @@
 		"net:tcp-server",
 		"citizen:server:instance",
 		"citizen:server:net",
+		"scripting",
 		"vendor:protobuf_lite",
 		"vendor:mbedtls"
 	],

--- a/code/components/voip-server-mumble/include/ServerMumbleVoice.h
+++ b/code/components/voip-server-mumble/include/ServerMumbleVoice.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace fx
+{
+	class MumbleVoice
+	{
+	public:
+		static void CreateChannel(int channelId);
+	};
+}

--- a/code/components/voip-server-mumble/src/ServerMumbleVoice.cpp
+++ b/code/components/voip-server-mumble/src/ServerMumbleVoice.cpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <StdInc.h>
+#include <ScriptEngine.h>
+
+#include <ServerMumbleVoice.h>
+#include "channel.h"
+
+void fx::MumbleVoice::CreateChannel(const int id)
+{
+	const std::string channelName = fmt::sprintf("Game Channel %d", id);
+
+	channel_t* parent = Chan_fromId(0);
+	if (parent == NULL)
+		return;
+
+	channel_t* channel_itr = NULL;
+	while (Chan_iterate_siblings(parent, &channel_itr) != NULL) {
+		if (strcmp(channel_itr->name, channelName.c_str()) == 0) {
+			break;
+		}
+	}
+
+	if (channel_itr != NULL)
+		return;
+
+	channel_t* newChannel = Chan_createChannel(channelName.c_str(), "Permanent channel.");
+	//newChannel->position = id;
+	newChannel->password = NULL;
+	newChannel->noenter = false;
+	newChannel->silent = false;
+
+	Chan_addChannel(parent, newChannel);
+}
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("MUMBLE_CREATE_CHANNEL", [](fx::ScriptContext& context)
+	{
+		int channelId = context.GetArgument<int>(0);
+
+		if (channelId != 0)
+		{
+			fx::MumbleVoice::CreateChannel(channelId);
+		}
+	});
+});


### PR DESCRIPTION
`MUMBLE_CREATE_CHANNEL` is a server-side native to create persistent mumble channels.
This would make the "grid channels" better as you do not have to worry about non-existing channels.