### PR TITLE
feat(onesync): add GET_ENTITY_SPEED native

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1622,6 +1622,20 @@ static void Init()
 		auto& task = tree->tasks[index];
 		return static_cast<int>(task.type);
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_SPEED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto v = entity->syncTree->GetVelocity();
+
+		float speed = 0.0f;
+
+		if (v)
+		{
+			speed = std::hypot(v->velX, v->velY, v->velZ);
+		}
+
+		return speed;
+	}));
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/GetEntitySpeed.md
+++ b/ext/native-decls/GetEntitySpeed.md
@@ -1,0 +1,22 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_ENTITY_SPEED
+
+```c
+float GET_ENTITY_SPEED(Entity entity);
+```
+
+Gets the current speed of the entity in meters per second.
+
+```
+To convert to MPH: speed * 2.236936
+To convert to KPH: speed * 3.6
+```
+
+## Parameters
+* **entity**: The entity to get the speed of
+
+## Return value
+The speed of the entity in meters per second


### PR DESCRIPTION
Currently doesn't work on peds as it seems they don't seem to have a CPhysicalVelocityDataNode