### PR TITLE
fix(dev/fxd): create missing dirs on download

### DIFF
--- a/code/tools/fxd/get-chrome.ps1
+++ b/code/tools/fxd/get-chrome.ps1
@@ -9,7 +9,7 @@ $SaveDir = "$WorkDir\code\build\"
 $CefName = (Get-Content $PSScriptRoot\..\ci\build.ps1 | Select-String "CefName =") -replace ".*`"(.*?)`"", "`$1"
 
 if (!(Test-Path "$SaveDir\$CefName.zip")) {
-	curl.exe -Lo "$SaveDir\$CefName.zip" "https://runtime.fivem.net/build/cef/$CefName.zip"
+	curl.exe --create-dirs -Lo "$SaveDir\$CefName.zip" "https://runtime.fivem.net/build/cef/$CefName.zip"
 }
 
 & $env:WINDIR\system32\tar.exe -C $WorkDir\vendor\cef -xf "$SaveDir\$CefName.zip"


### PR DESCRIPTION
On an fresh install the folder code/build/ doesn't exist and so curl needs to create the missing folders