### PR TITLE
Fix a bug causing tintValue to be ignored for interior entities

### DIFF
--- a/code/components/gta-streaming-five/src/UnkStuff.cpp
+++ b/code/components/gta-streaming-five/src/UnkStuff.cpp
@@ -353,4 +353,11 @@ static HookFunction hookFunction([]()
 		hook::put<int32_t>(location, (char*)mnbvhList - location + 4);
 		hook::put<int32_t>(location + 8, 4004);
 	}
+	
+	{
+		// fix R* bug causing CEntityDef tint values to not work in interiors
+		auto location = hook::get_pattern<char>("81 A3 ? ? ? ? 03 FF FF FF 0F B6");
+		hook::nop(location, 10);
+		hook::nop(location + 33, 6);
+	}
 });


### PR DESCRIPTION
For some reason R* was overriding tint value field with interior proxy pool index. Looks like a bug caused by mistyping. This bug was only affecting interior `CEntityDef`s.

Before fix:
![image](https://user-images.githubusercontent.com/10367215/134772972-f1a0eac2-0d6d-411c-8e35-248d1a6de28d.png)

After fix:
![image](https://user-images.githubusercontent.com/10367215/134772978-3c727bfc-32c3-46f1-8aef-363e43325397.png)
