### PR TITLE
fix(console): register new variables before setting their value in the set command

### DIFF
--- a/code/client/citicore/console/Console.Variables.cpp
+++ b/code/client/citicore/console/Console.Variables.cpp
@@ -35,9 +35,8 @@ ConsoleVariableManager::ConsoleVariableManager(console::Context* parentContext)
 		flags |= addFlags;
 
 		auto entry = CreateVariableEntry<std::string>(this, variable, "");
-		entry->SetValue(value);
-
 		Register(variable, flags, entry);
+		entry->SetValue(value);
 	};
 
 	m_setCommand = std::make_unique<ConsoleCommand>(m_parentContext, "set", [=](const std::string& variable, const std::string& value) {


### PR DESCRIPTION
SetValue triggers this event before the convar is registered, so it can't be found and the SendConvar call is skipped.
https://github.com/citizenfx/fivem/blob/34069da52f788a6e21c7ae2e9fc6d84dda932abe/code/components/nui-core/src/NUIConsole.cpp#L41-L49

This results in convars not being sent to the NUI when first created, unless this call in the UI happens *after* their creation. https://github.com/citizenfx/fivem/blob/446cb2c9d640a3bf1954caeec83a1ef8a2ae028b/ext/cfx-ui/src/app/game.service.ts#L328

This happens occasionally but not most of the time. Convars such as `ui_streamerMode` which are created by `seta` in fivem.cfg often don't reach the UI (unless they're modified again). Hence the bug described here https://forum.cfx.re/t/convar-ui-blurperfmode-is-not-honored-on-launch-and-blur-effect-makes-ui-almost-unresponsive-on-hidpi-displays/2050335
