### PR TITLE
Add crossbuild support of b1436 for RedM

### DIFF
--- a/code/client/launcher/CrossBuildLaunch.cpp
+++ b/code/client/launcher/CrossBuildLaunch.cpp
@@ -66,7 +66,7 @@ void XBR_EarlySelect()
 		;
 
 	// we *can't* call xbr:: APIs here since they'll `static`-initialize and break GameCache later
-	uint32_t builds[] = { 372, 1604, 2060, 2189, 2372, 1311, 1355, 43 };
+	uint32_t builds[] = { 372, 1604, 2060, 2189, 2372, 1311, 1355, 1436, 43 };
 	uint32_t requestedBuild = defaultBuild;
 
 	auto realCli = GetCommandLineW();

--- a/code/client/launcher/ExecutableLoader.Snapshot.cpp
+++ b/code/client/launcher/ExecutableLoader.Snapshot.cpp
@@ -68,16 +68,15 @@ inline uintptr_t GetTriggerEP()
 
 	if (xbr::IsGameBuild<1355>())
 	{
-		return 0x142DE455C;
+		return 0x142DE455C; // 1355.18
 	}
 
 	if (xbr::IsGameBuild<1436>())
 	{
-		return 0x142DE455C;
+		return 0x142E8B79C; // 1436.26
 	}
 
-	// 1311.20
-	return 0x142E0F92C;
+	return 0x142E0F92C; // 1311.20
 }
 
 #define TRIGGER_EP (GetTriggerEP())

--- a/code/client/launcher/ExecutableLoader.Snapshot.cpp
+++ b/code/client/launcher/ExecutableLoader.Snapshot.cpp
@@ -71,6 +71,11 @@ inline uintptr_t GetTriggerEP()
 		return 0x142DE455C;
 	}
 
+	if (xbr::IsGameBuild<1436>())
+	{
+		return 0x142DE455C;
+	}
+
 	// 1311.20
 	return 0x142E0F92C;
 }

