### PR TITLE
Better looking adaptive cards (CSS)

### DIFF
--- a/ext/cfx-ui/src/app/servers/connecting-popup.component.scss
+++ b/ext/cfx-ui/src/app/servers/connecting-popup.component.scss
@@ -116,11 +116,8 @@
 
 				width: calc(100% + var(--q2));
 
-				padding: var(--q1);
-			}
-
-			@include theme() using ($theme) {
-				background-color: rgba(gtv($theme, fgColor), .25);
+				padding: 0 !important;
+				background-color: transparent !important;
 			}
 		}
 

--- a/ext/cfx-ui/src/app/servers/connecting-popup.component.scss
+++ b/ext/cfx-ui/src/app/servers/connecting-popup.component.scss
@@ -115,8 +115,8 @@
 				margin-right: calc(var(--q1) * -1);
 
 				width: calc(100% + var(--q2));
-
-				padding: 0 !important;
+				padding: var(--q2);
+				
 				background-color: transparent !important;
 			}
 		}


### PR DESCRIPTION
Removing the gray background makes using cards more viable for custom defer messages.
And removing the padding makes a possible background image more integrated.

Before:
![before](https://i.imgur.com/NrJGsYc.png)

After:
![after](https://i.imgur.com/zwDZyjt.png)