### PR TITLE
feat(scripting/v8): global shared object, support for modern OOP-style frameworks

### DIFF
--- a/code/components/citizen-scripting-v8/src/V8ScriptRuntime.cpp
+++ b/code/components/citizen-scripting-v8/src/V8ScriptRuntime.cpp
@@ -1924,6 +1924,9 @@ result_t V8ScriptRuntime::Create(IScriptHost* scriptHost)
 		context->Global()->Set(context, String::NewFromUtf8(GetV8Isolate(), "window", NewStringType::kNormal).ToLocalChecked(), context->Global());
 	}
 
+	static Global<Object> sharedObject = Global<Object>::Global(GetV8Isolate(), Object::New(GetV8Isolate()));
+	context->Global()->Set(context, String::NewFromUtf8(GetV8Isolate(), "shared", NewStringType::kNormal).ToLocalChecked(), sharedObject.Get(GetV8Isolate()));
+
 	std::string nativesBuild = "natives_universal.js";
 
 	{


### PR DESCRIPTION
This patch creates a `global.shared` object inside every v8 scripting context, that may be used to exchange any data and objects between different fivem resources by reference without any extra data serialization. We use this functionality to create our TypeScript OOP framework with straightforward easy to use API: [NovaEngine](https://gitlab.com/novalife/engine).

I have not so much experience with v8, any help integrating this feature into fivem would be appreciated.