### PR TITLE
fix(onesync): CWeaponDamageEvent for 2372

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4374,7 +4374,7 @@ struct CWeaponDamageEvent
 
 void CWeaponDamageEvent::Parse(rl::MessageBuffer& buffer)
 {
-	if (Is2060()) {
+	if (Is2060() && !Is2372()) {
 		buffer.Read<uint16_t>(16);
 	}
 


### PR DESCRIPTION
Since 2372 the first unsigned int got removed from the buffer.