### PR TITLE
Prevent packet sniffing

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -828,7 +828,7 @@ static concurrency::task<std::optional<std::string>> ResolveUrl(const std::strin
 	{
 		// same as above, we need a record
 		skyr::url_record record;
-		record.scheme = "http";
+		record.scheme = "https"; // Enforcing HTTPS will prevent packet sniffing on the client side (Also auto generating cert the first time server starts will help too)
 
 		skyr::url newUri{ std::move(record) };
 		newUri.set_host(peerAddress->ToString());

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -828,7 +828,7 @@ static concurrency::task<std::optional<std::string>> ResolveUrl(const std::strin
 	{
 		// same as above, we need a record
 		skyr::url_record record;
-		record.scheme = "https"; // Enforcing HTTPS will prevent packet sniffing on the client side (Also auto generating cert the first time server starts will help too)
+		record.scheme = "https";
 
 		skyr::url newUri{ std::move(record) };
 		newUri.set_host(peerAddress->ToString());


### PR DESCRIPTION
Taking advantage of the fact that the server now supports https this is a good idea for making more difficult to sniff the initConnect creds.
Also this help people to build Nginx reverse proxies to make customs ratelimits and prevent Layer 7 attacks.