--- a/code/client/launcher/GameCache.cpp
+++ b/code/client/launcher/GameCache.cpp
@@ -1462,12 +1462,12 @@ std::map<std::string, std::string> UpdateGameCache()
 	// 1311/1355/1436 toggle
 	if (IsTargetGameBuild<1436>())
 	{
-		g_requiredEntries.push_back({ "RDR2.exe", "af5c7ac8e0364b9f16dd56038514b2b6183a856b", "ipfs://bafybeigxlkqrdkwepcj3svowxfrnkucznuli4ui4xmjxazpl7dp4vhf5my", 89612184 });
-		g_requiredEntries.push_back({ "appdata0_update.rpf", "40c389093bb843235119cf0aaffdc020beba493d", "ipfs://bafybeigobeu5yeiobdsobl3ln6em2djq3dyfq7uqx4z6sq7prpkjlludze", 3164575 });
+		g_requiredEntries.push_back({ "RDR2.exe", "3c7a863dd71ee4dc66b3ee2f031616c53ceb5090", "ipfs://bafybeigsscjuvgk7bz4hryhxrphzmchrrg4trsise2bbvq3utqdryqyddy", 89830808 });
+		g_requiredEntries.push_back({ "appdata0_update.rpf", "9d1d6bbe5aa65adf030ec38c5ab9ecc082840207", "ipfs://bafybeifjzvqpiybxsqvukwa6upnddkgoccsl5okg3hgvw3yyzxz7vca7f4", 3164575 });
 		g_requiredEntries.push_back({ "shaders_x64.rpf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "ipfs://bafybeihfgavfbsihf65dtv6vyipphbcfrrytcj53hulzkoy7nonpwh4h74", 233898030 });
-		g_requiredEntries.push_back({ "update_1.rpf", "e623e54e3e1dd938a84de780d331a939446e4ba0", "ipfs://bafybeiab4wxjx6gynce2za7tkztgdkthiyos4n2t5hbknzh5cts2eemrgq", 2836982634 });
-		g_requiredEntries.push_back({ "update_2.rpf", "e8a1cb04c4c8b4aba5b0a311a6a1e8d547393da4", "ipfs://bafybeiase5grglqhkivcifcllk6tvr2csc4befvtsyej6aph4xb65eyxhi", 152008398 });
-		g_requiredEntries.push_back({ "update_3.rpf", "b7035ca49f70ed0fc79d6f5690376c5b49784d21", "ipfs://bafybeihuvd6hkn6ba75d6xs3o2ecj5q5pkve7yuhf4jox4uhnu3bfq7awq", 132374108 });
+		g_requiredEntries.push_back({ "update_1.rpf", "0853366e69b29daf01c05d643557e75d610933e7", "ipfs://bafybeihk27hp3wz3ud4pzlyobloievuk3xrntxhl26exec3pgrhlplnmly", 2836982634 });
+		g_requiredEntries.push_back({ "update_2.rpf", "3550ce534b2997306ae1bc13fc3abeec4573389f", "ipfs://bafybeiaum2y7k6gzsde2xwlstdidcp5vyb6vyqgl5djkwjpb4uesvz2fde", 152008462 });
+		g_requiredEntries.push_back({ "update_3.rpf", "5f2f26d9eb31f51a21a15f6466814c289906ca35", "ipfs://bafybeic6gss2v42cuc2xol23lc6s36rgoqnmeuuzf72z4wuxdwda4svvf4", 132374108 });
 		g_requiredEntries.push_back({ "update_4.rpf", "39ca2bbb7a0ab8d8e09288ca8783b91654c9b91b", "ipfs://bafybeiefr5ayhajox2zcfwrkjvhoqt7c4ebcfiaxr3grjtrtvefd4en3fy", 2014659811 });
 	}
 	else if (IsTargetGameBuild<1355>())

--- a/code/client/launcher/GameCache.cpp
+++ b/code/client/launcher/GameCache.cpp
@@ -1459,8 +1459,19 @@ std::map<std::string, std::string> UpdateGameCache()
 		g_requiredEntries.push_back({ "update/x64/dlcpacks/mptuner/dlc.rpf", "7a7521b3396701f4fe8ae51347c6206c46306648", "nope:https://runtime.fivem.net/patches/dlcpacks/patchday4ng/dlc.rpfmpbiker/dlc.rpf", 3482869760 });
 	}
 #elif IS_RDR3
-	// 1311/1355 toggle
-	if (IsTargetGameBuild<1355>())
+	// 1311/1355/1436 toggle
+	if (IsTargetGameBuild<1436>())
+	{
+		g_requiredEntries.push_back({ "RDR2.exe", "af5c7ac8e0364b9f16dd56038514b2b6183a856b", "ipfs://todo", 89612184 });
+		g_requiredEntries.push_back({ "appdata0_update.rpf", "40c389093bb843235119cf0aaffdc020beba493d", "ipfs://todo", 3164575 });
+		g_requiredEntries.push_back({ "shaders_x64.rpf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "ipfs://todo", 233898030 });
+		g_requiredEntries.push_back({ "update_1.rpf", "e623e54e3e1dd938a84de780d331a939446e4ba0", "ipfs://todo", 2836982634 });
+		g_requiredEntries.push_back({ "update_2.rpf", "e8a1cb04c4c8b4aba5b0a311a6a1e8d547393da4", "ipfs://todo", 152008398 });
+		g_requiredEntries.push_back({ "update_3.rpf", "b7035ca49f70ed0fc79d6f5690376c5b49784d21", "ipfs://todo", 132374108 });
+		g_requiredEntries.push_back({ "update_4.rpf", "39ca2bbb7a0ab8d8e09288ca8783b91654c9b91b", "ipfs://todo", 2014659811 });
+
+	}
+	else if (IsTargetGameBuild<1355>())
 	{
 		g_requiredEntries.push_back({ "RDR2.exe", "c2fab1d25daef4779aafd2754ec9c593e674e7c3", "ipfs://bafybeigcudahnyogfbavh2fldp5irtm3jxvseysqyarkgibf75wcsmxo4i", 84664448 });
 		g_requiredEntries.push_back({ "appdata0_update.rpf", "307609c164e78adaf4e50e993328485e6264803f", "ipfs://bafybeieesm4cgypcfesnlr4n3q5ruxbjywarnarq75bso77nu6chapktbu", 3069247 });
@@ -1478,6 +1489,11 @@ std::map<std::string, std::string> UpdateGameCache()
 	if (IsTargetGameBuild<1355>())
 	{
 		g_requiredEntries.push_back({ "x64/dlcpacks/mp008/dlc.rpf", "66a50ed07293b92466423e1db5eed159551d8c25", "nope:https://runtime.fivem.net/patches/dlcpacks/patchday4ng/dlc.rpfmpbiker/dlc.rpf", 487150980 });
+	}
+
+	if (IsTargetGameBuild<1436>())
+	{
+		g_requiredEntries.push_back({ "x64/dlcpacks/mp009/dlc.rpf", "7ae2012968709d6d1079c88ee40369f4359778bf", "nope:https://runtime.fivem.net/patches/dlcpacks/patchday4ng/dlc.rpfmpbiker/dlc.rpf", 494360763 });
 	}
 #endif
 

--- a/code/client/launcher/GameCache.cpp
+++ b/code/client/launcher/GameCache.cpp
@@ -1462,14 +1462,13 @@ std::map<std::string, std::string> UpdateGameCache()
 	// 1311/1355/1436 toggle
 	if (IsTargetGameBuild<1436>())
 	{
-		g_requiredEntries.push_back({ "RDR2.exe", "af5c7ac8e0364b9f16dd56038514b2b6183a856b", "ipfs://todo", 89612184 });
-		g_requiredEntries.push_back({ "appdata0_update.rpf", "40c389093bb843235119cf0aaffdc020beba493d", "ipfs://todo", 3164575 });
-		g_requiredEntries.push_back({ "shaders_x64.rpf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "ipfs://todo", 233898030 });
-		g_requiredEntries.push_back({ "update_1.rpf", "e623e54e3e1dd938a84de780d331a939446e4ba0", "ipfs://todo", 2836982634 });
-		g_requiredEntries.push_back({ "update_2.rpf", "e8a1cb04c4c8b4aba5b0a311a6a1e8d547393da4", "ipfs://todo", 152008398 });
-		g_requiredEntries.push_back({ "update_3.rpf", "b7035ca49f70ed0fc79d6f5690376c5b49784d21", "ipfs://todo", 132374108 });
-		g_requiredEntries.push_back({ "update_4.rpf", "39ca2bbb7a0ab8d8e09288ca8783b91654c9b91b", "ipfs://todo", 2014659811 });
-
+		g_requiredEntries.push_back({ "RDR2.exe", "af5c7ac8e0364b9f16dd56038514b2b6183a856b", "ipfs://bafybeigxlkqrdkwepcj3svowxfrnkucznuli4ui4xmjxazpl7dp4vhf5my", 89612184 });
+		g_requiredEntries.push_back({ "appdata0_update.rpf", "40c389093bb843235119cf0aaffdc020beba493d", "ipfs://bafybeigobeu5yeiobdsobl3ln6em2djq3dyfq7uqx4z6sq7prpkjlludze", 3164575 });
+		g_requiredEntries.push_back({ "shaders_x64.rpf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "ipfs://bafybeihfgavfbsihf65dtv6vyipphbcfrrytcj53hulzkoy7nonpwh4h74", 233898030 });
+		g_requiredEntries.push_back({ "update_1.rpf", "e623e54e3e1dd938a84de780d331a939446e4ba0", "ipfs://bafybeiab4wxjx6gynce2za7tkztgdkthiyos4n2t5hbknzh5cts2eemrgq", 2836982634 });
+		g_requiredEntries.push_back({ "update_2.rpf", "e8a1cb04c4c8b4aba5b0a311a6a1e8d547393da4", "ipfs://bafybeiase5grglqhkivcifcllk6tvr2csc4befvtsyej6aph4xb65eyxhi", 152008398 });
+		g_requiredEntries.push_back({ "update_3.rpf", "b7035ca49f70ed0fc79d6f5690376c5b49784d21", "ipfs://bafybeihuvd6hkn6ba75d6xs3o2ecj5q5pkve7yuhf4jox4uhnu3bfq7awq", 132374108 });
+		g_requiredEntries.push_back({ "update_4.rpf", "39ca2bbb7a0ab8d8e09288ca8783b91654c9b91b", "ipfs://bafybeiefr5ayhajox2zcfwrkjvhoqt7c4ebcfiaxr3grjtrtvefd4en3fy", 2014659811 });
 	}
 	else if (IsTargetGameBuild<1355>())
 	{

--- a/code/client/launcher/StdInc.h
+++ b/code/client/launcher/StdInc.h
@@ -104,6 +104,8 @@ bool CheckFileOutdatedWithUI(const wchar_t* fileName, const std::vector<std::arr
 #define LAUNCHER_PERSONALITY_GAME
 #elif defined(LAUNCHER_PERSONALITY_GAME_1355)
 #define LAUNCHER_PERSONALITY_GAME
+#elif defined(LAUNCHER_PERSONALITY_GAME_1436)
+#define LAUNCHER_PERSONALITY_GAME
 #endif
 #elif defined(GTA_NY)
 #ifdef LAUNCHER_PERSONALITY_GAME_43

--- a/code/client/launcher/premake5.lua
+++ b/code/client/launcher/premake5.lua
@@ -104,7 +104,7 @@ local function launcherpersonality_inner(name, aslr)
 				local gameBuild = '1311'
 				
 				if name == 'game_1355' then gameBuild = '1355_18' end
-				if name == 'game_1436' then gameBuild = '1436_25' end
+				if name == 'game_1436' then gameBuild = '1436_26' end
 
 				local gameDump = ("C:\\f\\RDR2_%s.exe"):format(gameBuild)
 

--- a/code/client/launcher/premake5.lua
+++ b/code/client/launcher/premake5.lua
@@ -17,7 +17,7 @@ local function isGamePersonality(name)
 		return true
 	end
 	
-	if name == 'game_1311' or name == 'game_1355' then
+	if name == 'game_1311' or name == 'game_1355' or name == 'game_1436' then
 		return true
 	end
 	
@@ -104,6 +104,7 @@ local function launcherpersonality_inner(name, aslr)
 				local gameBuild = '1311'
 				
 				if name == 'game_1355' then gameBuild = '1355_18' end
+				if name == 'game_1436' then gameBuild = '1436_25' end
 
 				local gameDump = ("C:\\f\\RDR2_%s.exe"):format(gameBuild)
 
@@ -214,6 +215,7 @@ if _OPTIONS['game'] == 'five' then
 elseif _OPTIONS['game'] == 'rdr3' then
 	launcherpersonality 'game_1311'
 	launcherpersonality 'game_1355'
+	launcherpersonality 'game_1436'
 	launcherpersonality 'game_mtl'
 elseif _OPTIONS['game'] == 'ny' then
 	launcherpersonality 'game_43'

--- a/code/client/shared/CfxSubProcess.h
+++ b/code/client/shared/CfxSubProcess.h
@@ -96,6 +96,11 @@ inline const wchar_t* MakeCfxSubProcess(const std::wstring& processType, const s
 	{
 		productName += L"b1355_";
 	}
+
+	if (wcsstr(GetCommandLine(), L"b1436") != nullptr)
+	{
+		productName += L"b1436_";
+	}
 #endif
 #endif
 

--- a/code/client/shared/CrossBuildRuntime.h
+++ b/code/client/shared/CrossBuildRuntime.h
@@ -116,6 +116,25 @@ inline bool Is1355()
 
 	return false;
 }
+
+inline bool Is1436()
+{
+#ifdef IS_RDR3
+	static bool retval = ([]()
+	{
+		if (wcsstr(GetCommandLineW(), L"b1436") != nullptr)
+		{
+			return true;
+		}
+
+		return false;
+	})();
+
+	return retval;
+#endif
+
+	return false;
+}
 #pragma endregion
 
 namespace xbr
@@ -150,6 +169,11 @@ inline int GetGameBuild()
 #elif IS_RDR3
 	static int build = ([]()
 	{
+		if (Is1436())
+		{
+			return 1436;
+		}
+
 		if (Is1355())
 		{
 			return 1355;

--- a/code/components/extra-natives-rdr3/src/NativeFixes.cpp
+++ b/code/components/extra-natives-rdr3/src/NativeFixes.cpp
@@ -1,0 +1,89 @@
+/*
+* This file is part of the CitizenFX project - http://citizen.re/
+*
+* See LICENSE and MENTIONS in the root of the source tree for information
+* regarding licensing.
+*/
+
+#include "StdInc.h"
+#include <Local.h>
+
+#include <ScriptEngine.h>
+#include <Hooking.h>
+#include <scrEngine.h>
+#include <CrossBuildRuntime.h>
+
+static bool* g_textCentre;
+static bool* g_textDropshadow;
+
+
+static void RedirectNoppedTextNatives()
+{
+	// original hash, target hash
+	std::pair<uint64_t, uint64_t> nativesRedirects[] = {
+		{ 0xD79334A4BB99BAD1, 0x16794E044C9EFB58 }, // _DISPLAY_TEXT to _BG_DISPLAY_TEXT
+		{ 0x50A41AD966910F03, 0x16FA5CE47F184F1E }, // _SET_TEXT_COLOR to _BG_SET_TEXT_COLOR
+		{ 0x4170B650590B3B00, 0xA1253A3C870B6843 }, // _SET_TEXT_SCALE to _BG_SET_TEXT_SCALE
+	};
+
+	for (auto native : nativesRedirects)
+	{
+		auto targetHandler = fx::ScriptEngine::GetNativeHandler(native.second);
+
+		if (!targetHandler)
+		{
+			trace("Couldn't find 0x%08x handler to hook!\n", native.second);
+			return;
+		}
+
+		fx::ScriptEngine::RegisterNativeHandler(native.first, [=](fx::ScriptContext& ctx)
+		{
+			(*targetHandler)(ctx);
+		});
+	}
+}
+
+static void ImplementRemovedTextNatives()
+{
+	// SET_TEXT_CENTRE
+	fx::ScriptEngine::RegisterNativeHandler(0xBE5261939FBECB8C, [=](fx::ScriptContext& ctx)
+	{
+		auto value = *g_textCentre;
+
+		if (ctx.GetArgument<bool>(0))
+		{
+			value = 0;
+		}
+
+		*g_textCentre = value;
+	});
+
+	// SET_TEXT_DROPSHADOW
+	fx::ScriptEngine::RegisterNativeHandler(0x1BE39DBAA7263CA5, [=](fx::ScriptContext& ctx)
+	{
+		*g_textDropshadow = (ctx.GetArgument<int>(0) > 0);
+	});
+}
+
+static HookFunction hookFunction([]()
+{
+	if (xbr::IsGameBuildOrGreater<1436>())
+	{
+		auto location = hook::get_pattern<char>("0F 28 05 ? ? ? ? 83 25 ? ? ? ? 00 83 25 ? ? ? ? 00");
+
+		g_textCentre = hook::get_address<bool*>(location + 0x33) + 2;
+		g_textDropshadow = hook::get_address<bool*>(location + 0x3B) + 1;
+	}
+
+	rage::scrEngine::OnScriptInit.Connect([]()
+	{
+		// R* removed some text related natives since RDR3 1436.25 build.
+		// Redirecting original natives to their successors to keep cross build compatibility.
+		// Also re-implementing entirely removed natives.
+		if (xbr::IsGameBuildOrGreater<1436>())
+		{
+			RedirectNoppedTextNatives();
+			ImplementRemovedTextNatives();
+		}
+	});
+});

--- a/code/components/font-renderer/src/GtaGameInterface.cpp
+++ b/code/components/font-renderer/src/GtaGameInterface.cpp
@@ -456,6 +456,11 @@ static InitFunction initFunction([] ()
 				{
 					brandName += L" (b1355)";
 				}
+
+				if (Is1436())
+				{
+					brandName += L" (b1436)";
+				}
 #endif
 
 #if defined(GTA_NY)

--- a/code/components/gta-core-rdr3/src/EntityDeletionHacks.cpp
+++ b/code/components/gta-core-rdr3/src/EntityDeletionHacks.cpp
@@ -2,6 +2,7 @@
 #include "Hooking.h"
 
 #include "scrEngine.h"
+#include "CrossBuildRuntime.h"
 
 #include <boost/type_index.hpp>
 
@@ -91,7 +92,7 @@ static hook::cdecl_stub<void(fwEntity*)> deleteObject([]()
 
 static hook::cdecl_stub<void(netObject*, bool)> sendMarkAsNoLongerNeededEvent([]()
 {
-	return hook::get_pattern("49 8B 04 C0 40 84 34 01 0F 84", -47);
+	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("8A 55 28 48 8B CF C6 45 38 00 E8", -99) : hook::get_pattern("49 8B 04 C0 40 84 34 01 0F 84", -47);
 });
 
 static hook::cdecl_stub<void(fwEntity*, bool)> markAsNoLongerNeeded([]()

--- a/code/components/gta-core-rdr3/src/EntityDeletionHacks.cpp
+++ b/code/components/gta-core-rdr3/src/EntityDeletionHacks.cpp
@@ -2,7 +2,6 @@
 #include "Hooking.h"
 
 #include "scrEngine.h"
-#include "CrossBuildRuntime.h"
 
 #include <boost/type_index.hpp>
 
@@ -13,7 +12,7 @@ struct netObject
 	char pad[64]; // +0
 	uint16_t objectType; // +64
 	uint16_t objectId; // +66
-	char pad2[1]; // +68 
+	char pad2[1]; // +68
 	uint8_t ownerId; // +69
 	uint8_t nextOwnerId; // +70
 	bool isRemote; // +71
@@ -92,7 +91,7 @@ static hook::cdecl_stub<void(fwEntity*)> deleteObject([]()
 
 static hook::cdecl_stub<void(netObject*, bool)> sendMarkAsNoLongerNeededEvent([]()
 {
-	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("8A 55 28 48 8B CF C6 45 38 00 E8", -99) : hook::get_pattern("49 8B 04 C0 40 84 34 01 0F 84", -47);
+	return hook::get_pattern("48 89 5C 24 08 88 54 24 10 55 56 57 48");
 });
 
 static hook::cdecl_stub<void(fwEntity*, bool)> markAsNoLongerNeeded([]()

--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -89,7 +89,7 @@ static hook::thiscall_stub<void(netPlayerMgrBase*, CNetGamePlayer*)> _netPlayerM
 #ifdef GTA_FIVE
 	return hook::get_call(hook::get_pattern("FF 57 30 48 8B D6 49 8B CE E8", 9));
 #elif IS_RDR3
-	return hook::get_call((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B 01 FF 50 58 49 8B D7 48", 12) : hook::get_pattern("41 B9 FF 00 00 00 4D 8B C5", 21));
+	return hook::get_call(hook::get_pattern("48 8B 01 FF 50 ? 49 8B D7 48 8B CE E8", 12));
 #endif
 });
 
@@ -300,7 +300,7 @@ static hook::cdecl_stub<void(void*)> _pCtor([]()
 #ifdef IS_RDR3
 static hook::cdecl_stub<void(uint8_t)> _initUnkPlayerArray([]()
 {
-	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B C8 48 85 C0 74 ? 83 61 04 00 B8", -0x40) : hook::get_pattern("80 F9 20 73 ? 53 48 83 EC 20 8A D9");
+	return hook::get_call(hook::get_pattern("48 8B CB E8 ? ? ? ? 8A 4B 19 48 83 C4", 0x10));
 });
 #endif
 
@@ -1577,7 +1577,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("80 7A ? FF 48 8B EA 48 8B F1 0F", -0x13), UnkEventMgr, (void**)&g_origUnkEventMgr);
 #elif IS_RDR3
-	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("45 33 FF 80 FB 20 72 ? 41 8D 57 01 C7", -0x2B) : hook::get_pattern("4C 69 F0 ? ? ? ? 45 39 BC 3E ? ? ? ? 0F", -0x38), UnkEventMgr, (void**)&g_origUnkEventMgr);
+	MH_CreateHook(hook::get_pattern("41 57 48 83 EC 30 ? 8B ? ? 8B ? 48 83 C1 08 E8", -0x12), UnkEventMgr, (void**)&g_origUnkEventMgr);
 #endif
 
 	// return to disable breaking hooks
@@ -1612,7 +1612,7 @@ static HookFunction hookFunction([]()
 	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("33 DB 48 8B F9 48 39 99 ? ? ? ? 75 ? 8D 53 01", -10) : hook::get_pattern("48 39 99 ? ? ? ? 74 ? 48 81 C1 ? ? ? ? 48 8B 19 48 85", -15), AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
 
 	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "8A 41 45 3C 20 72 ? 33 C0 C3" : "80 79 45 20 72 ? 33 C0 C3"), netObject__GetPlayerOwner, (void**)&g_origGetOwnerNetPlayer);
-	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 83 EC 30 8A 59 46 80 FB FF 75", -6) : hook::get_pattern("0F B6 C8 48 8B 05 ? ? ? ? 48 8B 84 C8", -11), netObject__GetPendingPlayerOwner, (void**)&g_origGetPendingPlayerOwner);
+	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "48 89 5C 24 08 57 48 83 EC 30 8A 59 46" : "8A 41 46 3C FF 74"), netObject__GetPendingPlayerOwner, (void**)&g_origGetPendingPlayerOwner);
 #endif
 
 	// function is only 4 bytes, can't be hooked like this
@@ -1702,7 +1702,7 @@ static HookFunction hookFunction([]()
 		MH_CreateHook(hook::get_call(location + 0), netInterface_GetNumRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerListCount);
 		MH_CreateHook(hook::get_call(location + 8), netInterface_GetRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerList);
 #elif IS_RDR3
-		auto location = hook::get_pattern<char>((xbr::IsGameBuildOrGreater<1436>()) ? "48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B F0 E8" : "48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B F8 E8");
+		auto location = hook::get_pattern<char>("48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B ? E8");
 		MH_CreateHook(hook::get_call(location + 15), netInterface_GetNumRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerListCount);
 		MH_CreateHook(hook::get_call(location + 22), netInterface_GetRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerList);
 #endif
@@ -1730,7 +1730,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("4C 8B F9 74 7D", -0x2B), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "F6 86 D8 08 00 00 01 0F 84 ? ? ? ? 44 8A 05" : "F6 86 D8 08 00 00 01 74 ? 44 8A 05", -0x3B), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
+	MH_CreateHook(hook::get_pattern("4C 8B F9 49 8B CC 4C 8B F2 33 FF E8", -0x24), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
 #endif
 
 #ifdef GTA_FIVE
@@ -1750,7 +1750,7 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("45 8D 65 20 C6 81 ? ? 00 00 01 48 8D 59 08", -0x2F), ObjectManager_End, (void**)&g_origObjectManager_End);
 	MH_CreateHook(hook::get_call(hook::get_call(hook::get_pattern<char>("48 8D 05 ? ? ? ? 48 8B D9 48 89 01 E8 ? ? ? ? 84 C0 74 08 48 8B CB E8", -0x19) + 0x32)), PlayerManager_End, (void**)&g_origPlayerManager_End);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "C6 81 ? ? ? ? 01 49 8B ? E8 ? ? ? ? 45 8D 67" : "C6 81 ? ? ? ? 01 48 8B CD E8 ? ? ? ? 45 8D 67", -0x36), ObjectManager_End, (void**)&g_origObjectManager_End);
+	MH_CreateHook(hook::get_pattern("48 83 EC 30 45 33 FF 48 8B F1 44 38 B9", -0x18), ObjectManager_End, (void**)&g_origObjectManager_End);
 	MH_CreateHook(hook::get_call(hook::get_call(hook::get_pattern<char>("48 8D 05 ? ? ? ? 48 8B F9 48 89 01 E8 ? ? ? ? 84 C0 74 08 48 8B ? E8", -0xF) + 0x28)), PlayerManager_End, (void**)&g_origPlayerManager_End);
 #endif
 

--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -89,7 +89,7 @@ static hook::thiscall_stub<void(netPlayerMgrBase*, CNetGamePlayer*)> _netPlayerM
 #ifdef GTA_FIVE
 	return hook::get_call(hook::get_pattern("FF 57 30 48 8B D6 49 8B CE E8", 9));
 #elif IS_RDR3
-	return hook::get_call(hook::get_pattern("41 B9 FF 00 00 00 4D 8B C5", 21));
+	return hook::get_call((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B 01 FF 50 58 49 8B D7 48", 12) : hook::get_pattern("41 B9 FF 00 00 00 4D 8B C5", 21));
 #endif
 });
 
@@ -300,7 +300,7 @@ static hook::cdecl_stub<void(void*)> _pCtor([]()
 #ifdef IS_RDR3
 static hook::cdecl_stub<void(uint8_t)> _initUnkPlayerArray([]()
 {
-	return hook::get_pattern("80 F9 20 73 ? 53 48 83 EC 20 8A D9");
+	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B C8 48 85 C0 74 ? 83 61 04 00 B8", -0x40) : hook::get_pattern("80 F9 20 73 ? 53 48 83 EC 20 8A D9");
 });
 #endif
 
@@ -1547,8 +1547,8 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("4C 8B F1 41 BD 05", -0x22), PassObjectControlStub, (void**)&g_origPassObjectControl);
 	MH_CreateHook(hook::get_pattern("8A 41 49 4C 8B F2 48 8B", -0x10), SetOwnerStub, (void**)&g_origSetOwner);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("48 8B D9 E8 ? ? ? ? 33 ? 66 C7 83", xbr::IsGameBuildOrGreater<1355>() ? -0xA : -0x6), NetworkObjectMgrCtorStub, (void**)&g_origNetworkObjectMgrCtor);
-	MH_CreateHook(hook::get_pattern("83 FE 01 41 0F 9F C4 48 85 DB 74", -0x71), PassObjectControlStub, (void**)&g_origPassObjectControl);
+	MH_CreateHook(hook::get_pattern("48 8B D9 E8 ? ? ? ? 33 ? 66 C7 83", (xbr::IsGameBuildOrGreater<1355>()) ? -0xA : -0x6), NetworkObjectMgrCtorStub, (void**)&g_origNetworkObjectMgrCtor);
+	MH_CreateHook(hook::get_pattern("83 FE 01 41 0F 9F C4 48 85 DB 74", (xbr::IsGameBuildOrGreater<1436>()) ? -0x99 : -0x71), PassObjectControlStub, (void**)&g_origPassObjectControl);
 	MH_CreateHook(hook::get_pattern("80 79 ? ? 48 8B F2 48 8B F9 73", -0xF), SetOwnerStub, (void**)&g_origSetOwner);
 #endif
 
@@ -1577,7 +1577,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("80 7A ? FF 48 8B EA 48 8B F1 0F", -0x13), UnkEventMgr, (void**)&g_origUnkEventMgr);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("4C 69 F0 ? ? ? ? 45 39 BC 3E ? ? ? ? 0F", -0x38), UnkEventMgr, (void**)&g_origUnkEventMgr);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("45 33 FF 80 FB 20 72 ? 41 8D 57 01 C7", -0x2B) : hook::get_pattern("4C 69 F0 ? ? ? ? 45 39 BC 3E ? ? ? ? 0F", -0x38), UnkEventMgr, (void**)&g_origUnkEventMgr);
 #endif
 
 	// return to disable breaking hooks
@@ -1609,10 +1609,10 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("8A 41 49 3C FF 74 17 3C 20 73 13 0F B6 C8"), netObject__GetPlayerOwner, (void**)&g_origGetOwnerNetPlayer);
 	MH_CreateHook(hook::get_pattern("8A 41 4A 3C FF 74 17 3C 20 73 13 0F B6 C8"), netObject__GetPendingPlayerOwner, (void**)&g_origGetPendingPlayerOwner);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("48 39 99 ? ? ? ? 74 ? 48 81 C1 ? ? ? ? 48 8B 19 48 85", -15), AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("33 DB 48 8B F9 48 39 99 ? ? ? ? 75 ? 8D 53 01", -10) : hook::get_pattern("48 39 99 ? ? ? ? 74 ? 48 81 C1 ? ? ? ? 48 8B 19 48 85", -15), AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
 
-	MH_CreateHook(hook::get_pattern("80 79 45 20 72 ? 33 C0 C3"), netObject__GetPlayerOwner, (void**)&g_origGetOwnerNetPlayer);
-	MH_CreateHook(hook::get_pattern("0F B6 C8 48 8B 05 ? ? ? ? 48 8B 84 C8", -11), netObject__GetPendingPlayerOwner, (void**)&g_origGetPendingPlayerOwner);
+	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "8A 41 45 3C 20 72 ? 33 C0 C3" : "80 79 45 20 72 ? 33 C0 C3"), netObject__GetPlayerOwner, (void**)&g_origGetOwnerNetPlayer);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 83 EC 30 8A 59 46 80 FB FF 75", -6) : hook::get_pattern("0F B6 C8 48 8B 05 ? ? ? ? 48 8B 84 C8", -11), netObject__GetPendingPlayerOwner, (void**)&g_origGetPendingPlayerOwner);
 #endif
 
 	// function is only 4 bytes, can't be hooked like this
@@ -1653,7 +1653,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 		auto location = hook::get_pattern("48 8B D0 E8 ? ? ? ? E8 ? ? ? ? 83 BB ? ? ? ? 04", 3);
 #elif IS_RDR3
-		auto location = hook::get_pattern("48 85 C9 74 ? 4C 8D 44 24 40 40 88 7C", 18);
+		auto location = (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("40 0F B6 CF 48 89 44 CB 40 48", -5) : hook::get_pattern("48 85 C9 74 ? 4C 8D 44 24 40 40 88 7C", 18);
 #endif
 
 		hook::set_call(&g_origJoinBubble, location);
@@ -1677,9 +1677,10 @@ static HookFunction hookFunction([]()
 			MH_CreateHook(hook::get_call(hook::get_pattern("40 0F 92 C7 40 84 FF 0F 85 ? ? ? ? 40 8A CE E8", 16)), GetPlayerByIndex, nullptr);
 		}
 #elif IS_RDR3
-		auto match = hook::pattern("80 F9 20 73 13 48 8B").count(2);
-		MH_CreateHook(match.get(0).get<void>(0), GetPlayerByIndex, (void**)&g_origGetPlayerByIndex);
-		MH_CreateHook(match.get(1).get<void>(0), GetPlayerByIndex, nullptr);
+		auto pattern = (xbr::IsGameBuildOrGreater<1436>()) ? "80 F9 20 72 2B BA" : "80 F9 20 73 13 48 8B";
+		auto match = hook::pattern(pattern).count(2);
+		MH_CreateHook(match.get(0).get<void>((xbr::IsGameBuildOrGreater<1436>()) ? -19 : 0), GetPlayerByIndex, (void**)&g_origGetPlayerByIndex);
+		MH_CreateHook(match.get(1).get<void>((xbr::IsGameBuildOrGreater<1436>()) ? -19 : 0), GetPlayerByIndex, nullptr);
 #endif
 	}
 
@@ -1701,7 +1702,7 @@ static HookFunction hookFunction([]()
 		MH_CreateHook(hook::get_call(location + 0), netInterface_GetNumRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerListCount);
 		MH_CreateHook(hook::get_call(location + 8), netInterface_GetRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerList);
 #elif IS_RDR3
-		auto location = hook::get_pattern<char>("48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B F8 E8");
+		auto location = hook::get_pattern<char>((xbr::IsGameBuildOrGreater<1436>()) ? "48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B F0 E8" : "48 8B 07 48 8B CF FF 90 ? ? ? ? 44 8B F8 E8");
 		MH_CreateHook(hook::get_call(location + 15), netInterface_GetNumRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerListCount);
 		MH_CreateHook(hook::get_call(location + 22), netInterface_GetRemotePhysicalPlayers, (void**)&g_origGetNetworkPlayerList);
 #endif
@@ -1729,7 +1730,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("4C 8B F9 74 7D", -0x2B), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("F6 86 D8 08 00 00 01 74 ? 44 8A 05", -0x3B), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
+	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "F6 86 D8 08 00 00 01 0F 84 ? ? ? ? 44 8A 05" : "F6 86 D8 08 00 00 01 74 ? 44 8A 05", -0x3B), netObjectMgr__CountObjects, (void**)&g_origCountObjects);
 #endif
 
 #ifdef GTA_FIVE
@@ -1749,7 +1750,7 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("45 8D 65 20 C6 81 ? ? 00 00 01 48 8D 59 08", -0x2F), ObjectManager_End, (void**)&g_origObjectManager_End);
 	MH_CreateHook(hook::get_call(hook::get_call(hook::get_pattern<char>("48 8D 05 ? ? ? ? 48 8B D9 48 89 01 E8 ? ? ? ? 84 C0 74 08 48 8B CB E8", -0x19) + 0x32)), PlayerManager_End, (void**)&g_origPlayerManager_End);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("C6 81 ? ? ? ? 01 48 8B CD E8 ? ? ? ? 45 8D 67", -0x36), ObjectManager_End, (void**)&g_origObjectManager_End);
+	MH_CreateHook(hook::get_pattern((xbr::IsGameBuildOrGreater<1436>()) ? "C6 81 ? ? ? ? 01 49 8B ? E8 ? ? ? ? 45 8D 67" : "C6 81 ? ? ? ? 01 48 8B CD E8 ? ? ? ? 45 8D 67", -0x36), ObjectManager_End, (void**)&g_origObjectManager_End);
 	MH_CreateHook(hook::get_call(hook::get_call(hook::get_pattern<char>("48 8D 05 ? ? ? ? 48 8B F9 48 89 01 E8 ? ? ? ? 84 C0 74 08 48 8B ? E8", -0xF) + 0x28)), PlayerManager_End, (void**)&g_origPlayerManager_End);
 #endif
 
@@ -1777,7 +1778,7 @@ static HookFunction hookFunction([]()
 
 #ifdef IS_RDR3
 	// in RDR3 net player relevance position is cached in array indexed with physical player index, we need to patch it
-	MH_CreateHook(hook::get_pattern("44 0F A3 C0 0F 92 C0 41 88 02", -0x32), getNetPlayerRelevancePosition, (void**)&g_origGetNetPlayerRelevancePosition);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("0F A3 D0 0F 92 C0 88 06", -0x76) : hook::get_pattern("44 0F A3 C0 0F 92 C0 41 88 02", -0x32), getNetPlayerRelevancePosition, (void**)&g_origGetNetPlayerRelevancePosition);
 #endif
 
 	// always allow to migrate, even if not cloned on bit test
@@ -1817,7 +1818,14 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	hook::call(hook::get_pattern("48 C1 EA 04 E8 ? ? ? ? 48 8B 03", 17), delStub.GetCode());
 #elif IS_RDR3
-	hook::call(hook::get_pattern("48 8B 06 BA 01 00 00 00 48 8B CE FF 10 48 8B 5C 24 50", 8), delStub.GetCode());
+	if (xbr::IsGameBuildOrGreater<1436>())
+	{
+		hook::call(hook::get_pattern("48 8B 06 41 8B D4 48 8B CE FF 10 48 8B 5C", 6), delStub.GetCode());
+	} 
+	else
+	{
+		hook::call(hook::get_pattern("48 8B 06 BA 01 00 00 00 48 8B CE FF 10 48 8B 5C 24 50", 8), delStub.GetCode());
+	}
 #endif
 
 	// clobber nodes for all players, not just when connected to netplayermgr
@@ -1833,7 +1841,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 		auto location = hook::get_pattern("FF 90 D0 00 00 00 84 C0 0F 84 80 00 00 00", 0);
 #elif IS_RDR3
-		auto location = hook::get_pattern("49 8B D5 48 8B CF FF 90 ? ? ? ? 84 ? 74", 6);
+		auto location = hook::get_pattern("44 8A 84 24 ? ? ? ? ? 8B D5 48 8B CF FF 90", 14);
 #endif
 
 		hook::nop(location, 6);
@@ -2678,10 +2686,17 @@ static HookFunction hookFunctionEv([]()
 	MH_Initialize();
 
 	{
+#ifdef GTA_FIVE
 		auto location = hook::get_pattern<char>("E8 ? ? ? ? 48 8B CB E8 ? ? ? ? 84 C0 74 11 48 8B 0D", 0x14);
 
 		g_netEventMgr = hook::get_address<void*>(location);
 		MH_CreateHook(hook::get_call(location + 7), EventMgr_AddEvent, (void**)&g_origAddEvent);
+#elif IS_RDR3
+		auto location = hook::get_pattern<char>("C6 47 50 01 4C 8B C3 49 8B D7", (xbr::IsGameBuildOrGreater<1436>()) ? 0x59 : 0x21);
+
+		g_netEventMgr = hook::get_address<void*>(location);
+		MH_CreateHook(hook::get_call(location + 7), EventMgr_AddEvent, (void**)&g_origAddEvent);
+#endif
 	}
 
 	// we hook game event registration to store event names
@@ -2692,14 +2707,14 @@ static HookFunction hookFunctionEv([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("48 8B DA 48 8B F1 41 81 FF 00", -0x2A), ExecuteNetGameEvent, (void**)&g_origExecuteNetGameEvent);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("48 89 6C 24 60 4D 8B F1 49 8B F0 48 8B DA E8", -0x25), ExecuteNetGameEvent, (void**)&g_origExecuteNetGameEvent);
+	MH_CreateHook(hook::get_pattern("48 89 6C 24 60 4D 8B F1 49 8B ? 48 8B DA E8", -0x25), ExecuteNetGameEvent, (void**)&g_origExecuteNetGameEvent);
 #endif
 
 	// can cause crashes due to high player indices, default event sending
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("48 83 EC 30 80 7A ? FF 4C 8B D2", -0xC), SendGameEvent, (void**)&g_origSendGameEvent);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("48 83 EC 30 48 8B F9 4C 8B F2 48 83 C1 08", -0xE), SendGameEvent, (void**)&g_origSendGameEvent);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("41 8A 5E 19 45 33 E4 80 FB 20 72", -0x27) : hook::get_pattern("48 83 EC 30 48 8B F9 4C 8B F2 48 83 C1 08", -0xE), SendGameEvent, (void**)&g_origSendGameEvent);
 #endif
 
 	// fire applicability
