### PR TITLE
fix(server/impl): delete stream hash pairs for resource restarts

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
@@ -518,6 +518,7 @@ namespace fx
 		object->OnStop.Connect([=]()
 		{
 			m_resourcePairs.clear();
+			m_hashPairs.clear();
 		}, -500);
 	}
 


### PR DESCRIPTION
This should fix the case where stream_cache contains 'old' versions of streaming assets, slightly related to #859.