### PR TITLE
Implement array handlers support in RedM

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -1254,7 +1254,7 @@ public:
 private:
 	struct ArrayHandlerData
 	{
-		std::array<std::shared_ptr<ArrayHandlerBase>, 16> handlers;
+		std::array<std::shared_ptr<ArrayHandlerBase>, 20> handlers;
 
 		ArrayHandlerData();
 	};

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4013,8 +4013,12 @@ void ServerGameState::SendPacket(int peer, std::string_view data)
 
 ServerGameState::ArrayHandlerData::ArrayHandlerData()
 {
+#ifdef STATE_FIVE
 	handlers[4] = std::make_shared<ArrayHandler<128, 50>>(4);
 	handlers[7] = std::make_shared<ArrayHandler<128, 50>>(7);
+#elif STATE_RDR3
+	handlers[16] = std::make_shared<ArrayHandler<128, 400>>(16);
+#endif
 }
 
 auto ServerGameState::GetEntityLockdownMode(const fx::ClientSharedPtr& client) -> EntityLockdownMode

--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -3872,9 +3872,7 @@ static std::map<int, ObjectData> trackedObjects;
 
 #include <lz4.h>
 
-#ifdef GTA_FIVE
 extern void ArrayManager_Update();
-#endif
 
 static InitFunction initFunction([]()
 {
@@ -3902,10 +3900,7 @@ static InitFunction initFunction([]()
 			return;
 		}
 
-#ifdef GTA_FIVE
 		ArrayManager_Update();
-#endif
-
 		EventManager_Update();
 		TheClones->Update();
 	});

--- a/code/components/gta-net-five/src/CloneExperiments_ArrayHandler.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments_ArrayHandler.cpp
@@ -61,6 +61,7 @@ public:
 	}
 
 public:
+#ifdef GTA_FIVE
 	uint8_t m_pad[244 - 8]; // +8
 	uint16_t m_index; // 244
 	uint16_t m_count; // 246
@@ -68,6 +69,16 @@ public:
 	uint8_t m_elementSize; // 249
 	uint8_t m_pad2[14]; // 250
 	void* m_array; // 264
+#elif IS_RDR3
+	uint8_t m_pad[308 - 8]; // +8
+	uint16_t m_index; // 308
+	uint8_t m_pad2[130]; // 310
+	uint16_t m_count; // 440
+	uint8_t m_pad3[6]; // 442
+	uint8_t m_elementSize; // 448
+	uint8_t m_pad4[23]; // 449
+	void* m_array; // 472
+#endif
 };
 
 class netArrayManager
@@ -97,7 +108,7 @@ struct ArrayHandlerInfo
 	std::vector<size_t> hashes;
 };
 
-static std::array<std::unique_ptr<ArrayHandlerInfo>, 16> arrayHandlers;
+static std::array<std::unique_ptr<ArrayHandlerInfo>, 20> arrayHandlers;
 
 static auto GetArrayHandlerInfo(int index, rage::netArrayHandlerBase* handler)
 {
@@ -120,8 +131,12 @@ void ArrayManager_Update()
 	}
 
 	static const int arrayHandlers[] = {
+#ifdef GTA_FIVE
 		4, // incidents
 		7, // sticky bombs
+#elif IS_RDR3
+		16, // world doors
+#endif
 	};
 
 	for (int arrayIndex : arrayHandlers)

--- a/code/components/gta-net-rdr3/component.lua
+++ b/code/components/gta-net-rdr3/component.lua
@@ -13,6 +13,7 @@ return function()
 		'components/gta-net-five/src/ClientRPC.cpp',
 		'components/gta-net-five/src/CloneDebug.cpp',
 		'components/gta-net-five/src/CloneExperiments.cpp',
+		'components/gta-net-five/src/CloneExperiments_ArrayHandler.cpp',
 		'components/gta-net-five/src/CloneManager.cpp',
 		'components/gta-net-five/src/CloneObjectManager.cpp',
 		'components/gta-net-five/src/ObjectIdManager.cpp',


### PR DESCRIPTION
For now it only support world doors net array handler. This should fix door system natives sync between players *in scope*.