### PR TITLE
tweak(ext/cfx-ui): active route style for nav buttons

### DIFF
--- a/ext/cfx-ui/src/app/nav/app-nav.component.scss
+++ b/ext/cfx-ui/src/app/nav/app-nav.component.scss
@@ -139,6 +139,13 @@
 			font-size: var(--fs-2);
 		}
 
+        .active {
+            @include theme() using ($theme) {
+                color: gtv($theme, accentContrastColor);
+                background-color: gtv($theme, accentColor1);
+            };
+        }
+
 		&>* {
 			position: relative;
 
@@ -183,7 +190,7 @@
 				transition: all .2s ease;
 			}
 
-			&:hover, &:focus {
+			&:hover {
 				transition: none;
 
 				@include theme() using ($theme) {


### PR DESCRIPTION
I've done some changes for the nav buttons. 

- Added active route styles.
- Removed focus from the nav buttons

Here's how the active style looks like:
![image](https://user-images.githubusercontent.com/59088889/123292270-2f531100-d513-11eb-8479-d62ef0236825.png)


Reason for removing the focus was because if you did not clickaway, the selected nav button would overlap the other ones you tried to select, hiding some of the text.

**Before:**
![image](https://user-images.githubusercontent.com/59088889/123292090-00d53600-d513-11eb-9b83-26fcb9839065.png)

**Now:**
![image](https://user-images.githubusercontent.com/59088889/123292187-16e2f680-d513-11eb-9b53-50d36de1da49.png)
