### PR TITLE
feat(scripting/lua): register msgpack table extension

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -1086,6 +1086,32 @@ msgpack.extend({
 
 msgpack.settype("function", EXT_FUNCREF)
 
+--[[ Register msgpack extension for tables --]]
+local EXT_TABLE = 12
+
+msgpack.extend_clear(EXT_TABLE)
+
+msgpack.extend({
+	__ext = EXT_TABLE,
+
+	__pack = function(self, tag)
+		local userdata = msgpack.new()
+		userdata:_table(self)
+
+		local mt = getmetatable(self)
+		if mt then userdata:table(mt) end
+
+		return tostring(userdata), not mt and true
+	end,
+
+	__unpack = function(data, tag)
+		local tbl, mt = msgpack.unpack(data)
+		return setmetatable(tbl, mt)
+	end,
+})
+
+msgpack.settype("table", EXT_TABLE)
+
 -- exports compatibility
 local function getExportEventName(resource, name)
 	return string.format('__cfx_export_%s_%s', resource, name)

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -4,6 +4,7 @@
 
 const EXT_FUNCREF = 10;
 const EXT_LOCALFUNCREF = 11;
+const EXT_TABLE = 12;
 
 (function (global) {
 	let boundaryIdx = 1;
@@ -122,6 +123,7 @@ const EXT_LOCALFUNCREF = 11;
 	codec.addExtPacker(EXT_FUNCREF, Function, refFunctionPacker);
 	codec.addExtUnpacker(EXT_FUNCREF, refFunctionUnpacker);
 	codec.addExtUnpacker(EXT_LOCALFUNCREF, refFunctionUnpacker);
+	codec.addExtUnpacker(EXT_TABLE, unpack);
 
 	/**
 	 * Deletes ref function


### PR DESCRIPTION
Allow packing of tables without losing metatables (within the Lua ScRT). Maybe there's a reason not to do this 🤷

```lua
players[source] = setmetatable(self, {
	__index = mt,
})
	
exports('getPlayer', function(source)
	return players[source]
end)


local player = exports.resource:getPlayer(1)
player:set('name', 'not an rp name'
local name = player:get('name') -- you get the idea
```