### PR TITLE
fix(ext/cfx-ui): make pageHeader have the same margin as server filters

### DIFF
--- a/ext/cfx-ui/src/styles/variables.scss
+++ b/ext/cfx-ui/src/styles/variables.scss
@@ -160,7 +160,7 @@ $colorsNy: (
 	line-height: var(--header-height);
 	text-transform: uppercase;
 
-	padding-left: calc(var(--header-safe-left) + var(--qh));
+	padding-left: var(--header-safe-left);
 	padding-right: var(--header-safe-right);
 
 	margin-bottom: var(--q1);


### PR DESCRIPTION
Closes #816. Unsure if this is the correct art direction, but it looks fine on the pages I could find using this style.