### PR TITLE
Increase "ClothStore" poolsize from 60 to 600

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -154,7 +154,7 @@
 						</Item>
 						<Item>
 							<PoolName>ClothStore</PoolName>
-							<PoolSize value="60"/>
+							<PoolSize value="600"/>
 						</Item>
 						<Item>
 							<PoolName>CombatMeleeManager_Groups</PoolName>


### PR DESCRIPTION
A few months back I hit this limit with a bunch of models with cloth physics (yld files) seems I am back at that roadblock again (this time with only 4 models that have cloth physics). The current value of 60 does seem a bit low so increasing this doesn't seem to do much harm at 600. Probably can be tweaked in the future if necessary.

(redid this PR because the last one was absolutely horridly confusing)