### PR TITLE
feat(onesync): entity attached to native

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1633,6 +1633,28 @@ static void Init()
 
 		return speed;
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_ATTACHED_TO", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		int handle = 0;
+
+		if (auto attachment = entity->syncTree->GetAttachment())
+		{
+			if (attachment->attached)
+			{
+				auto resman = fx::ResourceManager::GetCurrent();
+				auto instance = resman->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+				auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+				if (auto entity = gameState->GetEntity(0, attachment->attachedTo))
+				{
+					handle = gameState->MakeScriptHandle(entity);
+				}
+			}
+		}
+
+		return handle;
+	}));
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/GetEntityAttachedTo.md
+++ b/ext/native-decls/GetEntityAttachedTo.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_ENTITY_ATTACHED_TO
+
+```c
+Entity GET_ENTITY_ATTACHED_TO(Entity entity);
+```
+
+Gets the entity that this entity is attached to.
+
+## Parameters
+* **entity**: The entity to check.
+
+## Return value
+The attached entity handle. 0 returned if the entity is not attached.


### PR DESCRIPTION
Adds the equivalent of [GET_ENTITY_ATTACHED_TO](https://docs.fivem.net/natives/?_0x48C2BED9180FE123) to the server