### PR TITLE
Small fixes in the settings menu

### DIFF
--- a/ext/cfx-ui/src/app/settings.service.ts
+++ b/ext/cfx-ui/src/app/settings.service.ts
@@ -117,7 +117,7 @@ export class SettingsService {
 				name: '#Settings_GameStreamProgress',
 				description: '#Settings_GameStreamProgressDesc',
 				type: 'checkbox',
-				getCb: () => this.gameService.getConvar('game_showStreamingProgress'),
+				getCb: () => this.gameService.getConvar('game_showStreamingProgress').pipe(map(a => a === 'true' ? 'true' : 'false')),
 				setCb: (value) => this.gameService.setConvar('game_showStreamingProgress', value),
 				category: '#SettingsCat_Game',
 			});


### PR DESCRIPTION
- Fixes the 'show streaming progress' setting displaying as off when actually enabled
![image](https://user-images.githubusercontent.com/35628223/105109784-21f1b080-5ab5-11eb-8112-b2e856e6195f.png)

~~- Changed the way default values are set in `DisplaySetting` so that the low-performance mode correctly shows as 'off' by default.~~ _Just realised what I did is a complete non-solution so I've reverted it_
![image](https://user-images.githubusercontent.com/35628223/105110226-12bf3280-5ab6-11eb-8cb6-b543b9bc5372.png)
