### PR TITLE
Add camera shake override setting

### DIFF
--- a/code/components/gta-core-five/src/DisableCameraShake.cpp
+++ b/code/components/gta-core-five/src/DisableCameraShake.cpp
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <StdInc.h>
+#include <GameInit.h>
+#include <Hooking.h>
+#include <CoreConsole.h>
+#include <nutsnbolts.h>
+
+static std::shared_ptr<ConVar<bool>> g_cameraShakeConvar;
+
+static void CameraShakeOverride()
+{
+	if (g_cameraShakeConvar->GetValue())
+	{
+		//Vehicle high speed camera shake
+		//48 8B D9                  mov     rbx, rcx
+		//48 81 C7 88 04 00 00      add     rdi, 488h     <--------------
+		//8B 6F 08                  mov     ebp, [rdi+8]
+
+		hook::nop(hook::get_pattern("48 8B D9 48 81 C7 ? ? ? ? 8B ? ? 85 ?", 3), 7);
+
+		//Ped running camera shake
+		//0F 29 70 E8				movaps xmmword ptr[rax - 18h], xmm6
+		//0F 29 78 D8				movaps  xmmword ptr [rax-28h], xmm7
+		//48 81 C7 08 08 00 00		add rdi, 808h		 <--------------
+		//48 8B F1					mov rsi, rcx
+
+		hook::nop(hook::get_pattern("57 48 81 EC ? ? ? ? 48 8B B9 ? ? ? ? 0F 29 70 E8 0F 29 78 D8 48 81 C7 ? ? ? ?", 23), 7);
+	}
+}
+
+static InitFunction initFunction([]()
+{
+	g_cameraShakeConvar = std::make_shared<ConVar<bool>>("cam_disableCameraShake", ConVar_Archive, false);
+
+	OnFirstLoadCompleted.Connect([]()
+	{
+		CameraShakeOverride();
+	});
+});

--- a/ext/cfx-ui/src/app/settings.service.ts
+++ b/ext/cfx-ui/src/app/settings.service.ts
@@ -160,6 +160,15 @@ export class SettingsService {
 				category: '#SettingsCat_Game',
 			});
 
+			this.addSetting('disableCameraShake', {
+				name: '#Settings_CameraShake',
+				description: '#Settings_CameraShakeDesc',
+				type: 'checkbox',
+				getCb: () => this.gameService.getConvar('cam_disableCameraShake').pipe(map(a => a === 'true' ? 'true' : 'false')),
+				setCb: (value) => this.gameService.setConvar('cam_disableCameraShake', value),
+				category: '#SettingsCat_Game',
+			});
+
 			this.addSetting('customEmoji', {
 				name: '#Settings_CustomEmoji',
 				description: '#Settings_CustomEmojiDesc',

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -63,6 +63,8 @@
     "#Settings_UseAudioFrameLimiterDesc": "Fix hitches at high frame rates by disabling rage::g_audUseFrameLimiter",
     "#Settings_HandbrakeCamera": "Handbrake camera",
     "#Settings_HandbrakeCameraDesc": "Automatically recenter the vehicle-follow camera when using the handbrake",
+    "#Settings_CameraShake": "Disable camera shake",
+    "#Settings_CameraShakeDesc": "Disables third person camera shake while running or driving a vehicle.",
     "#Settings_QueriesPerMinute": "Server browser: Max pings / minute",
     "#Settings_CustomEmoji": "Custom FiveM watermark emoji",
     "#Settings_CustomEmojiDesc": "An emoji to show in the FiveM watermark.",


### PR DESCRIPTION
Allows users to turn camera shake off, both while driving a vehicle and running (third person only).
Mainly a QOL change for people suffering from motion sickness due to camera shake.
Currently requires a game restart to take effect if changed manually in F8 console (eg. seta "cam_disableCameraShake" "true") as forcing value changes on address while game is running caused crashes (unsure why, works fine in base game), however, changing it in FiveM launcher settings works properly, so I went with that solution and hook on first load. Haven't had any issues doing it that way.