### PR TITLE
feat(scripting): Add GetPlayerTokens helper

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -493,6 +493,17 @@ if isDuplicityVersion then
 		return t
 	end
 
+	function GetPlayerTokens(player)
+		local numIds = GetNumPlayerTokens(player)
+		local t = {}
+
+		for i = 0, numIds - 1 do
+			table.insert(t, GetPlayerToken(player, i))
+		end
+
+		return t
+	end
+
 	function GetPlayers()
 		local num = GetNumPlayerIndices()
 		local t = {}

--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -89,6 +89,7 @@ declare function TriggerServerEvent(eventName: string, ...args: any[]): void
 declare function TriggerLatentServerEvent(eventName: string, bps: number, ...args: any[]): void
 
 declare function getPlayerIdentifiers(player: number|string): string[]
+declare function getPlayerTokens(player: number|string): string[]
 declare function getPlayers(): number[]
 
 declare function emitNet(eventName: string, target: number|string, ...args: any[]): void

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -215,11 +215,21 @@ const EXT_LOCALFUNCREF = 11;
 
 			TriggerLatentClientEventInternal(name, source, dataSerialized, dataSerialized.length, bps);
 		};
+
 		global.getPlayerIdentifiers = (player) => {
 			const numIds = GetNumPlayerIdentifiers(player);
 			let t = [];
 			for (let i = 0; i < numIds; i++) {
 				t[i] = GetPlayerIdentifier(player, i);
+			}
+			return t;
+		};
+
+		global.getPlayerTokens = (player) => {
+			const numIds = GetNumPlayerTokens(player);
+			let t = [];
+			for (let i = 0; i < numIds; i++) {
+				t[i] = GetPlayerToken(player, i);
 			}
 			return t;
 		};


### PR DESCRIPTION
I noticed that there wasn't a GetPlayerTokens helper, equivalent to GetPlayerIdentifiers, and figured it might be similarly helpful.