### PR TITLE
tweak(server/impl): remove unused reliable replay logic

### DIFF
--- a/code/components/citizen-server-impl/include/Client.h
+++ b/code/components/citizen-server-impl/include/Client.h
@@ -273,23 +273,6 @@ namespace fx
 			m_syncData = ptr;
 		}
 
-		inline void PushReplayPacket(int channel, const net::Buffer& buffer)
-		{
-			m_replayQueue.push({ buffer, channel });
-		}
-
-		inline void ReplayPackets()
-		{
-			std::tuple<net::Buffer, int> value;
-
-			while (m_replayQueue.try_pop(value))
-			{
-				const auto&[buffer, channel] = value;
-
-				SendPacket(channel, buffer, NetPacketType_Reliable);
-			}
-		}
-
 		inline bool IsDropping() const
 		{
 			return m_dropping;
@@ -407,9 +390,6 @@ namespace fx
 
 		// whether the client has sent a routing msg once
 		bool m_hasRouted;
-
-		// packets to resend when a new peer connects using this client
-		tbb::concurrent_queue<std::tuple<net::Buffer, int>> m_replayQueue;
 
 		// an arbitrary set of data
 		std::shared_mutex m_userDataMutex;

--- a/code/components/citizen-server-impl/include/GameServerNet.h
+++ b/code/components/citizen-server-impl/include/GameServerNet.h
@@ -11,8 +11,7 @@ namespace net
 enum NetPacketType
 {
 	NetPacketType_Unreliable,
-	NetPacketType_Reliable,
-	NetPacketType_ReliableReplayed
+	NetPacketType_Reliable
 };
 
 namespace fx

--- a/code/components/citizen-server-impl/include/ServerEventComponent.h
+++ b/code/components/citizen-server-impl/include/ServerEventComponent.h
@@ -20,7 +20,7 @@ namespace fx
 		};
 
 	public:
-		virtual void TriggerClientEvent(const std::string_view& eventName, const void* data, size_t dataLen, const std::optional<std::string_view>& targetSrc = std::optional<std::string_view>(), bool replayed = false);
+		virtual void TriggerClientEvent(const std::string_view& eventName, const void* data, size_t dataLen, const std::optional<std::string_view>& targetSrc = std::optional<std::string_view>());
 
 		inline virtual void AttachToObject(ServerInstanceBase* object) override
 		{
@@ -30,17 +30,11 @@ namespace fx
 		template<typename... TArg>
 		inline void TriggerClientEvent(const std::string_view& eventName, const std::optional<std::string_view>& targetSrc, const TArg&... args)
 		{
-			return TriggerClientEventInternal<false>(eventName, targetSrc, args...);
-		}
-
-		template<typename... TArg>
-		inline void TriggerClientEventReplayed(const std::string_view& eventName, const std::optional<std::string_view>& targetSrc, const TArg&... args)
-		{
-			return TriggerClientEventInternal<true>(eventName, targetSrc, args...);
+			return TriggerClientEventInternal(eventName, targetSrc, args...);
 		}
 
 	private:
-		template<bool Replayed, typename... TArg>
+		template<typename... TArg>
 		inline void TriggerClientEventInternal(const std::string_view& eventName, const std::optional<std::string_view>& targetSrc, const TArg&... args)
 		{
 			msgpack::sbuffer buf;
@@ -50,7 +44,7 @@ namespace fx
 			packer.pack_array(sizeof...(args));
 			pass{ (packer.pack(args), 0)... };
 
-			TriggerClientEvent(eventName, buf.data(), buf.size(), targetSrc, Replayed);
+			TriggerClientEvent(eventName, buf.data(), buf.size(), targetSrc);
 		}
 
 	private:

--- a/code/components/citizen-server-impl/src/ClientRegistry.cpp
+++ b/code/components/citizen-server-impl/src/ClientRegistry.cpp
@@ -203,14 +203,14 @@ namespace fx
 			fwRefContainer<ServerEventComponent> events = m_instance->GetComponent<ServerEventComponent>();
 
 			// send every player information about the joining client
-			events->TriggerClientEventReplayed("onPlayerJoining", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId());
+			events->TriggerClientEvent("onPlayerJoining", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId());
 
 			// send the JOINING CLIENT information about EVERY OTHER CLIENT
 			std::string target = fmt::sprintf("%d", client->GetNetId());
 
 			ForAllClients([&](const fx::ClientSharedPtr& otherClient)
 			{
-				events->TriggerClientEventReplayed("onPlayerJoining", target, otherClient->GetNetId(), otherClient->GetName(), otherClient->GetSlotId());
+				events->TriggerClientEvent("onPlayerJoining", target, otherClient->GetNetId(), otherClient->GetName(), otherClient->GetSlotId());
 			});
 		}
 		else
@@ -220,7 +220,7 @@ namespace fx
 			std::string target = fmt::sprintf("%d", client->GetNetId());
 			uint32_t bigModeSlot = (m_instance->GetComponent<fx::GameServer>()->GetGameName() == fx::GameName::GTA5) ? 128 : 16;
 
