### PR TITLE
tweak(cfxui): make scrollbar slightly wider

### DIFF
--- a/ext/cfx-ui/src/styles/global.scss
+++ b/ext/cfx-ui/src/styles/global.scss
@@ -214,10 +214,10 @@ button {
 }
 
 ::-webkit-scrollbar {
-	width: 2px;
+	width: 5px;
 }
 ::-webkit-scrollbar-thumb {
-	width: 2px;
+	width: 5px;
 	@include themeNoHost() using ($theme) {
 		background-color: rgba(gtv($theme, fgColor), .5);
 	}


### PR DESCRIPTION
Minuscule change, but apparently some people prefer clicking and dragging rather than using filters and scroll wheels. This just makes the scrollbar slightly wider (3px increase to 5px) so it's easier to click when it's not up against the side of the monitor (i.e. blocking mouse movement from going all the way to the right)