### PR TITLE
Fix codegen for TS for natives that return values by pointers

### DIFF
--- a/ext/natives/codegen_out_dts.lua
+++ b/ext/natives/codegen_out_dts.lua
@@ -157,11 +157,7 @@ local function printArgument(argument, native)
 
 	if argument.pointer then
 		if argument.type.nativeType == 'int' or argument.type.nativeType == 'float' then
-			if isSinglePointerNative(native) then
-				argType = 'number'
-			else
-				retType = 'number'
-			end
+			retType = 'number'
 		elseif argument.type.nativeType == 'vector3' then
 			retType = 'number[]'
 		else

--- a/ext/natives/codegen_out_dts.lua
+++ b/ext/natives/codegen_out_dts.lua
@@ -157,7 +157,12 @@ local function printArgument(argument, native)
 
 	if argument.pointer then
 		if argument.type.nativeType == 'int' or argument.type.nativeType == 'float' then
-			retType = 'number'
+			if isSinglePointerNative(native) then
+				argType = 'number'
+				retType = 'pointer'
+			else
+				retType = 'number'
+			end
 		elseif argument.type.nativeType == 'vector3' then
 			retType = 'number[]'
 		else
@@ -190,6 +195,8 @@ end
 local function formatDefinition(native)
 	local argsDefs = {}
 	local retTypes = {}
+	local markOptional = {}
+	local castUnknown = false -- We are not able to know whether a pointer is a return value or input, thus casting unknown
 
 	if native.returns then
 		table.insert(retTypes, printReturnType(native.returns))
@@ -201,6 +208,11 @@ local function formatDefinition(native)
 
 			if argType ~= nil then
 				table.insert(argsDefs, argumentName .. ': ' .. argType)
+				if retType == 'pointer' then markOptional[#argsDefs] = argumentName .. '?: ' .. argType end
+			end
+
+			if retType == 'pointer' then
+			    castUnknown = true
 			elseif retType ~= nil then
 				table.insert(retTypes, retType)
 			end
@@ -208,8 +220,12 @@ local function formatDefinition(native)
 	end
 
 	local retType
-
-	if #retTypes > 1 then
+	if castUnknown and #retTypes > 0 then
+		for index, optional in pairs(markOptional) do
+			argsDefs[index] = optional
+		end
+		retType = 'unknown[]'
+	elseif #retTypes > 1 then
 		retType = '[' .. table.concat(retTypes, ', ') .. ']'
 	elseif #retTypes == 1 then
 		retType = retTypes[1]
@@ -217,13 +233,17 @@ local function formatDefinition(native)
 		retType = 'void'
 	end
 
-	return '(' .. table.concat(argsDefs, ', ') .. '): ' .. retType
+	return '(' .. table.concat(argsDefs, ', ') .. '): ' .. retType, castUnknown and #retTypes > 0
 end
 
 local function printNative(native)
 	local name = printFunctionName(native)
 	local doc = formatDocString(native)
-	local def = formatDefinition(native)
+	local def, addCastWarning = formatDefinition(native)
+
+	if addCastWarning then
+		doc = ('%s// Return is unknown[] due to pointer value being input of the function\n'):format(doc)
+	end
 
 	local str = string.format("%sdeclare function %s%s;\n", doc, name, def)
 


### PR DESCRIPTION
This fixes native typing TS documentation:
Sample natives that has this issue:

https://runtime.fivem.net/doc/natives/?_0x2975C866E6713290
GetEntityPlayerIsFreeAimingAt
```
# C Declaration:
// GetEntityPlayerIsFreeAimingAt
BOOL GET_ENTITY_PLAYER_IS_FREE_AIMING_AT(Player player, Entity* entity);

# TS Declaration
/**
 * Returns TRUE if it found an entity in your crosshair within range of your weapon. Assigns the handle of the target to the *entity that you pass it.
 * Returns false if no entity found.
 */
declare function GetEntityPlayerIsFreeAimingAt(player: number, entity: number): number;
```

Other examples, just runtime links:
https://runtime.fivem.net/doc/natives/?_0x2E1202248937775C
https://runtime.fivem.net/doc/natives/?_0xDC16122C7A20C933

As you can see natives that has pointers in the declaration, are supposed to be return values, at least for natives that I saw.

The proposed fix fixes natives function/documentation generation so that it makes first pointers returnable.

Fixed Typing:
```
# TS Declaration
declare function GetEntityPlayerIsFreeAimingAt(player: number): [number, number];
```

This is only documentation generation fix, from what I saw - the function actually return array, so it's only documentation issue.

I am not sure about Lua/JS, if they have the same issue or not, but TS would be correctly typed after this PR. At least for the natives that I found have issues.