### PR TITLE
Client resources controll natives

### DIFF
--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -225,6 +225,42 @@ static InitFunction initFunction([] ()
 		context.SetResult(resources[i]->GetName().c_str());
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_NUM_STARTED_RESOURCES", [](fx::ScriptContext& context)
+	{
+		int count = 0;
+
+		auto manager = fx::ResourceManager::GetCurrent();
+		manager->ForAllResources([&] (fwRefContainer<fx::Resource> resource)
+		{
+			auto c_state = resource->GetState();
+			if (c_state == fx::ResourceState::Started) {
+				count++;
+			}
+		});
+
+		context.SetResult<int>(count);
+	});
+	
+	fx::ScriptEngine::RegisterNativeHandler("VERIFY_RESOURCE_NUM", [](fx::ScriptContext& context)
+	{
+		int user_num = context.GetArgument<int>(0);
+
+		resources.clear();
+		
+		auto manager = fx::ResourceManager::GetCurrent();
+		manager->ForAllResources([&] (fwRefContainer<fx::Resource> resource)
+		{
+			resources.push_back(resource.GetRef());
+		});
+
+		if (resources.size() != user_num) {
+			context.setResult<bool>(false);
+			return;
+		}
+		
+		context.setResult<bool>(true);
+	});
+	
 	fx::ScriptEngine::RegisterNativeHandler("GET_RESOURCE_STATE", [](fx::ScriptContext& context)
 	{
 		// find the resource


### PR DESCRIPTION
FiveM and cheats are a problem for non whitelisted servers so because now cheats hooks natives to trick most anticheats client-side resources adding new natives will stop some cheats for some time because they will hook again those functions too.

I know is not a big fix but idk c++ so is the best thing I can do for helping the community.
These natives will be used on my OpenSource Anti-Cheat project :)