### PR TITLE
feat(component/citizen-server-gui): Added convar to allow custom window title

### DIFF
--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -181,9 +181,9 @@ private:
 				auto hostNameVar = conCtx->GetVariableManager()->FindEntryRaw("sv_hostname");
 				auto iconVar = conCtx->GetVariableManager()->FindEntryRaw("sv_icon");
 				auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
-				auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
+				auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("disable_wintitle");
 
-				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "0")
+				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "1")
 				{
 					consoleWindowState.lastHostname = hostNameVar->GetValue();
 
@@ -227,9 +227,9 @@ private:
 					auto hostNameVar = conCtx->GetVariableManager()->FindEntryRaw("sv_hostname");
 					auto iconVar = conCtx->GetVariableManager()->FindEntryRaw("sv_icon");
 					auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
-					auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
+					auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("disable_wintitle");
 					
-					if (hostNameVar && state.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "0")
+					if (hostNameVar && state.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "1")
 					{
 						state.lastHostname = hostNameVar->GetValue();
 

--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -183,7 +183,7 @@ private:
 				auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
 				auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
 
-				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue() && consoletitle->GetValue() != "0")
+				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "0")
 				{
 					consoleWindowState.lastHostname = hostNameVar->GetValue();
 
@@ -229,7 +229,7 @@ private:
 					auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
 					auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
 					
-					if (hostNameVar && state.lastHostname != hostNameVar->GetValue() && consoletitle->GetValue() != "0")
+					if (hostNameVar && state.lastHostname != hostNameVar->GetValue() && changeConsoleTitle->GetValue() != "0")
 					{
 						state.lastHostname = hostNameVar->GetValue();
 

--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -181,8 +181,9 @@ private:
 				auto hostNameVar = conCtx->GetVariableManager()->FindEntryRaw("sv_hostname");
 				auto iconVar = conCtx->GetVariableManager()->FindEntryRaw("sv_icon");
 				auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
+				auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
 
-				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue())
+				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue() && consoletitle->GetValue() != "0")
 				{
 					consoleWindowState.lastHostname = hostNameVar->GetValue();
 
@@ -226,8 +227,9 @@ private:
 					auto hostNameVar = conCtx->GetVariableManager()->FindEntryRaw("sv_hostname");
 					auto iconVar = conCtx->GetVariableManager()->FindEntryRaw("sv_icon");
 					auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
-
-					if (hostNameVar && state.lastHostname != hostNameVar->GetValue())
+					auto changeConsoleTitle = conCtx->GetVariableManager()->FindEntryRaw("consoletitle");
+					
+					if (hostNameVar && state.lastHostname != hostNameVar->GetValue() && consoletitle->GetValue() != "0")
 					{
 						state.lastHostname = hostNameVar->GetValue();
 


### PR DESCRIPTION
Adds a new `disable_wintitle` convar that can be set to `1` to disable FXServer interfering with the console window title (to allow people to use batch files to set it).