### PR TITLE
Create Statebags abstraction for JS

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="./natives_universal.d.ts"/>
+/// <reference path="./natives_server.d.ts"/>
 
 interface IntPtrInitialized {}
 interface FloatPtrInitialized {}
@@ -29,39 +29,39 @@ type InputArgument =
     ResultAsLong |
     ResultAsObject;
 
-interface CitizenInterface {
-    trace(...args: string[]): void
-    setTickFunction(callback: Function): void
-    setEventFunction(callback: Function): void
+// interface CitizenInterface {
+//     trace(...args: string[]): void
+//     setTickFunction(callback: Function): void
+//     setEventFunction(callback: Function): void
 
-    setCallRefFunction(callback: Function): void
-    setDeleteRefFunction(callback: Function): void
-    setDuplicateRefFunction(callback: Function): void
-    canonicalizeRef(ref: number): string
-    invokeFunctionReference(ref: string, args: Uint8Array): Uint8Array
+//     setCallRefFunction(callback: Function): void
+//     setDeleteRefFunction(callback: Function): void
+//     setDuplicateRefFunction(callback: Function): void
+//     canonicalizeRef(ref: number): string
+//     invokeFunctionReference(ref: string, args: Uint8Array): Uint8Array
 
-    getTickCount(): number
-    invokeNative<T = void>(hash: string, ...args: InputArgument[]): T
-    startProfiling(name?: string): void
-    stopProfiling(name?: string): {}
+//     getTickCount(): number
+//     invokeNative<T = void>(hash: string, ...args: InputArgument[]): T
+//     startProfiling(name?: string): void
+//     stopProfiling(name?: string): {}
 
-    pointerValueIntInitialized(): IntPtrInitialized
-    pointerValueFloatInitialized(): FloatPtrInitialized
-    pointerValueInt(): IntPtr
-    pointerValueFloat(): FloatPtr
-    pointerValueVector(): VectorPtr
-    returnResultAnyway(): ReturnResultAnyway
-    resultAsInteger(): ResultAsInteger
-    resultAsFloat(): ResultAsFloat
-    resultAsString(): ResultAsString
-    resultAsVector(): ResultAsVector
-    resultAsLong(): ResultAsLong
-    rsesultAsObject(): ResultAsObject
+//     pointerValueIntInitialized(): IntPtrInitialized
+//     pointerValueFloatInitialized(): FloatPtrInitialized
+//     pointerValueInt(): IntPtr
+//     pointerValueFloat(): FloatPtr
+//     pointerValueVector(): VectorPtr
+//     returnResultAnyway(): ReturnResultAnyway
+//     resultAsInteger(): ResultAsInteger
+//     resultAsFloat(): ResultAsFloat
+//     resultAsString(): ResultAsString
+//     resultAsVector(): ResultAsVector
+//     resultAsLong(): ResultAsLong
+//     rsesultAsObject(): ResultAsObject
 
-    makeRefFunction(refFunction: Function): string
-}
+//     makeRefFunction(refFunction: Function): string
+// }
 
-declare var Citizen: CitizenInterface;
+// declare var Citizen: CitizenInterface;
 
 declare function addRawEventListener(eventName: string, callback: Function): void
 
@@ -91,3 +91,46 @@ declare function clearTick(callback: number): void
 declare var exports: any;
 
 declare var source: string;
+
+declare namespace Citizen {
+    export class Entity {
+        constructor(handle: number);
+        getMeta(key: string): any;
+        setMeta(key: string, data: any): boolean;
+        getReplicatedMeta(key: string): any;
+        setReplicatedMeta(key: string, data: any): boolean;
+    }
+    export class Player extends Entity {
+        constructor(pid?: number)
+    }
+
+    export function trace(...args: string[]): void;
+    export function setTickFunction(callback: Function): void;
+    export function setEventFunction(callback: Function): void;
+
+    export function setCallRefFunction(callback: Function): void;
+    export function setDeleteRefFunction(callback: Function): void;
+    export function setDuplicateRefFunction(callback: Function): void;
+    export function canonicalizeRef(ref: number): string;
+    export function invokeFunctionReference(ref: string, args: Uint8Array): Uint8Array;
+
+    export function getTickCount(): number;
+    export function invokeNative<T = void>(hash: string, ...args: InputArgument[]): T;
+    export function startProfiling(name?: string): void;
+    export function stopProfiling(name?: string): {};
+
+    export function pointerValueIntInitialized(): IntPtrInitialized;
+    export function pointerValueFloatInitialized(): FloatPtrInitialized;
+    export function pointerValueInt(): IntPtr;
+    export function pointerValueFloat(): FloatPtr;
+    export function pointerValueVector(): VectorPtr;
+    export function returnResultAnyway(): ReturnResultAnyway;
+    export function resultAsInteger(): ResultAsInteger;
+    export function resultAsFloat(): ResultAsFloat;
+    export function resultAsString(): ResultAsString;
+    export function resultAsVector(): ResultAsVector;
+    export function resultAsLong(): ResultAsLong;
+    export function rsesultAsObject(): ResultAsObject;
+
+    export function makeRefFunction(refFunction: Function): string;
+}

--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="./natives_server.d.ts"/>
+/// <reference path="./natives_universal.d.ts"/>
 
 interface IntPtrInitialized {}
 interface FloatPtrInitialized {}


### PR DESCRIPTION
A whole abstraction for using State Bags in Javascript:

Server:
```js
GlobalState.set('test', 'Global Test');
GlobalState.set('test2', 'Global Test 2', true);

onNet('someRandomEvent', () => {
    const entity = new Citizen.Entity(GetVehiclePedIsIn(GetPlayerPed(source)));
    // Player extend from Entity so all methods are available, only the constructor is different
    const player = new Citizen.Player(source);

    entity.setMeta('meta', 'Server Side Meta'); // will set a meta available serverside through all resources
    entity.setReplicatedMeta('meta', 'Replicated Meta'); // will set a replicated state bag

    console.log(entity.getMeta('meta')); // Server Side Meta
    console.log(entity.getReplicatedMeta('meta')); // Replicated Meta
}
```

Client:
```js
console.log(GlobalState.get('test')); // null
console.log(GlobalState.get('test2')); // Global Test 2

const me = new Citizen.Player();
const meToo = new Citizen.Player(-1);
const theOtherOne = new Citizen.Player(YourGetClosestPlayerFunction());
const veh = new Citizen.Entity(GetVehiclePedIsIn(PlayerPedId()));

veh.setMeta('meta', 'client value'); // will set a meta available clientside through all resources

console.log(veh.getMeta('meta')); // client value
console.log(veh.getReplicatedMeta('meta')); // Replicated Meta (Setted before by the server)
```

Meta & Replicated Meta can have the same key, their automaticly prefixed to prevent overriding

I use the "beta" of private properties of javascript, that's why you can see `#bag` in Entity class, that prevent get/set from any other class than Entity, but since nothing exist for 'protected' in JS, I use a small trick by using instanceof inside the Entity class to automaticly set the good prefix (entity/player) to the bag name

I gave access to Entity & Player trough Citizen namespace to prevent any conflicts with a lot of scripts which are already using Entity/Player in their code

Added definitions to index.d.ts, since an interface can't declare a class, I changed to export Citizen as a namespace and not a global var, it will not change anything for the runtime, shouldn't too for Typescript auto completion