### PR TITLE
Add mumble channel natives for rdr3 compatibility

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -1236,6 +1236,22 @@ static HookFunction hookFunction([]()
 			g_mumbleClient->SetAudioOutputDistance(dist);
 		});
 
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_CLEAR_VOICE_CHANNEL", [](fx::ScriptContext& context)
+		{
+			if (g_mumble.connected)
+			{
+				g_mumbleClient->SetChannel("Root");
+			}
+		});
+
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_VOICE_CHANNEL", [](fx::ScriptContext& context)
+		{
+			if (g_mumble.connected)
+			{
+				g_mumbleClient->SetChannel(fmt::sprintf("Game Channel %d", context.GetArgument<int>(0)));
+			}
+		});
+
 		scrBindGlobal("GET_AUDIOCONTEXT_FOR_CLIENT", getAudioContext);
 		scrBindGlobal("GET_AUDIOCONTEXT_FOR_SERVERID", getAudioContextByServerId);
 

--- a/ext/native-decls/MumbleClearVoiceChannel.md
+++ b/ext/native-decls/MumbleClearVoiceChannel.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_CLEAR_VOICE_CHANNEL
+
+```c
+void MUMBLE_CLEAR_VOICE_CHANNEL();
+```

--- a/ext/native-decls/MumbleSetVoiceChannel.md
+++ b/ext/native-decls/MumbleSetVoiceChannel.md
@@ -1,0 +1,12 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_SET_VOICE_CHANNEL
+
+```c
+void MUMBLE_SET_VOICE_CHANNEL(int channel);
+```
+
+## Parameters
+* **channel**: A game voice channel ID.


### PR DESCRIPTION
After some testing with the recent Disquse PR, it seems there are no equivalent for some natives present in gta5 :
 - NetworkClearVoiceChannel (0xE036A705F989E049)
 - NetworkSetVoiceChannel (0xEF6212C2EFEF1A23)
 
These natives simply don't exist in RDR3 so there is no way to move the mumble client to any other channel (from my understanding).

These natives can be added back simply with this PR.
If Disquse has other plans for these natives, or if you think this is not the right way to implement this, feel free to close this PR as I was just trying to help with my minimal knowledge :)