### PR TITLE
Update scheduler.lua

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -278,7 +278,7 @@ local function resumeThread(thread, coro) -- Internal utility
 		Citizen_SubmitBoundaryStart(thread[4 --[[SLQ_BOUNDARY]]], coro)
 	end
 	
-	local ok, wakeTimeOrErr = coroutine_resume(coro)
+	local ok, wakeTimeOrErr = coroutine_resume(coro, curTime)
 	
 	if ok then
 		thread = thread_lu[coro]
@@ -314,7 +314,7 @@ function Citizen.CreateThread(threadFunction)
 end
 
 function Citizen.Wait(msec)
-	coroutine_yield(curTime + msec)
+	return coroutine_yield(curTime + msec)
 end
 
 -- legacy alias (and to prevent people from calling the game's function)


### PR DESCRIPTION
I have no idea if this would be anything interesting.

Could be usefull to save a native call to GetGameTimer if you want to get tick time.

So this would allow you to do

```lua
local time = Citizen.Wait(0)
```

Instead of
```lua
Citizen.Wait(0)
local time = GetGameTimer()
```