### PR TITLE
feat(server/impl): update data node structs for RDR3

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -1200,7 +1200,7 @@ struct SyncTree : public SyncTreeBase
 			*modelHash = objectCreationNode->m_model;
 			return true;
 		}
-#if 0
+
 		auto[hasPan, playerAppearanceNode] = GetData<CPlayerAppearanceDataNode>();
 
 		if (hasPan)
@@ -1209,7 +1209,6 @@ struct SyncTree : public SyncTreeBase
 			return true;
 		}
 
-#endif
 		return false;
 	}
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -264,9 +264,6 @@ struct CPedCreationDataNode : GenericSerializeDataNode<CPedCreationDataNode>
 	uint32_t m_model;
 	ePopType m_popType;
 
-	bool isRespawnObjectId;
-	bool respawnFlaggedForRemoval;
-
 	template<typename TSerializer>
 	bool Serialize(TSerializer& s)
 	{ 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -403,20 +403,7 @@ struct CDoorScriptGameStateDataNode { bool Parse(SyncParseState& state) { return
 struct CHeliHealthDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CHeliControlDataNode { bool Parse(SyncParseState& state) { return true; } };
 
-struct CObjectCreationDataNode  : GenericSerializeDataNode<CObjectCreationDataNode>
-{
-	uint32_t m_model;
-	bool m_hasInitPhysics;
-
-	template<typename Serializer>
-	bool Serialize(Serializer& s)
-	{
-		s.Serialize(32, m_model);
-		s.Serialize(m_hasInitPhysics);
-
-		return true;
-	}
-};
+struct CObjectCreationDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CObjectGameStateDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CObjectScriptGameStateDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CPhysicalHealthDataNode { bool Parse(SyncParseState& state) { return true; } };

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -14,19 +14,22 @@
 
 namespace fx::sync
 {
-struct CVehicleCreationDataNode
+struct CVehicleCreationDataNode : GenericSerializeDataNode<CVehicleCreationDataNode>
 { 
 	uint32_t m_model;
 	ePopType m_popType;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
 	{
-		uint32_t model = state.buffer.Read<uint32_t>(32);
-		m_model = model;
+		// model
+		s.Serialize(32, m_model);
 
-		uint8_t popType = state.buffer.Read<uint8_t>(4);
+		// 4
+		auto popType = (int)m_popType;
+		s.Serialize(4, popType);
 		m_popType = (ePopType)popType;
-		
+
 		return true; 
 	} 
 };
@@ -261,10 +264,13 @@ struct CPedCreationDataNode : GenericSerializeDataNode<CPedCreationDataNode>
 	uint32_t m_model;
 	ePopType m_popType;
 
+	bool isRespawnObjectId;
+	bool respawnFlaggedForRemoval;
+
 	template<typename TSerializer>
 	bool Serialize(TSerializer& s)
 	{ 
-		// 7(?)
+		// 4
 		auto popType = (int)m_popType;
 		s.Serialize(4, popType);
 		m_popType = (ePopType)popType;
@@ -400,19 +406,17 @@ struct CDoorScriptGameStateDataNode { bool Parse(SyncParseState& state) { return
 struct CHeliHealthDataNode { bool Parse(SyncParseState& state) { return true; } };
 struct CHeliControlDataNode { bool Parse(SyncParseState& state) { return true; } };
 
-struct CObjectCreationDataNode
+struct CObjectCreationDataNode  : GenericSerializeDataNode<CObjectCreationDataNode>
 {
 	uint32_t m_model;
+	bool m_hasInitPhysics;
 
-	bool Unparse(SyncUnparseState& state)
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
 	{
-		state.buffer.Write<uint32_t>(32, m_model);
+		s.Serialize(32, m_model);
+		s.Serialize(m_hasInitPhysics);
 
-		return true;
-	}
-
-	bool Parse(SyncParseState& state)
-	{ 
 		return true;
 	}
 };
@@ -1192,7 +1196,7 @@ struct SyncTree : public SyncTreeBase
 			*modelHash = pedCreationNode->m_model;
 			return true;
 		}
-
+#if 0
 		auto[hasOcn, objectCreationNode] = GetData<CObjectCreationDataNode>();
 
 		if (hasOcn)
@@ -1200,7 +1204,7 @@ struct SyncTree : public SyncTreeBase
 			*modelHash = objectCreationNode->m_model;
 			return true;
 		}
-
+#endif
 		auto[hasPan, playerAppearanceNode] = GetData<CPlayerAppearanceDataNode>();
 
 		if (hasPan)


### PR DESCRIPTION
Idk if it's the right way to do this. I was used fivem SyncTrees as example.I did this becouse i wanted to use entityCreating event to block spawning some vehicles but GET_ENTITY_MODEL and GET_ENTITY_POPULATION_TYPE wasnt here

```
AddEventHandler('entityCreating', function(entity)
    print(entity)
    print(GetEntityTypeName(GetEntityType(entity)))
    print(GetPopulationTypeName(GetEntityPopulationType(entity)))
    print(GetEntityModel(entity))  
end)

function GetPopulationTypeName(type)
    for k, v in pairs(entityPopulationTypes) do
        if v == type then
            return k
        end
    end
end

function GetEntityTypeName(type)
    for k, v in pairs(entityTypes) do
        if v == type then
            return k
        end
    end
end

```

![image](https://user-images.githubusercontent.com/43894510/133887447-73658362-55b6-4d82-ac0e-2f2aeda77f1b.png)


