### PR TITLE
fix(voip/mumble): actively poll the jitter buffer in both modes

### DIFF
--- a/code/components/voip-mumble/include/MumbleAudioOutput.h
+++ b/code/components/voip-mumble/include/MumbleAudioOutput.h
@@ -102,6 +102,11 @@ private:
 			return isTalking;
 		}
 
+		virtual bool ShouldManagePoll()
+		{
+			return false;
+		}
+
 		virtual bool ShouldPollAudio()
 		{
 			return false;
@@ -128,6 +133,7 @@ private:
 		uint32_t lastTime;
 
 		std::mutex jitterLock;
+		std::shared_mutex pollLock;
 
 		int iLastConsume = 0;
 		int iBufferFilled = 0;
@@ -183,6 +189,11 @@ private:
 		virtual bool Valid() override
 		{
 			return context && context->destination();
+		}
+
+		virtual bool ShouldManagePoll()
+		{
+			return true;
 		}
 
 		virtual bool ShouldPollAudio()

--- a/code/components/voip-mumble/include/MumbleAudioOutput.h
+++ b/code/components/voip-mumble/include/MumbleAudioOutput.h
@@ -102,7 +102,7 @@ private:
 			return isTalking;
 		}
 
-		virtual bool ShouldManagePoll()
+		virtual bool ShouldPollAudio()
 		{
 			return false;
 		}
@@ -185,9 +185,11 @@ private:
 			return context && context->destination();
 		}
 
-		virtual bool ShouldManagePoll()
+		virtual bool ShouldPollAudio()
 		{
-			return true;
+			XAUDIO2_VOICE_STATE vs;
+			voice->GetState(&vs);
+			return vs.BuffersQueued == 0;
 		}
 
 		virtual void PushSound(int16_t* voiceBuffer, int len) override;

--- a/code/components/voip-mumble/src/MumbleAudioOutput.cpp
+++ b/code/components/voip-mumble/src/MumbleAudioOutput.cpp
@@ -262,6 +262,7 @@ void MumbleAudioOutput::ClientAudioState::OnBufferEnd(void* cxt)
 		isTalking = false;
 	}
 
+	std::unique_lock<std::shared_mutex> _(pollLock);
 	if (ShouldPollAudio())
 	{
 		PollAudio((48000 / 1000) * 10);
@@ -697,6 +698,12 @@ void MumbleAudioOutput::HandleClientVoiceData(const MumbleUser& user, uint64_t s
 		jitter_buffer_put(client->jitter, &jbp);
 	}
 
+	if (!client->ShouldManagePoll())
+	{
+		return;
+	}
+
+	std::unique_lock<std::shared_mutex> _(client->pollLock);
 	if (client->ShouldPollAudio())
 	{
 		client->PollAudio(numSamples);

--- a/code/components/voip-mumble/src/MumbleAudioOutput.cpp
+++ b/code/components/voip-mumble/src/MumbleAudioOutput.cpp
@@ -699,7 +699,7 @@ void MumbleAudioOutput::HandleClientVoiceData(const MumbleUser& user, uint64_t s
 
 	if (client->ShouldPollAudio())
 	{
-		client->PollAudio((48000 / 1000) * 10);
+		client->PollAudio(numSamples);
 	}
 }
 


### PR DESCRIPTION
This is my quick fix for this issue:
https://forum.cfx.re/t/fivem-voice-chat-lags-behind/2579415/

I believe the nativeAudio end does actively poll, so that's what I've configured on the other end. This might be a candidate for utilizing multiple cores, but maybe that's not worth the effort.