### PR TITLE
fix(nui/core): prevent actions that would break nui

### DIFF
--- a/code/components/nui-core/include/NUIClient.h
+++ b/code/components/nui-core/include/NUIClient.h
@@ -117,6 +117,19 @@ protected:
 
 	virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 
+	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
+		CefRefPtr<CefFrame> frame,
+		const CefString& target_url,
+		const CefString& target_frame_name,
+		CefLifeSpanHandler::WindowOpenDisposition target_disposition,
+		bool user_gesture,
+		const CefPopupFeatures& popupFeatures,
+		CefWindowInfo& windowInfo,
+		CefRefPtr<CefClient>& client,
+		CefBrowserSettings& settings,
+		CefRefPtr<CefDictionaryValue>& extra_info,
+		bool* no_javascript_access) override;
+
 // CefLoadHandler
 protected:
 	virtual void OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, TransitionType transitionType) override;


### PR DESCRIPTION
prevent opening new windows from NUI as these break input focus (target="_blank")
prevent navigation of the root NUI away from the root page (shift clicking links)