### PR TITLE
onesync: add CClearPedTasksEvent server event

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3249,7 +3249,7 @@ struct CClearPedTasksEvent
 	void Parse(rl::MessageBuffer& buffer)
 	{
 		pedId = buffer.Read<uint16_t>(13);
-		unk1 = buffer.Read<uint8_t>(1);
+		immediately = buffer.Read<uint8_t>(1);
 	}
 
 	inline std::string GetName()
@@ -3258,9 +3258,9 @@ struct CClearPedTasksEvent
 	}
 
 	int pedId;
-	bool unk1;
+	bool immediately;
 
-	MSGPACK_DEFINE_MAP(pedId, unk1);
+	MSGPACK_DEFINE_MAP(pedId, immediately);
 };
 
 struct CRespawnPlayerPedEvent

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3244,6 +3244,24 @@ struct CVehicleComponentControlEvent
 	MSGPACK_DEFINE_MAP(vehicleGlobalId, pedGlobalId, componentIndex, request, componentIsSeat, pedInSeat);
 };
 
+struct CClearPedTasksEvent
+{
+	void Parse(rl::MessageBuffer& buffer)
+	{
+		pedId = buffer.Read<uint16_t>(13);
+		unk1 = buffer.Read<uint8_t>(1);
+	}
+
+	inline std::string GetName()
+	{
+		return "clearPedTasksEvent";
+	}
+
+	int pedId;
+	bool unk1;
+
+	MSGPACK_DEFINE_MAP(pedId, unk1);
+};
 
 struct CRespawnPlayerPedEvent
 {
@@ -3459,6 +3477,7 @@ static std::function<bool()> GetEventHandler(fx::ServerInstanceBase* instance, c
 		case VEHICLE_COMPONENT_CONTROL_EVENT: return GetHandler<CVehicleComponentControlEvent>(instance, client, std::move(buffer));
 		case FIRE_EVENT: return GetHandler<CFireEvent>(instance, client, std::move(buffer));
 		case EXPLOSION_EVENT: return GetHandler<CExplosionEvent>(instance, client, std::move(buffer));
+		case NETWORK_CLEAR_PED_TASKS_EVENT: return GetHandler<CClearPedTasksEvent>(instance, client, std::move(buffer));
 	};
 
 	return {};


### PR DESCRIPTION
Seems to work fine when tested with 2 players.
Example usage:
```lua
AddEventHandler("clearPedTasksEvent", function(sender, data)
    print(sender, GetPlayerName(sender), json.encode(data))
    -- 128, SloPro, { "pedId": 1, "unk1": true }
end)
```
Can be cancelled to prevent syncing.