### PR TITLE
fix(scripting): rework server-internal events 

### DIFF
--- a/code/client/clrcore/InternalManager.cs
+++ b/code/client/clrcore/InternalManager.cs
@@ -372,7 +372,13 @@ namespace CitizenFX.Core
 
 			try
 			{
-				var obj = MsgPackDeserializer.Deserialize(argsSerialized, netSource: (sourceString.StartsWith("net") ? sourceString : null)) as List<object> ?? (IEnumerable<object>)new object[0];
+#if IS_FXSERVER
+				var netSource = (sourceString.StartsWith("net") || sourceString.StartsWith("internal-net")) ? sourceString : null;
+#else
+				var netSource = sourceString.StartsWith("net") ? sourceString : null;
+#endif
+
+				var obj = MsgPackDeserializer.Deserialize(argsSerialized, netSource) as List<object> ?? (IEnumerable<object>)new object[0];
 
 				var scripts = ms_definedScripts.ToArray();
 

--- a/code/client/clrcore/Server/ServerWrappers.cs
+++ b/code/client/clrcore/Server/ServerWrappers.cs
@@ -21,6 +21,12 @@ namespace CitizenFX.Core
 			{
 				sourceString = sourceString.Substring(4);
 			}
+#if IS_FXSERVER
+			else if (sourceString.StartsWith("internal-net:"))
+			{
+				sourceString = sourceString.Substring(13);
+			}
+#endif
 
 			m_handle = sourceString;
 		}

--- a/code/components/citizen-server-impl/src/ClientRegistry.cpp
+++ b/code/components/citizen-server-impl/src/ClientRegistry.cpp
@@ -134,7 +134,7 @@ namespace fx
 		 #/
 		declare function playerJoining(source: string, oldID: string): void;
 		*/
-		eventManager->TriggerEvent2("playerJoining", { fmt::sprintf("net:%d", client->GetNetId()) }, fmt::sprintf("%d", oldNetID));
+		eventManager->TriggerEvent2("playerJoining", { fmt::sprintf("internal-net:%d", client->GetNetId()) }, fmt::sprintf("%d", oldNetID));
 
 		// user code may lead to a drop event being sent here
 		if (client->IsDropping())

--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -1051,7 +1051,7 @@ namespace fx
 			->GetComponent<fx::ResourceEventManagerComponent>()
 			->TriggerEvent2(
 				"playerDropped",
-				{ fmt::sprintf("net:%d", client->GetNetId()) },
+				{ fmt::sprintf("internal-net:%d", client->GetNetId()) },
 				realReason
 			);
 

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -826,7 +826,7 @@ static InitFunction initFunction([]()
 					handover(data: { [key: string]: any }): void,
 				}, source: string): void;
 				*/
