### PR TITLE
fix(scripting/lua): support exported MRVs

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -957,13 +957,23 @@ setmetatable(exports, {
 				end
 
 				return function(self, ...)
-					local status, result = pcall(exportsCallbackCache[resource][k], ...)
+					local allPacked = table.pack(pcall(exportsCallbackCache[resource][k], ...))
+					local status, retValOrErr = allPacked[1], allPacked[2]
 
 					if not status then
-						error('An error happened while calling export ' .. k .. ' of resource ' .. resource .. ' (' .. result .. '), see above for details')
+						error('An error happened while calling export ' .. k .. ' of resource ' .. resource .. ' (' .. retValOrErr .. '), see above for details')
 					end
 
-					return result
+					-- 1: status
+					-- 2: error or return value ?? nil
+					-- 3+: any other ret vals 
+					if retValOrErr ~= nil and #allPacked > 2 then
+						-- this is the status of the pcall, we won't need this
+						table.remove(allPacked, 1)
+						return table.unpack(allPacked)
+					end
+
+					return retValOrErr
 				end
 			end,
 


### PR DESCRIPTION
I believe this is quite hacky and could be done cleaner, however, this is the only approach I could think of.

The issue is that MRVs aren't properly handled with the Lua ScRT because of it only returning the second parameter of `pcall`, which does not take into account MRVs. The only way to actually ensure that all MRVs are a gotten is through packing the `pcall` return values and handling it's return as normal, afterward we just check if the pack is >2 (has 2+ MRVs) and if so, we just remove 1st index and unpack. Othewise, just return the second retval of the `pcall` (first is status of the `pcall`).

Some tests for ensuring no regressions are introduced with these changes:

## Lua
### Setting in Lua and also getting
```lua
exports('test_exp', function(opts)
    if opts and opts.mrv then
        return 4, 3, 5, 7, 9
    end

    return 155
end)

local doTest = 1

local test_exp = function(...) return exports[GetCurrentResourceName()]:test_exp(...) end
local log = function(a) print("^3" .. a) end
local newLine = function() print() end

if doTest then
    newLine()
    log('Lua Test')
    log('Description: ^4Ensure MRVs are handled with exports from the Lua ScRT')
    log('Expect: ^4if ret val == 1 then return it, otherwise return all of them\n')
    do
        log('Returning 1 value:')
        local ret = test_exp()
        log(string.format('- %s | %s', ret, type(ret)))
    end

    newLine()
    do
        local ret, any, other, value, nein = test_exp({ mrv = true })
        log('Returning 5 values:')
        log(string.format('- %s | type: %s', ret, type(ret)))
        print(ret, any, other, value, nein)
    end
end
```

## JavaScript
### Only getting in JavaScript
JavaScript behaviour of getting Lua export MRVs was always just packing into an array.

```js
const { test_exp } = exports['test-lua'];

const doTest = 1;
const log = (a) => console.log(`^3${a}`);
const newLine = () => console.log();

if (doTest) {
    newLine();
    log('JavaScript Test');
    log('Description: ^4Ensuring no regressions are made with exporting any amount of values')
    log('Expect: ^4if ret val == 1 then return it, otherwise pack as an array\n');
    {
        log('Returning 1 value:');
        const ret = test_exp();
        log(`- ${ret} | ${typeof ret}`);
    }

    newLine();
    {
        const ret = test_exp({ mrv: true });
        const { length } = ret;
        log(`Returning ${length !== 0 && !length ? new Error('bad len') : length} values:`);
        log(`- ${ret} | type: ${typeof ret} | len: ${length}`);
    }
    newLine();
}
```

Expected output from running the above code:
![](https://lambda.sx/GYhT.png)