### PR TITLE
fix(extra-natives/five): validate CREATE_RUNTIME_TEXTURE size

### DIFF
--- a/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
+++ b/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
@@ -253,6 +253,16 @@ RuntimeTex* RuntimeTxd::CreateTexture(const char* name, int width, int height)
 		return nullptr;
 	}
 
+	if (width <= 0 || width > 8192)
+	{
+		return nullptr;
+	}
+
+	if (height <= 0 || height > 8192)
+	{
+		return nullptr;
+	}
+
 	auto tex = std::make_shared<RuntimeTex>(name, width, height);
 	m_txd->Add(name, tex->GetTexture());
 


### PR DESCRIPTION
Fixes #953.