-			events->TriggerClientEventReplayed("onPlayerJoining", target, client->GetNetId(), client->GetName(), bigModeSlot);
+			events->TriggerClientEvent("onPlayerJoining", target, client->GetNetId(), client->GetName(), bigModeSlot);
 		}
 
 		// trigger connection handlers

--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -589,20 +589,6 @@ namespace fx
 
 	void GameServer::InternalSendPacket(fx::Client* client, int peer, int channel, const net::Buffer& buffer, NetPacketType type)
 	{
-		// TODO: think of a more uniform way to determine null peers
-		NetPeerStackBuffer stackBuffer;
-		m_net->GetPeer(peer, stackBuffer);
-		if (stackBuffer.GetBase()->GetPing() == -1)
-		{
-			if (type == NetPacketType_ReliableReplayed)
-			{
-				client->PushReplayPacket(channel, buffer);
-			}
-
-			return;
-		}
-
-
 		GameServerPacket* packet = m_packetPool.construct(peer, channel, buffer, type);
 		m_netSendList.push(&packet->queueKey);
 	}
@@ -736,8 +722,6 @@ namespace fx
 					outMsg.Write(outStr.c_str(), outStr.size());
 
 					client->SendPacket(0, outMsg, NetPacketType_Reliable);
-
-					client->ReplayPackets();
 
 					if (wasNew)
 					{
@@ -1140,7 +1124,7 @@ namespace fx
 			if (!fx::IsBigMode() && isFinal)
 			{
 				// send every player information about the dropping client
-				events->TriggerClientEventReplayed("onPlayerDropped", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId());
+				events->TriggerClientEvent("onPlayerDropped", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId());
 			}
 		}
 
@@ -1484,7 +1468,7 @@ namespace fx
 					hostBroadcast.Write(client->GetNetBase());
 
 					gameServer->Broadcast(hostBroadcast);
-					//client->SendPacket(1, hostBroadcast, NetPacketType_ReliableReplayed);
+					//client->SendPacket(1, hostBroadcast, NetPacketType_Reliable);
 				}
 			}
 

--- a/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
+++ b/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
@@ -447,7 +447,7 @@ namespace fx
 			}
 
 			// fewer allocations!!
-			auto flags = ENET_PACKET_FLAG_NO_ALLOCATE | ((type == NetPacketType_Reliable || type == NetPacketType_ReliableReplayed) ? ENET_PACKET_FLAG_RELIABLE : (ENetPacketFlag)0);
+			auto flags = ENET_PACKET_FLAG_NO_ALLOCATE | ((type == NetPacketType_Reliable) ? ENET_PACKET_FLAG_RELIABLE : (ENetPacketFlag)0);
 			auto packet = enet_packet_create(bufferBytes, bufferLength, flags);
 
 			using NetBufferSharedPtr = std::shared_ptr<std::vector<uint8_t>>;

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -762,7 +762,7 @@ static InitFunction initFunction([]()
 
 				clientRegistry->ForAllClients([&](const fx::ClientSharedPtr& client)
 				{
-					client->SendPacket(0, outBuffer, NetPacketType_ReliableReplayed);
+					client->SendPacket(0, outBuffer, NetPacketType_Reliable);
 
 					trl->ReturnToken(client->GetConnectionToken());
 				});
@@ -797,7 +797,7 @@ static InitFunction initFunction([]()
 
 				clientRegistry->ForAllClients([&](const fx::ClientSharedPtr& client)
 				{
-					client->SendPacket(0, outBuffer, NetPacketType_ReliableReplayed);
+					client->SendPacket(0, outBuffer, NetPacketType_Reliable);
 				});
 			}, -1000);
 		});
