### PR TITLE
fix(scripting/v8): Default omitted timeout to 0

### DIFF
--- a/data/shared/citizen/scripting/v8/timer.js
+++ b/data/shared/citizen/scripting/v8/timer.js
@@ -14,7 +14,7 @@
     function setTimer(timer, callback, interval) {
         timers[timer.id] = {
             callback,
-            interval,
+            interval: Math.max(0, interval) || 0,
             lastRun: gameTime
         };
     }


### PR DESCRIPTION
... otherwise the [check](https://github.com/citizenfx/fivem/blob/6de33031bddd96fd0cec08a4b0bf34e22836d303/data/shared/citizen/scripting/v8/timer.js#L120) fails because nothing is greater than `undefined`.

This breaks interop with incorrect usage (as found in some npm modules) of `setTimeout` and `setInterval` where omitted timeouts are meant to default to 0 ([spec § 8.6.10](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers)), but instead just don't run the function at all due to the missing default/min value of 0.

I also renamed the property for convenience (`timeout` instead of `interval`).