### PR TITLE
[OneSync] Improve entity iteration logic

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1256,7 +1256,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 
 	for (int entityIndex = 0; entityIndex < maxValidEntity; entityIndex++)
 	{
-		relevantEntities[maxValidEntity] = {};
+		relevantEntities[entityIndex] = {};
 	}
 
 	++m_frameIndex;


### PR DESCRIPTION
Change how entities are iterated through in the main thread loop to improve performance. See commit for more details.