### PR TITLE
fix: use server url for getConfiguration

### DIFF
--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -324,7 +324,7 @@ public:
 
 	fwEvent<const char*> OnAttemptDisconnect;
 
-	fwEvent<NetAddress> OnInitReceived;
+	fwEvent<NetAddress, std::string> OnInitReceived;
 
 	fwEvent<NetAddress> OnConnectOKReceived;
 

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -572,7 +572,7 @@ void NetLibrary::RunFrame()
 
 			// trigger task event
 			OnConnectionProgress("Downloading content", 0, 1);
-			OnInitReceived(m_currentServer);
+			OnInitReceived(m_currentServer, m_currentServerUrl);
 
 			break;
 


### PR DESCRIPTION
`getConfiguration` was the only client endpoint not using the server URL I don't know if it was intended 
This will make the `host` param in the request more reliable 👍 