### PR TITLE
tweak(resources/gta): mark any resource as a valid binding tag

### DIFF
--- a/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
@@ -23,15 +23,21 @@ static InitFunction initFunction([]()
 		{
 			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
 
-			game::SetBindingTagActive(resource->GetName(), true);
-
-			resource->OnStop.Connect([resource]()
-			{
-				game::SetBindingTagActive(resource->GetName(), false);
-			});
-
 			game::RegisterBindingForTag(resource->GetName(), commandString, description, defaultMapper, defaultParameter);
 		}
+	});
+
+	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* resource)
+	{
+		resource->OnStart.Connect([resource]()
+		{
+			game::SetBindingTagActive(resource->GetName(), true);
+		});
+
+		resource->OnStop.Connect([resource]()
+		{
+			game::SetBindingTagActive(resource->GetName(), false);
+		});
 	});
 });
 #endif


### PR DESCRIPTION
Prior to this change, only resources that called REGISTER_KEY_MAPPING were a valid binding tag.

Fixes #1066.