### PR TITLE
RedM sampler state fix

### DIFF
--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -35,10 +35,6 @@ private:
 
 	uint32_t m_oldDepthStencilState;
 
-	uint32_t m_oldSamplerState;
-
-	uint32_t m_pointSamplerState;
-
 	bool m_targetMouseFocus = true;
 
 	bool m_lastTargetMouseFocus = true;
@@ -605,8 +601,6 @@ void GtaNuiInterface::SetTexture(fwRefContainer<GITexture> texture, bool pm)
 	SetTextureGtaIm(static_cast<GtaNuiTexture*>(texture.GetRef())->GetTexture());
 
 #if _HAVE_GRCORE_NEWSTATES
-	m_oldSamplerState = GetImDiffuseSamplerState();
-
 	m_oldRasterizerState = GetRasterizerState();
 	SetRasterizerState(GetStockStateIdentifier(RasterizerStateNoCulling));
 
@@ -662,7 +656,6 @@ void GtaNuiInterface::UnsetTexture()
 	SetRasterizerState(m_oldRasterizerState);
 	SetBlendState(m_oldBlendState);
 	SetDepthStencilState(m_oldDepthStencilState);
-	SetImDiffuseSamplerState(m_oldSamplerState);
 #endif
 
 	g_currentTexture = {};

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -425,19 +425,22 @@ static void InvokeRender()
 		return;
 	}
 
-	uint32_t state[9];
-	state[0] = 0x1010100;
-	state[1] = 0;
-	state[2] = 0x101;
-	state[3] = 0;
-	state[4] = 0;
-	state[5] = 0;
-	state[6] = 0;
-	state[7] = 0;
-	state[8] = 0x41400000; // 12.0f
+	if (!pointSampler)
+	{
+		uint32_t state[9];
+		state[0] = 0x1010100;
+		state[1] = 0;
+		state[2] = 0x101;
+		state[3] = 0;
+		state[4] = 0;
+		state[5] = 0;
+		state[6] = 0;
+		state[7] = 0;
+		state[8] = 0x41400000; // 12.0f
 
-	static auto fn = hook::get_call(hook::get_pattern("66 C7 45 E1 01 00 40 88 7D E3", 14));
-	pointSampler = ((uint8_t(*)(void* state))fn)(&state);
+		static auto fn = hook::get_call(hook::get_pattern("66 C7 45 E1 01 00 40 88 7D E3", 14));
+		pointSampler = ((uint8_t(*)(void* state))fn)(&state);
+	}
 
 	static std::once_flag of;
 


### PR DESCRIPTION
Fixes this little issue reported to occur on D3D12:

![GIF](https://user-images.githubusercontent.com/24576130/132974514-94e2d50e-486a-46d6-9949-4349d2cffdd7.gif)
