### PR TITLE
fix(gameconfig): increase AttachmentExtension pool

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -53,7 +53,7 @@
 						</Item>
 						<Item>
 							<PoolName>AttachmentExtension</PoolName>
-							<PoolSize value="430"/>
+							<PoolSize value="860"/>
 						</Item>
 						<Item>
 						  <PoolName>AudioHeap</PoolName>


### PR DESCRIPTION
Many people are actually getting this crash.
Some people started to manually edit this field and are not experiencing any side-effects, I believe it could be fine to just increase it