### PR TITLE
fix(events): Reenable gameEventTriggered for build 2189

### DIFF
--- a/code/components/gta-streaming-five/src/GameEventHooks.cpp
+++ b/code/components/gta-streaming-five/src/GameEventHooks.cpp
@@ -37,7 +37,7 @@ void*(*g_eventCall3)(void* group, void* event);
 template<decltype(g_eventCall1)* TFunc>
 void* HandleEventWrap(void* group, rage::fwEvent* event)
 {
-	if (event && !xbr::IsGameBuildOrGreater<2189>())
+	if (event)
 	{
 		try
 		{


### PR DESCRIPTION
This appears to be fixed for build 2189.

Tested it, played with it for a bit.
Couldn't find any info as to what exactly was causing the crash before (only found Pichot referencing it somewhere on the forum) but simply reenabled it and tested with it and didn't find any obvious issues with it.

I tested the CEventNetworkEntityDamage and CEventNetworkVehicleUndrivable they appeared to work fine.

Seems to me that some fix somewhere along the road fixed the events.