### PR TITLE
fix(game/five): support basic functionality on ARM64 again

### DIFF
--- a/code/client/citicore/SEHTableHandler.Win32.cpp
+++ b/code/client/citicore/SEHTableHandler.Win32.cpp
@@ -189,7 +189,7 @@ extern "C" void DLL_EXPORT CoreRT_SetupSEHHandler(void* moduleBase, void* module
 	// find the location to hook (RtlpxLookupFunctionTable from RtlLookupFunctionTable)
 	void* baseAddress = GetProcAddress(GetModuleHandle(L"ntdll.dll"), "RtlLookupFunctionTable");
 
-	if (baseAddress)
+	if (baseAddress && GetModuleHandle(L"xtajit64.dll") == nullptr)
 	{
 		void* internalAddress = FindCallFromAddress(baseAddress);
 

--- a/code/components/ros-patches-five/src/ros/LoopbackTcpServer.cpp
+++ b/code/components/ros-patches-five/src/ros/LoopbackTcpServer.cpp
@@ -1780,7 +1780,7 @@ void OnPreInitHook()
 //	DO_HOOK(L"ws2_32.dll", "FreeAddrInfoW", EP_FreeAddrInfoW, g_oldFreeAddrInfoW); // these three are hook-checked
 
 #ifndef _M_IX86
-	if (CfxIsWine() || GetProcAddress(GetModuleHandle(L"kernel32.dll"), "EnterUmsSchedulingMode") == nullptr) // ARM64X 21277 doesn't expose EnterUmsSchedulingMode
+	if (CfxIsWine() || GetModuleHandle(L"xtajit64.dll") != nullptr) // xtajit64.dll = arm64 jit
 	{
 		DO_HOOK(L"ws2_32.dll", "getaddrinfo", EP_GetAddrInfo, g_oldGetAddrInfo); // enabled because wine, probably going to fail
 	}


### PR DESCRIPTION
Still requires removing adhesive.dll, but at least the game itself doesn't break anymore.