### PR TITLE
fix(clrcore): correctly extract identifier values containing ':'

### DIFF
--- a/code/client/clrcore/Server/ServerWrappers.cs
+++ b/code/client/clrcore/Server/ServerWrappers.cs
@@ -130,7 +130,7 @@ namespace CitizenFX.Core
 		/// </example>
 		/// <param name="type">The identifier type to return.</param>
 		/// <returns>The identifier value (without prefix), or null if it could not be found.</returns>
-		public string this[string type] => this.FirstOrDefault(id => id.Split(':')[0].Equals(type, StringComparison.InvariantCultureIgnoreCase))?.Split(':')?.Last();
+		public string this[string type] => this.FirstOrDefault(id => id.Split(':')[0].Equals(type, StringComparison.InvariantCultureIgnoreCase))?.Split(new char[] { ':' }, 2)?.Last();
 	}
 
 	public class PlayerList : IEnumerable<Player>


### PR DESCRIPTION
IPv6 addresses are incorrectly extracted as they contain `:`, examples:

- `ip:[::ffff:127.0.0.1]` extracts as `127.0.0.1]`
- `ip:[::1]` extracts as `1]`

Limiting the number of substrings to 2 ensures that everything after `ip:` is kept together