@@ -2727,7 +2742,7 @@ static HookFunction hookFunctionEv([]()
 #ifdef GTA_FIVE
 	hook::call(hook::get_pattern("33 C9 E8 ? ? ? ? E9 FD FE FF FF", 2), NetEventError);
 #elif IS_RDR3
-	hook::call(hook::get_pattern("BA 01 00 00 00 FF ? ? BA 5B 52 1C A4", 22), NetEventError);
+	hook::call((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("74 ? 48 8B 01 40 8A D6 FF ? ? BA", 25) : hook::get_pattern("BA 01 00 00 00 FF ? ? BA 5B 52 1C A4", 22), NetEventError);
 #endif
 
 	MH_EnableHook(MH_ALL_HOOKS);
@@ -3510,7 +3525,7 @@ static HookFunction hookFunctionTime([]()
 	MH_CreateHook(hook::get_pattern("48 8B D9 48 39 79 08 0F 85 ? ? 00 00 41 8B E8", -32), func, (void**)&g_origInitializeTime);
 #elif IS_RDR3
 	void* func = (xbr::IsGameBuildOrGreater<1355>()) ? (void*)&netTimeSync__InitializeTimeStub<1355> : &netTimeSync__InitializeTimeStub<1311>;
-	MH_CreateHook(hook::get_pattern("48 89 51 08 41 83 F8 02 44 0F 45 C8", -49), func, (void**)&g_origInitializeTime);
+	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("83 C8 FF 4C 89 77 08 83 FD", -87) : hook::get_pattern("48 89 51 08 41 83 F8 02 44 0F 45 C8", -49), func, (void**)&g_origInitializeTime);
 #endif
 
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -29,8 +29,6 @@
 
 #include <tbb/concurrent_queue.h>
 
-#include <CrossBuildRuntime.h>
-
 #include <ResourceManager.h>
 #include <StateBagComponent.h>
 #include <IteratorView.h>
@@ -2214,7 +2212,7 @@ static hook::cdecl_stub<void(rage::netObjectMgr*, rage::netObject*)> _processRem
 #ifdef GTA_FIVE
 	return hook::get_pattern("39 42 74 75 12 39 42 70 75 0D", -0x11);
 #elif IS_RDR3
-	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("F6 43 48 01 74 ? 33 C9 48 8D 43", -0x3C) : hook::get_pattern("74 ? F6 42 48 01 74 ? 45 8B C2 48", -0xD);
+	return hook::get_call(hook::get_pattern("48 8B 7F 10 45 84 FF 74 ? 48 8B D6 ? 8B ? E8", 0xF));
 #endif
 });
 

