### PR TITLE
Add CORS Support to all Endpoints

### DIFF
--- a/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
@@ -224,6 +224,7 @@ static InitFunction initFunction([]()
 
 		instance->GetComponent<fx::HttpServerManager>()->AddEndpoint("/info.json", [=](const fwRefContainer<net::HttpRequest>& request, const fwRefContainer<net::HttpResponse>& response)
 		{
+			response->SetHeader("Access-Control-Allow-Origin", "*");
 			if (processRequestParanoia(request))
 			{
 				response->SetStatusCode(403);
@@ -265,6 +266,7 @@ static InitFunction initFunction([]()
 
 		instance->GetComponent<fx::HttpServerManager>()->AddEndpoint("/dynamic.json", [=](const fwRefContainer<net::HttpRequest>& request, const fwRefContainer<net::HttpResponse>& response)
 		{
+			response->SetHeader("Access-Control-Allow-Origin", "*");
 			if (processRequestParanoia(request))
 			{
 				response->SetStatusCode(403);
@@ -301,6 +303,7 @@ static InitFunction initFunction([]()
 
 		instance->GetComponent<fx::HttpServerManager>()->AddEndpoint("/players.json", [instance](const fwRefContainer<net::HttpRequest>& request, const fwRefContainer<net::HttpResponse>& response)
 		{
+			response->SetHeader("Access-Control-Allow-Origin", "*");
 			if (processRequestParanoia(request))
 			{
 				response->SetStatusCode(403);
@@ -408,6 +411,7 @@ static InitFunction initFunction([]()
 
 		instance->GetComponent<fx::HttpServerManager>()->AddEndpoint("/profileData.json", [=](const fwRefContainer<net::HttpRequest>& request, const fwRefContainer<net::HttpResponse>& response)
 		{
+			response->SetHeader("Access-Control-Allow-Origin", "*");
 			if (!lastProfile)
 			{
 				response->SetStatusCode(404);
@@ -416,7 +420,6 @@ static InitFunction initFunction([]()
 				return;
 			}
 
-			response->SetHeader("Access-Control-Allow-Origin", "*");
 
 			response->End(lastProfile->dump(-1, ' ', false, json::error_handler_t::replace));
 		});


### PR DESCRIPTION
Add the "Access-Control-Allow-Origin" header to all endpoints, allowing them to be accessed by web clients.

Currently this is only present on the "/profileData.json" endpoint, when there is data. This means that if it returns an empty response (Line 418) it will trigger a CORS error on all web clients. It also triggers a CORS error on all other endpoints.