### PR TITLE
feat(resources/core): statebag trigger event on changes

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ComponentHolder.h>
+#include <ResourceManager.h>
+#include <ResourceEventComponent.h>
 
 #include <optional>
 #include <string_view>
@@ -13,7 +15,6 @@
 
 namespace fx
 {
-class ResourceManager;
 
 class StateBagGameInterface
 {
@@ -114,6 +115,7 @@ public:
 
 public:
 	static fwRefContainer<StateBagComponent> Create(StateBagRole role);
+	fwRefContainer<fx::ResourceEventManagerComponent> eventManager;
 };
 }
 

--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -117,7 +117,6 @@ private:
 StateBagImpl::StateBagImpl(StateBagComponentImpl* parent, std::string_view id)
 	: m_parent(parent), m_id(id)
 {
-	
 }
 
 StateBagImpl::~StateBagImpl()
@@ -162,6 +161,8 @@ void StateBagImpl::SetKey(std::string_view key, std::string_view data, bool repl
 			SendKeyAll(key);
 		}
 	}
+
+	m_parent->eventManager->QueueEvent2("__cfx_internal:stateBagSetKey", {}, m_id, std::string{ key });
 }
 
 std::optional<int> StateBagImpl::GetOwningPeer()
@@ -426,7 +427,7 @@ std::shared_ptr<StateBag> StateBagComponentImpl::PreCreateStateBag(std::string_v
 
 void StateBagComponentImpl::AttachToObject(fx::ResourceManager* object)
 {
-
+	eventManager = object->GetComponent<fx::ResourceEventManagerComponent>();
 }
 
 void StateBagComponentImpl::HandlePacket(int source, std::string_view dataRaw)


### PR DESCRIPTION
Triggers __cfx_internal:stateBagSetKey event on every StateBag update (local or replicated). I put it inside cfx_internal, because in my opinion, the final api written on top of this event, should be bound to StateBag objects in user scripts. 

**Use case**: imagine we have a nui status bar with hunger, thirst, and a whole bunch of buffs/conditions player may have. It would be much easier to update it from state on change, rather than creating a loop that would compare current values to previous ones  every second, detect changes and send values to nui.

Tested it up locally for an hour, hope I didn't mess up with pointers and concurrency.