### PR TITLE
fix: applies the same margin-right to 'fa' as 'fab'

### DIFF
--- a/ext/cfx-ui/src/app/settings/settings.component.scss
+++ b/ext/cfx-ui/src/app/settings/settings.component.scss
@@ -63,8 +63,10 @@
 				}
 
 				.html {
-					::ng-deep .fab {
-						margin-right: var(--qh);
+					::ng-deep {
+						.fa, .fab {
+							margin-right: var(--qh);
+						}
 					}
 				}
 


### PR DESCRIPTION
Noticed the lack of margin for the `fa-road` icon here, it uses `fa`, not `fab`, so that's why the `margin-right` doesn't get applied.

Before:
![](https://i.imgur.com/zY88QGh.png)

After:
![](https://i.imgur.com/Fk6fJRS.png)