### PR TITLE
fix(audio/five): add 2 extra allocation buckets

### DIFF
--- a/code/components/extra-natives-five/src/NuiAudioSink.cpp
+++ b/code/components/extra-natives-five/src/NuiAudioSink.cpp
@@ -551,7 +551,7 @@ namespace rage
 	{
 		_audSoundInitParams_ctor(this);
 
-		m_pad[0x9A] = *initParamVal;
+		SetAllocationBucket(*initParamVal);
 	}
 
 	class audRequestedSettings
@@ -1094,7 +1094,7 @@ void MumbleAudioEntity::Poll(int samples)
 	}
 }
 
-static constexpr int kExtraAudioBuckets = 4;
+static constexpr int kExtraAudioBuckets = 6;
 static uint32_t bucketsUsed[kExtraAudioBuckets];
 
 void MumbleAudioEntity::MInit()


### PR DESCRIPTION
This *should* add 64 extra slots (in case there's 128+ audio entities trying to be created at the same time). See https://forum.cfx.re/t/3776013/12.