### PR TITLE
fix(onesync-natives): compatibility with game seat indexes

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1001,7 +1001,7 @@ static InitFunction initFunction([]()
     {
         auto vn = entity->syncTree->GetVehicleGameState();
 
-        int seatArg = context.GetArgument<int>(1);
+        int seatArg = context.GetArgument<int>(1) + 2;
 
         // get the current resource manager
         auto resourceManager = fx::ResourceManager::GetCurrent();
@@ -1030,7 +1030,7 @@ static InitFunction initFunction([]()
     {
         auto vn = entity->syncTree->GetVehicleGameState();
 
-        int seatArg = context.GetArgument<int>(1);
+        int seatArg = context.GetArgument<int>(1) + 2;
 
         // get the current resource manager
         auto resourceManager = fx::ResourceManager::GetCurrent();


### PR DESCRIPTION
For sync nodes, the driver seat index starts at 1, and so on
This fixes the compatibility with the game seat index that starts at -1 for the driver