### PR TITLE
Add tooltips explaining premium levels in cfx-ui

### DIFF
--- a/ext/cfx-ui/src/app/servers/components/detail/servers-detail.component.html
+++ b/ext/cfx-ui/src/app/servers/components/detail/servers-detail.component.html
@@ -44,6 +44,8 @@
 								[class.ag]="server.premium === 'ag'"
 								[class.au]="server.premium === 'au'"
 								[class.pt]="server.premium === 'pt'"
+								data-balloon-pos="right"
+								[attr.aria-label]="premiumName"
 							>
 								<span>{{ server.premium }}</span>
 							</div>

--- a/ext/cfx-ui/src/app/servers/components/detail/servers-detail.component.ts
+++ b/ext/cfx-ui/src/app/servers/components/detail/servers-detail.component.ts
@@ -220,6 +220,10 @@ export class ServersDetailComponent implements OnInit, OnDestroy {
 		});
 	}
 
+	get premiumName() {
+		return this.serversService.getNameForPremium(this.server.premium);
+	}
+
 	apFeedInitialized = false;
 
 	private updateServer() {

--- a/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.html
+++ b/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.html
@@ -25,6 +25,8 @@
 		[class.ag]="premium === 'ag'"
 		[class.au]="premium === 'au'"
 		[class.pt]="premium === 'pt'"
+		data-balloon-pos="right"
+		[attr.aria-label]="premiumName"
 	>
 		<span><div>{{ premium }}</div></span>
 	</div>

--- a/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.scss
+++ b/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.scss
@@ -92,6 +92,7 @@
 		bottom: 2px;
 
 		width: var(--q4);
+		pointer-events: none;
 
 		z-index: 1;
 

--- a/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.ts
+++ b/ext/cfx-ui/src/app/servers/components/list/servers-list-item.component.ts
@@ -66,6 +66,10 @@ export class ServersListItemComponent implements OnInit, OnChanges, OnDestroy, A
 		return this.rawServer.data.vars.premium;
 	}
 
+	get premiumName() {
+		return this.serversService.getNameForPremium(this.premium);
+	}
+
 	public ngOnInit() {
 		this.hoverIntent = hoverintent(this.elementRef.nativeElement, () => {
 			this.serversService.getServer(this.rawServer.address, true);

--- a/ext/cfx-ui/src/app/servers/servers.service.ts
+++ b/ext/cfx-ui/src/app/servers/servers.service.ts
@@ -342,6 +342,19 @@ export class ServersService {
 			.catch(() => new PinConfig());
 	}
 
+	getNameForPremium(premium: string) {
+		switch (premium) {
+			case 'pt':
+				return 'Element Club Platinum';
+			case 'au':
+				return 'Element Club Aurum';
+			case 'ag':
+				return 'Element Club Argentum';
+		}
+
+		return '';
+	}
+
 	parseAddress(addr: string): [string, number] {
 		if (!addr) {
 			return null;


### PR DESCRIPTION
## Motivation

Users can't be expected to understand the periodic table or the fact server subscriptions are named after elements.

See the following (real) support questions:

> what do all the little tag abbreviation means in the server list? like Pt

> In the server browser some servers have "AG" or a "PT" icon in front of it... does PT means that they have the patreon sub?

> another thing, why some servers aren't portuguese but they show as PT list

## Solution

This might be helpable with minimal impact by adding a tooltip:

![image](https://user-images.githubusercontent.com/24576130/129435127-edd944c1-275d-4a93-b3f0-5c2aac6380a2.png)

This changeset adds such a tooltip to the server list as well as the detail page.