### PR TITLE
Fix IconColor being set to Color attribute of Checkpoint

### DIFF
--- a/code/client/clrcore/External/Checkpoint.cs
+++ b/code/client/clrcore/External/Checkpoint.cs
@@ -359,7 +359,7 @@ namespace CitizenFX.Core
 				{
 					return;
 				}
-				MemoryAccess.WriteInt(memoryAddress + 80, Color.ToArgb());
+				MemoryAccess.WriteInt(memoryAddress + 80, value.ToArgb());
 			}
 		}
 		/// <summary>
@@ -383,7 +383,7 @@ namespace CitizenFX.Core
 				{
 					return;
 				}
-				MemoryAccess.WriteInt(memoryAddress + 84, Color.ToArgb());
+				MemoryAccess.WriteInt(memoryAddress + 84, value.ToArgb());
 			}
 		}
 


### PR DESCRIPTION
Probably originally due to conflicting definitions, IconColor was set to the checkpoint's Color regardless of what value was passed to the setter