### PR TITLE
Text natives for RedM

### DIFF
--- a/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
@@ -7,14 +7,16 @@
 
 #include <StdInc.h>
 
-#if defined(GTA_FIVE)
 #include <ScriptEngine.h>
 
 #include <Resource.h>
 #include <fxScripting.h>
 
 #include <CustomText.h>
+
+#if defined(GTA_FIVE)
 #include <sfFontStuff.h>
+#endif
 
 static bool AddTextEntryForResource(fx::Resource* resource, uint32_t hashKey, const char* textValue)
 {
@@ -94,6 +96,7 @@ static InitFunction initFunction([] ()
 		context.SetResult<bool>(false);
 	});
 
+#if defined(GTA_FIVE)
 	fx::ScriptEngine::RegisterNativeHandler("REGISTER_FONT_ID", [](fx::ScriptContext& context)
 	{
 		context.SetResult(sf::RegisterFontIndex(context.GetArgument<const char*>(0)));
@@ -142,5 +145,5 @@ static InitFunction initFunction([] ()
 			context.GetArgument<float>(3), context.GetArgument<float>(4),
 			context.GetArgument<float>(5));
 	});
-});
 #endif
+});

--- a/code/components/gta-core-rdr3/include/CustomText.h
+++ b/code/components/gta-core-rdr3/include/CustomText.h
@@ -1,0 +1,23 @@
+/*
+* This file is part of the CitizenFX project - http://citizen.re/
+*
+* See LICENSE and MENTIONS in the root of the source tree for information
+* regarding licensing.
+*/
+
+#pragma once
+
+#ifdef COMPILING_GTA_CORE_RDR3
+#define GTA_CORE_EXPORT DLL_EXPORT
+#else
+#define GTA_CORE_EXPORT DLL_IMPORT
+#endif
+
+namespace game
+{
+	void GTA_CORE_EXPORT AddCustomText(const std::string& key, const std::string& value);
+
+	void GTA_CORE_EXPORT AddCustomText(uint32_t hash, const std::string& value);
+
+	void GTA_CORE_EXPORT RemoveCustomText(uint32_t hash);
+}

--- a/code/components/gta-core-rdr3/src/CustomText.cpp
+++ b/code/components/gta-core-rdr3/src/CustomText.cpp
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include "StdInc.h"
+#include "Hooking.h"
+#include "MinHook.h"
+
+#include <mutex>
+#include <stack>
+
+#include <boost/optional.hpp>
+
+#include <CustomText.h>
+
+static const char* (*g_origGetText)(void* theText, int a2, uint32_t* hash, int* a4);
+
+static std::mutex g_textMutex;
+static std::unordered_map<uint32_t, std::string> g_textMap;
+
+static const char* GetText(void* theText, int a2, uint32_t* hash, int* a4)
+{
+	{
+		std::unique_lock<std::mutex> lock(g_textMutex);
+
+		auto it = g_textMap.find(*hash);
+
+		if (it != g_textMap.end())
+		{
+			return it->second.c_str();
+		}
+	}
+
+	return g_origGetText(theText, a2, hash, a4);
+}
+
+void AddCustomText(const char* key, const char* value)
+{
+	std::unique_lock<std::mutex> lock(g_textMutex);
+	g_textMap[HashString(key)] = value;
+}
+
+namespace game
+{
+	void AddCustomText(const std::string& key, const std::string& value)
+	{
+		AddCustomText(HashString(key.c_str()), value);
+	}
+
+	void AddCustomText(uint32_t hash, const std::string& value)
+	{
+		std::unique_lock<std::mutex> lock(g_textMutex);
+		g_textMap[hash] = value;
+	}
+
+	void RemoveCustomText(uint32_t hash)
+	{
+		std::unique_lock<std::mutex> lock(g_textMutex);
+
+		g_textMap.erase(hash);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	g_textMap[0xB3390E91] = "Build ~1~ (RedM)";
+
+	MH_Initialize();
+	MH_CreateHook(hook::get_pattern("48 81 C1 D0 00 00 00 E8 ? ? ? ? 48 8B CE 83 FB FF 74 ? 44 8B 44 24 50", -57), GetText, (void**)&g_origGetText);
+	MH_EnableHook(MH_ALL_HOOKS);
+});


### PR DESCRIPTION
Backported code allowing people to use `ADD_TEXT_ENTRY` and `ADD_TEXT_ENTRY_BY_HASH` natives in RedM.
![image](https://user-images.githubusercontent.com/10367215/79247750-9727b980-7e83-11ea-900d-65ecb0fb5dde.png)
![image](https://user-images.githubusercontent.com/10367215/79247799-a3ac1200-7e83-11ea-9adb-768c5838466b.png)
