### PR TITLE
Update MumbleIsConnected.md

### DIFF
--- a/ext/native-decls/MumbleIsConnected.md
+++ b/ext/native-decls/MumbleIsConnected.md
@@ -5,11 +5,11 @@ apiset: client
 ## MUMBLE_IS_CONNECTED
 
 ```c
-BOOL MUMBLE_IS_CONNECTED();
+NUMBER|BOOL MUMBLE_IS_CONNECTED();
 ```
 
-This native will return true if the user succesfully connected to the voice server.
+This native will return 1 if the user succesfully connected to the voice server.
 If the user disabled the voice-chat setting it will return false.
 
 ## Return value
-True if the player is connected to a mumble server.
+1 if the player is connected to a mumble server.


### PR DESCRIPTION
When player is connected to Mumble the native `MumbleIsConnected` returns `1` (number).  When player is not connected the native returns `false` (boolean). I am not sure if this is an intended behaviour, therefor I propose to update documentation first.