### PR TITLE
feat(mumble): support external voice server

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -860,7 +860,7 @@ static HookFunction hookFunction([]()
 			}
 			else
 			{
-				trace("Exception: Couldn't resolve Mumble server address.\n");
+				throw std::exception("Couldn't resolve Mumble server address.");
 			}
 		});
 

--- a/ext/native-decls/MumbleIsConnected.md
+++ b/ext/native-decls/MumbleIsConnected.md
@@ -1,0 +1,12 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_IS_CONNECTED
+
+```c
+BOOL MUMBLE_IS_CONNECTED();
+```
+
+## Return value
+True if the player is connected to a mumble server.

--- a/ext/native-decls/MumbleIsConnected.md
+++ b/ext/native-decls/MumbleIsConnected.md
@@ -8,5 +8,8 @@ apiset: client
 BOOL MUMBLE_IS_CONNECTED();
 ```
 
+This native will return true if the user succesfully connected to the voice server.
+If the user disabled the voice-chat setting it will return false.
+
 ## Return value
 True if the player is connected to a mumble server.

--- a/ext/native-decls/MumbleSetServerAddress.md
+++ b/ext/native-decls/MumbleSetServerAddress.md
@@ -1,0 +1,13 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_SET_SERVER_ADDRESS
+
+```c
+void MUMBLE_SET_SERVER_ADDRESS(char* address, int port);
+```
+
+## Parameters
+* **address**: The address of the mumble server.
+* **port**: The port of the mumble server.

--- a/ext/native-decls/MumbleSetServerAddress.md
+++ b/ext/native-decls/MumbleSetServerAddress.md
@@ -8,6 +8,8 @@ apiset: client
 void MUMBLE_SET_SERVER_ADDRESS(char* address, int port);
 ```
 
+Changes the Mumble server address to connect to, and reconnects to the new address.
+
 ## Parameters
 * **address**: The address of the mumble server.
 * **port**: The port of the mumble server.


### PR DESCRIPTION
This has been tested with the mumble server component removed and using two external grumble servers