### PR TITLE
feat(natives/five): network world state control for ropes

### DIFF
--- a/code/components/extra-natives-five/src/NativeEdits.cpp
+++ b/code/components/extra-natives-five/src/NativeEdits.cpp
@@ -1,0 +1,27 @@
+#include <StdInc.h>
+#include <GameInit.h>
+#include <Hooking.h>
+#include <ScriptEngine.h>
+
+static bool* g_ropesCreateNetworkWorldState;
+
+static HookFunction hookFunction([]()
+{
+	g_ropesCreateNetworkWorldState = (bool*)hook::AllocateStubMemory(1);
+	*g_ropesCreateNetworkWorldState = false;
+
+	// replace ADD_ROPE native net game check whether to create CNetworkRopeWorldStateData
+	auto location = hook::get_pattern<uint32_t>("80 3D ? ? ? ? ? 74 71 E8 ? ? ? ? 48", 2);
+	*location = (intptr_t)g_ropesCreateNetworkWorldState - (intptr_t)location - 5;
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ROPES_CREATE_NETWORK_WORLD_STATE", [](fx::ScriptContext& context)
+	{
+		bool shouldCreate = context.GetArgument<bool>(0);
+		*g_ropesCreateNetworkWorldState = shouldCreate;
+	});
+
+	OnKillNetworkDone.Connect([]()
+	{
+		*g_ropesCreateNetworkWorldState = false;
+	});
+});

--- a/ext/native-decls/SetRopesCreateNetworkWorldState.md
+++ b/ext/native-decls/SetRopesCreateNetworkWorldState.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_ROPES_CREATE_NETWORK_WORLD_STATE
+
+```c
+void SET_ROPES_CREATE_NETWORK_WORLD_STATE(BOOL shouldCreate);
+```
+
+Toggles whether the usage of [ADD_ROPE](#_0xE832D760399EB220) should create an underlying CNetworkRopeWorldStateData. By default this is set to false.
+
+## Parameters
+* **shouldCreate**: Whether to create an underlying network world state


### PR DESCRIPTION
Unlike other natives which implement world state, ADD_ROPE does not have a parameter to whether you want the rope networked. Instead it relies on a net game check whether to create an underlying CNetworkRopeWorldStateData. As network world state is currently not implemented, this leads to a memory leak and pool being filled upon multiple rope creations. This native aims to solve two problems:

- Prevent the issue aforementioned
- Maintain backwards compatibility for future, as if world state was to be implemented, all ropes (which people assumed to be non-networked) would suddenly be networked without this