### PR TITLE
tweak(server/impl): move QuickEdit disable to monitor

### DIFF
--- a/code/client/citicore/console/Console.Base.cpp
+++ b/code/client/citicore/console/Console.Base.cpp
@@ -155,19 +155,6 @@ static void PrintfTraceListener(ConsoleChannel channel, const char* out)
 				g_allowVt = true;
 			}
 		}
-
-		{
-			HANDLE hConsole = GetStdHandle(STD_INPUT_HANDLE);
-
-			DWORD consoleMode;
-			if (GetConsoleMode(hConsole, &consoleMode))
-			{
-				consoleMode |= ENABLE_EXTENDED_FLAGS;
-				consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
-
-				SetConsoleMode(hConsole, consoleMode);
-			}
-		}
 	});
 #else
 	g_allowVt = true;

--- a/code/components/citizen-server-monitor/src/MonitorInstance.cpp
+++ b/code/components/citizen-server-monitor/src/MonitorInstance.cpp
@@ -176,6 +176,24 @@ namespace fx
 
 )");
 
+		// disable QuickEdit in *monitor mode only*
+		// #TODO: detect if we're running under Windows Terminal, in which case
+		//        selection isn't suspending
+#ifdef _WIN32
+		{
+			HANDLE hConsole = GetStdHandle(STD_INPUT_HANDLE);
+
+			DWORD consoleMode;
+			if (GetConsoleMode(hConsole, &consoleMode))
+			{
+				consoleMode |= ENABLE_EXTENDED_FLAGS;
+				consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
+
+				SetConsoleMode(hConsole, consoleMode);
+			}
+		}
+#endif
+
 		// initialize the server configuration
 		std::shared_ptr<ConVar<std::string>> rootVar;
 


### PR DESCRIPTION
This is annoying since Windows Terminal started accepting this flag as well, despite it not being of any use.