### PR TITLE
Optimizations to Citizen.Wait

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -143,7 +143,11 @@ function Citizen.CreateThread(threadFunction)
 end
 
 function Citizen.Wait(msec)
-	coroutine.yield(GetGameTimer() + msec)
+	if msec > 5 then
+		coroutine.yield(GetGameTimer() + msec)
+	else
+		coroutine.yield(0)
+	end
 end
 
 -- legacy alias (and to prevent people from calling the game's function)


### PR DESCRIPTION
Don't use GetGameTimer if we know we only want to wait till the next frame. This saves a lot of native calls if there's a lot of threads.

Value of 5 is choosen as a reasonable value.