### PR TITLE
feat(nui): allow using texture cursor instead of host cursor

### DIFF
--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -369,6 +369,7 @@ namespace nui
 	bool OVERLAY_DECL HasMainUI();
 	void OVERLAY_DECL SetMainUI(bool enable);
 	void OVERLAY_DECL SetHideCursor(bool hide);
+	void OVERLAY_DECL CursorType(int cursorType);
 
 	void ProcessInput();
 

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -26,6 +26,7 @@ static bool g_hasFocus = false;
 bool g_hasCursor = false;
 bool g_keepInput = false;
 static bool g_hasOverriddenFocus = false;
+int g_cursorType = 0;
 extern bool g_mainUIFlag;
 POINT g_cursorPos;
 
@@ -140,7 +141,7 @@ namespace nui
 					NUIRenderHandler* nrh = (NUIRenderHandler*)rh.get();
 
 					RevokeDragDrop(g_nuiGi->GetHWND());
-					
+
 					HRESULT hr = RegisterDragDrop(g_nuiGi->GetHWND(), nrh->GetDropTarget());
 					if (FAILED(hr))
 					{
@@ -210,7 +211,12 @@ namespace nui
 	void ProcessInput()
 	{
 	}
-}
+
+	void CursorType(int cursorType)
+	{
+		g_cursorType = cursorType;
+	}
+	}
 
 int GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam)
 {
@@ -404,7 +410,7 @@ static HookFunction initFunction([] ()
 				{
 					keyEvent.character = '\r';
 					keyEvent.unmodified_character = '\r';
-					
+
 					browser->GetHost()->SendKeyEvent(keyEvent);
 
 					keyEvent.type = KEYEVENT_CHAR;
@@ -638,15 +644,15 @@ static HookFunction initFunction([] ()
 			case WM_LBUTTONDOWN:
 			case WM_RBUTTONDOWN:
 			case WM_MBUTTONDOWN:
-			case WM_LBUTTONDBLCLK: 
-			case WM_RBUTTONDBLCLK: 
+			case WM_LBUTTONDBLCLK:
+			case WM_RBUTTONDBLCLK:
 			case WM_MBUTTONDBLCLK: {
 				int x = GET_X_LPARAM(lParam);
 				int y = GET_Y_LPARAM(lParam);
 				int btnType =
 					((msg == WM_LBUTTONDOWN || msg == WM_LBUTTONDBLCLK) ? 0 : (
 						(msg == WM_RBUTTONDOWN || msg == WM_RBUTTONDBLCLK) ? 1 : 2));
-				
+
 				inputTarget.MouseEvent(btnType, x, y, true);
 
 				if (!g_keepInput)

--- a/code/components/nui-core/src/NUIRenderCallbacks.cpp
+++ b/code/components/nui-core/src/NUIRenderCallbacks.cpp
@@ -11,6 +11,8 @@ extern nui::GameInterface* g_nuiGi;
 
 extern bool g_hasCursor;
 extern bool g_shouldHideCursor;
+extern int g_cursorType;
+
 extern POINT g_cursorPos;
 
 extern bool g_isDragging;
@@ -132,9 +134,14 @@ static HookFunction initFunction([] ()
 
 		// are we in any situation where we need a cursor?
 		bool needsNuiCursor = (nui::HasMainUI() || g_hasCursor) && !g_shouldHideCursor;
-		g_nuiGi->SetHostCursorEnabled(needsNuiCursor);
 
-		// we set the host cursor above unconditionally- this is for cases where the host cursor isn't sufficient
+		if (g_cursorType != 1)
+		{
+			g_nuiGi->SetHostCursorEnabled(needsNuiCursor);
+		}
+		
+
+		// we set the host cursor above if not disabled by SetNuiCursorType - this is for cases where the host cursor isn't sufficient
 		if (needsNuiCursor)
 		{
 			// do we need to draw a non-host cursor?
@@ -147,6 +154,10 @@ static HookFunction initFunction([] ()
 			}
 			// if we're SDK guest, also draw the cursor texture
 			else if (launch::IsSDKGuest())
+			{
+				shouldDrawCursorTexture = true;
+			}
+			else if (g_cursorType == 1)
 			{
 				shouldDrawCursorTexture = true;
 			}

--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -153,7 +153,7 @@ static InitFunction initFunction([] ()
 			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
 
 			++nuiWindowIdx;
-			
+
 			m_autogenHandle = fmt::sprintf("nui_resource_%d", nuiWindowIdx);
 
 			nui::CreateNUIWindow(m_autogenHandle, width, height, url);
@@ -302,7 +302,7 @@ static InitFunction initFunction([] ()
 		.AddMethod("SEND_DUI_MOUSE_DOWN", &NUIWindowWrapper::InjectMouseDown)
 		.AddMethod("SEND_DUI_MOUSE_UP", &NUIWindowWrapper::InjectMouseUp)
 		.AddMethod("SEND_DUI_MOUSE_WHEEL", &NUIWindowWrapper::InjectMouseWheel)
-		.AddMethod("DESTROY_DUI", &NUIWindowWrapper::Destroy);		
+		.AddMethod("DESTROY_DUI", &NUIWindowWrapper::Destroy);
 
 	// this *was* a multiset before but some resources would not correctly pair set/unset and then be stuck in 'set' state
 	static std::unordered_set<std::string> focusVotes;
@@ -489,5 +489,15 @@ static InitFunction initFunction([] ()
 				updateFocus();
 			}
 		}
+	});
+	fx::ScriptEngine::RegisterNativeHandler("SET_NUI_CURSOR_TYPE", [](fx::ScriptContext& context)
+	{
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			nui::CursorType(context.GetArgument<int>(0));
+		}
+		
 	});
 });


### PR DESCRIPTION
Offers the ability to use the texture cursor instead of the host cursor with SET_NUI_CURSOR_TYPE;

I think the texture cursor looks alot better than the default OS cursor most people will have.