### PR TITLE
Fix scheduler bad argument #1 to 'unpack' (table expected, got nil)

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -861,7 +861,7 @@ funcref_mt = msgpack.extend({
 				return table.unpack(Citizen.Await(p))
 			end
 
-			return table.unpack(rvs)
+			return rvs and table.unpack(rvs) or nil
 		else
 			return InvokeRpcEvent(tonumber(netSource.source:sub(5)), ref, {...})
 		end


### PR DESCRIPTION
It fixes the common error after disconnecting from the server. Sometimes the value appears to be nil and you can't unpack nil