### PR TITLE
Uptade native information

### DIFF
--- a/ext/native-decls/GetVehicleOilLevel.md
+++ b/ext/native-decls/GetVehicleOilLevel.md
@@ -5,6 +5,7 @@ apiset: client
 ## GET_VEHICLE_OIL_LEVEL
 
 ```c
+// 0xFC7F8EF4
 float GET_VEHICLE_OIL_LEVEL(Vehicle vehicle);
 ```
 
@@ -13,3 +14,12 @@ float GET_VEHICLE_OIL_LEVEL(Vehicle vehicle);
 * **vehicle**: 
 
 ## Return value
+Return a value between 0.0 and 10.0 representing the current oil level.
+
+## Examples
+```lua
+-- A short example of how to print value of oil level in Lua
+local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+local oilLvl = GetVehicleOilLevel(vehicle)
+print(oilLvl)
+```

--- a/ext/native-decls/GetVehicleOilLevel.md
+++ b/ext/native-decls/GetVehicleOilLevel.md
@@ -5,7 +5,6 @@ apiset: client
 ## GET_VEHICLE_OIL_LEVEL
 
 ```c
-// 0xFC7F8EF4
 float GET_VEHICLE_OIL_LEVEL(Vehicle vehicle);
 ```
 
@@ -18,7 +17,7 @@ Return a value between 0.0 and 10.0 representing the current oil level.
 
 ## Examples
 ```lua
--- A short example of how to print value of oil level in Lua
+-- A short example printing the oil level value in Lua
 local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
 local oilLvl = GetVehicleOilLevel(vehicle)
 print(oilLvl)

--- a/ext/native-decls/SetVehicleOilLevel.md
+++ b/ext/native-decls/SetVehicleOilLevel.md
@@ -3,13 +3,20 @@ ns: CFX
 apiset: client
 ---
 ## SET_VEHICLE_OIL_LEVEL
-
 ```c
 void SET_VEHICLE_OIL_LEVEL(Vehicle vehicle, float level);
 ```
 
+Setting the oil level value. This native does not affect vehicle performance.
 
 ## Parameters
 * **vehicle**: 
-* **level**: 
+* **level**: Recommended value between 0.0 and 10.0 maximum (used by default in game).
+
+## Examples
+```lua
+-- A short example setting the oil level value in Lua
+local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+SetVehicleOilLevel(vehicle, 10.0)
+```
 


### PR DESCRIPTION
Additional information about how to use the native and what does it return in value. Return a value between 0.0 and 10.0 have been tested on almost every GTA cars / planes / boats. Most common vehicle use by player will return 5.0 and some vehicles will have a 0.0 for some reason.

Information use:

- https://imgur.com/a/UTnBryk

Code use:

- https://pastebin.com/2cSy35zW

Car get from:

- https://www.gtabase.com/grand-theft-auto-v/vehicles/