### PR TITLE
fix(conhost/v2): drawperf gpu temp won't exceed Sol's surface temperature

### DIFF
--- a/code/components/conhost-v2/src/DrawPerf.cpp
+++ b/code/components/conhost-v2/src/DrawPerf.cpp
@@ -271,7 +271,15 @@ static InitFunction initFunction([]()
 
 						if (SUCCEEDED(D3DKMTQueryAdapterInfo(&queryAdapterInfo)))
 						{
-							metrics.push_back(fmt::sprintf("GPU Temp: %.0f\xC2\xB0""C", adapterPerfData.Temperature / 10.f));
+							float fracTemp = adapterPerfData.Temperature / 10.f;
+
+							// some (AMD?) GPU drivers return temperatures of '6900 C' here, so we divide those to be within range again
+							if (fracTemp > 200) // 200 is a bit outrageous
+							{
+								fracTemp /= 100.0f;
+							}
+
+							metrics.push_back(fmt::sprintf("GPU Temp: %.0f\xC2\xB0""C", fracTemp));
 						}
 					}
 				}


### PR DESCRIPTION
AMD driver authors didn't read 'deci-Celsius' at one point and instead give callers milli-Celsius. Thanks, AMD!