### PR TITLE
Fix server list filter input on Safari

### DIFF
--- a/ext/cfx-ui/src/app/servers/components/filters/server-filter.component.scss
+++ b/ext/cfx-ui/src/app/servers/components/filters/server-filter.component.scss
@@ -116,6 +116,10 @@
 			};
 		}
 
+		input {
+			user-select: text;
+		}
+
 		input:focus + .search-dropdown {
 			transform: translateY(0);
 			opacity: 1;


### PR DESCRIPTION
Users on Safari (and maybe other WebKit browsers) aren't able to input text to the server search box because it's inheriting `user-select: none`, so this override should resolve that.