### PR TITLE
fix(nui/core): add SDK guest storage directory

### DIFF
--- a/code/components/nui-core/src/NUIInitialize.cpp
+++ b/code/components/nui-core/src/NUIInitialize.cpp
@@ -54,6 +54,8 @@ namespace nui
 fwRefContainer<NUIWindow> FindNUIWindow(fwString windowName);
 }
 
+std::wstring GetNUIStoragePath();
+
 nui::GameInterface* g_nuiGi;
 
 struct GameRenderData
@@ -1261,7 +1263,7 @@ void Initialize(nui::GameInterface* gi)
         return;
     }
 
-	std::wstring cachePath = MakeRelativeCitPath(fmt::sprintf(L"data\\nui-storage%s", ToWide(launch::GetPrefixedLaunchModeKey("-"))));
+	std::wstring cachePath = GetNUIStoragePath();
 	CreateDirectory(cachePath.c_str(), nullptr);
 
 	// delete any old CEF logs
@@ -1490,4 +1492,16 @@ void Initialize(nui::GameInterface* gi)
 #endif
 	});
 }
+}
+
+std::wstring GetNUIStoragePath()
+{
+	std::wstring lmSuffix;
+
+	if (launch::IsSDKGuest())
+	{
+		lmSuffix = L"-guest";
+	}
+
+	return MakeRelativeCitPath(fmt::sprintf(L"data\\nui-storage%s%s", ToWide(launch::GetPrefixedLaunchModeKey("-")), lmSuffix));
 }

--- a/code/components/nui-core/src/NUIWindow.cpp
+++ b/code/components/nui-core/src/NUIWindow.cpp
@@ -22,11 +22,11 @@
 
 #include <CefOverlay.h>
 
-#include <CL2LaunchMode.h>
-
 extern nui::GameInterface* g_nuiGi;
 
 #include "memdbgon.h"
+
+extern std::wstring GetNUIStoragePath();
 
 namespace nui
 {
@@ -395,7 +395,7 @@ void NUIWindow::Initialize(CefString url)
 	}
 	else
 	{
-		auto cachePath = MakeRelativeCitPath(fmt::sprintf(L"data\\nui-storage%s\\context-%s", ToWide(launch::GetPrefixedLaunchModeKey("-")), ToWide(m_windowContext)));
+		auto cachePath = fmt::sprintf(L"%s\\context-%s", GetNUIStoragePath(), ToWide(m_windowContext));
 		CreateDirectory(cachePath.c_str(), nullptr);
 
 		CefRequestContextSettings rcConfig;


### PR DESCRIPTION
See #793, this moves the SDK guest into a `nui-storage-fxdk-guest` directory.