### PR TITLE
fix: GET_GAME_TIMER

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -230,13 +230,14 @@ end
 SetTimeout = Citizen.SetTimeout
 
 Citizen.SetTickRoutine(function()
+	curTime = GetGameTimer()
+
 	if not hadThread then
 		return
 	end
 
 	-- flag to skip thread exec if we don't have any
 	local thisHadThread = false
-	curTime = GetGameTimer()
 
 	for coro, thread in pairs(newThreads) do
 		rawset(threads, coro, thread)


### PR DESCRIPTION
At this moment, if we call a function without using a thread, wait function totally not work. After check, time must always be obtained, even if there is no thread.