### PR TITLE
native-decls: remove useless aliases

### DIFF
--- a/ext/native-decls/GetVehicleWheelRimColliderSize.md
+++ b/ext/native-decls/GetVehicleWheelRimColliderSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["GET_VEHICLE_WHEEL_RIM_COLLIDER_SIZE"]
 ---
 ## GET_VEHICLE_WHEEL_RIM_COLLIDER_SIZE
 

--- a/ext/native-decls/GetVehicleWheelSize.md
+++ b/ext/native-decls/GetVehicleWheelSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["GET_VEHICLE_WHEEL_SIZE"]
 ---
 ## GET_VEHICLE_WHEEL_SIZE
 

--- a/ext/native-decls/GetVehicleWheelTireColliderSize.md
+++ b/ext/native-decls/GetVehicleWheelTireColliderSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["GET_VEHICLE_WHEEL_TIRE_COLLIDER_SIZE"]
 ---
 ## GET_VEHICLE_WHEEL_TIRE_COLLIDER_SIZE
 

--- a/ext/native-decls/GetVehicleWheelTireColliderWidth.md
+++ b/ext/native-decls/GetVehicleWheelTireColliderWidth.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["GET_VEHICLE_WHEEL_TIRE_COLLIDER_WIDTH"]
 ---
 ## GET_VEHICLE_WHEEL_TIRE_COLLIDER_WIDTH
 

--- a/ext/native-decls/GetVehicleWheelWidth.md
+++ b/ext/native-decls/GetVehicleWheelWidth.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["GET_VEHICLE_WHEEL_WIDTH"]
 ---
 ## GET_VEHICLE_WHEEL_WIDTH
 

--- a/ext/native-decls/SetVehicleWheelRimColliderSize.md
+++ b/ext/native-decls/SetVehicleWheelRimColliderSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["SET_VEHICLE_WHEEL_RIM_COLLIDER_SIZE"]
 ---
 ## SET_VEHICLE_WHEEL_RIM_COLLIDER_SIZE
 

--- a/ext/native-decls/SetVehicleWheelSize.md
+++ b/ext/native-decls/SetVehicleWheelSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["SET_VEHICLE_WHEEL_SIZE"]
 ---
 ## SET_VEHICLE_WHEEL_SIZE
 

--- a/ext/native-decls/SetVehicleWheelTireColliderSize.md
+++ b/ext/native-decls/SetVehicleWheelTireColliderSize.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["SET_VEHICLE_WHEEL_TIRE_COLLIDER_SIZE"]
 ---
 ## SET_VEHICLE_WHEEL_TIRE_COLLIDER_SIZE
 

--- a/ext/native-decls/SetVehicleWheelTireColliderWidth.md
+++ b/ext/native-decls/SetVehicleWheelTireColliderWidth.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["SET_VEHICLE_WHEEL_TIRE_COLLIDER_WIDTH"]
 ---
 ## SET_VEHICLE_WHEEL_TIRE_COLLIDER_WIDTH
 

--- a/ext/native-decls/SetVehicleWheelWidth.md
+++ b/ext/native-decls/SetVehicleWheelWidth.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-aliases: ["SET_VEHICLE_WHEEL_WIDTH"]
 ---
 ## SET_VEHICLE_WHEEL_WIDTH
 


### PR DESCRIPTION
This removes useless aliases for these extra natives
* [GetVehicleWheelWidth](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/GetVehicleWheelWidth.md)
* [GetVehicleWheelSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/GetVehicleWheelSize.md)
* [GetVehicleWheelTireColliderWidth](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/GetVehicleWheelTireColliderWidth.md)
* [GetVehicleWheelTireColliderSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/GetVehicleWheelTireColliderSize.md)
* [GetVehicleWheelRimColliderSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/GetVehicleWheelRimColliderSize.md)

* [SetVehicleWheelWidth](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/SetVehicleWheelWidth.md)
* [SetVehicleWheelSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/SetVehicleWheelSize.md)
* [SetVehicleWheelTireColliderWidth](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/SetVehicleWheelTireColliderWidth.md)
* [SetVehicleWheelTireColliderSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/SetVehicleWheelTireColliderSize.md)
* [SetVehicleWheelRimColliderSize](https://github.com/citizenfx/fivem/blob/master/ext/native-decls/SetVehicleWheelRimColliderSize.md)

which were introduced in: 
* https://github.com/citizenfx/fivem/pull/361 + https://github.com/citizenfx/natives/pull/247
* https://github.com/citizenfx/fivem/pull/367 + https://github.com/citizenfx/natives/pull/252