### PR TITLE
Assorted quit fixes

### DIFF
--- a/code/components/citizen-server-impl/include/ClientRegistry.h
+++ b/code/components/citizen-server-impl/include/ClientRegistry.h
@@ -89,6 +89,12 @@ namespace fx
 
 		inline void RemoveClient(const fx::ClientSharedPtr& client)
 		{
+			if (!client->IsDropping())
+			{
+				// some code expects OnDrop to follow any OnClientCreated
+				client->OnDrop();
+			}
+
 			m_clientsByPeer[client->GetPeer()].reset();
 			m_clientsByNetId[client->GetNetId()].reset();
 			m_clientsByConnectionToken[client->GetConnectionToken()].reset();

--- a/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
+++ b/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
@@ -405,11 +405,14 @@ namespace fx
 				return;
 			}
 
+			// save the peer as m_peerHandles will see an erase
+			auto peer = peerPair->second;
+
 			// enet_peer_reset will not trigger a disconnect event, so we'll manually run that
-			OnDisconnect(peerPair->second);
+			OnDisconnect(peer);
 
 			// reset the peer
-			enet_peer_reset(peerPair->second);
+			enet_peer_reset(peer);
 		}
 
 		virtual TimeoutInfo GatherTimeoutInfo(int peerId) override

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -1890,6 +1890,10 @@ void NetLibrary::Disconnect(const char* reason)
 		if (m_impl)
 		{
 			m_impl->Flush();
+
+			// this is *somewhat* needed to ensure the server gets our msgIQuit first
+			Sleep(std::min(750, m_impl->GetPing() + abs(m_impl->GetVariance())));
+
 			m_impl->Reset();
 		}
 


### PR DESCRIPTION
1. Timeout with '23ms' showing instead of `quit` message.
2. A crash observed while implementing the earlier fix.
3. Something led to stray clients showing in `svgui`'s player list.