### PR TITLE
fix(nui): only refocus iframe if we are in the parent body

### DIFF
--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -88,8 +88,10 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		
 		frameEscapeFunctions[frameName] = () => {
 			setTimeout(() => {
-				frame.contentWindow.focus();
-			});
+				if (document.activeElement == document.body) {
+					frame.contentWindow.focus();
+				}
+			}, 32);
 		}
 
 		frame.contentWindow.GetParentResourceName = function()


### PR DESCRIPTION
This will only re-focus if we tabbed to the body element, and not a child iframe.