### PR TITLE
feat(onesync): vehicle damage status research

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -474,6 +474,13 @@ struct CHeliHealthNodeData
 	int tailRotorHealth;
 };
 
+struct CVehicleDamageStatusNodeData
+{
+	bool damagedByBullets;
+	bool anyWindowBroken;
+	bool windowsState[8];
+};
+
 enum ePopType
 {
 	POPTYPE_UNKNOWN = 0,
@@ -555,6 +562,8 @@ public:
 	virtual CDummyObjectCreationNodeData* GetDummyObjectState() = 0;
 
 	virtual CHeliHealthNodeData* GetHeliHealth() = 0;
+
+	virtual CVehicleDamageStatusNodeData* GetVehicleDamageStatus() = 0;
 
 	virtual void CalculatePosition() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -831,7 +831,91 @@ struct CVehicleAppearanceDataNode {
 	}
 };
 
-struct CVehicleDamageStatusDataNode { bool Parse(SyncParseState& state) { return true; } };
+struct CVehicleDamageStatusDataNode
+{
+	CVehicleDamageStatusNodeData data;
+
+	bool Parse(SyncParseState& state)
+	{
+		bool anyBodyDeformation = state.buffer.ReadBit();
+
+		if (anyBodyDeformation)
+		{
+			uint8_t frontDamageLevel = state.buffer.Read<uint8_t>(2);
+			uint8_t rearDamageLevel = state.buffer.Read<uint8_t>(2);
+			uint8_t leftDamageLevel = state.buffer.Read<uint8_t>(2);
+			uint8_t rightDamageLevel = state.buffer.Read<uint8_t>(2);
+			uint8_t rearLeftLevel = state.buffer.Read<uint8_t>(2);
+			uint8_t rearRightLevel = state.buffer.Read<uint8_t>(2);
+		}
+
+		data.damagedByBullets = state.buffer.ReadBit();
+
+		if (data.damagedByBullets)
+		{
+			for (int i = 0; i < 6; i++)
+			{
+				uint8_t bulletsCount = state.buffer.Read<uint8_t>(8);
+			}
+		}
+
+		bool anyBumperBroken = state.buffer.ReadBit();
+
+		if (anyBumperBroken)
+		{
+			uint8_t frontBumperState = state.buffer.Read<uint8_t>(2);
+			uint8_t rearBumperState = state.buffer.Read<uint8_t>(2);
+		}
+
+		bool anyLightBroken = state.buffer.ReadBit();
+
+		if (anyLightBroken)
+		{
+			for (int i = 0; i < 22; i++)
+			{
+				bool lightBroken = state.buffer.ReadBit();
+			}
+		}
+
+		data.anyWindowBroken = state.buffer.ReadBit();
+
+		if (data.anyWindowBroken)
+		{
+			for (int i = 0; i < 8; i++)
+			{
+				data.windowsState[i] = state.buffer.ReadBit();
+			}
+		}
+
+		bool unk = state.buffer.ReadBit();
+
+		if (unk)
+		{
+			for (int i = 0; i < 8; i++)
+			{
+				float unk2 = state.buffer.ReadSignedFloat(10, 100.0f);
+
+				if (unk2 != 100.0f)
+				{
+					int unk3 = state.buffer.Read<int>(8);
+				}
+			}
+		}
+
+		bool anySirenBroken = state.buffer.ReadBit();
+
+		if (anySirenBroken)
+		{
+			for (int i = 0; i < 20; i++)
+			{
+				bool sirenBroken = state.buffer.ReadBit();
+			}
+		}
+
+		return true;
+	}
+};
+
 struct CVehicleComponentReservationDataNode { bool Parse(SyncParseState& state) { return true; } };
 
 struct CVehicleHealthDataNode
@@ -3284,6 +3368,13 @@ struct SyncTree : public SyncTreeBase
 	virtual CHeliHealthNodeData* GetHeliHealth() override
 	{
 		auto [hasNode, node] = GetData<CHeliHealthDataNode>();
+
+		return hasNode ? &node->data : nullptr;
+	}
+
+	virtual CVehicleDamageStatusNodeData* GetVehicleDamageStatus() override
+	{
+		auto [hasNode, node] = GetData<CVehicleDamageStatusDataNode>();
 
 		return hasNode ? &node->data : nullptr;
 	}

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -1203,6 +1203,11 @@ struct SyncTree : public SyncTreeBase
 		return nullptr;
 	}
 
+	virtual CVehicleDamageStatusNodeData* GetVehicleDamageStatus() override
+	{
+		return nullptr;
+	}
+
 	virtual void CalculatePosition() override
 	{
 		// TODO: cache it?

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1671,6 +1671,31 @@ static void Init()
 
 		return heliHealth ? float(heliHealth->tailRotorHealth) : 0.0f;
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("HAS_VEHICLE_BEEN_DAMAGED_BY_BULLETS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto status = entity->syncTree->GetVehicleDamageStatus();
+
+		return status ? status->damagedByBullets : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_WINDOW_INTACT", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto status = entity->syncTree->GetVehicleDamageStatus();
+		int index = context.GetArgument<int>(1);
+
+		if (!status)
+		{
+			return false;
+		}
+
+		if (index < 0 || index > 7)
+		{
+			return false;
+		}
+
+		return status->anyWindowBroken ? !status->windowsState[index] : true;
+	}));
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/HasVehicleBeenDamagedByBullets.md
+++ b/ext/native-decls/HasVehicleBeenDamagedByBullets.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## HAS_VEHICLE_BEEN_DAMAGED_BY_BULLETS
+
+```c
+BOOL HAS_VEHICLE_BEEN_DAMAGED_BY_BULLETS(Vehicle vehicle);
+```
+
+## Parameters
+* **vehicle**: The target vehicle.
+
+## Return value
+Returns whether or not the target vehicle has been damaged by bullets.

--- a/ext/native-decls/IsVehicleWindowIntact.md
+++ b/ext/native-decls/IsVehicleWindowIntact.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## IS_VEHICLE_WINDOW_INTACT
+
+```c
+BOOL IS_VEHICLE_WINDOW_INTACT(Vehicle vehicle, int windowIndex);
+```
+
+See the client-side [IS_VEHICLE_WINDOW_INTACT](https://docs.fivem.net/natives/?_0x46E571A0E20D01F1) for a window indexes list.
+
+## Parameters
+* **vehicle**: The target vehicle.
+* **windowIndex**: The window index.
+
+## Return value


### PR DESCRIPTION
This PR adds 2 natives : 
- `HAS_VEHICLE_BEEN_DAMAGED_BY_BULLETS`
- `IS_VEHICLE_WINDOW_INTACT`