### PR TITLE
feature(devtools): add convar to disable memory profiler

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -174,8 +174,10 @@ static InitFunction initFunction([]()
 	static std::mutex mutex;
 
 	static bool taskMgrEnabled;
+	static bool disableMemoryProfiler;
 
 	static ConVar<bool> taskMgrVar("resmon", ConVar_Archive, false, &taskMgrEnabled);
+	static ConVar<bool> disableMemoryProfilerVar("disableMemoryProfiler", ConVar_Archive, false, &disableMemoryProfiler);
 
 	static tbb::concurrent_unordered_map<std::string, std::optional<ResourceMetrics>> metrics;
 	static TickMetrics<64> scriptFrameMetrics;
@@ -238,7 +240,7 @@ static InitFunction initFunction([]()
 			auto& metric = *metrics[resource->GetName()];
 			metric.ticks.Append(usec() - metric.tickStart);
 
-			if ((usec() - metric.memoryLastFetched) > (!taskMgrEnabled ? 20s : 500ms))
+			if (!disableMemoryProfiler && (usec() - metric.memoryLastFetched) > (!taskMgrEnabled ? 20s : 500ms))
 			{
 				int64_t totalBytes = GetTotalBytes(resource);
 


### PR DESCRIPTION
This is but a workaround.

The memory profiler seems to cause some deadlocks on certain systems (including mine) which seems to be caused by the StaticHeapAllocator in the MonoComponentHost (specifically the HeapFree being called by g_memoryUsages.clear() ).

Having resmon open makes the deadlock appear way more, and attaching a debugger always has the MainThread stuck on the specific call pointed out above.

Adding a convar to disable the memory profiler completely would be a "workaround" for this.

Couldn't really find anything about it to fix it so this could be a nice workaround to just disable it if you have issues with it.