### PR TITLE
feat(nui/resources): allow for unregistration of NuiCallbackTypes

### DIFF
--- a/code/components/nui-resources/include/ResourceUI.h
+++ b/code/components/nui-resources/include/ResourceUI.h
@@ -58,6 +58,8 @@ public:
 
 	void AddCallback(const std::string& type, ResUICallback callback);
 
+	void DeleteCallback(const std::string& type);
+
 	bool InvokeCallback(const std::string& type, const std::string& query, const std::multimap<std::string, std::string>& headers, const std::string& data, ResUIResultCallback resultCB);
 
 	void SignalPoll();

--- a/code/components/nui-resources/src/ResourceUI.cpp
+++ b/code/components/nui-resources/src/ResourceUI.cpp
@@ -109,6 +109,11 @@ void ResourceUI::AddCallback(const std::string& type, ResUICallback callback)
 	m_callbacks.insert({ type, callback });
 }
 
+void ResourceUI::DeleteCallback(const std::string& type)
+{
+	m_callbacks.erase(type);
+}
+
 bool ResourceUI::InvokeCallback(const std::string& type, const std::string& query, const std::multimap<std::string, std::string>& headers, const std::string& data, ResUIResultCallback resultCB)
 {
 	auto set = fx::GetIteratorView(m_callbacks.equal_range(type));

--- a/code/components/nui-resources/src/ResourceUICallbacks.cpp
+++ b/code/components/nui-resources/src/ResourceUICallbacks.cpp
@@ -337,4 +337,25 @@ static InitFunction initFunction([] ()
 			}
 		}
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("UNREGISTER_NUI_CALLBACK_TYPE", [](fx::ScriptContext& context) {
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+			if (resource)
+			{
+				fwRefContainer<ResourceUI> resourceUI = resource->GetComponent<ResourceUI>();
+
+				if (resourceUI.GetRef())
+				{
+					std::string type = context.CheckArgument<const char*>(0);
+
+					resourceUI->DeleteCallback(type);
+				}
+			}
+		}
+	});
 });

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -605,6 +605,10 @@ function RemoveEventHandler(eventData)
 		error('Invalid event data passed to RemoveEventHandler()')
 	end
 
+	if eventData.__cfxNuiType then
+		UnregisterNuiCallbackType(eventData.__cfxNuiType)
+	end
+
 	-- remove the entry
 	eventHandlers[eventData.name].handlers[eventData.key] = nil
 end
@@ -1183,7 +1187,7 @@ if not isDuplicityVersion then
 	function RegisterNUICallback(type, callback)
 		RegisterNuiCallbackType(type)
 
-		AddEventHandler('__cfx_nui:' .. type, function(body, resultCallback)
+		local eventData = AddEventHandler('__cfx_nui:' .. type, function(body, resultCallback)
 --[[
 			-- Lua 5.4: Create a to-be-closed variable to monitor the NUI callback handle.
 			local hasCallback = false
@@ -1209,7 +1213,12 @@ if not isDuplicityVersion then
 			if err then
 				Citizen.Trace("error during NUI callback " .. type .. ": " .. err .. "\n")
 			end
+
 		end)
+
+		eventData.__cfxNuiType = type
+
+		return eventData
 	end
 
 	local _sendNuiMessage = SendNuiMessage

--- a/ext/native-decls/UnregisterNuiCallbackType.md
+++ b/ext/native-decls/UnregisterNuiCallbackType.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+---
+## UNREGISTER_NUI_CALLBACK_TYPE
+
+```c
+void UNREGISTER_NUI_CALLBACK_TYPE(char* type);
+```
+
+Will unregister and cleanup a NUI Callback type. 
+Used within ScRT function definition to remove a NUI Callback.
+
+## Parameters
+* **type**: The type to unregister (types are registered with RegisterNuiCallbackType)


### PR DESCRIPTION
This is a pull request to enable a pattern of dynamic registration and cleanup of NUI Callbacks. <s>Although this is technically possible at the moment, by registering/unregistering the underlying `__cfx_nui:{event}`, this is never cleaned up within the ResourceUI container's internal callback map.</s>

In response to feedback, this draft will not target NUI callbacks utilizing events and ScRT wrappers. Instead it will focus on erasing callbacks registered with `REGISTER_RAW_NUI_CALLBACK`.