### PR TITLE
fix(ros): don't try to use a Steam ticket if the app is borrowed

### DIFF
--- a/code/components/ros-patches-five/src/LegitimacyChecking.cpp
+++ b/code/components/ros-patches-five/src/LegitimacyChecking.cpp
@@ -263,7 +263,8 @@ std::string GetAuthSessionTicket(uint32_t appID)
 	} shutdown;
 
 	// get local ownership
-	if (!SteamApps()->BIsSubscribedApp(appID))
+	if (!SteamApps()->BIsSubscribed() ||
+		SteamApps()->GetAppOwner() != SteamUser()->GetSteamID())
 	{
 		return "";
 	}


### PR DESCRIPTION
This should fix some edge cases where users are signed in to a Steam account with borrowed RDO/RDR copy, but they're actually only intending to use a R* store copy.