### PR TITLE
feat(extra-natives-five): add GET_WEAPON_ANIMATION_OVERRIDE

### DIFF
--- a/ext/native-decls/GetWeaponAnimationOverride.md
+++ b/ext/native-decls/GetWeaponAnimationOverride.md
@@ -1,0 +1,22 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_WEAPON_ANIMATION_OVERRIDE
+
+```c
+Hash GET_WEAPON_ANIMATION_OVERRIDE(Ped ped);
+```
+A getter for [SET_WEAPON_ANIMATION_OVERRIDE](_0x1055AC3A667F09D9).
+
+## Examples
+
+```lua
+local weaponAnimation = GetWeaponAnimationOverride(PlayerPedId())
+```
+
+## Parameters
+* **ped**: The target ped.
+
+## Return value
+The weapon animation override.


### PR DESCRIPTION
Adds a getter for [SET_WEAPON_ANIMATION_OVERRIDE](https://docs.fivem.net/natives/?_0x1055AC3A667F09D9), tested across all game builds (1604, 2060, 2189 and 2372).