### PR TITLE
fix(streaming/five): re-enable cache loader hook for 2189+

### DIFF
--- a/code/components/gta-streaming-five/src/CacheLoader.cpp
+++ b/code/components/gta-streaming-five/src/CacheLoader.cpp
@@ -43,17 +43,6 @@ static void LoadCacheHook(const char* filenameBase, const char* rootPath, int is
 			{
 				static auto streamingModule = streaming::Manager::GetInstance()->moduleMgr.GetStreamingModule("rpf");
 				const auto& packName = streaming::GetStreamingNameForIndex(streamingModule->baseIdx + i);
-
-				// this didn't fix anything, missing `++i` made it seem like it did
-#if 0
-				// downtown_01_metadata for *whatever* reason breaks if this is used as long as mpheist4 dlc is loaded
-				if (packName.find("downtown_01_metadata") != std::string::npos)
-				{
-					++i; // !!!!!
-					continue;
-				}
-#endif
-
 				file.isDLC = false;
 
 				file.cacheFlags &= ~1;
@@ -207,10 +196,7 @@ static HookFunction hookFunction([]()
 	}
 
 	MH_Initialize();
-	if (!xbr::IsGameBuildOrGreater<2189>())
-	{
-		MH_CreateHook(hook::get_pattern("B9 00 00 04 00 BF 01 00 00 00 39", -0x5D), LoadCacheHook, (void**)&g_loadCacheOld);
-	}
+	MH_CreateHook(hook::get_pattern("B9 00 00 04 00 BF 01 00 00 00 39", -0x5D), LoadCacheHook, (void**)&g_loadCacheOld);
 	MH_EnableHook(MH_ALL_HOOKS);
 });
 


### PR DESCRIPTION
Closes #825.

Some dead code directly related to this was removed as well.

> [     21953] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x140dd2b10 (2) took 162msec
> [     22797] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x1408f5b5c (53) took 849msec
> [     24625] [         fivem]             MainThrd/ Loading content XML: dlc_patchDay23NGCRC:/content.xml
> [     25141] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x1407e3f7c (56) took 2346msec
> [     25266] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x14092011c (24) took 83msec
> [     25453] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x140921fcc (33) took 127msec
> [     25516] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x140e32d14 (38) took 64msec
> [     25610] [         fivem]             MainThrd/ LoadScreenFuncs::OnEnd: Instrumented function 0x140924768 (45) took 76msec

Function 36 is not showing up anymore (debug build, so other slowness is expected).