### PR TITLE
feat(onesync): NAK rewrite, server side

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -655,6 +655,15 @@ struct ClientEntityState
 	eastl::fixed_vector<EntityUniqifierPair, 16> deletions;
 };
 
+struct SyncedEntityData
+{
+	std::chrono::milliseconds nextSync;
+	std::chrono::milliseconds syncDelta;
+	sync::SyncEntityPtr entity;
+	bool forceUpdate;
+	bool hasCreated;
+};
+
 constexpr auto maxSavedClientFrames = 256;
 
 struct GameStateClientData : public sync::ClientSyncDataBase
@@ -674,7 +683,6 @@ struct GameStateClientData : public sync::ClientSyncDataBase
 
 	glm::mat4x4 viewMatrix{};
 
-	eastl::bitset<roundToWord(MaxObjectId)> createdEntities;
 	eastl::fixed_hash_map<uint32_t, uint64_t, 100> pendingCreates;
 	eastl::fixed_hash_map<uint64_t, ClientEntityState, maxSavedClientFrames, maxSavedClientFrames, false> frameStates;
 	uint64_t firstSavedFrameState = 0;
@@ -684,7 +692,7 @@ struct GameStateClientData : public sync::ClientSyncDataBase
 	eastl::fixed_hash_map<int, int, 128> playersToSlots;
 	eastl::bitset<128> playersInScope;
 	
-	eastl::fixed_hash_map<uint32_t, std::tuple<std::chrono::milliseconds /* nextSync */, std::chrono::milliseconds /* syncDelta */, sync::SyncEntityPtr /* entity */, bool /* forceUpdate */>, 128> syncedEntities;
+	eastl::fixed_hash_map<uint32_t, SyncedEntityData, 128> syncedEntities;
 	eastl::fixed_hash_map<uint32_t, sync::SyncEntityPtr, 16> entitiesToDestroy;
 
 	uint32_t syncTs = 0;

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -705,7 +705,7 @@ struct SyncedEntityData
 	bool hasCreated;
 };
 
-constexpr auto maxSavedClientFrames = 256;
+constexpr auto maxSavedClientFrames = 768;
 
 struct GameStateClientData : public sync::ClientSyncDataBase
 {
@@ -837,7 +837,7 @@ private:
 	std::unique_ptr<ThreadPool> m_tg;
 
 	// as bitset is not thread-safe
-	std::mutex m_objectIdsMutex;
+	std::shared_mutex m_objectIdsMutex;
 	eastl::bitset<roundToWord(MaxObjectId)> m_objectIdsSent;
 	eastl::bitset<roundToWord(MaxObjectId)> m_objectIdsUsed;
 	eastl::bitset<roundToWord(MaxObjectId)> m_objectIdsStolen;

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -3229,63 +3229,6 @@ using CPlayerSyncTree = SyncTree<
 		>
 	>
 >;
-using CAutomobileSyncTree = SyncTree<
-	ParentNode<
-		NodeIds<127, 0, 0>, 
-		ParentNode<
-			NodeIds<1, 0, 0>, 
-			NodeWrapper<NodeIds<1, 0, 0>, CVehicleCreationDataNode>, 
-			NodeWrapper<NodeIds<1, 0, 0>, CAutomobileCreationDataNode>
-		>, 
-		ParentNode<
-			NodeIds<127, 127, 0>, 
-			ParentNode<
-				NodeIds<127, 127, 0>, 
-				ParentNode<
-					NodeIds<127, 127, 0>, 
-					NodeWrapper<NodeIds<127, 127, 0>, CGlobalFlagsDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 0>, CDynamicEntityGameStateDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 0>, CPhysicalGameStateDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 0>, CVehicleGameStateDataNode>
-				>, 
-				ParentNode<
-					NodeIds<127, 127, 1>, 
-					NodeWrapper<NodeIds<127, 127, 1>, CEntityScriptGameStateDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 1>, CPhysicalScriptGameStateDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 1>, CVehicleScriptGameStateDataNode>, 
-					NodeWrapper<NodeIds<127, 127, 1>, CEntityScriptInfoDataNode>
-				>
-			>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CPhysicalAttachDataNode>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CVehicleAppearanceDataNode>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CVehicleDamageStatusDataNode>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CVehicleComponentReservationDataNode>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CVehicleHealthDataNode>, 
-			NodeWrapper<NodeIds<127, 127, 0>, CVehicleTaskDataNode>
-		>, 
-		ParentNode<
-			NodeIds<127, 86, 0>, 
-			NodeWrapper<NodeIds<87, 87, 0>, CSectorDataNode>, 
-			NodeWrapper<NodeIds<87, 87, 0>, CSectorPositionDataNode>, 
-			NodeWrapper<NodeIds<87, 87, 0>, CEntityOrientationDataNode>, 
-			NodeWrapper<NodeIds<87, 87, 0>, CPhysicalVelocityDataNode>, 
-			NodeWrapper<NodeIds<87, 87, 0>, CVehicleAngVelocityDataNode>, 
-			ParentNode<
-				NodeIds<127, 86, 0>, 
-				NodeWrapper<NodeIds<86, 86, 0>, CVehicleSteeringDataNode>, 
-				NodeWrapper<NodeIds<87, 87, 0>, CVehicleControlDataNode>, 
-				NodeWrapper<NodeIds<127, 127, 0>, CVehicleGadgetDataNode>
-			>
-		>, 
-		ParentNode<
-			NodeIds<4, 0, 0>, 
-			NodeWrapper<NodeIds<4, 0, 0>, CMigrationDataNode>, 
-			NodeWrapper<NodeIds<4, 0, 0>, CPhysicalMigrationDataNode>, 
-			NodeWrapper<NodeIds<4, 0, 1>, CPhysicalScriptMigrationDataNode>, 
-			NodeWrapper<NodeIds<4, 0, 0>, CVehicleProximityMigrationDataNode>
-		>
-	>
->;
 using CTrainSyncTree = SyncTree<
 	ParentNode<
 		NodeIds<127, 0, 0>, 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -409,9 +409,18 @@ struct NodeWrapper : public NodeBase
 			couldWrite = false;
 		}
 
