### PR TITLE
tweak(devtools): don't get memory metrics during normal gameplay

### DIFF
--- a/code/components/citizen-devtools/include/ResourceMonitor.h
+++ b/code/components/citizen-devtools/include/ResourceMonitor.h
@@ -87,10 +87,18 @@ namespace fx
 		virtual double GetAvgScriptMs();
 		virtual double GetAvgFrameMs();
 
+		inline void SetShouldGetMemory(bool should)
+		{
+			m_shouldGetMemory = should;
+		}
+
 	public:
 		static DEVTOOLS_EXPORT ResourceMonitor* GetCurrent();
 
 		static DEVTOOLS_EXPORT fwEvent<const std::string&> OnWarning;
 		static DEVTOOLS_EXPORT fwEvent<> OnWarningGone;
+
+	private:
+		bool m_shouldGetMemory = false;
 	};
 }

--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -364,6 +364,9 @@ static InitFunction initFunction([]()
 		}
 #endif
 
+		// #TODO: SDK should explicitly notify the resource monitor is opened
+		resourceMonitor->SetShouldGetMemory(taskMgrEnabled || launch::IsSDKGuest());
+
 #ifndef IS_FXSERVER
 		if (launch::IsSDKGuest())
 		{


### PR DESCRIPTION
This leads to longer GC pauses with Mono stuff in use, when in most cases this information is fairly useless.

Also closes #688.