### PR TITLE
tweak(voip/mumble): increase UDP timeout and ping frequency

### DIFF
--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -27,6 +27,8 @@
 
 #include <uvw.hpp>
 
+using namespace std::literals::chrono_literals;
+
 namespace net
 {
 	class UvLoopHolder;
@@ -192,6 +194,10 @@ private:
 	uint32_t m_udpPings[12];
 
 	int m_voiceTarget;
+
+	const std::chrono::milliseconds m_udpTimeout = 10000ms;
+
+	const std::chrono::milliseconds m_udpPingFrequency = 1000ms;
 
 	std::chrono::milliseconds m_lastUdp;
 

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -22,8 +22,6 @@ using json = nlohmann::json;
 
 static __declspec(thread) MumbleClient* g_currentMumbleClient;
 
-using namespace std::chrono_literals;
-
 inline std::chrono::milliseconds msec()
 {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
@@ -180,7 +178,7 @@ void MumbleClient::Initialize()
 		{
 			static bool hadUDP = false;
 			static bool warnedUDP = false;
-			bool hasUDP = ((msec() - m_lastUdp) <= 7500ms);
+			bool hasUDP = ((msec() - m_lastUdp) <= m_udpTimeout);
 			
 			if (hasUDP && !hadUDP)
 			{
@@ -401,7 +399,7 @@ void MumbleClient::Initialize()
 						SendUDP(pingBuf, pds.size());
 					}
 
-					m_nextPing = msec() + 2500ms;
+					m_nextPing = msec() + m_udpPingFrequency;
 				}
 			}
 			else
@@ -719,9 +717,7 @@ void MumbleClient::SetListenerMatrix(float position[3], float front[3], float up
 
 void MumbleClient::SendVoice(const char* buf, size_t size)
 {
-	using namespace std::chrono_literals;
-
-	if ((msec() - m_lastUdp) > 7500ms)
+	if ((msec() - m_lastUdp) > m_udpTimeout)
 	{
 		Send(MumbleMessageType::UDPTunnel, buf, size);
 	}

--- a/docs/building.md
+++ b/docs/building.md
@@ -5,6 +5,7 @@
 To build FiveM, RedM or FXServer on Windows you need the following dependencies:
 
 * A Windows machine with Visual Studio 2019 (Build Tools/Community is fine) installed with the following workloads:
+  - ASP.NET and web development
   - .NET desktop environment
   - Desktop development with C++
   - Universal Windows Platform development
@@ -22,6 +23,7 @@ Then, execute the following commands in a `cmd.exe` shell to set up the build en
 ```bat
 set BOOST_ROOT=C:\libraries\boost_1_63_0
 set PATH=%path%;C:\tools\python27amd64
+python -m pip install ply jinja2
 git clone https://github.com/citizenfx/fivem.git
 cd fivem
 git submodule init


### PR DESCRIPTION
This increases both the UDP timeout and the frequency of the UDP pings. At their previous values, only two
ping attempts would be made prior to the timeout lapsing. Two UDP drops in a row, assuming no voice transmissions, would result in UDP mode being disabled.

At 5% to 15% packet loss in either direction, this occurrence wasn't as unlikely as you'd think:
```
5% = 1/20
(1/20) * (1/20) = 0.0025%
0.25% chance every 7.5s

15% = 1/6.66~
(1/6.66) * (1/6.66) = 0.0225%
2.25% chance every 7.5s
```

A series of trials on an unpatched client with 15% drop on inbound and outbound UDP traffic:

1. UDP lost at 17s.
2. UDP lost at 2m30s.
3. UDP lost at 1m20s.
4. UDP lost at 1m24s.
5. UDP lost at 6m12s.

A series of trials on a patched client with 25% drop on inbound and outbound UDP traffic:

1. UDP lost at 8m20s.
2. UDP lost at 14m5s.
3. UDP still connected after 30m.

Keeping the UDP connection active, even though Opus packets will be lost, seems preferable to dropping into TCP mode. As of now, TCP mode is prone to other issues like bottlenecks and voice delay, both of which seem to be the combined result of packet loss and latency.