--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -1193,7 +1193,6 @@ bool CloneManagerLocal::HandleCloneCreate(const msgClone& msg)
 
 	AssociateSyncTree(obj->GetObjectId(), syncTree);
 
-
 #ifdef IS_RDR3
 	auto check = syncTree->m_18(obj, -1);
 	auto canSync = obj->CanSyncWithNoGameObject();
@@ -2215,7 +2214,7 @@ static hook::cdecl_stub<void(rage::netObjectMgr*, rage::netObject*)> _processRem
 #ifdef GTA_FIVE
 	return hook::get_pattern("39 42 74 75 12 39 42 70 75 0D", -0x11);
 #elif IS_RDR3
-	return hook::get_pattern("74 ? F6 42 48 01 74 ? 45 8B C2 48", -0xD);
+	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("F6 43 48 01 74 ? 33 C9 48 8D 43", -0x3C) : hook::get_pattern("74 ? F6 42 48 01 74 ? 45 8B C2 48", -0xD);
 #endif
 });
 

--- a/code/components/gta-net-five/src/CloneObjectManager.cpp
+++ b/code/components/gta-net-five/src/CloneObjectManager.cpp
@@ -150,13 +150,23 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("8A 42 4C 45 33 FF 48 8B DA C0 E8 02", -0x21), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
 	MH_CreateHook(hook::get_pattern("44 8A 62 4B 33 DB 41 8B E9", -0x20), netObjectMgrBase__ChangeOwner, (void**)&g_orig_netObjectMgrBase__ChangeOwner); //
 	MH_CreateHook(hook::get_pattern("44 38 33 75 30 66 44", -0x40), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject); //
