### PR TITLE
Fix(prebuild): Clear LUA_CPATH

### DIFF
--- a/prebuild_natives.cmd
+++ b/prebuild_natives.cmd
@@ -3,6 +3,8 @@
 setlocal EnableDelayedExpansion
 
 set path=C:\msys64\usr\bin;%path%
+set LUA_PATH=
+set LUA_CPATH=
 
 pacman --noconfirm --needed -Sy make curl diffutils libcurl
 


### PR DESCRIPTION
Using a custom LUA_CPATH which doesn't search the current directory would break the prebuild script.