### PR TITLE
Change alpine integrated run.sh

### DIFF
--- a/code/tools/ci/run.sh
+++ b/code/tools/ci/run.sh
@@ -3,4 +3,6 @@
 cd /opt/cfx-server
 [ -d cache ] || mkdir cache
 
-exec /opt/cfx-server/FXServer $SERVER_ARGS $*
+exec /opt/cfx-server/ld-musl-x86_64.so.1 \
+    --library-path "/usr/lib/v8/:/lib/:/usr/lib/" -- \
+    /opt/cfx-server/FXServer +set citizen_dir /opt/cfx-server/citizen/ $SERVER_ARGS $*


### PR DESCRIPTION
For create a docker container from scratch with your alpine folder, this run.sh don't work anymore. This probably a default library path problem. Manually setted, it's ok.