### PR TITLE
Update some extra-natives patterns for b2060

### DIFF
--- a/code/components/extra-natives-five/src/PlayerNatives.cpp
+++ b/code/components/extra-natives-five/src/PlayerNatives.cpp
@@ -54,8 +54,7 @@ static HookFunction hookFunction([]()
 	VehicleDefenseModifierOffset = *hook::get_pattern<int>("F6 C1 ? 75 ? 48 8B 83 ? ? ? ? 48 8B 4E", 0x13);
 	WeaponDefenseModifier2Offset = *hook::get_pattern<int>("F3 0F 11 80 ? ? ? ? 8A 87 ? ? ? ? C0 E0", 0x4);
 	MeleeWeaponDamageModifierOffset = *hook::get_pattern<int>("F3 0F 11 80 ? ? ? ? F3 0F 10 8F ? ? ? ? 48 8B 85", 0x4);
-	// #TODO2060
-	//MeleeWeaponDefenseModifierOffset = *hook::get_pattern<int>("45 84 45 ? 74 ? 48 8B 83", 0x11);
+	MeleeWeaponDefenseModifierOffset = *hook::get_pattern<int>("45 84 ? ? 74 ? 48 8B 83", 0x11);
 
 	{
 		auto location = hook::get_pattern<char>("48 8B F8 E8 ? ? ? ? F3 0F 10 00 F3 0F 10 48 04", -0x5A);

--- a/code/components/extra-natives-five/src/TimeExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/TimeExtraNatives.cpp
@@ -7,23 +7,12 @@
 #include <ICoreGameInit.h>
 #include <gameSkeleton.h>
 
-#include <CrossBuildRuntime.h>
-
 static uint32_t* msPerMinute;
 static uint32_t msPerMinuteDefault = 2000;
 
 static HookFunction initFunction([]()
 {
-	if (Is2060())
-	{
-		// #TODO2060
-		return;
-	}
-
-	{
-		auto location = hook::get_pattern("8B 0D ? ? ? ? B8 D3 4D 62 10 69 C9 A0 05", 0);
-		msPerMinute = hook::get_address<uint32_t*>((char*)location + 2);
-	}
+	msPerMinute = hook::get_address<uint32_t*>(hook::get_pattern("66 0F 6E 05 ? ? ? ? 0F 57 F6", 4));
 
 	rage::OnInitFunctionEnd.Connect([](rage::InitFunctionType type)
 	{


### PR DESCRIPTION
Fixes `SET_MILLISECONDS_PER_GAME_MINUTE` and `GET_PLAYER_WEAPON_DEFENSE_MODIFIER`, as promised.