-				bool shouldAllow = eventManager->TriggerEvent2("playerConnecting", { fmt::sprintf("net:%d", lockedClient->GetNetId()) }, lockedClient->GetName(), cbComponent->CreateCallback([noReason](const msgpack::unpacked& unpacked)
+				bool shouldAllow = eventManager->TriggerEvent2("playerConnecting", { fmt::sprintf("internal-net:%d", lockedClient->GetNetId()) }, lockedClient->GetName(), cbComponent->CreateCallback([noReason](const msgpack::unpacked& unpacked)
 				{
 					auto obj = unpacked.get().as<std::vector<msgpack::object>>();
 

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -5,6 +5,7 @@ local debug = debug
 local coroutine_close = coroutine.close or (function(c) end) -- 5.3 compatibility
 local hadThread = false
 local curTime = 0
+local isDuplicityVersion = IsDuplicityVersion()
 
 -- setup msgpack compat
 msgpack.set_string('string_compat')
@@ -291,7 +292,7 @@ Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 
 			deserializingNetEvent = { source = eventSource }
 			_G.source = tonumber(eventSource:sub(5))
-		elseif IsDuplicityVersion() and eventSource:sub(1, 12) == 'internal-net' then
+		elseif isDuplicityVersion and eventSource:sub(1, 12) == 'internal-net' then
 			deserializingNetEvent = { source = eventSource:sub(10) }
 			_G.source = tonumber(eventSource:sub(14))
 		end
@@ -457,7 +458,7 @@ function TriggerEvent(eventName, ...)
 	end)
 end
 
-if IsDuplicityVersion() then
+if isDuplicityVersion then
 	function TriggerClientEvent(eventName, playerId, ...)
 		local payload = msgpack.pack({...})
 
@@ -672,7 +673,7 @@ if GetCurrentResourceName() == 'sessionmanager' then
 
 		local eventTriggerFn = TriggerServerEvent
 		
-		if IsDuplicityVersion() then
+		if isDuplicityVersion then
 			eventTriggerFn = function(name, ...)
 				TriggerClientEvent(name, source, ...)
 			end
@@ -744,7 +745,7 @@ AddEventHandler(repName, function(retId, args, err)
 	end
 end)
 
-if IsDuplicityVersion() then
+if isDuplicityVersion then
 	AddEventHandler('playerDropped', function(reason)
 		local source = source
 
@@ -777,7 +778,7 @@ InvokeRpcEvent = function(source, ref, args)
 
 	local eventTriggerFn = TriggerServerEvent
 
-	if IsDuplicityVersion() then
+	if isDuplicityVersion then
 		eventTriggerFn = function(name, ...)
 			TriggerClientEvent(name, src, ...)
 		end
@@ -902,7 +903,7 @@ end
 -- callback cache to avoid extra call to serialization / deserialization process at each time getting an export
 local exportsCallbackCache = {}
 
-local exportKey = (IsDuplicityVersion() and 'server_export' or 'export')
+local exportKey = (isDuplicityVersion and 'server_export' or 'export')
 
 do
 	local resource = GetCurrentResourceName()
@@ -923,7 +924,7 @@ end
 
 -- Remove cache when resource stop to avoid calling unexisting exports
 local function lazyEventHandler() -- lazy initializer so we don't add an event we don't need
-	AddEventHandler(('on%sResourceStop'):format(IsDuplicityVersion() and 'Server' or 'Client'), function(resource)
+	AddEventHandler(('on%sResourceStop'):format(isDuplicityVersion and 'Server' or 'Client'), function(resource)
 		exportsCallbackCache[resource] = {}
 	end)
 
@@ -984,7 +985,7 @@ setmetatable(exports, {
 })
 
 -- NUI callbacks
-if not IsDuplicityVersion() then
+if not isDuplicityVersion then
 	function RegisterNUICallback(type, callback)
 		RegisterNuiCallbackType(type)
 
@@ -1013,8 +1014,6 @@ local EXT_PLAYER = 42
 msgpack.extend_clear(EXT_ENTITY, EXT_PLAYER)
 
 local function NewStateBag(es)
-	local sv = IsDuplicityVersion()
-
 	return setmetatable({}, {
 		__index = function(_, s)
 			if s == 'set' then
@@ -1029,7 +1028,7 @@ local function NewStateBag(es)
 		
 		__newindex = function(_, s, v)
 			local payload = msgpack.pack(v)
-			SetStateBagValue(es, s, payload, payload:len(), sv)
+			SetStateBagValue(es, s, payload, payload:len(), isDuplicityVersion)
 		end
 	})
 end
@@ -1041,7 +1040,7 @@ local entityTM = {
 		if s == 'state' then
 			local es = ('entity:%d'):format(NetworkGetNetworkIdFromEntity(t.__data))
 			
-			if IsDuplicityVersion() then
+			if isDuplicityVersion then
 				EnsureEntityStateBag(t.__data)
 			end
 		
@@ -1130,6 +1129,6 @@ function Player(ent)
 	return ent
 end
 
-if not IsDuplicityVersion() then
+if not isDuplicityVersion then
 	LocalPlayer = Player(-1)
 end

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -8,6 +8,7 @@ const EXT_LOCALFUNCREF = 11;
 (function (global) {
 	let boundaryIdx = 1;
 	let lastBoundaryStart = null;
+	const isDuplicityVersion = IsDuplicityVersion();
 
 	// temp
 	global.FormatStackTrace = function (args, argLength) {
@@ -200,7 +201,7 @@ const EXT_LOCALFUNCREF = 11;
 
 	global.TriggerEvent = global.emit;
 
-	if (IsDuplicityVersion()) {
+	if (isDuplicityVersion) {
 		global.emitNet = (name, source, ...args) => {
 			const dataSerialized = pack(args);
 
@@ -398,7 +399,7 @@ const EXT_LOCALFUNCREF = 11;
 				}
 
 				global.source = parseInt(source.substr(4));
-			} else if (IsDuplicityVersion() && source.startsWith('internal-net')) {
+			} else if (isDuplicityVersion && source.startsWith('internal-net')) {
 				global.source = parseInt(source.substr(13));
 			}
 
@@ -442,8 +443,8 @@ const EXT_LOCALFUNCREF = 11;
 
 	// Compatibility layer for legacy exports
 	const exportsCallbackCache = {};
-	const exportKey = (IsDuplicityVersion()) ? 'server_export' : 'export';
-	const eventType = (IsDuplicityVersion() ? 'Server' : 'Client');
+	const exportKey = isDuplicityVersion ? 'server_export' : 'export';
+	const eventType = isDuplicityVersion ? 'Server' : 'Client';
 
 	const getExportEventName = (resource, name) => `__cfx_export_${resource}_${name}`;
 
@@ -536,8 +537,6 @@ const EXT_LOCALFUNCREF = 11;
 	const EXT_PLAYER = 42;
 
 	global.NewStateBag = (es) => {
-		const sv = IsDuplicityVersion();
-
 		return new Proxy({}, {
 			get(_, k) {
 				if (k === 'set') {
@@ -552,7 +551,7 @@ const EXT_LOCALFUNCREF = 11;
 
 			set(_, k, v) {
 				const payload = msgpack_pack(v);
-				return SetStateBagValue(es, k, payload, payload.length, sv);
+				return SetStateBagValue(es, k, payload, payload.length, isDuplicityVersion);
 			},
 		});
 	};
@@ -564,7 +563,7 @@ const EXT_LOCALFUNCREF = 11;
 			if (k === 'state') {
 				const es = `entity:${NetworkGetNetworkIdFromEntity(t.__data)}`;
 
-				if (IsDuplicityVersion()) {
+				if (isDuplicityVersion) {
 					EnsureEntityStateBag(t.__data);
 				}
 

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -159,7 +159,7 @@ const EXT_LOCALFUNCREF = 11;
 	// Events
 	const emitter = new EventEmitter2();
 	const rawEmitter = new EventEmitter2();
-	const netSafeEventNames = new Set(['playerDropped', 'playerConnecting']);
+	const netSafeEventNames = new Set();
 
 	// Raw events
 	global.addRawEventListener = rawEmitter.on.bind(rawEmitter);
@@ -398,6 +398,8 @@ const EXT_LOCALFUNCREF = 11;
 				}
 
 				global.source = parseInt(source.substr(4));
+			} else if (IsDuplicityVersion() && source.startsWith('internal-net')) {
+				global.source = parseInt(source.substr(13));
 			}
 
 			const payload = unpack(payloadSerialized) || [];


### PR DESCRIPTION
~~playerJoining is emitted by the server and is considered a net event but wasn't added to the safe net events whitelist for Lua or JS.~~

Server only events which are internally considered net events (like playerConnecting, playerDropped and playerJoining) are now handled separately from proper network events and cannot be triggered by clients unless the event is explicitly registered as a network event.

This fixes issues with the playerJoining event and stops malicious clients from triggering playerConnecting or playerDropped themselves.
