### PR TITLE
temporary fix for REGISTER_SOMETHING_FROM_URL native

### DIFF
--- a/code/components/citizen-resources-client/src/ResourceCacheDeviceV2.cpp
+++ b/code/components/citizen-resources-client/src/ResourceCacheDeviceV2.cpp
@@ -399,7 +399,7 @@ concurrency::task<RcdFetchResult> ResourceCacheDeviceV2::DoFetch(const ResourceC
 					hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[8], hash[9],
 					hash[10], hash[11], hash[12], hash[13], hash[14], hash[15], hash[16], hash[17], hash[18], hash[19]);
 
-				if (hashString == entry.referenceHash)
+				if (hashString == entry.referenceHash || (downloaded && entry.referenceHash.empty()))
 				{
 					fillResult(*cacheEntry);
 				}


### PR DESCRIPTION
hacky way to prevent cache device looping and exiting after 4 times since it doesn't have a reference hash:)