### PR TITLE
feat(onesync): add CVehicleTaskDataNode parse/unparse

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1216,7 +1216,36 @@ struct CVehicleHealthDataNode
 	}
 };
 
-struct CVehicleTaskDataNode { bool Parse(SyncParseState& state) { return true; } };
+struct CVehicleTaskDataNode
+{
+	int m_taskId;
+	int m_taskType;
+
+	bool Parse(SyncParseState& state)
+	{
+		auto taskId = state.buffer.Read<int>(7);
+
+		if (taskId >= 453)
+		{
+			taskId -= 453;
+		}
+
+		m_taskId = taskId;
+
+		auto taskType = state.buffer.Read<int>(8);
+		m_taskType = taskType;
+
+		return true;
+	}
+
+	bool Unparse(rl::MessageBuffer& buffer)
+	{
+		buffer.Write<int>(7, m_taskId);
+		buffer.Write<int>(8, m_taskType);
+
+		return true;
+	}
+};
 
 struct CSectorDataNode
 {


### PR DESCRIPTION
Didn't found any info on how vehicle tasks are handled internally to create any getters native :/
Idk if that's relevant to have the node parsed without any use case but here you go