### PR TITLE
NUI_HAS_FOCUS native

### DIFF
--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -348,6 +348,8 @@ namespace nui
 	bool OVERLAY_DECL HasFrame(const std::string& frameName);
 	void OVERLAY_DECL SignalPoll(fwString frameName);
 
+	bool OVERLAY_DECL HasFocus();
+	bool OVERLAY_DECL HasFocusKeepInput();
 	void OVERLAY_DECL GiveFocus(const std::string& frameName, bool hasFocus, bool hasCursor = false);
 	void OVERLAY_DECL OverrideFocus(bool hasFocus);
 	void OVERLAY_DECL KeepInput(bool keepInput);

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -18,6 +18,8 @@
 #include <windowsx.h>
 #include <console/Console.VariableHelpers.h>
 
+using nui::HasFocus;
+
 extern nui::GameInterface* g_nuiGi;
 
 static bool g_hasFocus = false;
@@ -32,11 +34,6 @@ static ConVar<bool> uiLoadingCursor("ui_loadingCursor", ConVar_None, false);
 bool isKeyDown(WPARAM wparam)
 {
 	return (GetKeyState(wparam) & 0x8000) != 0;
-}
-
-bool HasFocus()
-{
-	return (g_hasFocus || g_hasOverriddenFocus);
 }
 
 #include <shared_mutex>
@@ -75,6 +72,16 @@ namespace nui
 	}
 
 	extern fwRefContainer<NUIWindow> FindNUIWindow(fwString windowName);
+
+	bool HasFocus()
+	{
+		return (g_hasFocus || g_hasOverriddenFocus);
+	}
+
+	bool HasFocusKeepInput()
+	{
+		return g_keepInput;
+	}
 
 	void GiveFocus(const std::string& frameName, bool hasFocus, bool hasCursor)
 	{

--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -363,6 +363,16 @@ static InitFunction initFunction([] ()
 		});
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("IS_NUI_FOCUSED", [] (fx::ScriptContext& context)
+	{
+		context.SetResult(nui::HasFocus());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_NUI_FOCUS_KEEPING_INPUT", [] (fx::ScriptContext& context)
+	{
+		context.SetResult(nui::HasFocusKeepInput());
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_NUI_FOCUS", [] (fx::ScriptContext& context)
 	{
 		fx::OMPtr<IScriptRuntime> runtime;

--- a/ext/native-decls/IsNuiFocusKeepingInput.md
+++ b/ext/native-decls/IsNuiFocusKeepingInput.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## IS_NUI_FOCUS_KEEPING_INPUT
+
+```c
+BOOL IS_NUI_FOCUS_KEEPING_INPUT();
+```
+
+Checks if keyboard input is enabled during NUI focus using `SET_NUI_FOCUS_KEEP_INPUT`.
+
+## Return value
+True or false.

--- a/ext/native-decls/IsNuiFocused.md
+++ b/ext/native-decls/IsNuiFocused.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## IS_NUI_FOCUSED
+
+```c
+BOOL IS_NUI_FOCUSED();
+```
+
+Returns the current NUI focus state previously set with `SET_NUI_FOCUS`.
+
+## Return value
+True or false.


### PR DESCRIPTION
It allows to easily detect when some external resource already took NUI focus and not to start our own focus-aimed actions in that case.