### PR TITLE
changed source type back to string

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -110,4 +110,4 @@ declare function Player(entity: number|string): EntityInterface
 
 declare var exports: any;
 
-declare var source: number;
+declare var source: string;


### PR DESCRIPTION
cool that source is number, but all the natives that require source, assume that it's string