### PR TITLE
tweak(conhost): revert console and developer tools censorship on prod

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -754,6 +754,7 @@ static void EnsureConsoles()
 	}
 }
 
+<<<<<<< HEAD
 bool IsNonProduction()
 {
 #if !defined(GTA_FIVE) || defined(_DEBUG)
@@ -774,6 +775,8 @@ bool IsNonProduction()
 #endif
 }
 
+=======
+>>>>>>> parent of ab7ef4208 (tweak(conhost): censor out console and 'non-trivial' tools when running prod)
 void DrawConsole()
 {
 	EnsureConsoles();

--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -771,18 +771,33 @@ bool IsNonProduction()
 		return _wcsicmp(resultPath, L"production") == 0 || _wcsicmp(resultPath, L"prod") == 0;
 	})();
 
+<<<<<<< HEAD
 	return !isProd || moo.GetValue() == 31337;
 #endif
 }
 
 =======
 >>>>>>> parent of ab7ef4208 (tweak(conhost): censor out console and 'non-trivial' tools when running prod)
+=======
+	return !isProd;
+#endif
+}
+
+>>>>>>> parent of c5a9e4a53 (feat(conhost): add non-production warning and more obvious connect/quit commands)
 void DrawConsole()
 {
 	EnsureConsoles();
 
+<<<<<<< HEAD
 	static bool pOpen = true;
 	g_consoles[0]->Draw("", &pOpen);
+=======
+	if (IsNonProduction())
+	{
+		static bool pOpen = true;
+		g_consoles[0]->Draw("", &pOpen);
+	}
+>>>>>>> parent of c5a9e4a53 (feat(conhost): add non-production warning and more obvious connect/quit commands)
 }
 
 void DrawMiniConsole()

--- a/code/components/conhost-v2/src/DevGui.cpp
+++ b/code/components/conhost-v2/src/DevGui.cpp
@@ -239,14 +239,6 @@ static InitFunction initFunction([]()
 	});
 
 #ifndef IS_FXSERVER
-	static ConVar<std::string> uiConnectHost("uiConnectHost", ConVar_Archive, "");
-
-	static ConsoleCommand uiConnect("uiConnect", []()
-	{
-		console::GetDefaultContext()->ExecuteSingleCommandDirect(ProgramArguments{
-		"connect", uiConnectHost.GetValue() });
-	});
-
 	console::GetDefaultContext()->AddToBuffer(R"(
 devgui_convar "Tools/Performance/Resource Monitor" resmon
 devgui_convar "Tools/Performance/Streaming Memory Viewer" strmem
@@ -268,11 +260,8 @@ devgui_cmd "Launch/SP/GTA5" "loadlevel gta5"
 devgui_cmd "Launch/SP/RDR3" "loadlevel rdr3"
 devgui_cmd "Launch/SP/Blank Map" "loadlevel blank"
 devgui_cmd "Launch/MP/Localhost" "connect localhost"
-devgui_convar "Launch/MP/Connect" "uiConnectHost"
-devgui_cmd "Launch/MP/Connect to host above" "uiConnect"
 devgui_cmd "Launch/MP/Disconnect" "disconnect"
 devgui_cmd "Launch/Quit" "quit"
-devgui_cmd "Quit/Quit" "quit"
 
 devgui_cmd "Tools/Performance/Profiler/Start Recording - 5 frames" "profiler record 5"
 devgui_cmd "Tools/Performance/Profiler/View Last Recording" "profiler view"

--- a/code/components/conhost-v2/src/DevGui.cpp
+++ b/code/components/conhost-v2/src/DevGui.cpp
@@ -220,8 +220,6 @@ void DrawDevGui()
 	}
 }
 
-extern bool IsNonProduction();
-
 static InitFunction initFunction([]()
 {
 	static ConsoleCommand devguiAddCmd("devgui_cmd", [](const DevGuiPath& path, const std::string& commandString)
@@ -250,7 +248,19 @@ static InitFunction initFunction([]()
 	});
 
 	console::GetDefaultContext()->AddToBuffer(R"(
+devgui_convar "Tools/Performance/Resource Monitor" resmon
+devgui_convar "Tools/Performance/Streaming Memory Viewer" strmem
+devgui_convar "Tools/Streaming/Streaming Stats" strdbg
+devgui_convar "Tools/Streaming/Streaming List" strlist
+devgui_convar "Tools/Network/OneSync/Network Object Viewer" netobjviewer
+devgui_convar "Tools/Network/OneSync/Network SyncLog" netobjviewer_syncLog
+devgui_convar "Tools/Network/OneSync/Network Time" net_showTime
+devgui_convar "Tools/Network/Network Command Log" net_showCommands
+devgui_convar "Tools/Network/Network Event Log" netEventLog
+devgui_cmd "Tools/NUI/Open DevTools" nui_devTools
+
 devgui_convar "Overlays/Draw FPS" cl_drawFPS
+devgui_convar "Overlays/Draw Performance" cl_drawPerf
 devgui_convar "Overlays/NetGraph" netgraph
 
 devgui_cmd "Launch/SP/Story Mode" "storymode"
@@ -270,12 +280,14 @@ devgui_cmd "Tools/Performance/Profiler/View Last Recording" "profiler view"
 set "game_mute" "profile_sfxVolume 0; profile_musicVolumeInMp 0; profile_musicVolume 0"
 set "game_unmute" "profile_sfxVolume 25; profile_musicVolumeInMp 10; profile_musicVolume 10"
 
+devgui_convar "Game/Enable Handbrake Camera" cam_enableHandbrakeCamera
 devgui_convar "Game/SFX Volume" profile_sfxVolume
 devgui_cmd "Game/Mute" "vstr game_mute"
 devgui_cmd "Game/Unmute" "vstr game_unmute"
 
 devgui_convar "Overlays/Draw Performance" cl_drawPerf
 )");
+<<<<<<< HEAD
 
 	if (IsNonProduction())
 	{
@@ -292,5 +304,7 @@ devgui_convar "Tools/Network/Network Event Log" netEventLog
 devgui_cmd "Tools/NUI/Open DevTools" nui_devTools
 )");
 	}
+=======
+>>>>>>> parent of ab7ef4208 (tweak(conhost): censor out console and 'non-trivial' tools when running prod)
 #endif
 });


### PR DESCRIPTION
Canary update channel is inherently unstable a lot of the times / sometimes fully unusable, since it was made for testing changes into the FiveM mod itself.
That's not something we would like to use on daily basis for creating and testing our own stuff (by we I mean server developers, cars / clothes / maps mod creators - none of the people I've talked to were happy about this undesirable changes), but we are now forced to do so because tools we need were disabled.
It's also important to perform testing using the same client (update channel) players will later use, so this request reverts console and dev tools blocking on production client.