### PR TITLE
fix(scheduler): return event handler

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -446,7 +446,7 @@ function RegisterNetEvent(eventName, cb)
 	tableEntry.safeForNet = true
 
 	if cb then
-		AddEventHandler(eventName, cb)
+		return AddEventHandler(eventName, cb)
 	end
 end
 


### PR DESCRIPTION
- useful if you need/want to remove the EventHandler later.