### PR TITLE
fix(docs): update vs2019 to vs2022

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -4,7 +4,7 @@
 
 To build FiveM, RedM or FXServer on Windows you need the following dependencies:
 
-* A Windows machine with Visual Studio 2019 (Build Tools/Community is fine) installed with the following workloads:
+* A Windows machine with Visual Studio 2022 (Build Tools/Community is fine) installed with the following workloads:
   - .NET desktop environment
   - Desktop development with C++
   - Universal Windows Platform development


### PR DESCRIPTION
This comes from a conversation with someone in another discord having issues trying to build the files because they were using vs2019 instead of vs2022