### PR TITLE
fix(vish): Improve compatibility for ScriptHookV-targeting scripts

### DIFF
--- a/code/components/scripthookv/src/VishCompat.cpp
+++ b/code/components/scripthookv/src/VishCompat.cpp
@@ -265,12 +265,12 @@ DLL_EXPORT uint64_t* getGlobalPtr(int)
 DLL_EXPORT int getGameVersion()
 {
 	if (xbr::IsGameBuild<372>()) return 5;   // VER_1_0_372_2_NOSTEAM
-	if (xbr::IsGameBuild<1604>()) return 49; // VER_1_0_1604_1_NOSTEAM
+	if (xbr::IsGameBuild<1604>()) return 47; // VER_1_0_1604_0_NOSTEAM
 	if (xbr::IsGameBuild<2060>()) return 60; // VER_1_0_2060_0_NOSTEAM
 	if (xbr::IsGameBuild<2189>()) return 64; // VER_1_0_2189_0_NOSTEAM
 	if (xbr::IsGameBuild<2372>()) return 70; // VER_1_0_2372_0_NOSTEAM
 
-	return 49; // Default build
+	return 47; // Default build
 }
 
 class FishNativeContext : public NativeContext

--- a/code/components/scripthookv/src/VishCompat.cpp
+++ b/code/components/scripthookv/src/VishCompat.cpp
@@ -16,6 +16,7 @@
 #include <IteratorView.h>
 
 #include <LaunchMode.h>
+#include <CrossBuildRuntime.h>
 
 #include <memory>
 
@@ -260,14 +261,16 @@ DLL_EXPORT uint64_t* getGlobalPtr(int)
 	return dummyGlobal;
 }
 
-enum eGameVersion : int
+// ScriptHookV uses incremental numbers instead of build
+DLL_EXPORT int getGameVersion()
 {
-	DummyVersion = 44 // VER_1_0_1493_1_NOSTEAM
-};
+	if (xbr::IsGameBuild<372>()) return 5;   // VER_1_0_372_2_NOSTEAM
+	if (xbr::IsGameBuild<1604>()) return 49; // VER_1_0_1604_1_NOSTEAM
+	if (xbr::IsGameBuild<2060>()) return 60; // VER_1_0_2060_0_NOSTEAM
+	if (xbr::IsGameBuild<2189>()) return 64; // VER_1_0_2189_0_NOSTEAM
+	if (xbr::IsGameBuild<2372>()) return 70; // VER_1_0_2372_0_NOSTEAM
 
-DLL_EXPORT eGameVersion getGameVersion()
-{
-	return DummyVersion;
+	return 49; // Default build
 }
 
 class FishNativeContext : public NativeContext

--- a/code/components/scripthookv/src/VishRenderer.cpp
+++ b/code/components/scripthookv/src/VishRenderer.cpp
@@ -251,7 +251,7 @@ DLL_EXPORT void drawTexture(int id, int index, int level, int time,
 	instance.center[1] = centerY;
 	instance.pos[0] = posX;
 	instance.pos[1] = posY;
-	instance.rotation = rotation;
+	instance.rotation = rotation * -360.0f;
 	instance.aspectValue = screenHeightScaleFactor;
 	instance.color = CRGBA::FromFloat(r, g, b, a);
 


### PR DESCRIPTION
Sorry for increasing your review workload.

Here are a few changes to improve compatibility and closer resemble a few minor things that scripts for ScriptHookV may rely on:
- Return the ScriptHookV version number
- Match the rotation of `drawTexture`

I'm kind of at wit's end about the version number thing and FiveM's `GetGameVersion`.

On one hand, Alexander Blade's decision to *randomly* assign numbers where builds already are a thing baffles me, but at least there was consistency *until* `1.0.1734.0` which they forgot/were too late with, and just *skipped* it, but did not skip adding the version number, breaking the pattern. Then the initial Epic Games patch `1.0.1868.4` had its own separate `eGameVersion` number, but *not* the subsequent one, once again breaking the pattern. It's horrible and I would rather not use it, but alas, legacy persists. So here's just a hard-ish coded thing that matches the non-Steam builds.

I hope this thing builds. Sorry, I couldn't get FiveM to build locally so I just made these changes on GitHub itself.

Feel free to reject if it makes no sense, this is my last effort on getting my things to cooperate with FiveM, I have no energy to adapt my ScriptHookV monstrosities to not cause issues in FiveM.