### PR TITLE
ENet peer fixes, run 2

### DIFF
--- a/code/components/net/src/NetLibraryImplV2.cpp
+++ b/code/components/net/src/NetLibraryImplV2.cpp
@@ -180,6 +180,8 @@ void NetLibraryImplV2::Reset()
 	if (m_serverPeer)
 	{
 		enet_peer_disconnect(m_serverPeer, 0);
+		Flush();
+		Flush();
 	}
 }
 


### PR DESCRIPTION
- Fixes a potential workaround for the ENet peer data mitigation.
- Fixes m_peerHandles not getting cleaned on 'unclean' disconnect.
- Fixes `quit` command not gracefully closing the server-side ENet peer.