### PR TITLE
Changed thread hang warning from 90s to 45s

### DIFF
--- a/code/components/citizen-server-impl/src/ServerWatchdog.cpp
+++ b/code/components/citizen-server-impl/src/ServerWatchdog.cpp
@@ -406,7 +406,7 @@ static InitFunction initFunction([]()
 							PlatformAbort();
 						}
 
-						if ((msec() - pair.second) > 90s)
+						if ((msec() - pair.second) > 45s)
 						{
 							bark(pair.first);
 						}


### PR DESCRIPTION
Within 45 seconds we can already know something bad is happening, good to print while it can.