### PR TITLE
feat(clr): add ClientScript and ServerScript, allow missing types

### DIFF
--- a/code/client/clrcore/ClientScript.cs
+++ b/code/client/clrcore/ClientScript.cs
@@ -1,0 +1,8 @@
+#if !IS_FXSERVER
+namespace CitizenFX.Core
+{
+	public abstract class ClientScript : BaseScript
+	{
+	}
+}
+#endif

--- a/code/client/clrcore/ServerScript.cs
+++ b/code/client/clrcore/ServerScript.cs
@@ -1,0 +1,8 @@
+#if IS_FXSERVER
+namespace CitizenFX.Core
+{
+	public abstract class ServerScript : BaseScript
+	{
+	}
+}
+#endif


### PR DESCRIPTION
```
This change adds ClientScript and ServerScript classes that are present
in the respective environments to differentiate client and server sided
scripts. This also allows the C# and F# compilers to unambiguously link
against the correct libraries when referencing both assemblies.

In addition, we handle an exception that is thrown when loading types
with missing assemblies, e.g. ServerScript is missing on the client.

See https://forum.cfx.re/t/2006775
```