### PR TITLE
Make provide work with exports

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -981,6 +981,13 @@ setmetatable(exports, {
 		AddEventHandler(getExportEventName(GetCurrentResourceName(), exportName), function(setCB)
 			setCB(func)
 		end)
+			
+		local provides = GetResourceMetadata(GetCurrentResourceName(), 'provide')
+		if provides then
+		    AddEventHandler(getExportEventName(provides, exportName), function(setCB)
+			setCB(func)
+		    end)
+		end
 	end
 })
 


### PR DESCRIPTION
Providing for a resource will allow exports to work too.

Ex:
```lua
-- new_resource/fxmanifest
provide 'old_resource'

-- new_resource/shared.lua
exports('TestFunction', function()
    print('new test')
end)

-- some other random resource
exports['old_resource']:TestFunction()
```
Output:
> new test