### PR TITLE
Increase script handler pools size for RDR3

### DIFF
--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -1724,10 +1724,18 @@
           <PoolName>CScenarioPropManager::ActiveSchedule</PoolName>
           <PoolSize value="32"/>
         </Item>
-                <Item>
-	              <PoolName>CGameScriptHandlerNetwork</PoolName>
-	              <PoolSize value="50"/>
-	            </Item>
+        <Item>
+          <PoolName>CGameScriptHandlerNetwork</PoolName>
+          <PoolSize value="750"/>
+        </Item>
+        <Item>
+          <PoolName>CGameScriptHandlerNetComponent</PoolName>
+          <PoolSize value="850"/>
+        </Item>
+        <Item>
+          <PoolName>CGameScriptHandler</PoolName>
+          <PoolSize value="750"/>
+        </Item>
 				<Item>
 					<PoolName>NavMeshRoute</PoolName>
 					<PoolSize value="200"/>


### PR DESCRIPTION
Should resolve script handler pool crashes in RedM (`CGameScriptHandler` a.k.a. 0x1182232C).