### PR TITLE
Uptade native SetVehicleOilLevel

### DIFF
--- a/ext/native-decls/SetVehicleOilLevel.md
+++ b/ext/native-decls/SetVehicleOilLevel.md
@@ -8,8 +8,15 @@ apiset: client
 void SET_VEHICLE_OIL_LEVEL(Vehicle vehicle, float level);
 ```
 
+Adjust the vehicle's oil value. This native does not affect vehicle performance.
 
 ## Parameters
 * **vehicle**: 
-* **level**: 
+* **level**: Recommended value between 0.0 and 10.0 maximum (used by default in game).
 
+## Examples
+```lua
+-- A short example of how to set a value for oil level in Lua
+local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+SetVehicleOilLevel(vehicle, 10.0)
+```


### PR DESCRIPTION
Additional information about how to use the native and description. Set a value between 0.0 and 10.0 have been tested on almost every GTA cars / planes / boats and it's the most common way used by default in game. Even with 0.0, vehicle can still work perfectly. 

Code use:
https://pastebin.com/3mHiYmTn
Car tested from:
https://www.gtabase.com/grand-theft-auto-v/vehicles/
Tested server:
build 2189 | Canary More
FiveM last client Uptade from 20 h 58 / 2021-17-06 (UTC−4)