### PR TITLE
feat(onesync): ped task tree node parsing and natives

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -325,6 +325,23 @@ struct CPedOrientationNodeData
 	float desiredHeading;
 };
 
+struct CPedTaskTreeDataNodeData
+{
+	uint32_t scriptCommand;
+	uint32_t scriptTaskStage;
+
+	uint32_t specifics;
+
+	struct
+	{
+		uint32_t type;
+		bool active;
+		uint32_t priority;
+		uint32_t treeDepth;
+		uint32_t sequenceId;
+	} tasks[8];
+};
+
 struct CPlaneGameStateDataNodeData
 {
 	uint32_t landingGearState;
@@ -431,6 +448,8 @@ public:
 	virtual CVehicleGameStateNodeData* GetVehicleGameState() = 0;
 
 	virtual CVehicleAppearanceNodeData* GetVehicleAppearance() = 0;
+
+	virtual CPedTaskTreeDataNodeData* GetPedTaskTree() = 0;
 
 	virtual CPlaneGameStateDataNodeData* GetPlaneGameState() = 0;
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1565,4 +1565,36 @@ static InitFunction initFunction([]()
 
 		return state ? state->nozzlePosition : 0.0f;
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_SCRIPT_TASK_COMMAND", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto tree = entity->syncTree->GetPedTaskTree();
+
+		return tree ? tree->scriptCommand : 0x811E343C;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_SCRIPT_TASK_STAGE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto tree = entity->syncTree->GetPedTaskTree();
+
+		return tree ? tree->scriptTaskStage : 3;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_SPECIFIC_TASK_TYPE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto tree = entity->syncTree->GetPedTaskTree();
+		if (!tree)
+		{
+			return Is2060() ? 531 : 530;
+		}
+
+		int index = context.GetArgument<int>(1);
+		if (index < 0 || index > 7)
+		{
+			return Is2060() ? 531 : 530;
+		}
+
+		auto& task = tree->tasks[index];
+		return static_cast<int>(task.type);
+	}));
 });

--- a/ext/native-decls/GetPedScriptTaskCommand.md
+++ b/ext/native-decls/GetPedScriptTaskCommand.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_PED_SCRIPT_TASK_COMMAND
+
+```c
+Hash GET_PED_SCRIPT_TASK_COMMAND(Ped ped);
+```
+
+Gets the script task command currently assigned to the ped. Tasks: https://alloc8or.re/gta5/doc/enums/eScriptTaskHash.txt
+
+## Parameters
+* **ped**: The target ped.
+
+## Return value
+The script task command currently assigned to the ped. A value of 0x811E343C denotes no script task is assigned.

--- a/ext/native-decls/GetPedScriptTaskCommand.md
+++ b/ext/native-decls/GetPedScriptTaskCommand.md
@@ -8,7 +8,7 @@ apiset: server
 Hash GET_PED_SCRIPT_TASK_COMMAND(Ped ped);
 ```
 
-Gets the script task command currently assigned to the ped. Tasks: https://alloc8or.re/gta5/doc/enums/eScriptTaskHash.txt
+Gets the script task command currently assigned to the ped.
 
 ## Parameters
 * **ped**: The target ped.

--- a/ext/native-decls/GetPedScriptTaskStage.md
+++ b/ext/native-decls/GetPedScriptTaskStage.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_PED_SCRIPT_TASK_STAGE
+
+```c
+int GET_PED_SCRIPT_TASK_STAGE(Ped ped);
+```
+
+Gets the stage of the peds scripted task.
+
+## Parameters
+* **ped**: The target ped.
+
+## Return value
+The stage of the ped's scripted task. A value of 3 denotes no script task is assigned.

--- a/ext/native-decls/GetPedSpecificTaskType.md
+++ b/ext/native-decls/GetPedSpecificTaskType.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_PED_SPECIFIC_TASK_TYPE
+
+```c
+int GET_PED_SPECIFIC_TASK_TYPE(Ped ped, int index);
+```
+
+Gets the type of a ped's specific task given an index of the CPedTaskSpecificDataNode nodes. Types: https://alloc8or.re/gta5/doc/enums/eTaskTypeIndex.txt
+A ped will typically have a task at index 0, if a ped has multiple tasks at once they will be in the order 0, 1, 2, etc.
+
+## Parameters
+* **ped**: The target ped.
+* **index**: A zero-based index with a maximum value of 7.
+
+## Return value
+The type of the specific task.
+1604: A value of 530 denotes no script task is assigned or an invalid input was given.
+2060+: A value of 531 denotes no script task is assigned or an invalid input was given.

--- a/ext/native-decls/GetPedSpecificTaskType.md
+++ b/ext/native-decls/GetPedSpecificTaskType.md
@@ -8,7 +8,7 @@ apiset: server
 int GET_PED_SPECIFIC_TASK_TYPE(Ped ped, int index);
 ```
 
-Gets the type of a ped's specific task given an index of the CPedTaskSpecificDataNode nodes. Types: https://alloc8or.re/gta5/doc/enums/eTaskTypeIndex.txt
+Gets the type of a ped's specific task given an index of the CPedTaskSpecificDataNode nodes.
 A ped will typically have a task at index 0, if a ped has multiple tasks at once they will be in the order 0, 1, 2, etc.
 
 ## Parameters


### PR DESCRIPTION
Add parsing for the CPedTaskTreeDataNode and adds three getter natives for tasks