### PR TITLE
Assorted cursor fixes

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostImpl.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostImpl.cpp
@@ -504,6 +504,7 @@ static HookFunction initFunction([]()
 	io.ConfigWindowsResizeFromEdges = true;
 
 	io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+	io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
 
 	io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos; // We can honor io.WantSetMousePos requests (optional, rarely used)
 	io.BackendFlags |= ImGuiBackendFlags_PlatformHasViewports; // We can create multi-viewports on the Platform side (optional)

--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -692,16 +692,6 @@ void GtaNuiInterface::SetHostCursor(HCURSOR cursor)
 
 void GtaNuiInterface::SetHostCursorEnabled(bool enabled)
 {
-	static bool wasEnabled;
-
-	if (!enabled && wasEnabled)
-	{
-		SetClassLongPtr(CoreGetGameWindow(), GCLP_HCURSOR,
-			static_cast<LONG>(reinterpret_cast<LONG_PTR>(IDC_ARROW)));
-	}
-
-	wasEnabled = enabled;
-
 	InputHook::SetHostCursorEnabled(enabled);
 }
 #endif

--- a/code/components/nui-core/src/NUIClient.cpp
+++ b/code/components/nui-core/src/NUIClient.cpp
@@ -215,9 +215,18 @@ void NUIClient::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 	model->Clear();
 }
 
+extern HCURSOR g_defaultCursor;
+
 bool NUIClient::OnCursorChange(CefRefPtr<CefBrowser> browser, CefCursorHandle cursor, cef_cursor_type_t type, const CefCursorInfo& custom_cursor_info)
 {
-	g_nuiGi->SetHostCursor(cursor);
+	if (!cursor || type == CT_POINTER)
+	{
+		g_nuiGi->SetHostCursor(g_defaultCursor);
+	}
+	else
+	{
+		g_nuiGi->SetHostCursor(cursor);
+	}
 
 	return true;
 }

--- a/code/components/nui-core/src/NUIRenderCallbacks.cpp
+++ b/code/components/nui-core/src/NUIRenderCallbacks.cpp
@@ -23,6 +23,9 @@ extern std::shared_mutex g_nuiFocusStackMutex;
 extern std::list<std::string> g_nuiFocusStack;
 #endif
 
+HCURSOR g_defaultCursor;
+extern HCURSOR InitDefaultCursor();
+
 static HookFunction initFunction([] ()
 {
 #ifndef IS_RDR3
@@ -42,6 +45,14 @@ static HookFunction initFunction([] ()
 
 	g_nuiGi->OnRender.Connect([]()
 	{
+		static auto initCursor = ([]()
+		{
+			g_defaultCursor = InitDefaultCursor();
+			g_nuiGi->SetHostCursor(g_defaultCursor);
+
+			return true;
+		})();
+
 		// if we're in the main UI, make sure it has focus
 		if (nui::HasMainUI())
 		{


### PR DESCRIPTION
This PR includes two changes:

- b015dcc5433560287261deaec27cd49645aa44b0 implements something similar to #1109, replaces the default arrow cursor in NUI contexts with the citizen_cursor, though keeping the hardware cursor rendering for it.
- 3f8a1d129426b551cc9c9c8a7b0d5e11b9182dee *may* help with https://forum.cfx.re/t/cursor-invisible-after-opening-f8-console/4768705/27, I'm unable to actually repro the issue there so it might not fix it, however this flag being added doesn't break any existing behavior.

## Rationale
Bug fix and user request.

## Potential impact
No breaking issues are expected. This does not change any public API either.