-	MH_CreateHook(hook::get_pattern("41 80 78 ? FF 74 2D 41 0F B6 40"), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)& g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
+	MH_CreateHook(hook::get_pattern("41 80 78 ? FF 74 2D 41 0F B6 40"), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 #elif IS_RDR3
-	MH_CreateHook(xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("48 8B F2 41 B0 01 0F B7 52", -0x1B) : hook::get_pattern("41 0F B7 55 00 41 B0 01 48 8B E9 E8", xbr::IsGameBuildOrGreater<1355>() ? -0x20 : -0x27), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject); //
-	MH_CreateHook(xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("4C 8D 2D ? ? ? ? 48 8B F2 48 8B E9 BB", -0x1F) : hook::get_pattern("45 33 FF C1 E8 03 48 8B F2 48 8B E9 A8 01", -0x24), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
+	if (xbr::IsGameBuildOrGreater<1436>())
+	{
+		MH_CreateHook(hook::get_pattern("48 8B F2 41 B0 01 0F B7 52", -0x1B), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject); //
+		MH_CreateHook(hook::get_pattern("4C 8D 2D ? ? ? ? 48 8B F2 48 8B E9 BB", -0x1F), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
+		MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x64), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
+	}
+	else
+	{
+		MH_CreateHook(hook::get_pattern("41 0F B7 55 00 41 B0 01 48 8B E9 E8", xbr::IsGameBuildOrGreater<1355>() ? -0x20 : -0x27), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject); //
+		MH_CreateHook(hook::get_pattern("45 33 FF C1 E8 03 48 8B F2 48 8B E9 A8 01", -0x24), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
+		MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x3B), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
+	}
+
 	MH_CreateHook(hook::get_pattern("41 83 F9 04 75 ? 8D 4B 20 E8 ? ? ? ? 48", -0x31), netObjectMgrBase__ChangeOwner, (void**)&g_orig_netObjectMgrBase__ChangeOwner); //
 	MH_CreateHook(hook::get_pattern("45 8A F0 0F B7 F2 E8 ? ? ? ? 33 DB 38", -0x24), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject); //
-	MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", xbr::IsGameBuildOrGreater<1435>() ? -0x64 : -0x3B), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 #endif
 
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/code/components/gta-net-five/src/CloneObjectManager.cpp
+++ b/code/components/gta-net-five/src/CloneObjectManager.cpp
@@ -152,11 +152,11 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("44 38 33 75 30 66 44", -0x40), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject); //
 	MH_CreateHook(hook::get_pattern("41 80 78 ? FF 74 2D 41 0F B6 40"), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)& g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 #elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("41 0F B7 55 00 41 B0 01 48 8B E9 E8",  xbr::IsGameBuildOrGreater<1355>() ? -0x20 : -0x27), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject); //
-	MH_CreateHook(hook::get_pattern("45 33 FF C1 E8 03 48 8B F2 48 8B E9 A8 01", -0x24), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
+	MH_CreateHook(xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("48 8B F2 41 B0 01 0F B7 52", -0x1B) : hook::get_pattern("41 0F B7 55 00 41 B0 01 48 8B E9 E8", xbr::IsGameBuildOrGreater<1355>() ? -0x20 : -0x27), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject); //
+	MH_CreateHook(xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("4C 8D 2D ? ? ? ? 48 8B F2 48 8B E9 BB", -0x1F) : hook::get_pattern("45 33 FF C1 E8 03 48 8B F2 48 8B E9 A8 01", -0x24), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject); //
 	MH_CreateHook(hook::get_pattern("41 83 F9 04 75 ? 8D 4B 20 E8 ? ? ? ? 48", -0x31), netObjectMgrBase__ChangeOwner, (void**)&g_orig_netObjectMgrBase__ChangeOwner); //
 	MH_CreateHook(hook::get_pattern("45 8A F0 0F B7 F2 E8 ? ? ? ? 33 DB 38", -0x24), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject); //
-	MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x3B), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
+	MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", xbr::IsGameBuildOrGreater<1435>() ? -0x64 : -0x3B), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 #endif
 
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/code/components/gta-net-rdr3/src/CoreNetworking.cpp
+++ b/code/components/gta-net-rdr3/src/CoreNetworking.cpp
@@ -570,12 +570,12 @@ static hook::cdecl_stub<void(void*)> _rlPresence_GamerPresence_Clear([]()
 
 static hook::cdecl_stub<void(int)> _rlPresence_refreshSigninState([]()
 {
-	return (xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 81 EC ? ? ? ? 45 33 ED 44 8B F9 44", -0x18) : hook::get_pattern("48 8D 54 24 20 48 69 ? ? ? ? ? 48 8D 05 ? ? ? ? 4C", -0x35);
+	return hook::get_call(hook::get_pattern("40 84 FF 74 0E 33 C9 E8", 7));
 });
 
 static hook::cdecl_stub<void(int)> _rlPresence_refreshNetworkStatus([]()
 {
-	return hook::get_pattern("45 33 ? 8B DE EB 0F 48 8D", xbr::IsGameBuildOrGreater<1436>() ? -0x7A : -0x7D);
+	return hook::get_call(hook::get_pattern("40 84 FF 74 0E 33 C9 E8", 14));
 });
 
 // unused if we use sc sessions
@@ -775,15 +775,8 @@ static HookFunction hookFunction([]()
 
 	// skip seamless host for is-host call
 	//hook::put<uint8_t>(hook::get_pattern("75 1B 38 1D ? ? ? ? 74 36"), 0xEB);
-	
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		rlPresence__m_GamerPresences = hook::get_address<void*>(hook::get_pattern("48 81 EC ? ? ? ? 45 33 ED 44 8B F9 44", 0x35 - 0x18));
-	}
-	else
-	{
-		rlPresence__m_GamerPresences = hook::get_address<void*>(hook::get_pattern("48 8D 54 24 20 48 69 ? ? ? ? ? 48 8D 05 ? ? ? ? 4C", 0x44 - 0x35));
-	}
+
+	rlPresence__m_GamerPresences = hook::get_address<void*>(hook::get_pattern("F6 84 01 ? ? ? ? 02 74 ? 48 05", -4));
 
 	static LoggedInt tryHostStage = 0;
 
@@ -994,7 +987,7 @@ static HookFunction hookFunction([]()
 	{
 		hook::jump(hook::get_pattern("75 42 8D 53 03 C7 44 24 20 F4 D2", -0x21), Return<int, 2>);
 		hook::jump(hook::get_pattern("A9 FD FF FF FF 0F 85 B1 00 00 00 48", -0x3E), Return<int, 2>);
-	} 
+	}
 	else
 	{
 		hook::jump(hook::get_pattern("75 21 4C 8D 0D ? ? ? ? 41 B8 30 10 00 10", -0x21), Return<int, 2>);

--- a/code/components/gta-net-rdr3/src/netObject.cpp
+++ b/code/components/gta-net-rdr3/src/netObject.cpp
@@ -3,6 +3,7 @@
 #include <Hooking.h>
 #include <netObject.h>
 #include <netSyncTree.h>
+#include <CrossBuildRuntime.h>
 
 #include <atPool.h>
 #include <Pool.h>
@@ -47,38 +48,75 @@ netObject* CreateCloneObject(NetObjEntityType type, uint16_t objectId, uint8_t a
 
 static HookFunction hookFunction([]()
 {
-	auto location = hook::get_pattern<char>("0F 8E ? 0F 00 00 41 8A 55", 20);
+	if (xbr::IsGameBuildOrGreater<1436>())
+	{
+		auto location = hook::get_pattern<char>("7F 2B 41 B9 B8 0A 00 00 C7", 66);
+		createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
+		createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x9D);
+		createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0x13A);
+		createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x1D7);
+		createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x274);
+		createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x311);
+		createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x3B3);
+		createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x455);
+		createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x531);
+		createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x5CE);
+		createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x66F);
+		createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x70C);
+		createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x7A9);
+		createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x846);
+		createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x8E3);
+		createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x980);
+		createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0xA70);
+		createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0xB12);
+		createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0xBB4);
+		createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0xC56);
+		createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0xCF3);
+		createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0xD90);
+		createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xE2C);
+		createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xECE);
+		createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xFA6);
+		createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0x1048);
+		createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0x10EA);
+		createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0x118C);
+		createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0x122E);
+		createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0x12CC);
+	}
+	else
+	{
+		auto location = hook::get_pattern<char>("0F 8E ? 0F 00 00 41 8A 55", 20);
+		createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
+		createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x6E);
+		createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0xDD);
+		createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x14B);
+		createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x1B9);
+		createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x227);
+		createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x29B);
+		createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x30F);
+		createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x3B2);
+		createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x420);
+		createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x493);
+		createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x501);
+		createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x56F);
+		createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x5DE);
+		createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x64D);
+		createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x6BB);
+		createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0x76E);
+		createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0x7E2);
+		createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0x850);
+		createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0x8BF);
+		createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0x92D);
+		createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0x99C);
+		createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xA0A);
+		createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xA79);
+		createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xB1A);
+		createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xB8E);
+		createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xC02);
+		createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0xC76);
+		createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0xCEA);
+		createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0xD56);	
+	}
 
