### PR TITLE
'Tickless' resources

### DIFF
--- a/code/client/shared/EventCore.h
+++ b/code/client/shared/EventCore.h
@@ -311,6 +311,11 @@ public:
 private:
 	size_t ConnectInternal(TFunc func, int order)
 	{
+		if (!func)
+		{
+			return -1;
+		}
+
 		auto cookie = m_connectCookie++;
 		auto cb = std::unique_ptr<callback>(new callback(func));
 		cb->order = order;
@@ -341,6 +346,11 @@ private:
 public:
 	void Disconnect(size_t cookie)
 	{
+		if (cookie == -1)
+		{
+			return;
+		}
+
 		callback* prev = nullptr;
 
 		for (auto cb = m_callbacks.get(); cb; cb = cb->next.get())
@@ -383,7 +393,7 @@ public:
 
 		for (auto cb = m_callbacks.get(); cb; cb = cb->next.get())
 		{
-			if (cb->function && !std::invoke(cb->function, args...))
+			if (!std::invoke(cb->function, args...))
 			{
 				return false;
 			}

--- a/code/client/shared/Utils.cpp
+++ b/code/client/shared/Utils.cpp
@@ -183,13 +183,6 @@ void TraceRealV(const char* channel, const char* func, const char* file, int lin
 	CoreTrace(channel, func, file, line, buffer.data());
 
 #ifdef _WIN32
-	static CRITICAL_SECTION dbgCritSec;
-
-	if (!dbgCritSec.DebugInfo)
-	{
-		InitializeCriticalSectionAndSpinCount(&dbgCritSec, 100);
-	}
-
 #if !defined(GTA_NY)
 	if (CoreIsDebuggerPresent())
 	{

--- a/code/components/citizen-resources-core/include/Resource.h
+++ b/code/components/citizen-resources-core/include/Resource.h
@@ -98,9 +98,9 @@ public:
 	virtual bool Stop() = 0;
 
 	//
-	// Executes a tick on the resource.
+	// Runs a top-level execution callback.
 	//
-	virtual void Tick() = 0;
+	virtual void Run(std::function<void()>&& func) = 0;
 
 	//
 	// Gets a reference to the owning resource manager.
@@ -129,9 +129,14 @@ public:
 	fwEvent<> OnStop;
 
 	//
-	// An event to handle tasks to be performed when the resource ticks.
+	// An event invoked when the resource enters a top-level execution cycle.
 	//
-	fwEvent<> OnTick;
+	fwEvent<> OnEnter;
+
+	//
+	// An event invoked when the resource leaves a top-level execution cycle.
+	//
+	fwEvent<> OnLeave;
 
 	//
 	// An event to handle tasks to be performed when a resource is created, after the game loads.

--- a/code/components/citizen-resources-core/include/ResourceEventComponent.h
+++ b/code/components/citizen-resources-core/include/ResourceEventComponent.h
@@ -37,17 +37,6 @@ private:
 
 	ResourceEventManagerComponent* m_managerComponent;
 
-private:
-	struct EventData
-	{
-		std::string eventName;
-		std::string eventSource;
-		std::string eventPayload;
-	};
-
-private:
-	tbb::concurrent_queue<EventData> m_eventQueue;
-
 public:
 	ResourceEventComponent();
 
@@ -97,6 +86,7 @@ private:
 		std::string eventName;
 		std::string eventSource;
 		std::string eventPayload;
+		ResourceEventComponent* filter = nullptr;
 	};
 
 private:
@@ -135,12 +125,12 @@ public:
 	//
 	// Triggers an event immediately. Returns a value indicating whether the event was not canceled.
 	//
-	bool TriggerEvent(const std::string& eventName, const std::string& eventPayload, const std::string& eventSource = std::string());
+	bool TriggerEvent(const std::string& eventName, const std::string& eventPayload, const std::string& eventSource = std::string(), ResourceEventComponent* filter = nullptr);
 
 	//
 	// Enqueues an event for execution on the next resource manager tick.
 	//
-	void QueueEvent(const std::string& eventName, const std::string& eventPayload, const std::string& eventSource = std::string());
+	void QueueEvent(const std::string& eventName, const std::string& eventPayload, const std::string& eventSource = std::string(), ResourceEventComponent* filter = nullptr);
 
 public:
 	//

--- a/code/components/citizen-resources-core/include/ResourceImpl.h
+++ b/code/components/citizen-resources-core/include/ResourceImpl.h
@@ -13,7 +13,7 @@ namespace fx
 {
 class ResourceManagerImpl;
 
-class ResourceImpl : public Resource
+class ResourceImpl final : public Resource
 {
 private:
 	std::string m_name;
@@ -41,7 +41,7 @@ public:
 
 	virtual bool Stop() override;
 
-	virtual void Tick() override;
+	virtual void Run(std::function<void()>&& fn) override;
 
 	virtual ResourceManager* GetManager() override;
 

--- a/code/components/citizen-resources-core/include/ResourceManagerImpl.h
+++ b/code/components/citizen-resources-core/include/ResourceManagerImpl.h
@@ -15,7 +15,7 @@
 
 namespace fx
 {
-class ResourceManagerImpl : public ResourceManager
+class ResourceManagerImpl final : public ResourceManager
 {
 private:
 	std::recursive_mutex m_resourcesMutex;

--- a/code/components/citizen-resources-core/src/Resource.cpp
+++ b/code/components/citizen-resources-core/src/Resource.cpp
@@ -126,7 +126,7 @@ bool ResourceImpl::Stop()
 	return true;
 }
 
-void ResourceImpl::Tick()
+void ResourceImpl::Run(std::function<void()>&& fn)
 {
 	if (m_state != ResourceState::Started)
 	{
@@ -135,11 +135,14 @@ void ResourceImpl::Tick()
 
 	// save data in case we need to trace this back from dumps
 	char resourceNameBit[128];
-	strncpy(resourceNameBit, GetName().c_str(), std::size(resourceNameBit));
+	memcpy(resourceNameBit, GetName().c_str(), std::min(std::size(resourceNameBit), GetName().length() + 1));
 	debug::Alias(resourceNameBit);
 
-	// process tick
-	OnTick();
+	OnEnter();
+	fn();
+
+	// #TODO: unwind-dtor
+	OnLeave();
 }
 
 void ResourceImpl::Destroy()

--- a/code/components/citizen-resources-core/src/ResourceManager.cpp
+++ b/code/components/citizen-resources-core/src/ResourceManager.cpp
@@ -12,8 +12,6 @@
 
 #include <skyr/url.hpp>
 
-#include <ETWProviders/etwprof.h>
-
 static fx::ResourceManager* g_globalManager;
 static thread_local fx::ResourceManager* g_currentManager;
 
@@ -22,19 +20,6 @@ namespace fx
 ResourceManagerImpl::ResourceManagerImpl()
 {
 	OnInitializeInstance(this);
-
-	OnTick.Connect([this]()
-	{
-		// execute resource tick functions
-		ForAllResources([](fwRefContainer<Resource> resource)
-		{
-			// #TODO: 32 bit
-#ifdef _M_AMD64
-			CETWScope etwScope(va("%s tick", resource->GetName()));
-#endif
-			resource->Tick();
-		});
-	});
 }
 
 fwRefContainer<ResourceMounter> ResourceManagerImpl::GetMounterForUri(const std::string& uri)

--- a/code/components/citizen-scripting-core/include/PushEnvironment.h
+++ b/code/components/citizen-scripting-core/include/PushEnvironment.h
@@ -17,17 +17,26 @@ namespace fx
 	class PushEnvironment
 	{
 	private:
+		static inline auto CreateHandler()
+		{
+			OMPtr<IScriptRuntimeHandler> handler;
+			assert(FX_SUCCEEDED(fx::MakeInterface(&handler, CLSID_ScriptRuntimeHandler)));
+
+			return handler;
+		}
+
 		static inline auto EnsureHandler()
 		{
-			static auto rv = ([]()
+			static auto handler = CreateHandler();
+
+			if (!handler.GetRef())
 			{
-				OMPtr<IScriptRuntimeHandler> handler;
-				fx::MakeInterface(&handler, CLSID_ScriptRuntimeHandler);
+				handler = CreateHandler();
+			}
 
-				return handler;
-			})();
+			assert(handler.GetRef());
 
-			return rv;
+			return handler;
 		}
 
 		OMPtr<IScriptRuntimeHandler> m_handler;
@@ -57,14 +66,14 @@ namespace fx
 			
 		}
 
-		inline PushEnvironment(PushEnvironment&& right)
+		inline PushEnvironment(PushEnvironment&& right) noexcept
 			: m_handler(right.m_handler), m_curRuntime(right.m_curRuntime)
 		{
 			right.m_curRuntime = {};
 			right.m_handler = {};
 		}
 
-		inline PushEnvironment& operator=(PushEnvironment&& right)
+		inline PushEnvironment& operator=(PushEnvironment&& right) noexcept
 		{
 			m_handler = right.m_handler;
 			m_curRuntime = right.m_curRuntime;

--- a/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
+++ b/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
@@ -14,11 +14,17 @@
 
 #include "ResourceMetaDataComponent.h"
 
+#ifdef COMPILING_CITIZEN_SCRIPTING_CORE
+#define SCRIPTING_CORE_EXPORT DLL_EXPORT
+#else
+#define SCRIPTING_CORE_EXPORT DLL_IMPORT
+#endif
+
 namespace fx
 {
 class Resource;
 
-class ResourceScriptingComponent : public fwRefCountable
+class ResourceScriptingComponent final : public fwRefCountable
 {
 private:
 	Resource* m_resource;
@@ -27,7 +33,7 @@ private:
 
 	tbb::concurrent_unordered_map<int32_t, fx::OMPtr<IScriptRuntime>> m_scriptRuntimes;
 
-	tbb::concurrent_unordered_map<int32_t, fx::OMPtr<IScriptTickRuntime>> m_tickRuntimes;
+	std::unordered_map<int32_t, fx::OMPtr<IScriptTickRuntime>> m_tickRuntimes;
 
 	tbb::concurrent_unordered_set<std::string> m_eventsHandled;
 
@@ -82,6 +88,8 @@ public:
 	{
 		m_eventsHandled.insert(eventName);
 	}
+
+	SCRIPTING_CORE_EXPORT void Tick();
 };
 
 class ScriptMetaDataComponent : public OMClass<ScriptMetaDataComponent, IScriptHostWithResourceData, IScriptHostWithManifest>

--- a/code/components/citizen-scripting-core/include/fxScripting.idl
+++ b/code/components/citizen-scripting-core/include/fxScripting.idl
@@ -93,6 +93,14 @@ interface IScriptTickRuntime : fxIBase
 	void Tick();
 };
 
+[ptr] native u64Ptr(uint64_t);
+
+[uuid(195FB3BD-1A64-4EBD-A1CC-8052ED7EB0BD)]
+interface IScriptTickRuntimeWithBookmarks : fxIBase
+{
+	void TickBookmarks(in u64Ptr bookmarks, in int32_t numBookmarks);
+};
+
 [uuid(637140DB-24E5-46BF-A8BD-08F2DBAC519A)]
 interface IScriptEventRuntime : fxIBase
 {
@@ -159,6 +167,13 @@ interface IScriptDebugRuntime : fxIBase
 	void SetScriptIdentifier(in charPtr fileName, in int32_t scriptId);
 };
 
+[uuid(2A7E092D-6CE9-4B9D-AC4F-8DA818BD0DA4)]
+interface IScriptHostWithBookmarks : fxIBase
+{
+	void ScheduleBookmark(in IScriptTickRuntimeWithBookmarks runtime, in uint64_t bookmark, in int64_t deadline);
+
+	void RemoveBookmarks(in IScriptTickRuntimeWithBookmarks runtime);
+};
 
 %{C++
 #include "PushEnvironment.h"

--- a/code/components/citizen-scripting-mono/include/MonoThreadAttachment.h
+++ b/code/components/citizen-scripting-mono/include/MonoThreadAttachment.h
@@ -1,4 +1,4 @@
 #pragma once
 
 // ensures that Mono is attached to the current thread
-DLL_IMPORT void MonoEnsureThreadAttached();
+extern "C" DLL_IMPORT void MonoEnsureThreadAttached();

--- a/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
@@ -8,7 +8,7 @@
 #include "StdInc.h"
 #include <om/OMComponent.h>
 
-#include <Resource.h>
+#include <ResourceManager.h>
 
 #include <fxScripting.h>
 
@@ -582,7 +582,7 @@ struct MonoAttachment
 	}
 };
 
-DLL_EXPORT void MonoEnsureThreadAttached()
+extern "C" DLL_EXPORT void MonoEnsureThreadAttached()
 {
 	if (!g_rootDomain)
 	{
@@ -657,9 +657,7 @@ static InitFunction initFunction([] ()
 {
 	static ConVar<bool> memoryUsageVar("mono_enableMemoryUsageTracking", ConVar_None, true, &g_enableMemoryUsage);
 
-	// should've been ResourceManager but ResourceManager OnTick happens _after_ individual resource ticks
-	// which is too early for on-start Mono resources to have run
-	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* instance)
+	fx::ResourceManager::OnInitializeInstance.Connect([](fx::ResourceManager* instance)
 	{
 		instance->OnTick.Connect([]()
 		{

--- a/code/components/citizen-server-fxdk/include/SdkIpc.h
+++ b/code/components/citizen-server-fxdk/include/SdkIpc.h
@@ -9,6 +9,8 @@
 
 #include <condition_variable>
 
+#include <ResourceMonitor.h>
+
 #include <UvLoopManager.h>
 #include <ResourceManager.h>
 #include <ServerInstanceBase.h>
@@ -103,6 +105,8 @@ namespace fxdk
 		fwRefContainer<fx::ServerInstanceBase> m_instance;
 
 		SingleshotSemaphore m_inited;
+
+		std::unique_ptr<fx::ResourceMonitor> m_resourceMonitor;
 
 		void Quit(const std::string& error);
 	};

--- a/code/components/citizen-server-fxdk/src/SdkIpc.cpp
+++ b/code/components/citizen-server-fxdk/src/SdkIpc.cpp
@@ -750,11 +750,13 @@ namespace fxdk
 
 		g_messagesQueue.clear();
 
+		m_resourceMonitor = std::make_unique<fx::ResourceMonitor>();
+
 		m_timer = GetSdkIpcLoop()->resource<uvw::TimerHandle>();
 
-		m_timer->on<uvw::TimerEvent>([ipc](const uvw::TimerEvent& evt, uvw::TimerHandle&)
+		m_timer->on<uvw::TimerEvent>([this, ipc](const uvw::TimerEvent& evt, uvw::TimerHandle&)
 		{
-			const auto& resourceDatas = fx::ResourceMonitor::GetCurrent()->GetResourceDatas();
+			const auto& resourceDatas = m_resourceMonitor->GetResourceDatas();
 
 			std::vector<std::tuple<std::string, double, double, int64_t, int64_t>> resourceDatasClean;
 			for (const auto& data : resourceDatas)

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -4,6 +4,7 @@
 #include <ResourceEventComponent.h>
 #include <ResourceMetaDataComponent.h>
 #include <ResourceManagerConstraintsComponent.h>
+#include <ResourceScriptingComponent.h>
 
 #include <fxScripting.h>
 
@@ -1231,7 +1232,9 @@ static InitFunction initFunction2([]()
 			if (resource.GetRef())
 			{
 				resource->GetManager()->MakeCurrent();
-				resource->Tick();
+
+				// #TODOTICKLESS: handle bookmark-based resources
+				resource->GetComponent<fx::ResourceScriptingComponent>()->Tick();
 			}
 		}, true);
 	});

--- a/code/components/citizen-server-impl/src/ServerWatchdog.cpp
+++ b/code/components/citizen-server-impl/src/ServerWatchdog.cpp
@@ -270,7 +270,7 @@ struct WatchdogWarningComponent : public fwRefCountable, public fx::IAttached<fx
 			}
 		}, 100);
 
-		resource->OnTick.Connect([resourceName]()
+		resource->OnEnter.Connect([resourceName]()
 		{
 			auto th = GetThread();
 
@@ -280,7 +280,7 @@ struct WatchdogWarningComponent : public fwRefCountable, public fx::IAttached<fx
 			}
 		}, INT32_MIN);
 
-		resource->OnTick.Connect([]()
+		resource->OnLeave.Connect([]()
 		{
 			auto th = GetThread();
 

--- a/code/components/scripting-server/include/ScriptEngine.h
+++ b/code/components/scripting-server/include/ScriptEngine.h
@@ -162,3 +162,28 @@ namespace fx
 		static void RegisterNativeHandler(const std::string& nativeName, TNativeHandler function);
 	};
 }
+
+// common helper
+class FxNativeInvoke
+{
+private:
+	static inline void Invoke(fx::ScriptContext& cxt, const boost::optional<fx::TNativeHandler>& handler)
+	{
+		(*handler)(cxt);
+	}
+
+public:
+	template<typename R, typename... Args>
+	static inline R Invoke(const boost::optional<fx::TNativeHandler>& handler, Args... args)
+	{
+		fx::ScriptContextBuffer cxt;
+		(cxt.Push(args), ...);
+
+		Invoke(cxt, handler);
+
+		if constexpr (!std::is_void_v<R>)
+		{
+			return cxt.GetResult<R>();
+		}
+	}
+};


### PR DESCRIPTION
Removes `OnTick` for resources itself, instead handling this in manager scope. Also, implements native 'bookmarks' for Lua scheduling instead of doing this in the HLL.

Closes #1153 once merged - perhaps-WIP currently.

# Rationale

Servers often have hundreds of (mostly idle) Lua resources. Profiling showed around 30-40% of script frame time spent on servers like Tycoon (see #1153) was overhead.

# Validation

## Performance
* Earlier versions of this patch set went down from 1.5 msec of script time to <0.2 msec of script tick time in a contrived setup (200 resources each having a single Wait(5000) no-op loop + chat/spawnmanager/mapmanager as used in basic-gamemode)
* Tycoon went down from 5.8 msec of script time to 4.0 msec of script time.
* The queue bits aren't micro-optimized, needs profiling later on.

## Correctness
* Can join and play on Tycoon and a default server without issues. vMenu (a C# resource) also still executes and is tracked.
* Stack trace stitching was tested using `stest` series of resources.
* Profiler was tested to still record general resource data.
* Resource monitor shows data, uncertain if it is entirely correct.
* Citizen.Await still works.

# Risks

* Execution order doesn't exactly match old logic, sometimes resources may run interleaved.
* ~~Profiler has only had minimal testing,~~ some other diag tools (resmon?) may break too in rare scenarios (resource start/stop?).
* ~~`StartResource` on the server from a bookmark may be unsafe, this hasn't been tested.~~ Works fine.
* ~~RPC hasn't been tested, yet.~~ Also works, and correctly attributes to script.