### PR TITLE
NUI focus tweaks

### DIFF
--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -328,7 +328,18 @@ static InitFunction initFunction([] ()
 		}
 
 		{
-			auto shouldKeepInput = !focusKeepInputVotes.empty();
+			// find if the keep-input list overlaps with the general vote list
+			bool shouldKeepInput = false;
+
+			for (const auto& resource : focusKeepInputVotes)
+			{
+				if (focusVotes.find(resource) != focusVotes.end() ||
+					focusCursorVotes.find(resource) != focusCursorVotes.end())
+				{
+					shouldKeepInput = true;
+					break;
+				}
+			}
 
 			if (shouldKeepInput != lastFocusKeepInput)
 			{

--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
@@ -24,9 +25,17 @@ iframe
 }
 </style>
 <script type="text/javascript">
-// raw javascript ftfw
 window.citFrames = {};
-window.focusStack = [];
+
+/**
+ * @type string[]
+ */
+let zStack = [];
+
+/**
+ * @type string[]
+ */
+let focusStack = [];
 
 let handoverBlob = {};
 let serverAddress = '';
@@ -57,7 +66,7 @@ registerPushFunction(function(type, ...args) {
 				return;
 			}
 
-			citFrames[frameName].contentWindow.postMessage(data, '*');
+			citFrames[frameName]?.contentWindow?.postMessage(data, '*');
 
 			break;
 		}
@@ -68,8 +77,7 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 {
 	if (msg == "createFrame")
 	{
-		var frame = document.createElement('iframe');
-	
+		const frame = document.createElement('iframe');
 		frame.name = frameName;
 		frame.style.visibility = 'hidden';
 		frame.allow = 'microphone *; camera *;';
@@ -77,9 +85,17 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		frame.tabIndex = -1;
 
 		citFrames[frameName] = frame;
-		focusStack.push(frameName);
+		zStack.push(frameName);
+
+		const curElement = document.activeElement;
+		const hadFocus = (curElement?.tagName.toUpperCase() === 'IFRAME');
 		
 		document.body.appendChild(frame);
+
+		if (hadFocus) {
+			frame.blur();
+			curElement.focus();
+		}
 
 		frame.contentWindow.addEventListener('DOMContentLoaded', function()
 		{
@@ -112,10 +128,11 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 			return;
 		}
 
-		focusStack = focusStack.filter(function(val) { return val !== frameName; });
+		zStack = zStack.filter(val => val !== frameName);
 		
 		// bye!
 		document.body.removeChild(citFrames[frameName]);
+		delete citFrames[frameName];
 	}
 });
 
@@ -126,35 +143,57 @@ registerPollFunction(function(frameName)
 		return;
 	}
 	
-	var frame = citFrames[frameName];
-	frame.contentWindow.postMessage({ type: 'poll' }, '*');
+	const frame = citFrames[frameName];
+	frame?.contentWindow.postMessage({ type: 'poll' }, '*');
 });
 
 focusFrame = function(frameName)
 {
-	// rearrange the focus stack
-	focusStack = focusStack.filter(function(val) { return val !== frameName; });
-	focusStack.push(frameName);
+	// rearrange the z/focus stacks
+	zStack = zStack.filter(val => val !== frameName);
+	zStack.push(frameName);
 
-	// iterate the array
-	for (var i = 0; i < focusStack.length; i++)
+	focusStack = focusStack.filter(val => val !== frameName);
+	focusStack.splice(0, 0, frameName);
+
+	// iterate the z order array
+	for (let i = 0; i < zStack.length; i++)
 	{
-		var thisFrame = citFrames[focusStack[i]];
-		thisFrame.style.zIndex = i.toString();
+		const thisFrame = citFrames[zStack[i]];
+		if (thisFrame) {
+			thisFrame.style.zIndex = i.toString();
+		}
 	}
 
-	// register blur event for unintentional tab escapes
-	citFrames[frameName].contentWindow.addEventListener("blur", frameEscapeFunctions[frameName]);
-	// and focus the frame itself
-	citFrames[frameName].contentWindow.focus();
+	const curFrame = citFrames[frameName];
+
+	if (curFrame) {
+		// set our z index to topmost
+		curFrame.style.zIndex = 99999;
+
+		// register blur event for unintentional tab escapes
+		curFrame.contentWindow.addEventListener("blur", frameEscapeFunctions[frameName]);
+		// and focus the frame itself
+		curFrame.contentWindow.focus();
+	}
 };
 
 blurFrame = function(frameName)
 {
-	// intentional blur, remove blur listener
-	citFrames[frameName].contentWindow.removeEventListener("blur", frameEscapeFunctions[frameName]);
-	// remove focus
-	citFrames[frameName].contentWindow.blur();
+	const curFrame = citFrames[frameName];
+	focusStack = focusStack.filter(val => val !== frameName);
+
+	if (curFrame) {
+		// intentional blur, remove blur listener
+		curFrame.contentWindow.removeEventListener("blur", frameEscapeFunctions[frameName]);
+		// remove focus
+		curFrame.contentWindow.blur();
+	}
+
+	// refocus the top frame in the focus stack, if any
+	if (focusStack.length >= 1) {
+		focusFrame(focusStack[0]);
+	}
 };
 </script>
 </head>


### PR DESCRIPTION
Fixes a few common UI gotchas:

1. https://forum.cfx.re/t/problem-with-chat-console-input/4764187 - keep-input resources conflicting with focus resources
2. Some fixes for UI focus getting lost on the browser side when unfocusing, starting or restarting a new resource. ~~This still doesn't handle the case where two resources unfocus after one another, nor does it handle the case where the last unfocused resource is actually _not_ the currently-focused resource: this _might_ need fixing before merging (i.e. keeping an actual focus stack with _only_ focused frames, and the Z order list separately).~~