### PR TITLE
fix(net): prevent enet connection without connection token

### DIFF
--- a/code/components/citizen-server-impl/include/ClientRegistry.h
+++ b/code/components/citizen-server-impl/include/ClientRegistry.h
@@ -92,6 +92,7 @@ namespace fx
 			m_clientsByPeer[client->GetPeer()].reset();
 			m_clientsByNetId[client->GetNetId()].reset();
 			m_clientsByConnectionToken[client->GetConnectionToken()].reset();
+			m_clientsByConnectionTokenHash[HashString(client->GetConnectionToken().c_str())].reset();
 
 			if (client->GetSlotId() >= 0 && client->GetSlotId() < m_clientsBySlotId.size())
 			{
@@ -198,6 +199,16 @@ namespace fx
 			return ptr;
 		}
 
+		inline bool HasClientByConnectionTokenHash(uint32_t hash)
+		{
+			if (auto it = m_clientsByConnectionTokenHash.find(hash); it != m_clientsByConnectionTokenHash.end())
+			{
+				return it->second.lock();
+			}
+
+			return false;
+		}
+
 		template<typename TFn>
 		inline void ForAllClientsLocked(TFn&& cb)
 		{
@@ -260,6 +271,7 @@ namespace fx
 		tbb::concurrent_unordered_map<net::PeerAddress, fx::ClientWeakPtr> m_clientsByEndPoint;
 		tbb::concurrent_unordered_map<std::string, fx::ClientWeakPtr> m_clientsByTcpEndPoint;
 		tbb::concurrent_unordered_map<std::string, fx::ClientWeakPtr> m_clientsByConnectionToken;
+		tbb::concurrent_unordered_map<uint32_t, fx::ClientWeakPtr> m_clientsByConnectionTokenHash;
 		tbb::concurrent_unordered_map<int, fx::ClientWeakPtr> m_clientsByPeer;
 
 		std::mutex m_clientSlotMutex;

--- a/code/components/citizen-server-impl/src/ClientRegistry.cpp
+++ b/code/components/citizen-server-impl/src/ClientRegistry.cpp
@@ -135,7 +135,13 @@ namespace fx
 
 		client->OnAssignConnectionToken.Connect([this, weakClient]()
 		{
-			m_clientsByConnectionToken[weakClient.lock()->GetConnectionToken()] = weakClient;
+			auto client = weakClient.lock();
+
+			if (client)
+			{
+				m_clientsByConnectionToken[client->GetConnectionToken()] = weakClient;
+				m_clientsByConnectionTokenHash[HashString(client->GetConnectionToken().c_str())] = weakClient;
+			}
 		});
 
 		OnClientCreated(client);

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -435,19 +435,11 @@ static InitFunction initFunction([]()
 			auto gameBuild = (gameBuildIt != postMap.end()) ? gameBuildIt->second : "0";
 			auto gameName = (gameNameIt != postMap.end()) ? gameNameIt->second : "";
 
-			if (protocol < 6)
+			if (protocol < 12)
 			{
-				sendError("Client/server version mismatch.");
+				sendError("Client/server version mismatch. Restart your game client to update. If that did not help, "
+					"this server is using too new a version for the current game client.");
 				return;
-			}
-
-			if (fx::IsOneSync())
-			{
-				if (protocol < 11)
-				{
-					sendError("Client/server version mismatch.");
-					return;
-				}
 			}
 
 			// verify game name

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -30,7 +30,7 @@
 
 #include <concurrent_queue.h>
 
-#define NETWORK_PROTOCOL 11
+#define NETWORK_PROTOCOL 12
 
 enum NetAddressType
 {

--- a/code/components/net/include/NetLibraryImplBase.h
+++ b/code/components/net/include/NetLibraryImplBase.h
@@ -42,7 +42,7 @@ public:
 		return SendReliableCommand(type, buffer, length);
 	}
 
-	virtual void SendConnect(const std::string& connectData) = 0;
+	virtual void SendConnect(const std::string& token, const std::string& connectData) = 0;
 
 	virtual bool HasTimedOut() = 0;
 

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -610,7 +610,7 @@ void NetLibrary::RunFrame()
 		case CS_CONNECTING:
 			if ((GetTickCount() - m_lastConnect) > 5000 && m_impl->IsDisconnected())
 			{
-				m_impl->SendConnect(fmt::sprintf("token=%s&guid=%llu", m_token, (uint64_t)GetGUID()));
+				m_impl->SendConnect(m_token, fmt::sprintf("token=%s&guid=%llu", m_token, (uint64_t)GetGUID()));
 
 				m_lastConnect = GetTickCount();
 
@@ -649,7 +649,7 @@ void NetLibrary::RunFrame()
 			{
 				if ((GetTickCount() - m_lastReconnect) > 5000)
 				{
-					m_impl->SendConnect(fmt::sprintf("token=%s&guid=%llu", m_token, (uint64_t)GetGUID()));
+					m_impl->SendConnect(m_token, fmt::sprintf("token=%s&guid=%llu", m_token, (uint64_t)GetGUID()));
 
 					m_lastReconnect = GetTickCount();
 

--- a/code/components/net/src/NetLibraryImplV2.cpp
+++ b/code/components/net/src/NetLibraryImplV2.cpp
@@ -34,7 +34,7 @@ public:
 
 	virtual void Flush() override;
 
-	virtual void SendConnect(const std::string& connectData) override;
+	virtual void SendConnect(const std::string& m_token, const std::string& connectData) override;
 
 	virtual bool IsDisconnected() override;
 
@@ -44,8 +44,6 @@ public:
 
 private:
 	void ProcessPacket(const uint8_t* data, size_t size, NetPacketMetrics& metrics, ENetPacketFlag flags);
-
-	void SendPacketQueue();
 
 private:
 	std::string m_connectData;
@@ -315,13 +313,13 @@ void NetLibraryImplV2::RunFrame()
 	}
 }
 
-void NetLibraryImplV2::SendConnect(const std::string& connectData)
+void NetLibraryImplV2::SendConnect(const std::string& token, const std::string& connectData)
 {
 	m_timedOut = false;
 	m_connectData = connectData;
 
 	auto addr = m_base->GetCurrentServer().GetENetAddress();
-	m_serverPeer = enet_host_connect(m_host, &addr, 2, 0);
+	m_serverPeer = enet_host_connect(m_host, &addr, 2, HashString(token.c_str()));
 
 	// all-but-disable the backoff-based timeout, and set the hard timeout to 30 seconds (equivalent to server-side check!)
 	enet_peer_timeout(m_serverPeer, 10000000, 10000000, 30000);

--- a/vendor/citizen_enet/include/enet/enet.h
+++ b/vendor/citizen_enet/include/enet/enet.h
@@ -407,6 +407,7 @@ typedef struct _ENetHost
    size_t               maximumWaitingData;          /**< the maximum aggregate amount of buffer space a peer may use waiting for packets to be delivered */
 
    void                 (*peerTimeoutCb)(_ENetHost* host, ENetPeer* peer);
+   bool                 (*validateDataCb)(_ENetHost* host, const ENetAddress* address, enet_uint32 data);
 } ENetHost;
 
 /**

--- a/vendor/citizen_enet/src/host.cpp
+++ b/vendor/citizen_enet/src/host.cpp
@@ -115,6 +115,7 @@ enet_host_create (const ENetAddress * address, size_t peerCount, size_t channelL
 
     host -> intercept = NULL;
     host -> peerTimeoutCb = NULL;
+    host -> validateDataCb = NULL;
 
     enet_list_clear (& host -> dispatchQueue);
 

--- a/vendor/citizen_enet/src/protocol.cpp
+++ b/vendor/citizen_enet/src/protocol.cpp
@@ -324,6 +324,9 @@ enet_protocol_handle_connect (ENetHost * host, ENetProtocolHeader * header, ENet
     if (peer == NULL || duplicatePeers >= host -> duplicatePeers)
       return NULL;
 
+    if (host -> validateDataCb && !host -> validateDataCb (host, &host->receivedAddress, ENET_NET_TO_HOST_32(command->connect.data)))
+        return NULL;
+
     if (channelCount > host -> channelLimit)
       channelCount = host -> channelLimit;
     peer -> channels = (ENetChannel *) enet_malloc (channelCount * sizeof (ENetChannel));


### PR DESCRIPTION
**DO NOT MERGE UNTIL RIGHT BEFORE A PRODUCTION RELEASE**: this changes the minimum net protocol version leading to confused server owners.

We use the `data` field in enet_host_connect to pass a derivative of the connection token, which then is checked *early* in ENet connectivity (before allocating a temporary peer).

This should mitigate the scenario where fake peers either spam UDP packets to not get acknowledged, or acknowledge without ever sending an initial connection.