### PR TITLE
feat(scripting/v8): Add SendNUIMessage as helper function

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -91,6 +91,8 @@ declare function TriggerLatentServerEvent(eventName: string, bps: number, ...arg
 declare function getPlayerIdentifiers(player: number|string): string[]
 declare function getPlayers(): number[]
 
+declare function SendNUIMessage(data: any): void
+
 declare function emitNet(eventName: string, target: number|string, ...args: any[]): void
 declare function TriggerClientEvent(eventName: string, target: number|string, ...args: any[]): void
 declare function TriggerLatentClientEvent(eventName: string, target: number|string, bps: number, ...args: any[]): void

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -235,6 +235,11 @@ const EXT_LOCALFUNCREF = 11;
 			return t;
 		};
 	} else {
+		global.SendNUIMessage = (data) => {
+			const dataJson = JSON.stringify(data)
+			SendNuiMessage(dataJson)
+		}
+
 		global.emitNet = (name, ...args) => {
 			const dataSerialized = pack(args);
 


### PR DESCRIPTION
This PR aims to establish further feature parity between the Lua & v8 ScRT, it adds a simple global helper function, `SendNUIMessage`, that will automatically JSON encode its passed argument, just as its Lua counterpart does. 

I wasn't sure how you would have wanted this cased as there is a mix between PascalCase and CamelCase for globals, so stuck with the PascalCase Lua format.