### PR TITLE
Patch fly through windscreen in netgames + extra natives

### DIFF
--- a/code/components/gta-streaming-five/src/UnkStuff.cpp
+++ b/code/components/gta-streaming-five/src/UnkStuff.cpp
@@ -775,9 +775,6 @@ static HookFunction hookFunction([]()
 		// netgame checks for vehicle fuel tank leaking
 		hook::nop(hook::get_pattern("48 83 65 7F 00 0F 29 45 27 48 8D 45 77", -0xE3), 7);
 		hook::nop(hook::get_call(hook::get_pattern<char>("40 53 48 83 EC 20 48 8B D9 E8 ? ? ? ? 84 C0 74 32 8A 83 D8", 9)) + 0x19, 2);
-
-		// netgame check for fly through windscreen
-		hook::nop(hook::get_pattern("45 33 ED 44 38 ? ? ? ? 02 4D 8B E1", 3), 7);
 	}
 
 	// increase the heap size for allocator 0

--- a/code/components/gta-streaming-five/src/UnkStuff.cpp
+++ b/code/components/gta-streaming-five/src/UnkStuff.cpp
@@ -775,6 +775,9 @@ static HookFunction hookFunction([]()
 		// netgame checks for vehicle fuel tank leaking
 		hook::nop(hook::get_pattern("48 83 65 7F 00 0F 29 45 27 48 8D 45 77", -0xE3), 7);
 		hook::nop(hook::get_call(hook::get_pattern<char>("40 53 48 83 EC 20 48 8B D9 E8 ? ? ? ? 84 C0 74 32 8A 83 D8", 9)) + 0x19, 2);
+
+		// netgame check for fly through windscreen
+		hook::nop(hook::get_pattern("45 33 ED 44 38 ? ? ? ? 02 4D 8B E1", 3), 7);
 	}
 
 	// increase the heap size for allocator 0

--- a/ext/native-decls/ResetFlyThroughWindscreenParams.md
+++ b/ext/native-decls/ResetFlyThroughWindscreenParams.md
@@ -1,0 +1,11 @@
+---
+ns: CFX
+apiset: client
+---
+## RESET_FLY_THROUGH_WINDSCREEN_PARAMS
+
+```c
+void RESET_FLY_THROUGH_WINDSCREEN_PARAMS();
+```
+
+Resets parameters which is used by the game for checking is ped needs to fly through windscreen after a crash to default values.

--- a/ext/native-decls/SetFlyThroughWindscreenParams.md
+++ b/ext/native-decls/SetFlyThroughWindscreenParams.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_FLY_THROUGH_WINDSCREEN_PARAMS
+
+```c
+BOOL SET_FLY_THROUGH_WINDSCREEN_PARAMS(float vehMinSpeed, float unkMinSpeed, float unkModifier, float minDamage);
+```
+
+Sets some in-game parameters which is used for checks is ped needs to fly through windscreen after a crash.
+
+## Parameters
+* **vehMinSpeed**: Vehicle minimum speed (default 35.0).
+* **unkMinSpeed**: Unknown minimum speed (default 40.0).
+* **unkModifier**: Unknown modifier (default 17.0).
+* **minDamage**: Minimum damage (default 2000.0).
+
+## Return value
+A bool indicating if parameters was set successfully.


### PR DESCRIPTION
Preview: https://gfycat.com/tautgenerousfiddlercrab
Changed params: https://gfycat.com/lametemptingiberiannase
Can be disabled using `SET_PED_CONFIG_FLAG` and 32 flag set to false.

Natives:
```cpp
BOOL SET_FLY_THROUGH_WINDSCREEN_PARAMS(float vehMinSpeed, float unkMinSpeed, float unkModifier, float minDamage);
void RESET_FLY_THROUGH_WINDSCREEN_PARAMS();
```