### PR TITLE
feat(extra-natives-five): SET_DEFAULT_*_MULTIPLIER natives

### DIFF
--- a/code/components/extra-natives-five/src/DensityNatives.cpp
+++ b/code/components/extra-natives-five/src/DensityNatives.cpp
@@ -6,12 +6,17 @@
 #include <Resource.h>
 #include <fxScripting.h>
 
+#include <GameInit.h>
+
 static float* g_pedDensity;
 static float* g_pedScenarioDensity;
 static float* g_ambientPedRange;
 static float* g_ambientVehicleRangeMultiplier;
 static float* g_parkedVehicleDensity;
 static float* g_vehicleDensity;
+
+static char* g_pedLocation;
+static char* g_vehicleLocation;
 
 static HookFunction hookFunction([]()
 {
@@ -21,6 +26,8 @@ static HookFunction hookFunction([]()
 		g_pedDensity = hook::get_address<float*>(location + 35) + 1;
 		g_pedScenarioDensity = hook::get_address<float*>(location + 45) + 1;
 		g_ambientPedRange = hook::get_address<float*>(location + 65) + 1;
+
+		g_pedLocation = location;
 	}
 
 	{
@@ -29,6 +36,8 @@ static HookFunction hookFunction([]()
 		g_ambientVehicleRangeMultiplier = hook::get_address<float*>(location + 7) + 1;
 		g_vehicleDensity = hook::get_address<float*>(location + 17) + 1;
 		g_parkedVehicleDensity = hook::get_address<float*>(location + 27) + 1;
+
+		g_vehicleLocation = location;
 	}
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_PED_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
@@ -64,5 +73,54 @@ static HookFunction hookFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("GET_RANDOM_VEHICLE_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
 	{
 		context.SetResult<float>(*g_vehicleDensity);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_PED_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_pedLocation + 39, multiplier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_SCENARIO_PED_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_pedLocation + 49, multiplier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_AMBIENT_PED_RANGE_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_pedLocation + 69, multiplier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_AMBIENT_VEHICLE_RANGE_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_vehicleLocation + 11, multiplier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_VEHICLE_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_vehicleLocation + 21, multiplier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEFAULT_PARKED_VEHICLE_DENSITY_MULTIPLIER", [](fx::ScriptContext& context)
+	{
+		float multiplier = context.GetArgument<float>(0);
+		hook::put<float>(g_vehicleLocation + 31, multiplier);
+	});
+
+	OnKillNetworkDone.Connect([]
+	{
+		// Ped Density, Scenario Ped Density, Ped Ambient Range 
+		hook::put<float>(g_pedLocation + 39, 1.0f);
+		hook::put<float>(g_pedLocation + 49, 1.0f);
+		hook::put<float>(g_pedLocation + 69, 1.0f);
+
+		// Vehicle Ambient Range, Vehicle Density, Parked Vehicle Density
+		hook::put<float>(g_vehicleLocation + 11, 1.0f);
+		hook::put<float>(g_vehicleLocation + 21, 1.0f);
+		hook::put<float>(g_vehicleLocation + 31, 1.0f);
 	});
 });

--- a/ext/native-decls/SetDefaultAmbientPedRangeMultiplier.md
+++ b/ext/native-decls/SetDefaultAmbientPedRangeMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_AMBIENT_PED_RANGE_MULTIPLIER
+
+```c
+void SET_DEFAULT_AMBIENT_PED_RANGE_MULTIPLIER(float multiplier);
+```
+
+Sets the ambient ped range multiplier that will be set every tick by the game.
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.

--- a/ext/native-decls/SetDefaultAmbientVehicleRangeMultiplier.md
+++ b/ext/native-decls/SetDefaultAmbientVehicleRangeMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_AMBIENT_VEHICLE_RANGE_MULTIPLIER
+
+```c
+void SET_DEFAULT_AMBIENT_VEHICLE_RANGE_MULTIPLIER(float multiplier);
+```
+
+Sets the ambient vehicle range multiplier that will be set every tick by the game.
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.

--- a/ext/native-decls/SetDefaultParkedVehicleDensityMultiplier.md
+++ b/ext/native-decls/SetDefaultParkedVehicleDensityMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_PARKED_VEHICLE_DENSITY_MULTIPLIER
+
+```c
+void SET_DEFAULT_PARKED_VEHICLE_DENSITY_MULTIPLIER(float multiplier);
+```
+
+Sets the parked vehicle density multiplier that will be set every tick by the game. This value is not limited to 1.0 and defines the maximum value that can be set by [SET_PARKED_VEHICLE_DENSITY_MULTIPLIER_THIS_FRAME](#_0xEAE6DCC7EEE3DB1D)
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.

--- a/ext/native-decls/SetDefaultPedDensityMultiplier.md
+++ b/ext/native-decls/SetDefaultPedDensityMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_PED_DENSITY_MULTIPLIER
+
+```c
+void SET_DEFAULT_PED_DENSITY_MULTIPLIER(float multiplier);
+```
+
+Sets the ped density multiplier that will be set every tick by the game. This value is not limited to 1.0 and defines the maximum value that can be set by [SET_PED_DENSITY_MULTIPLIER_THIS_FRAME](#_0x95E3D6257B166CF2)
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.

--- a/ext/native-decls/SetDefaultScenarioPedDensityMultiplier.md
+++ b/ext/native-decls/SetDefaultScenarioPedDensityMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_SCENARIO_PED_DENSITY_MULTIPLIER
+
+```c
+void SET_DEFAULT_SCENARIO_PED_DENSITY_MULTIPLIER(float multiplier);
+```
+
+Sets the scenario ped density multiplier that will be set every tick by the game. This value is not limited to 1.0 and defines the maximum value that can be set by [SET_SCENARIO_PED_DENSITY_MULTIPLIER_THIS_FRAME](#_0x7A556143A1C03898)
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.

--- a/ext/native-decls/SetDefaultVehicleDensityMultiplier.md
+++ b/ext/native-decls/SetDefaultVehicleDensityMultiplier.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_DEFAULT_VEHICLE_DENSITY_MULTIPLIER
+
+```c
+void SET_DEFAULT_VEHICLE_DENSITY_MULTIPLIER(float multiplier);
+```
+
+Sets the vehicle density multiplier that will be set every tick by the game. This value is not limited to 1.0 and defines the maximum value that can be set by [SET_VEHICLE_DENSITY_MULTIPLIER_THIS_FRAME](#_0x245A6883D966D537)
+
+## Parameters
+* **multiplier**: The value to set. Default is 1.0.


### PR DESCRIPTION
This pull request was initially created by DelphinusBeta before it was closed.
Just to reiterate, the natives allow you to go over a multiplier of 1.0 and do not need to be called on tick and has been tested on 1604 + 2189.
The PopulateNow native helps to show the increase in vehicles when using more than 1.0
