### PR TITLE
Fix overlapping style for filters in servers page

### DIFF
--- a/ext/cfx-ui/src/app/servers/components/filters/server-filter.component.scss
+++ b/ext/cfx-ui/src/app/servers/components/filters/server-filter.component.scss
@@ -283,6 +283,12 @@
 				}
 			}
 
+			&:focus-within {
+				.label {
+					display: none;
+				}
+			}
+
 			&:hover, &:focus-within {
 				@include theme() using($theme) {
 					.trigger {
@@ -399,6 +405,12 @@
 							color: gtv($theme, accentContrastColor);
 						}
 					}
+				}
+			}
+
+			&:focus-within {
+				.label {
+					display: none;
 				}
 			}
 


### PR DESCRIPTION
Another PR similar to [#749 ](https://github.com/citizenfx/fivem/pull/749). This fixes the current style where selected filters overlaps  other filters when hovering on them. All it does is remove the text when you select one.

Accidentally forgot to remove the 'z-index' when I was testing something, so it became two commits. Might just want to squash it. My bad 😄 

**When selected**
![image](https://user-images.githubusercontent.com/59088889/123490396-39106d80-d614-11eb-8958-f88c7dfbea16.png)

**Before (when hovering)**
![image](https://user-images.githubusercontent.com/59088889/123490460-57766900-d614-11eb-8ad9-f866df4063f8.png)

**Now**
![image](https://user-images.githubusercontent.com/59088889/123490471-6230fe00-d614-11eb-9afa-22bc928d8c93.png)