@@ -1049,7 +1049,7 @@ static InitFunction initFunction([]()
 #include <ScriptEngine.h>
 #include <optional>
 
-void fx::ServerEventComponent::TriggerClientEvent(const std::string_view& eventName, const void* data, size_t dataLen, const std::optional<std::string_view>& targetSrc, bool replayed)
+void fx::ServerEventComponent::TriggerClientEvent(const std::string_view& eventName, const void* data, size_t dataLen, const std::optional<std::string_view>& targetSrc)
 {
 	// build the target event
 	net::Buffer outBuffer;
@@ -1079,14 +1079,14 @@ void fx::ServerEventComponent::TriggerClientEvent(const std::string_view& eventN
 		if (client)
 		{
 			// TODO(fxserver): >MTU size?
-			client->SendPacket(0, outBuffer, (!replayed) ? NetPacketType_Reliable : NetPacketType_ReliableReplayed);
+			client->SendPacket(0, outBuffer, NetPacketType_Reliable);
 		}
 	}
 	else
 	{
 		clientRegistry->ForAllClients([&](const fx::ClientSharedPtr& client)
 		{
-			client->SendPacket(0, outBuffer, (!replayed) ? NetPacketType_Reliable : NetPacketType_ReliableReplayed);
+			client->SendPacket(0, outBuffer, NetPacketType_Reliable);
 		});
 	}
 }

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1419,7 +1419,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 									{
 										int otherSlot = plit->second;
 
-										sec->TriggerClientEventReplayed("onPlayerDropped", fmt::sprintf("%d", client->GetNetId()), ownerNetId, ownerRef->GetName(), otherSlot);
+										sec->TriggerClientEvent("onPlayerDropped", fmt::sprintf("%d", client->GetNetId()), ownerNetId, ownerRef->GetName(), otherSlot);
 
 										/*NETEV playerLeftScope SERVER
 								/#*
@@ -1562,7 +1562,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 									clientData->playersInScope[slotId] = entityClient->GetNetId();
 									clientData->playersToSlots[entityClient->GetNetId()] = slotId;
 
-									sec->TriggerClientEventReplayed("onPlayerJoining", fmt::sprintf("%d", client->GetNetId()), entityClient->GetNetId(), entityClient->GetName(), slotId);
+									sec->TriggerClientEvent("onPlayerJoining", fmt::sprintf("%d", client->GetNetId()), entityClient->GetNetId(), entityClient->GetName(), slotId);
 
 									auto ecData = GetClientDataUnlocked(this, entityClient);
 
@@ -2138,7 +2138,7 @@ void ServerGameState::SendWorldGrid(void* entry /* = nullptr */, const fx::Clien
 
 				msg.Write(reinterpret_cast<char*>(grid->state) + base, length);
 
-				client->SendPacket(1, msg, NetPacketType_ReliableReplayed);
+				client->SendPacket(1, msg, NetPacketType_Reliable);
 			}
 		}
 	};
@@ -2645,7 +2645,7 @@ void ServerGameState::HandleClientDrop(const fx::ClientSharedPtr& client, uint16
 			if (si != clientData->playersToSlots.end())
 			{
 				fwRefContainer<ServerEventComponent> events = m_instance->GetComponent<ServerEventComponent>();
-				events->TriggerClientEventReplayed("onPlayerDropped", fmt::sprintf("%d", tgtClient->GetNetId()), netId, client->GetName(), si->second);
+				events->TriggerClientEvent("onPlayerDropped", fmt::sprintf("%d", tgtClient->GetNetId()), netId, client->GetName(), si->second);
 
 				clientData->playersInScope.reset(si->second);
 				clientData->playersToSlots.erase(si);
@@ -3771,7 +3771,7 @@ void ServerGameState::SendObjectIds(const fx::ClientSharedPtr& client, int numId
 		outBuffer.Write<uint16_t>(size);
 	}
 
-	client->SendPacket(1, outBuffer, NetPacketType_ReliableReplayed);
+	client->SendPacket(1, outBuffer, NetPacketType_Reliable);
 }
 
 template<int MaxElemSize, int Count>
@@ -3995,7 +3995,7 @@ void ServerGameState::SendPacket(int peer, std::string_view data)
 		buffer.Write<uint32_t>(HashRageString("msgStateBag"));
 		buffer.Write(data.data(), data.size());
 
-		client->SendPacket(1, buffer, NetPacketType_ReliableReplayed);
+		client->SendPacket(1, buffer, NetPacketType_Reliable);
 	}
 }
 
@@ -5833,7 +5833,7 @@ static InitFunction initFunction([]()
 			netBuffer.Write<uint32_t>(reqSeq);
 			netBuffer.Write<uint32_t>((msec().count()) & 0xFFFFFFFF);
 
-			client->SendPacket(1, netBuffer, NetPacketType_ReliableReplayed);
+			client->SendPacket(1, netBuffer, NetPacketType_Reliable);
 		} });
 	}, 999999);
 });

--- a/code/components/citizen-server-impl/src/state/ServerRPC.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerRPC.cpp
@@ -81,7 +81,7 @@ static InitFunction initFunction([]()
 					{
 						for (auto& [ native, buffer ] : entry.second)
 						{
-							unsafeClient->SendPacket(0, buffer, NetPacketType_ReliableReplayed);
+							unsafeClient->SendPacket(0, buffer, NetPacketType_Reliable);
 						}
 					}
 				}
@@ -486,7 +486,7 @@ static InitFunction initFunction([]()
 				{
 					if (cl)
 					{
-						cl->SendPacket(0, buffer, NetPacketType_ReliableReplayed);
+						cl->SendPacket(0, buffer, NetPacketType_Reliable);
 					}
 				};
 
@@ -497,7 +497,7 @@ static InitFunction initFunction([]()
 						std::unique_lock<std::shared_mutex> _(entity->guidMutex);
 						entity->onCreationRPC.push_back([buffer](const fx::ClientSharedPtr& client)
 						{
-							client->SendPacket(0, buffer, NetPacketType_ReliableReplayed);
+							client->SendPacket(0, buffer, NetPacketType_Reliable);
 						});
 					}
 				}


### PR DESCRIPTION
'Reconnecting' flow has been removed a long time ago, and some of this code was hitting perf-related issues on large servers.