### PR TITLE
fix: change GetMemoryUsage / Resource Monitor usage to KiB to avoid overflow

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -1998,7 +1998,7 @@ result_t LuaScriptRuntime::RequestMemoryUsage()
 result_t LuaScriptRuntime::GetMemoryUsage(int64_t* memoryUsage)
 {
 	LuaPushEnvironment pushed(this);
-	*memoryUsage = (lua_gc(m_state, LUA_GCCOUNT, 0) * 1024) + lua_gc(m_state, LUA_GCCOUNTB, 0);
+	*memoryUsage = lua_gc(m_state, LUA_GCCOUNT, 0);
 
 	return FX_S_OK;
 }

--- a/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
@@ -199,7 +199,7 @@ static void gc_event(MonoProfiler* profiler, MonoProfilerGCEvent event, uint32_t
 
 			mono_gc_walk_heap(0, [](MonoObject *obj, MonoClass *klass, uintptr_t size, uintptr_t num, MonoObject **refs, uintptr_t *offsets, void *data) -> int
 			{
-				g_memoryUsages[mono_object_get_domain(obj)] += size;
+				g_memoryUsages[mono_object_get_domain(obj)] += size / 1024;
 
 				return 0;
 			}, nullptr);


### PR DESCRIPTION
This change was made to avoid the resource monitor displaying a negative value when a script has extreme memory usage. This was caused by the int64 overflowing.

It implements the following changes
- GetMemoryUsage function returns a value in kilobytes rather than bytes
- Resource monitor displays KiB as the lowest value, without decimal points
- Resource time warning logic changed to compensate for the new value

This was tested on a custom FX server with a C# and lua script, and it seemed to be working properly. If this should be implemented differently, or I have missed something please let me know. I looked through the repo to see if anything else relied on GetMemoryUsage, and personally couldn't find anything.

Note: As far as I know, JS scripting does not implement GetMemoryUsage, and therefore this was not changed.