### PR TITLE
fix double server id in getAudioContextByServerId

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -564,9 +564,7 @@ static std::shared_ptr<lab::AudioContext> getAudioContextByServerId(int serverId
 		return {};
 	}
 
-	std::string name = fmt::sprintf("[%d] %s",
-		serverId,
-		ToNarrow(g_mumbleClient->GetPlayerNameFromServerId(serverId)));
+	std::string name = ToNarrow(g_mumbleClient->GetPlayerNameFromServerId(serverId));
 	return g_mumbleClient->GetAudioContext(name);
 }
 


### PR DESCRIPTION
GetPlayerNameFromServerId already has the correct format for GetAudioContext and does not need formatted