### PR TITLE
fix(vendor): move libuv to a fork for downlevel compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	url = https://github.com/miloyip/rapidjson.git
 [submodule "vendor/libuv"]
 	path = vendor/libuv
-	url = https://github.com/libuv/libuv.git
+	url = https://github.com/citizenfx/libuv.git
 [submodule "vendor/fmtlib"]
 	path = vendor/fmtlib
 	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
Windows 7 strikes yet again.