### PR TITLE
tweak(lua/scheduler): Return nil on invalid ref

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -587,7 +587,7 @@ Citizen.SetCallRefRoutine(function(refId, argsSerialized)
 	if not refPtr then
 		Citizen.Trace('Invalid ref call attempt: ' .. refId .. "\n")
 
-		return msgpack.pack({})
+		return msgpack.pack(nil)
 	end
 	
 	local ref = refPtr.func


### PR DESCRIPTION
This avoids if statements expecting a boolean from a ref passing if a ref is invalid.

This would copy the behaviour of having an error in a ref call, this would probably crash some plugins which lack checking but seems better than having a plugin continue on and causing havok further down the road.