### PR TITLE
feat(resources/client): external KVP commands

### DIFF
--- a/ext/native-decls/kvp/external/GetExternalKvpFloat.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpFloat.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_EXTERNAL_KVP_FLOAT
+
+```c
+float GET_EXTERNAL_KVP_FLOAT(char* resource, char* key);
+```
+
+A getter for [SET_RESOURCE_KVP_FLOAT](#_0x9ADD2938), but for a specified resource.
+
+## Parameters
+* **resource**: The resource to fetch from.
+* **key**: The key to fetch
+
+## Return value
+A float that contains the value stored in the Kvp or nil/null if none.
+
+## Examples
+
+```lua
+local kvpValue = GetExternalKvpFloat('drugs', 'mollis') 
+if kvpValue then
+	-- do something!
+end
+```

--- a/ext/native-decls/kvp/external/GetExternalKvpInt.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpInt.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_EXTERNAL_KVP_INT
+
+```c
+int GET_EXTERNAL_KVP_INT(char* resource, char* key);
+```
+
+A getter for [SET_RESOURCE_KVP_INT](#_0x6A2B1E8), but for a specified resource.
+
+## Parameters
+* **resource**: The resource to fetch from.
+* **key**: The key to fetch
+
+## Return value
+A int that contains the value stored in the Kvp or nil/null if none.
+
+## Examples
+
+```lua
+local kvpValue = GetExternalKvpInt('food', 'bananabread') 
+if kvpValue then
+	-- do something!
+end
+```

--- a/ext/native-decls/kvp/external/GetExternalKvpString.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpString.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_EXTERNAL_KVP_STRING
+
+```c
+char* GET_EXTERNAL_KVP_STRING(char* resource, char* key);
+```
+
+A getter for [SET_RESOURCE_KVP](#_0x21C7A35B), but for a specified resource.
+
+## Parameters
+* **resource**: The resource to fetch from.
+* **key**: The key to fetch
+
+## Return value
+A string that contains the value stored in the Kvp or nil/null if none.
+
+## Examples
+
+```lua
+local kvpValue = GetExternalKvpString('food', 'codfish') 
+if kvpValue then
+	-- do something!
+end
+```

--- a/ext/native-decls/kvp/external/StartFindExternalKvp.md
+++ b/ext/native-decls/kvp/external/StartFindExternalKvp.md
@@ -1,0 +1,37 @@
+---
+ns: CFX
+apiset: client
+---
+## START_FIND_EXTERNAL_KVP
+
+```c
+int START_FIND_EXTERNAL_KVP(char* resourceName, char* prefix);
+```
+
+Equivalent of [START_FIND_KVP](#_0xDD379006), but for another resource than the current one.
+
+## Parameters
+* **resourceName**: The resource to try finding the key/values for
+* **prefix**: A prefix match
+
+## Return value
+A KVP find handle to use with [FIND_KVP](#_0xBD7BEBC5) and close with [END_FIND_KVP](#_0xB3210203)
+
+## Examples
+```lua
+local kvpHandle = StartFindExternalKvp('drugs', 'mollis:')
+
+if kvpHandle ~= -1 then 
+	local key
+	
+	repeat
+		key = FindKvp(kvpHandle)
+
+		if key then
+			print(('%s: %s'):format(key, GetResourceKvpString(key)))
+		end
+	until key
+
+	EndFindKvp(kvpHandle)
+end
+```


### PR DESCRIPTION
Allows getting KVP data from resources other than the current one.

Example:
```lua
print(GetExternalKvpString('vMenu', 'mp_ped_a but off by one'))
```

Requested:
> Is there a way to get KVPs from a resource without making a resource with its name? I want to seamlessly import stuff from vMenu (vehicle mods etc) without loading vMenu itself on the server. Am I basically forced to name a resource vMenu and then use it to fetch the info?
