### PR TITLE
fix(natives/five): gamer tags on top of each other

### DIFF
--- a/code/components/extra-natives-five/src/GamerTagNatives.cpp
+++ b/code/components/extra-natives-five/src/GamerTagNatives.cpp
@@ -54,6 +54,7 @@ static HookFunction initFunction([]()
 			pop(rcx);
 
 			mov(rsi, rax);
+			mov(rax, rbx);
 
 			ret();
 		}


### PR DESCRIPTION
This fixes an issue (from #770) with the newer gamer builds having tags on top of each other when using default game behavior. In 1604, RAX is unused beyond the detour so does not require the original value back. However, in 2060+ RAX is used after and thus its original value (ped pointer from RBX) must be restored. Tested on all game builds with multiple players in and out of vehicles.