### PR TITLE
fix: gracefully handle invalid UTF-8 sequences

### DIFF
--- a/code/client/citicore/StructuredTraceImpl.cpp
+++ b/code/client/citicore/StructuredTraceImpl.cpp
@@ -46,7 +46,7 @@ extern "C" void DLL_EXPORT StructuredTraceReal(const char* channel, const char* 
 		{ "file", file },
 		{ "line", line },
 		{ "data", j }
-	}).dump());
+	}).dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace));
 
 	g_consoleCondVar.notify_all();
 }

--- a/code/shared/StructuredTrace.h
+++ b/code/shared/StructuredTrace.h
@@ -41,7 +41,10 @@ extern "C" void StructuredTraceReal(const char* channel, const char* func, const
 
 #define StructuredTrace(...) do { \
 	if (StructuredTraceEnabled()) { \
+		try { \
 		StructuredTraceReal(_CFX_NAME_STRING(_CFX_COMPONENT_NAME), _CFX_TRACE_FUNC, _CFX_TRACE_FILE, __LINE__, nlohmann::json::object({ __VA_ARGS__ })); \
+		} catch (const std::exception& e) { \
+		} \
 	} \
 } while (false);
 


### PR DESCRIPTION
Possibly standardize this across all nlohmann::json::dump invocations? e.g., citizen-game, etc.

Initially reported by Willemde20