### PR TITLE
feat: MUMBLE_SET_AUDIO_OUTPUT_DISTANCE & MUMBLE_SET_AUDIO_INPUT_DISTANCE

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -842,6 +842,20 @@ static HookFunction hookFunction([]()
 			}
 		});
 
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_INPUT_DISTANCE", [=](fx::ScriptContext& context)
+		{
+			float dist = context.GetArgument<float>(0);
+
+			g_mumbleClient->SetAudioInputDistance(dist);
+		});
+
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_OUTPUT_DISTANCE", [=](fx::ScriptContext& context)
+		{
+			float dist = context.GetArgument<float>(0);
+
+			g_mumbleClient->SetAudioOutputDistance(dist);
+		});
+
 		scrBindGlobal("GET_AUDIOCONTEXT_FOR_CLIENT", getAudioContext);
 		scrBindGlobal("GET_AUDIOCONTEXT_FOR_SERVERID", getAudioContextByServerId);
 

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -882,7 +882,7 @@ static HookFunction hookFunction([]()
 			}
 		});
 
-		fx::ScriptEngine::RegisterNativeHandler(0x031E11F3D447647E, [=](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler(0x031E11F3D447647E, [](fx::ScriptContext& context)
 		{
 			if (!g_mumble.connected)
 			{
@@ -904,7 +904,7 @@ static HookFunction hookFunction([]()
 		auto origSetChannel = fx::ScriptEngine::GetNativeHandler(0xEF6212C2EFEF1A23);
 		auto origClearChannel = fx::ScriptEngine::GetNativeHandler(0xE036A705F989E049);
 
-		fx::ScriptEngine::RegisterNativeHandler(0xEF6212C2EFEF1A23, [=](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler(0xEF6212C2EFEF1A23, [](fx::ScriptContext& context)
 		{
 			(*origSetChannel)(context);
 

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -842,14 +842,14 @@ static HookFunction hookFunction([]()
 			}
 		});
 
-		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_INPUT_DISTANCE", [=](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_INPUT_DISTANCE", [](fx::ScriptContext& context)
 		{
 			float dist = context.GetArgument<float>(0);
 
 			g_mumbleClient->SetAudioInputDistance(dist);
 		});
 
-		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_OUTPUT_DISTANCE", [=](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_AUDIO_OUTPUT_DISTANCE", [](fx::ScriptContext& context)
 		{
 			float dist = context.GetArgument<float>(0);
 
@@ -882,7 +882,7 @@ static HookFunction hookFunction([]()
 			}
 		});
 
-		fx::ScriptEngine::RegisterNativeHandler(0x031E11F3D447647E, [](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler(0x031E11F3D447647E, [=](fx::ScriptContext& context)
 		{
 			if (!g_mumble.connected)
 			{
@@ -904,7 +904,7 @@ static HookFunction hookFunction([]()
 		auto origSetChannel = fx::ScriptEngine::GetNativeHandler(0xEF6212C2EFEF1A23);
 		auto origClearChannel = fx::ScriptEngine::GetNativeHandler(0xE036A705F989E049);
 
-		fx::ScriptEngine::RegisterNativeHandler(0xEF6212C2EFEF1A23, [](fx::ScriptContext& context)
+		fx::ScriptEngine::RegisterNativeHandler(0xEF6212C2EFEF1A23, [=](fx::ScriptContext& context)
 		{
 			(*origSetChannel)(context);
 

--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -103,6 +103,10 @@ public:
 
 	virtual void SetAudioDistance(float distance) = 0;
 
+	virtual void SetAudioInputDistance(float distance) = 0;
+
+	virtual void SetAudioOutputDistance(float distance) = 0;
+
 	virtual float GetAudioDistance() = 0;
 
 	virtual void SetActorPosition(float position[3]) = 0;

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -120,6 +120,10 @@ public:
 
 	virtual void SetAudioDistance(float distance) override;
 
+	virtual void SetAudioInputDistance(float distance) override;
+
+	virtual void SetAudioOutputDistance(float distance) override;
+
 	virtual float GetAudioDistance() override;
 
 	virtual void SetActorPosition(float position[3]) override;

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -505,6 +505,16 @@ void MumbleClient::SetAudioDistance(float distance)
 	m_audioOutput.SetDistance(distance);
 }
 
+void MumbleClient::SetAudioInputDistance(float distance)
+{
+	m_audioInput.SetDistance(distance);
+}
+
+void MumbleClient::SetAudioOutputDistance(float distance)
+{
+	m_audioOutput.SetDistance(distance);
+}
+
 float MumbleClient::GetAudioDistance()
 {
 	return m_audioOutput.GetDistance();

--- a/ext/native-decls/MumbleSetAudioInputDistance.md
+++ b/ext/native-decls/MumbleSetAudioInputDistance.md
@@ -8,7 +8,7 @@ apiset: client
 void MUMBLE_SET_AUDIO_INPUT_DISTANCE(float distance);
 ```
 
-Sets the current input distance. The player will talk to players within this distance.
+Sets the current input distance. The player will be able to talk to other players within this distance.
 
 ## Parameters
 * **distance**: The input distance.

--- a/ext/native-decls/MumbleSetAudioInputDistance.md
+++ b/ext/native-decls/MumbleSetAudioInputDistance.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_SET_AUDIO_INPUT_DISTANCE
+
+```c
+void MUMBLE_SET_AUDIO_INPUT_DISTANCE(float distance);
+```
+
+Sets the current input distance. The player will talk to players within this distance.
+
+## Parameters
+* **distance**: The input distance.

--- a/ext/native-decls/MumbleSetAudioOutputDistance.md
+++ b/ext/native-decls/MumbleSetAudioOutputDistance.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_SET_AUDIO_OUTPUT_DISTANCE
+
+```c
+void MUMBLE_SET_AUDIO_OUTPUT_DISTANCE(float distance);
+```
+
+Sets the current output distance. The player will be able to hear other players talking within this distance.
+
+## Parameters
+* **distance**: The output distance.


### PR DESCRIPTION
Allows to individually set Mumble's input / output distance since `NetworkSetTalkerProximity` forces both to be on the same distance. This shall allow players to talk in a different distance than what they can hear (useful for roleplay proximity voice so for example people can whisper but still hear people shouting in a distance).