### PR TITLE
feat(scheduler.lua): add `require` function to load scripts at runtime (Lazy Loading)   

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,5 +194,3 @@ privates_config.lua
 
 # python files
 *.pyc
-
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ privates_config.lua
 
 # python files
 *.pyc
+
+.idea/

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -1148,9 +1148,6 @@ end
 
 local requireCached = {}
 
--- lua's require function to load script at runtime.
--- note: for client, scripts should be added to `file` entries in the fx manifest
--- ex script path : resource-name.dir.file
 function require(scriptPath)
 
 	if type(scriptPath) ~= 'string' then

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -1158,7 +1158,7 @@ function require(scriptPath)
 	end
 
 	if requireCached[scriptPath] then
-		return
+		return requireCached[scriptPath]
 	end
 
 	local dotIndex = string.find(scriptPath, '%.')
@@ -1178,7 +1178,7 @@ function require(scriptPath)
 	end
 
 	local res                 = func()
-	requireCached[scriptPath] = true
+	requireCached[scriptPath] = res
 	return res
 
 end

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -1145,3 +1145,43 @@ end
 if not isDuplicityVersion then
 	LocalPlayer = Player(-1)
 end
+
+local requireCached = {}
+
+-- lua's require function to load script at runtime.
+-- note: for client, scripts should be added to `file` entries in the fx manifest
+-- ex script path : resource-name.dir.file
+function require(scriptPath)
+
+	if type(scriptPath) ~= 'string' then
+		error('Expected script path to be a string')
+	end
+
+	if requireCached[scriptPath] then
+		return
+	end
+
+	local dotIndex = string.find(scriptPath, '%.')
+	local resource = string.sub(scriptPath, 1, dotIndex - 1)
+	local file     = string.sub(scriptPath, dotIndex + 1)
+	file           = string.gsub(file, '%.', '/')
+	local content  = LoadResourceFile(resource, string.format('%s.lua', file))
+
+	if not content then
+		error('Specified script is not found.')
+	end
+
+	local func, err = load(content)
+
+	if not func then
+		error(err)
+	end
+
+	local res                 = func()
+	requireCached[scriptPath] = true
+	return res
+
+end
+
+-- for cfx naming convention
+Require = require


### PR DESCRIPTION
This `require` function will load scripts at runtime, it works like lua's original `require` function that is being disable by CFX
for security reasons. this will use CFX natives to load scripts instead of adding them to `client_script` or `server_script` entries.
Also this will help to do lazy loading scripts on demand.

usage: will be the same as lua `require` function. we don't use `/` for directory separator not the .lua extension to make it same as lua on other platforms.
```lua
require('resource-name.dir.dir.script') 
```

As per the cfx documentation with **client** side, you need to add the file to `file` entry in fxmanifest in order to load it at runtime.

Thank you _blattersturm_ for your points for my previous PR, I changed what you mentioned in order to meet the requirements.
feel free to add changes that I need to work on.  

#735 