### PR TITLE
fix(scripting/v8): fixed getPlayers() & source type definition

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -89,7 +89,7 @@ declare function TriggerServerEvent(eventName: string, ...args: any[]): void
 declare function TriggerLatentServerEvent(eventName: string, bps: number, ...args: any[]): void
 
 declare function getPlayerIdentifiers(player: number|string): string[]
-declare function getPlayers(): number[]
+declare function getPlayers(): string[]
 
 declare function emitNet(eventName: string, target: number|string, ...args: any[]): void
 declare function TriggerClientEvent(eventName: string, target: number|string, ...args: any[]): void
@@ -107,4 +107,4 @@ declare function Player(entity: number|string): EntityInterface
 
 declare var exports: any;
 
-declare var source: string;
+declare var source: number;


### PR DESCRIPTION
`global.getPlayers()` returns an array of strings not numbers.

`global.source` is being parsed as an integer during net events in `main.js`