### PR TITLE
fix(game/five): resolve game bug where trailer attachment could make game crash

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.TrailerAttachment.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.TrailerAttachment.cpp
@@ -1,0 +1,44 @@
+#include <StdInc.h>
+
+#include <jitasm.h>
+#include <Hooking.h>
+
+static HookFunction hookFunction([]
+{
+	// fixes a crash when a CTrailer is attached to an entity not deriving from CVehicle
+	auto location = hook::get_pattern("48 85 F6 0F 84 85 00 00 00 41", 3);
+
+	static struct : jitasm::Frontend
+	{
+		intptr_t location;
+		intptr_t retSuccess;
+		intptr_t retFail;
+
+		void Init(intptr_t location)
+		{
+			this->location = location;
+			this->retSuccess = location + 6;
+			this->retFail = location + 6 + 0x85;
+		}
+
+		void InternalMain() override
+		{
+			test(rsi, rsi);					// if (rsi)
+			jz("fail");						// {
+											//
+			cmp(byte_ptr[rsi + 40], 3);		//     if (rsi->type == vehicle) // new check
+			jne("fail");					//     {
+											//
+			mov(rax, retSuccess);			//         [run original code]
+			jmp(rax);						//
+											//
+			L("fail");						//     }
+			mov(rax, retFail);				// }
+			jmp(rax);						//
+		}
+	} patchStub;
+
+	patchStub.Init(reinterpret_cast<intptr_t>(location));
+	hook::nop(location, 6);
+	hook::jump(location, patchStub.GetCode());
+});


### PR DESCRIPTION
Bug mainly affects 2372 as bad-luck pointer instead of a nullptr.

Repro (client script, assumes entity lockdown disabled):

```lua
RequestModel('tanker')
RequestModel('a_m_m_skater_01')
LoadAllObjectsNow()

local pos = GetEntityCoords(PlayerPedId())
local trailer = CreateVehicle(`tanker`, pos, 0.0, true, false)
local ped = CreatePed(23, `a_m_m_skater_01`, pos, 0.0, true, false)

AttachEntityToEntity(trailer, ped, 0)
```

followed by blowing up the trailer with an RPG.