### PR TITLE
gameconfig: Increased phInstGta

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -382,7 +382,7 @@
 						</Item>
 						<Item>
 							<PoolName>phInstGta</PoolName>
-							<PoolSize value="16384"/>
+							<PoolSize value="32768"/>
 						</Item>
 						<Item>
 							<PoolName>PhysicsBounds</PoolName>


### PR DESCRIPTION
Raised phInstGta from 16384 to 32768 to allow more polygons to cut down on "texture lost" or "world lost" when using non-lore cars.