### PR TITLE
feat(nui/resources): Add UNREGISTER_RAW_NUI_CALLBACK

### DIFF
--- a/code/components/nui-resources/include/ResourceUI.h
+++ b/code/components/nui-resources/include/ResourceUI.h
@@ -58,6 +58,8 @@ public:
 
 	void AddCallback(const std::string& type, ResUICallback callback);
 
+	void RemoveCallback(const std::string& type);
+
 	bool InvokeCallback(const std::string& type, const std::string& query, const std::multimap<std::string, std::string>& headers, const std::string& data, ResUIResultCallback resultCB);
 
 	void SignalPoll();

--- a/code/components/nui-resources/src/ResourceUI.cpp
+++ b/code/components/nui-resources/src/ResourceUI.cpp
@@ -109,6 +109,13 @@ void ResourceUI::AddCallback(const std::string& type, ResUICallback callback)
 	m_callbacks.insert({ type, callback });
 }
 
+void ResourceUI::RemoveCallback(const std::string& type)
+{
+	// Note: This is called by UNREGISTER_RAW_NUI_CALLBACK but
+	// can still technically target event based NUI Callbacks
+	m_callbacks.erase(type);
+}
+
 bool ResourceUI::InvokeCallback(const std::string& type, const std::string& query, const std::multimap<std::string, std::string>& headers, const std::string& data, ResUIResultCallback resultCB)
 {
 	auto set = fx::GetIteratorView(m_callbacks.equal_range(type));

--- a/code/components/nui-resources/src/ResourceUIRawCallbacks.cpp
+++ b/code/components/nui-resources/src/ResourceUIRawCallbacks.cpp
@@ -128,4 +128,26 @@ static InitFunction initFunction([] ()
 			}
 		}
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("UNREGISTER_RAW_NUI_CALLBACK", [](fx::ScriptContext& ctx)
+	{
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+			if (resource)
+			{
+				fwRefContainer<ResourceUI> resourceUI = resource->GetComponent<ResourceUI>();
+
+				if (resourceUI.GetRef())
+				{
+					std::string type = ctx.CheckArgument<const char*>(0);
+
+					resourceUI->RemoveCallback(type);
+				}
+			}
+		}
+	});
 });

--- a/ext/native-decls/UnregisterRawNuiCallback.md
+++ b/ext/native-decls/UnregisterRawNuiCallback.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+---
+## UNREGISTER_RAW_NUI_CALLBACK
+
+```c
+void UNREGISTER_RAW_NUI_CALLBACK(char* callbackType);
+```
+Will unregister and cleanup a registered NUI callback handler.
+
+Use along side the REGISTER_RAW_NUI_CALLBACK native.
+
+## Parameters
+* **callbackType**: The callback type to target
+


### PR DESCRIPTION
This is an updated version of #903 that takes into account comments regarding moving away from events and ScRT wrappers.

Usage:
```lua
RegisterRawNuiCallback('nuiEvent', myHandlerFunc)
UnregisterRawNuiCallback('nuiEvent')
```

Comments and suggestions about implementation details are welcome!