### PR TITLE
Feat: Enable mumble bans + disable text + admin pass convar

### DIFF
--- a/code/components/voip-server-mumble/src/conf.cpp
+++ b/code/components/voip-server-mumble/src/conf.cpp
@@ -41,8 +41,10 @@
 #define DEFAULT_MAX_CLIENTS 1024
 #define DEFAULT_MAX_BANDWIDTH 76000
 #define DEFAULT_BINDPORT 64738
-#define DEFAULT_BAN_LENGTH (60*60)
+#define DEFAULT_BAN_LENGTH 0
 #define DEFAULT_OPUS_THRESHOLD 100
+
+std::shared_ptr<ConVar<std::string>> mumble_adminPass;
 
 void Conf_init(const char *conffile)
 {
@@ -87,7 +89,7 @@ const char *getStrConf(param_t param)
 		case PASSPHRASE:
 			return "";
 		case ADMIN_PASSPHRASE:
-			return "";
+			return mumble_adminPass->GetValue().c_str();
 		case WELCOMETEXT:
 			return DEFAULT_WELCOME;
 		case DEFAULT_CHANNEL:
@@ -124,9 +126,9 @@ bool_t getBoolConf(param_t param)
 {
 	switch (param) {
 		case ALLOW_TEXTMESSAGE:
-			return true;
-		case ENABLE_BAN:
 			return false;
+		case ENABLE_BAN:
+			return true;
 		case SYNC_BANFILE:
 			return false;
 		case SHOW_ADDRESSES:
@@ -227,3 +229,8 @@ int Conf_getNextChannelLink(conf_channel_link_t *chlink, int index)
 
 	return -1;
 }
+
+static InitFunction initFunction([]()
+{
+	mumble_adminPass = std::make_shared<ConVar<std::string>>("mumble_adminPass", ConVar_None, "");
+});

--- a/code/components/voip-server-mumble/src/messagehandler.cpp
+++ b/code/components/voip-server-mumble/src/messagehandler.cpp
@@ -135,12 +135,13 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			break;
 		}
 
-		/*if (SSLi_getSHA1Hash(client->ssl, client->hash) && Ban_isBanned(client)) {
-			char hexhash[41];
-			SSLi_hash2hex(client->hash, hexhash);
-			Log_info("Client with hash '%s' is banned. Disconnecting", hexhash);
+		if (Ban_isBanned(client)) {
+			char buf[64];
+			sprintf(buf, "You were banned from the server");
+			Log_info("Client is banned. Disconnecting");
+			sendServerReject(client, buf, MumbleProto::Reject_RejectType_None);
 			goto disconnect;
-		}*/
+		}
 
 		client_itr = NULL;
 		while (Client_iterate(&client_itr) != NULL) {


### PR DESCRIPTION
Add: "mumble_adminPass" convar to be able to become mumble admin and kick/ban users
Disable text channels
Enable bans (until server restart)