### PR TITLE
feat(onesync): add SET_PLAYER_CULLING_RADIUS native

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -478,10 +478,22 @@ struct SyncEntityState
 
 	virtual ~SyncEntityState();
 
-	inline float GetDistanceCullingRadius()
+	inline float GetDistanceCullingRadius(float playerCullingRadius)
 	{
-		// #TODO1S: figure out a good value for this
-		return overrideCullingRadius != 0.0f ? overrideCullingRadius : (424.0f * 424.0f);
+		//Use priority ordering
+		if (overrideCullingRadius != 0.0f) 
+		{
+			return overrideCullingRadius;
+		}
+		else if (playerCullingRadius != 0.0f) 
+		{
+			return playerCullingRadius;
+		}
+		else
+		{
+			// #TODO1S: figure out a good value for this
+			return (424.0f * 424.0f);
+		}
 	}
 
 	inline uint32_t GetScriptHash()
@@ -812,6 +824,13 @@ struct GameStateClientData : public sync::ClientSyncDataBase
 	std::shared_ptr<fx::StateBag> playerBag;
 
 	uint32_t routingBucket = 0;
+
+	float playerCullingRadius = 0.0f;
+	
+	inline float GetPlayerCullingRadius()
+	{
+		return playerCullingRadius;
+	}
 
 	GameStateClientData()
 		: syncing(false)

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -838,7 +838,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 					float diffY = entityPos.y - playerPos.y;
 
 					float distSquared = (diffX * diffX) + (diffY * diffY);
-					if (distSquared < entity->GetDistanceCullingRadius())
+					if (distSquared < entity->GetDistanceCullingRadius(clientDataUnlocked->GetPlayerCullingRadius())) 
 					{
 						isRelevant = true;
 					}

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1414,4 +1414,29 @@ static InitFunction initFunction([]()
 		// Return the entity
 		return gameState->MakeScriptHandle(returnEntity);
 	}));
+  
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_CULLING_RADIUS", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
+	{
+		if (context.GetArgumentCount() > 1)
+		{
+			float radius = context.GetArgument<float>(1);
+
+			if (radius >= 0)
+			{
+				// get the current resource manager
+				auto resourceManager = fx::ResourceManager::GetCurrent();
+
+				// get the owning server instance
+				auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+
+				// get the server's game state
+				auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+				auto [lock, clientData] = gameState->ExternalGetClientData(client);
+				clientData->playerCullingRadius = radius * radius;
+			}
+		}
+
+		return true;
+	}));
 });

--- a/ext/native-decls/SetPlayerCullingRadius.md
+++ b/ext/native-decls/SetPlayerCullingRadius.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_PLAYER_CULLING_RADIUS
+
+```c
+void SET_PLAYER_CULLING_RADIUS(char* playerSrc, float radius);
+```
+
+Sets the culling radius for the specified player.
+Set to `0.0` to reset.
+
+## Parameters
+* **playerSrc**: The player to set the culling radius for.
+* **radius**: The radius.


### PR DESCRIPTION
This PR adds the ability to set a players culling radius on onesync infinity with the following native:

SET_PLAYER_CULLING_RADIUS(playerSrc,radius)

This also decides the priority of which culling distance to use in the following order, thanks to @PichotM for the idea. example:

- entity radius if set by SET_ENTITY_DISTANCE_CULLING_RADIUS
- player radius if set by SET_PLAYER_CULLING_RADIUS
- default radius (424.0f)
