### PR TITLE
fix(voip-mumble): don't read mumble prefix if not enough data

### DIFF
--- a/code/components/voip-mumble/src/MumbleDataHandler.cpp
+++ b/code/components/voip-mumble/src/MumbleDataHandler.cpp
@@ -37,9 +37,13 @@ void MumbleDataHandler::HandleIncomingData(const uint8_t* data, size_t length)
 		// if this is a new 'packet'
 		if (m_readBytes == 0)
 		{
+			if (read < 6)
+			{
+				return;
+			}
+
 			const MumblePacketHeader* header = (const MumblePacketHeader*)origin;
 
-			m_readBytes = 0;
 			m_totalBytes = header->GetPacketLength();
 			m_messageType = header->GetPacketType();
 


### PR DESCRIPTION
Reading mumble prefix when not enough data are available will lead to crashes due to memory corruptions
Fix taken from reference mumble client:
https://github.com/mumble-voip/mumble/blob/464fc4a36dd53bc5f7af47b09a30fe885512d9bd/src/Connection.cpp#L118

Tested and approved :)