### PR TITLE
(voip/mumble): fix MumbleIsConnected returning 1

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -116,6 +116,7 @@ static struct
 
 static void Mumble_Connect()
 {
+	g_mumble.connected = false;
 	g_mumble.errored = false;
 	g_mumble.connecting = true;
 


### PR DESCRIPTION
instead of false when player get suddenly disconnected and cannot reconnect. e.g. murmur server is down