-		if (state.isFirstUpdate && !TIds::CanSendOnFirstUpdate())
+		if (state.isFirstUpdate)
 		{
-			couldWrite = false;
+			if (!TIds::CanSendOnFirstUpdate())
+			{
+				couldWrite = false;
+			}
+
+			// if this doesn't need activation flags, don't write it
+			if ((std::get<2>(TIds::GetIds()) & 1) == 0)
+			{
+				couldWrite = false;
+			}
 		}
 		
 		if (shouldWrite(state, TIds::GetIds(), couldWrite))

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -485,7 +485,7 @@ static InitFunction initFunction([]()
 
 			json data = json::object();
 			data["protocol"] = 5;
-			data["bitVersion"] = 0x202007151853;
+			data["bitVersion"] = 0x202010191044;
 			data["sH"] = shVar->GetValue();
 			data["enhancedHostSupport"] = ehVar->GetValue() && !fx::IsOneSync();
 			data["onesync"] = fx::IsOneSync();

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1354,7 +1354,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 								// }
 
 								auto startBit = cmdState.cloneBuffer.GetCurrentBit();
-								cmdState.maybeFlushBuffer(3 + /* 13 */ 16 + 16 + 4 + 32 + 16 + 32 + 12 + (len * 8));
+								cmdState.maybeFlushBuffer(3 + /* 13 */ 16 + 16 + 4 + 32 + 16 + 64 + 32 + 12 + (len * 8));
 								cmdState.cloneBuffer.Write(3, syncType);
 								cmdState.cloneBuffer.Write(13, entity->handle);
 								cmdState.cloneBuffer.Write(16, entityClient->GetNetId());
@@ -1446,8 +1446,14 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 		// emplace new frame
 		clientDataUnlocked->frameStates.emplace(m_frameIndex, std::move(ces));
 
-		scl->Execute(client);
+		m_tg->tryPost([scl, client]() mutable 
+		{
+			scl->Execute(client);
 
+			scl = {};
+			client = {};
+		});
+	
 		GS_LOG("Tick completed for cl %d.\n", client->GetNetId());
 	});
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -663,7 +663,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 						}
 					}
 					// it's a script-less entity, we can collect it.
