### PR TITLE
feat(mumble): increase TARGET_MAX_CHANNELS to 256

### DIFF
--- a/code/components/voip-server-mumble/src/voicetarget.h
+++ b/code/components/voip-server-mumble/src/voicetarget.h
@@ -35,8 +35,8 @@
 #include "client.h"
 #include "list.h"
 
-#define TARGET_MAX_CHANNELS 16
-#define TARGET_MAX_SESSIONS 32
+#define TARGET_MAX_CHANNELS 256
+#define TARGET_MAX_SESSIONS 256
 
 typedef struct {
 	int channel;


### PR DESCRIPTION
This is a follow-up commit to https://github.com/citizenfx/fivem/pull/1017

This is meant to fix this issue: https://github.com/AvarianKnight/pma-voice/issues/166

