### PR TITLE
Allow events to be logged on console

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -458,6 +458,11 @@ end
 
 function TriggerEvent(eventName, ...)
 	local payload = msgpack.pack({...})
+	Citizen.CreateThread(function()
+		local EventData = ({"Server Event Registered: " .. eventName})
+		local payload_a = msgpack.pack(EventData)
+		return TriggerEventInternal("trigger_log", payload_a, payload_a:len())
+	end)
 
 	return runWithBoundaryEnd(function()
 		return TriggerEventInternal(eventName, payload, payload:len())


### PR DESCRIPTION
Hello there, first pull ever

I've been watching scheduler.lua for a while and I didn't see any kind of event logging in the server console, I made one on my own, but it would be great for script developers to identify any undesired behaviour in the scripting also to identify performance issues even though we have profilers, this is not a priority.

Have a good night everyone.