### PR TITLE
fix(build/linux): update base alpine, force openssl 1.1

### DIFF
--- a/code/tools/ci/build_server_2.sh
+++ b/code/tools/ci/build_server_2.sh
@@ -8,6 +8,7 @@ JOB_SLOTS=${JOB_SLOTS:-24}
 
 # upgrade to edge (keep v3.12 for downgrades)
 echo http://dl-cdn.alpinelinux.org/alpine/v3.12/main > /etc/apk/repositories
+echo http://dl-cdn.alpinelinux.org/alpine/v3.14/main >> /etc/apk/repositories
 echo http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
 echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
 echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
@@ -33,10 +34,10 @@ apk --no-cache update
 apk del curl
 
 # install runtime dependencies
-apk add --no-cache curl=7.72.0-r99 libssl1.1 libunwind libstdc++ zlib c-ares icu-libs v8 musl-dbg
+apk add --no-cache curl=7.72.0-r99 libssl1.1 libcrypto1.1 libunwind libstdc++ zlib c-ares icu-libs v8 musl-dbg
 
 # install compile-time dependencies
-apk add --no-cache --virtual .dev-deps lld curl-dev=7.72.0-r99 clang clang-dev build-base linux-headers openssl-dev python2 python3 py3-pip py3-setuptools lua5.3 lua5.3-dev mono-reference-assemblies=5.16.1.0-r9990 mono-dev=5.16.1.0-r9990 libmono=5.16.1.0-r9990 mono-corlib=5.16.1.0-r9990 mono=5.16.1.0-r9990 mono-reference-assemblies-4.x=5.16.1.0-r9990 mono-reference-assemblies-facades=5.16.1.0-r9990 mono-csc=5.16.1.0-r9990 mono-runtime=5.16.1.0-r9990 c-ares-dev v8-dev nodejs~=12 nodejs-dev~=12 npm yarn clang-libs git cargo
+apk add --no-cache --virtual .dev-deps lld curl-dev=7.72.0-r99 clang clang-dev build-base linux-headers openssl1.1-compat-dev python2 python3 py3-pip py3-setuptools lua5.3 lua5.3-dev mono-reference-assemblies=5.16.1.0-r9990 mono-dev=5.16.1.0-r9990 libmono=5.16.1.0-r9990 mono-corlib=5.16.1.0-r9990 mono=5.16.1.0-r9990 mono-reference-assemblies-4.x=5.16.1.0-r9990 mono-reference-assemblies-facades=5.16.1.0-r9990 mono-csc=5.16.1.0-r9990 mono-runtime=5.16.1.0-r9990 c-ares-dev v8-dev nodejs~=12 nodejs-dev~=12 npm yarn clang-libs git cargo
 
 # install ply
 python3 -m pip install ply

--- a/code/tools/ci/build_server_proot.sh
+++ b/code/tools/ci/build_server_proot.sh
@@ -17,7 +17,7 @@ curl -H "Content-Type: application/json" -s -d "$json" "$TG_WEBHOOK" || true
 curl -H "Content-Type: application/json" -s -d "$json" "$DISCORD_WEBHOOK" || true
 
 # get an alpine rootfs
-curl -sLo alpine-minirootfs-3.11.5-x86_64.tar.gz http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86_64/alpine-minirootfs-3.11.5-x86_64.tar.gz
+curl -sLo alpine-minirootfs-3.14.2-x86_64.tar.gz https://dl-cdn.alpinelinux.org/alpine/v3.14/releases/x86_64/alpine-minirootfs-3.14.2-x86_64.tar.gz
 
 cd ..
 
@@ -48,7 +48,7 @@ adduser -D -u 1000 build
 # extract the alpine root FS
 mkdir alpine
 cd alpine
-tar xf ../alpine-minirootfs-3.11.5-x86_64.tar.gz
+tar xf ../alpine-minirootfs-3.14.2-x86_64.tar.gz
 cd ..
 
 export CI_BRANCH=$CI_BUILD_REF_NAME


### PR DESCRIPTION
The JS ecosystem expects deprecated hashes like 'md4' to exist and of course these are removed in OpenSSL 3.