### PR TITLE
fix(rdr3) improve hook for NETWORK_GET_PLAYER_INDEX_FROM_PED native 

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -1623,7 +1623,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 		auto location = hook::get_pattern("74 ? 48 8B 88 ? ? ? ? 48 85 C9 74 ? E8 ? ? ? ? 0F B6", 14);
 #elif IS_RDR3
-		auto location = hook::get_pattern("48 85 C9 74 ? E8 ? ? ? ? 0F B6 C0 EB", 5);
+		auto location = hook::get_pattern("48 85 C9 74 ? E8 ? ? ? ? 0F B6 C0 EB 05", 5);
 #endif
 		hook::set_call(&g_origGetOwnerPlayerId, location);
 		hook::call(location, netObject__GetPlayerOwnerId);


### PR DESCRIPTION
```
  local playerid = NetworkGetPlayerIndexFromPed(target)
  print(playerid)
  print(NetworkIsPlayerActive(playerid))
  print(GetPlayerServerId(playerid))
```
before
![RfTIOIn](https://user-images.githubusercontent.com/43894510/133898474-dbc33a89-e7f2-4506-91d9-fe191a24ae4b.png)
after
![test23234](https://user-images.githubusercontent.com/43894510/133898477-b27735b9-640d-4958-8f84-3cb2fd25b68d.PNG)
 