-					else if (!entity->IsOwnedByScript() && entity->type != sync::NetObjEntityType::Player)
+					else if (!entity->IsOwnedByScript() && (entity->type != sync::NetObjEntityType::Player || !entity->GetClient()))
 					{
 						FinalizeClone({}, entity->handle);
 						continue;

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -2607,13 +2607,13 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 		}
 
 		{
-			std::unique_lock _(m_entityListMutex);
-			m_entityList.push_back(entity);
+			std::unique_lock _(m_entitiesByIdMutex);
+			m_entitiesById[objectId] = { entity };
 		}
 
 		{
-			std::unique_lock _(m_entitiesByIdMutex);
-			m_entitiesById[objectId] = { entity };
+			std::unique_lock _(m_entityListMutex);
+			m_entityList.push_back(entity);
 		}
 
 		// update all clients' lists so the system knows that this entity is valid and should not be deleted anymore

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -975,6 +975,27 @@ static InitFunction initFunction([]()
 		return uint32_t(node ? node->curWeapon : 0);
 	}));
 
+		fx::ScriptEngine::RegisterNativeHandler(0x69696969, makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+		{
+			auto resourceManager = fx::ResourceManager::GetCurrent();
+			auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+			auto gameState = instance->GetComponent<fx::ServerGameState>();
+			// get the server's client registry
+			auto clientRegistry = instance->GetComponent<fx::ClientRegistry>();
+
+			// parse the client ID
+			const char* id = context.CheckArgument<const char*>(1);
+
+			uint32_t netId = atoi(id);
+
+			auto client = clientRegistry->GetClientByNetID(netId);
+
+
+			gameState->ReassignEntity(entity->handle, client);
+
+			return 69;
+		}));
+
 	fx::ScriptEngine::RegisterNativeHandler("IS_PED_A_PLAYER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		return entity->type == fx::sync::NetObjEntityType::Player;

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -975,27 +975,6 @@ static InitFunction initFunction([]()
 		return uint32_t(node ? node->curWeapon : 0);
 	}));
 
-		fx::ScriptEngine::RegisterNativeHandler(0x69696969, makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
-		{
-			auto resourceManager = fx::ResourceManager::GetCurrent();
-			auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
-			auto gameState = instance->GetComponent<fx::ServerGameState>();
-			// get the server's client registry
-			auto clientRegistry = instance->GetComponent<fx::ClientRegistry>();
-
-			// parse the client ID
-			const char* id = context.CheckArgument<const char*>(1);
-
-			uint32_t netId = atoi(id);
-
-			auto client = clientRegistry->GetClientByNetID(netId);
-
-
-			gameState->ReassignEntity(entity->handle, client);
-
-			return 69;
-		}));
-
 	fx::ScriptEngine::RegisterNativeHandler("IS_PED_A_PLAYER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		return entity->type == fx::sync::NetObjEntityType::Player;

--- a/code/components/citizen-server-impl/src/state/ServerRPC.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerRPC.cpp
@@ -465,7 +465,10 @@ static InitFunction initFunction([]()
 
 				auto sendToClient = [&](const fx::ClientSharedPtr& cl)
 				{
-					cl->SendPacket(0, buffer, NetPacketType_ReliableReplayed);
+					if (cl)
+					{
+						cl->SendPacket(0, buffer, NetPacketType_ReliableReplayed);
+					}
 				};
 
 				if (clientIdx == -2)

--- a/vendor/citizen_util/include/citizen_util/shared_reference.h
+++ b/vendor/citizen_util/include/citizen_util/shared_reference.h
@@ -122,6 +122,11 @@ struct shared_reference
 		return value == other.value;
 	}
 
+	bool operator<(const shared_reference& other) const
+	{
+		return value < other.value;
+	}
+
 	T& operator*() const
 	{
 		return *value;
@@ -309,6 +314,16 @@ struct weak_reference
 	bool operator==(const weak_reference& other) const
 	{
 		return value == other.value;
+	}
+
+	bool operator<(const SharedT& other) const
+	{
+		return value < other.value;
+	}
+
+	bool operator<(const weak_reference& other) const
+	{
+		return value < other.value;
 	}
 
 	~weak_reference()


### PR DESCRIPTION
Required client changes were added in the following commits already:

* 13180f79624f47b5760ad9dcdd27c60166a7a248 (feat(onesync): NAK rewrite, initial client patchset)
* 4ae35f223b56125b0e38216df2dd642abda035a4 (fix(onesync/client): fix some cases of 0-length node writes in WriteTreeCfx)

Server-side logic is pending some testing by users, but here's a summary:

* No more automatic repeat request (ARQ), clients will explicitly request a resend of a full packet, or of a certain entity's state.
* A number of tweaks and bug fixes related to this, such as:
  * ServerRPC null pointer check (might be able to be moved out?)
  * World grid 'cooldown' timer, to prevent population spawning before a client can be made aware of what's going on around them.