-	createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
-	createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x6E);
-	createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0xDD);
-	createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x14B);
-	createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x1B9);
-	createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x227);
-	createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x29B);
-	createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x30F);
-	createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x3B2);
-	createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x420);
-	createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x493);
-	createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x501);
-	createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x56F);
-	createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x5DE);
-	createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x64D);
-	createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x6BB);
-	createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0x76E);
-	createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0x7E2);
-	createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0x850);
-	createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0x8BF);
-	createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0x92D);
-	createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0x99C);
-	createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xA0A);
-	createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xA79);
-	createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xB1A);
-	createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xB8E);
-	createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xC02);
-	createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0xC76);
-	createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0xCEA);
-	createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0xD56);
 
 	validatePoolHashes[(int)NetObjEntityType::Animal] = HashString("CNetObjPedBase");
 	validatePoolHashes[(int)NetObjEntityType::Automobile] = HashString("CNetObjVehicle");

--- a/code/components/gta-streaming-rdr3/src/Streaming.cpp
+++ b/code/components/gta-streaming-rdr3/src/Streaming.cpp
@@ -1,13 +1,12 @@
 #include <StdInc.h>
 #include <Hooking.h>
 #include <Streaming.h>
-#include <CrossBuildRuntime.h>
 
 static void* g_storeMgr;
 
 static hook::cdecl_stub<void(bool)> g_loadObjectsNow([]()
 {
-	return hook::get_call(hook::get_pattern(xbr::IsGameBuildOrGreater<1436>() ? "03 CB 8B 4C C8 04 80 E1 03 80 F9 01 74 2B" : "03 CB 8B 4C C8 04 80 E1 03 80 F9 01 75", -0x12));
+	return hook::get_call(hook::get_pattern("33 C9 E8 ? ? ? ? 8B 0D ? ? ? ? 48 8B 05 ? ? ? ? 03 CB", 2));
 });
 
 static hook::cdecl_stub<void(void*, uint32_t, int)> g_requestObject([]()

--- a/code/components/gta-streaming-rdr3/src/Streaming.cpp
+++ b/code/components/gta-streaming-rdr3/src/Streaming.cpp
@@ -1,12 +1,13 @@
 #include <StdInc.h>
 #include <Hooking.h>
 #include <Streaming.h>
+#include <CrossBuildRuntime.h>
 
 static void* g_storeMgr;
 
 static hook::cdecl_stub<void(bool)> g_loadObjectsNow([]()
 {
-	return hook::get_call(hook::get_pattern("03 CB 8B 4C C8 04 80 E1 03 80 F9 01 75", -0x12));
+	return hook::get_call(hook::get_pattern(xbr::IsGameBuildOrGreater<1436>() ? "03 CB 8B 4C C8 04 80 E1 03 80 F9 01 74 2B" : "03 CB 8B 4C C8 04 80 E1 03 80 F9 01 75", -0x12));
 });
 
 static hook::cdecl_stub<void(void*, uint32_t, int)> g_requestObject([]()

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -1775,7 +1775,7 @@ concurrency::task<void> NetLibrary::ConnectToServer(const std::string& rootUrl)
 #if defined(GTA_FIVE)
 							if (buildRef != 1604 && buildRef != 2060 && buildRef != 2189 && buildRef != 2372)
 #else
-							if (buildRef != 1311 && buildRef != 1355)
+							if (buildRef != 1311 && buildRef != 1355 && buildRef != 1436)
 #endif
 							{
 								OnConnectionError(va("Server specified an invalid game build enforcement (%d).", buildRef), json::object({

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -484,7 +484,7 @@ static void WrapEndDraw(void* cxt)
 	//rt[0] = (*(void* (__fastcall**)(__int64))(**(uint64_t**)sgaDriver + 1992i64))(*(uint64_t*)sgaDriver);
 	rt[0] = (*(void*(__fastcall**)(__int64))(**(uint64_t**)sgaDriver + g_swapchainBackbufferOffset))(*(uint64_t*)sgaDriver);
 
-	static auto ds = hook::get_address<int*>(xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("44 8B CE 48 8B 05 ? ? ? ? 33 C9 48 89", 6) : hook::get_pattern("44 8B CE 48 89 05 ? ? ? ? 41 B8 02", 19));
+	static auto ds = hook::get_address<int*>(hook::get_pattern("4C 8B ? ? ? ? ? 84 D2 74 ? 4C", 3));
 
 	setRTs(cxt, 1, rt, true);
 	setDSs(cxt, *(void**)ds, true);
@@ -584,7 +584,7 @@ static HookFunction hookFunction([]()
 	sgaDriver = hook::get_address<decltype(sgaDriver)>(hook::get_pattern("C6 82 ? ? 00 00 01 C6 82 ? ? 00 00 01 48 8B 0D", 17));
 
 	g_textureFactory = hook::get_address<decltype(g_textureFactory)>(hook::get_pattern("48 8D 54 24 50 C7 44 24 50 80 80 00 00 48 8B C8", 0x25));
-	
+
 	if (xbr::IsGameBuildOrGreater<1436>())
 	{
 		g_d3d12Driver = hook::get_address<void*>(hook::get_pattern("75 04 33 C0 EB 1A E8", 28));

--- a/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
+++ b/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
@@ -11,6 +11,7 @@
 #include <Hooking.h>
 
 #include <ICoreGameInit.h>
+#include <CrossBuildRuntime.h>
 
 fwEvent<> OnLookAliveFrame;
 fwEvent<> OnGameFrame;
@@ -148,7 +149,8 @@ static HookFunction hookFunction([]()
 	hook::set_call(&g_origLookAlive, lookAliveFrameCall);
 	hook::call(lookAliveFrameCall, OnLookAlive);
 
-	auto runState = hook::pattern("8B CA 8B F2 E8").count(1).get(0).get<char>(-0x15);
+	auto runState = (xbr::IsGameBuildOrGreater<1436>()) ? hook::pattern("85 F6 78 ? 75 ? 83 FB 01 75").count(1).get(0).get<char>(-0x2A) : hook::pattern("8B CA 8B F2 E8").count(1).get(0).get<char>(-0x15);
+
 	MH_Initialize();
 	MH_CreateHook(runState, DoAppState, (void**)&g_appState);
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
+++ b/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
@@ -149,7 +149,7 @@ static HookFunction hookFunction([]()
 	hook::set_call(&g_origLookAlive, lookAliveFrameCall);
 	hook::call(lookAliveFrameCall, OnLookAlive);
 
-	auto runState = (xbr::IsGameBuildOrGreater<1436>()) ? hook::pattern("85 F6 78 ? 75 ? 83 FB 01 75").count(1).get(0).get<char>(-0x2A) : hook::pattern("8B CA 8B F2 E8").count(1).get(0).get<char>(-0x15);
+	auto runState = hook::pattern("85 F6 78 ? 75 ? 83 FB 01 75").count(1).get(0).get<char>(xbr::IsGameBuildOrGreater<1436>() ? -0x2A : -0x1E);
 
 	MH_Initialize();
 	MH_CreateHook(runState, DoAppState, (void**)&g_appState);

--- a/code/components/ros-patches-five/src/ros/Entitlements.cpp
+++ b/code/components/ros-patches-five/src/ros/Entitlements.cpp
@@ -741,7 +741,29 @@ mapper->AddGameService("ugc.asmx/Publish", [](const std::string& body)
 			auto rs = rss.str();
 			rs = "";
 
-			if (Is1355())
+			if (Is1436())
+			{
+				return fmt::sprintf(R"(
+<?xml version="1.0" encoding="utf-8"?>
+<Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ms="0" xmlns="GetBuildManifestFull">
+  <Status>1</Status>
+  <Result BuildId="81" VersionNumber="1.0.1436.25" BuildDateUtc="2019-11-05T11:39:37.0266667">
+    <FileManifest>
+		<FileDetails FileEntryId="9178" FileEntryVersionId="9648" FileSize="89612184" TimestampUtc="2019-11-05T11:39:34.8800000">
+			<RelativePath>RDR2.exe</RelativePath>
+			<SHA256Hash>096420ddeb42dc1f156e68b3da20e258664e8f1a9fc2afeb2a2b50eb133fe3d2</SHA256Hash>
+			<FileChunks>
+				<Chunk FileChunkId="13046" SHA256Hash="096420ddeb42dc1f156e68b3da20e258664e8f1a9fc2afeb2a2b50eb133fe3d2" StartByteOffset="0" Size="89612184" />
+			</FileChunks>
+		</FileDetails>
+%s
+    </FileManifest>
+    <IsPreload>false</IsPreload>
+  </Result>
+</Response>)",
+				rs);
+			}
+			else if (Is1355())
 			{
 				return fmt::sprintf(R"(
 <?xml version="1.0" encoding="utf-8"?>
@@ -1023,7 +1045,7 @@ mapper->AddGameService("ugc.asmx/Publish", [](const std::string& body)
   </Result>
 </Response>)",
 		Is372() ? 4 : (Is2060() ? 83 : (Is2372() ? 92 : (Is2189() ? 88 : 80))),
-		Is1355() ? 80 : 79);
+		Is1355() ? 80 : (Is1436() ? 81 : 79));
 	});
 
 

--- a/code/components/ros-patches-five/src/ros/Entitlements.cpp
+++ b/code/components/ros-patches-five/src/ros/Entitlements.cpp
@@ -747,13 +747,13 @@ mapper->AddGameService("ugc.asmx/Publish", [](const std::string& body)
 <?xml version="1.0" encoding="utf-8"?>
 <Response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ms="0" xmlns="GetBuildManifestFull">
   <Status>1</Status>
-  <Result BuildId="81" VersionNumber="1.0.1436.25" BuildDateUtc="2019-11-05T11:39:37.0266667">
+  <Result BuildId="82" VersionNumber="1.0.1436.26" BuildDateUtc="2019-11-05T11:39:37.0266667">
     <FileManifest>
-		<FileDetails FileEntryId="9178" FileEntryVersionId="9648" FileSize="89612184" TimestampUtc="2019-11-05T11:39:34.8800000">
+		<FileDetails FileEntryId="9178" FileEntryVersionId="9648" FileSize="89830808" TimestampUtc="2019-11-05T11:39:34.8800000">
 			<RelativePath>RDR2.exe</RelativePath>
-			<SHA256Hash>096420ddeb42dc1f156e68b3da20e258664e8f1a9fc2afeb2a2b50eb133fe3d2</SHA256Hash>
+			<SHA256Hash>d3ac2403bac567a460617af4dc3df15d0928b0e8634da76dcf64de56ad7bdf87</SHA256Hash>
 			<FileChunks>
-				<Chunk FileChunkId="13046" SHA256Hash="096420ddeb42dc1f156e68b3da20e258664e8f1a9fc2afeb2a2b50eb133fe3d2" StartByteOffset="0" Size="89612184" />
+				<Chunk FileChunkId="13046" SHA256Hash="d3ac2403bac567a460617af4dc3df15d0928b0e8634da76dcf64de56ad7bdf87" StartByteOffset="0" Size="89830808" />
 			</FileChunks>
 		</FileDetails>
 %s
@@ -1045,7 +1045,7 @@ mapper->AddGameService("ugc.asmx/Publish", [](const std::string& body)
   </Result>
 </Response>)",
 		Is372() ? 4 : (Is2060() ? 83 : (Is2372() ? 92 : (Is2189() ? 88 : 80))),
-		Is1355() ? 80 : (Is1436() ? 81 : 79));
+		Is1355() ? 80 : (Is1436() ? 82 : 79));
 	});
 
 

--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -387,7 +387,7 @@
                 </Item>
                 <Item>
                   <PoolName>CScenarioInfo</PoolName>
-                  <PoolSize value="2590"/>
+                  <PoolSize value="2605"/>
                 </Item>
                 <Item>
                     <PoolName>CTacticalAnalysis</PoolName>
@@ -415,11 +415,11 @@
 				</Item>
                 <Item>
 					<PoolName>CGameScriptResource</PoolName>
-                  <PoolSize value="2466"/>
+                  <PoolSize value="2526"/>
                 </Item>
                 <Item>
                   <PoolName>ClothStore</PoolName>
-                  <PoolSize value="1010"/>
+                  <PoolSize value="1100"/>
                 </Item>
 				<Item>
 					<PoolName>CCombatMeleeGroup</PoolName>
@@ -947,11 +947,11 @@
                 </Item>
                 <Item>
                   <PoolName>CScriptEntityExtension</PoolName>
-                  <PoolSize value="400"/>
+                  <PoolSize value="600"/>
                 </Item>
                 <Item>
                   <PoolName>CScriptEntityIdExtension</PoolName>
-                  <PoolSize value="500"/>
+                  <PoolSize value="600"/>
                 </Item>
                 <Item>
                   <PoolName>CVehicleChaseDirector</PoolName>
@@ -1107,7 +1107,7 @@
                 </Item>
                 <Item>
                   <PoolName>FragmentStore</PoolName>
-                  <PoolSize value="8740"/>
+                  <PoolSize value="8756"/>
                 </Item>
                 <Item>
                   <PoolName>fwScriptGuid</PoolName>
@@ -1307,7 +1307,7 @@
                 </Item>
                 <Item>
                   <PoolName>MetaDataStore</PoolName>
-                  <PoolSize value="44450"/>
+                  <PoolSize value="44620"/>
                 </Item>
                 <Item>
                   <PoolName>NavMeshes</PoolName>
@@ -1404,7 +1404,7 @@
                 </Item>
                 <Item>
                   <PoolName>CWeaponComponentInfo</PoolName>
-                  <PoolSize value="790"/>
+                  <PoolSize value="840"/>
                 </Item>
                 <Item>
                   <PoolName>phInstGta</PoolName>
@@ -1570,7 +1570,7 @@
 				<Item>
                   <!-- Size of the CWaypointRecording streaming module. -->
                   <PoolName>wptrec</PoolName>
-                  <PoolSize value="3100"/>
+                  <PoolSize value="3150"/>
                 </Item>
                 <Item>
                   <PoolName>fwLodNode</PoolName>
@@ -1791,7 +1791,7 @@
                 </Item>
                 <Item>
                   <PoolName>CUnlock</PoolName>
-                  <PoolSize value="25000"/>
+                  <PoolSize value="27000"/>
                 </Item>
                 <!-- ExtensionComponents -->
                 <Item>
@@ -1924,7 +1924,7 @@
 				</Item>
 				<Item>
 					<PoolName>scrGlobals</PoolName>
-					<PoolSize value="8388608"/>
+					<PoolSize value="8488608"/>
 				</Item>
               </Entries>
             </PoolSizes>
@@ -2155,7 +2155,7 @@
               <MaxTimeModelInfos value="10"/>
               <MaxVehicleModelInfos value="200"/>
               <MaxWeaponModelInfos value="350"/>
-			  <MaxExtraWeaponModelInfos value = "159"/>
+			  <MaxExtraWeaponModelInfos value = "205"/>
             </ConfigModelInfo>
 
 			<ConfigComponentSystem>
@@ -2173,7 +2173,7 @@
             </ConfigExtensions>
 
             <ConfigStreamingEngine>
-			  <ArchiveCount value="4600"/>
+			  <ArchiveCount value="4650"/>
 			  <MinVideoMemory value="5120"/>
             </ConfigStreamingEngine>
 
@@ -2267,7 +2267,7 @@
 				<RosTitleVersion value="11"/>
 				<RosScVersion value="11"/>
 				<RosGameServerVersionNumber value="17"/>
-				<RosGameServerCatalogReleaseId>mp008</RosGameServerCatalogReleaseId>
+				<RosGameServerCatalogReleaseId>mp009</RosGameServerCatalogReleaseId>
 				<RosScId value="13"/>
 				<TitleDirectoryName>Red Dead Redemption 2</TitleDirectoryName>
 				<MultiplayerSessionTemplateName>SessionTemplate</MultiplayerSessionTemplateName>
@@ -3845,7 +3845,7 @@
 				</ConfigExtensions>
 
 				<ConfigStreamingEngine>
-					<ArchiveCount value="4650"/>
+					<ArchiveCount value="4700"/>
 					<MinVideoMemory value="5120"/>
 				</ConfigStreamingEngine>
 
@@ -3955,7 +3955,7 @@
 					<RosTitleVersion value="11"/>
 					<RosScVersion value="11"/>
 					<RosGameServerVersionNumber value="1017"/>
-					<RosGameServerCatalogReleaseId>mp008</RosGameServerCatalogReleaseId>
+					<RosGameServerCatalogReleaseId>mp009</RosGameServerCatalogReleaseId>
 					<RosScId value="13"/>
 					<SteamAppId value="1174180"/>
 					<TitleDirectoryName>Red Dead Redemption 2</TitleDirectoryName>
@@ -4255,7 +4255,7 @@
 				<RosTitleVersion value="11"/>
 				<RosScVersion value="11"/>
 				<RosGameServerVersionNumber value="2017"/>
-				<RosGameServerCatalogReleaseId>mp008</RosGameServerCatalogReleaseId>
+				<RosGameServerCatalogReleaseId>mp009</RosGameServerCatalogReleaseId>
 				<RosScId value="13"/>
 				<TitleDirectoryName>Redemption 2</TitleDirectoryName>
 				<MultiplayerSessionTemplateName>SessionTemplate</MultiplayerSessionTemplateName>
@@ -4383,7 +4383,7 @@
 						</Item>
 						<Item>
 						  <ResourceTypeName>SEQUENCE_TASK</ResourceTypeName>
-						  <ExpectedMaximum value="11"/>
+						  <ExpectedMaximum value="13"/>
 						</Item>
 						<Item>
 						  <ResourceTypeName>GROUP_TASK</ResourceTypeName>
@@ -4395,7 +4395,7 @@
 						</Item>
 						<Item>
 						  <ResourceTypeName>CHECKPOINT</ResourceTypeName>
-						  <ExpectedMaximum value="6"/>
+						  <ExpectedMaximum value="64"/>
 						</Item>
 						<Item>
 						  <ResourceTypeName>TEXT_DATABASE</ResourceTypeName>

--- a/ext/native-decls/GetGameBuildNumber.md
+++ b/ext/native-decls/GetGameBuildNumber.md
@@ -20,6 +20,7 @@ Possible values:
 * RedM
   * 1311
   * 1355
+  * 1436
 * LibertyM
   * 43
 * FXServer


### PR DESCRIPTION
Used build: 1436.26 (latest at this moment).
Re-implemented most popular removed natives for backward compatibility
DLSS works with some minor manual tweaks.
