### PR TITLE
feat(glue): forced streamer mode using `fivem://`

### DIFF
--- a/code/components/glue/src/ConnectToNative.cpp
+++ b/code/components/glue/src/ConnectToNative.cpp
@@ -1118,9 +1118,12 @@ void Component_RunPreInit()
 			nng_socket socket;
 			nng_dialer dialer;
 
+			auto j = nlohmann::json::object({ { "host", connectHost }, { "params", connectParams } });
+			std::string connectMsg = j.dump(-1, ' ', false, nlohmann::detail::error_handler_t::strict);
+
 			nng_push0_open(&socket);
 			nng_dial(socket, "ipc:///tmp/fivem_connect", &dialer, 0);
-			nng_send(socket, const_cast<char*>(connectHost.c_str()), connectHost.size(), 0);
+			nng_send(socket, const_cast<char*>(connectMsg.c_str()), connectMsg.size(), 0);
 
 			if (!hostData->gamePid)
 			{
@@ -1204,7 +1207,8 @@ static InitFunction connectInitFunction([]()
 			std::string connectMsg(buffer, buffer + bufLen);
 			nng_free(buffer, bufLen);
 
-			ConnectTo(connectMsg);
+			auto connectData = nlohmann::json::parse(connectMsg);
+			ConnectTo(connectData["host"], false, connectData["params"]);
 
 			SetForegroundWindow(FindWindow(L"grcWindow", nullptr));
 		}

--- a/ext/cfx-ui/src/app/game.service.ts
+++ b/ext/cfx-ui/src/app/game.service.ts
@@ -6,6 +6,7 @@ import { Server, ServerHistoryEntry } from './servers/server';
 import { environment } from '../environments/environment';
 import { LocalStorage } from './local-storage';
 import { Observable, BehaviorSubject } from 'rxjs';
+import * as query from 'query-string';
 
 export class ConnectStatus {
 	public server: Server;
@@ -431,8 +432,15 @@ export class CfxGameService extends GameService {
 						break;
 					case 'connectTo':
 						const address: string = event.data.hostnameStr;
+						const connectParams = query.parse(event.data.connectParams);
 
 						if (!this.inConnecting) {
+							if ('streamerMode' in connectParams) {
+								const streamerMode = ['true', '1'].includes(<string>connectParams.streamerMode);
+								this._streamerMode = streamerMode;
+								this.invokeStreamerModeChanged(streamerMode);
+							}
+
 							this.zone.run(() => {
 								this.inConnecting = true;
 


### PR DESCRIPTION
Force streamer mode value per-session using:
`fivem://connect/127.0.0.1?streamerMode=true` (or `=1`)
Does **not** set the archived variable `ui_streamerMode`.

**Currently only supports FiveM 'cold start'.**
(calling fivem:// when FiveM is closed)

I am not sure how to correctly (and neatly) pass the `streamerMode` value [through the socket to the running FiveM instance](https://github.com/citizenfx/fivem/blob/4fb12d066857851f9619281e2eba7b0271fd0b38/code/components/glue/src/ConnectToNative.cpp#L1196).
Would appreciate guidance if anyone is up for it.