### PR TITLE
Fix a typo on the UI

### DIFF
--- a/ext/cfx-ui/src/app/servers/connecting-popup.component.ts
+++ b/ext/cfx-ui/src/app/servers/connecting-popup.component.ts
@@ -39,7 +39,7 @@ export class ConnectingPopupComponent implements OnInit {
 			this.overlayTitle = '#Servers_Connecting';
 			this.overlayMessage = '#Servers_ConnectingTo';
 			this.overlayMessageData = {
-				serverName: a?.address || 'unkown',
+				serverName: a?.address || 'unknown',
 			};
 			this.showOverlay = true;
 			this.overlayClosable = false;


### PR DESCRIPTION
This typo shows up when joining a server using `fivem://connect/cfx.re/join/{token}`.

Example:
![image](https://user-images.githubusercontent.com/16978528/90713561-74a31400-e25a-11ea-876f-2365a5e0c252.png)
