### PR TITLE
tweak(scripting/csharp): use GetActivePlayers for PlayerList

### DIFF
--- a/code/client/clrcore/PlayerList.cs
+++ b/code/client/clrcore/PlayerList.cs
@@ -14,12 +14,10 @@ namespace CitizenFX.Core
 
 		public IEnumerator<Player> GetEnumerator()
 		{
-			for (var i = 0; i < MaxPlayers; i++)
+			var list = (IList<object>)(object)API.GetActivePlayers();
+			foreach (var p in list)
 			{
-				if (API.NetworkIsPlayerActive(i))
-				{
-					yield return new Player(i);
-				}
+				yield return new Player(Convert.ToInt32(p));
 			}
 		}
 


### PR DESCRIPTION
This saves around 50-100 microseconds (usec) on the 3970X with vMenu on a server with a single player online.