### PR TITLE
feat(onesync): re-add NETWORK_GET_FIRST_ENTITY_OWNER

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -139,6 +139,19 @@ static void Init()
 		return retval;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_FIRST_ENTITY_OWNER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+    {
+        int retval = -1;
+        auto firstOwner = entity->GetFirstOwner();
+
+        if (firstOwner && !entity->firstOwnerDropped)
+        {
+            retval = firstOwner->GetNetId();
+        }
+
+        return retval;
+    }));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_COORDS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		float position[3];

--- a/ext/native-decls/NetworkGetFirstEntityOwner.md
+++ b/ext/native-decls/NetworkGetFirstEntityOwner.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## NETWORK_GET_FIRST_ENTITY_OWNER
+
+```c
+int NETWORK_GET_FIRST_ENTITY_OWNER(Entity entity);
+```
+
+Returns the first owner ID of the specified entity.
+
+## Parameters
+* **entity**: The entity to get the first owner for.
+
+## Return value
+The server ID of the first entity owner.


### PR DESCRIPTION
It's hard to keep a grudge against even the abusers who use this call, even though it's not having any actual valid use cases, and using it for such a thing would be wrong... it's somehow become part of the ecosystem.

Fixes #884, again.