### PR TITLE
feat(streaming-five): Add support for other Game Events (Emitting and Reacting)

### DIFF
--- a/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
@@ -9,42 +9,43 @@
 
 static InitFunction initFunction([]
 {
-	OnTriggerGameEventReact.Connect([](std::string_view data)
+	OnTriggerGameEventReact.Connect([](const GameEventData& data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();
 		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
 
-		/*NETEV gameEventReact CLIENT
+		/*NETEV gameEventReact:CEventName CLIENT
 		/#*
 		 * An event that is triggered when the game triggers an internal network event.
+		 * CEventName can be any event name that GTA 5 throws, e.g.: "gameEventEmit:CEventShockingCarCrash".
+		 * see: https://docs.fivem.net/docs/game-references/game-events/ for a list of known events.
 		 *
-		 * @param name - The name of the triggered event.
-		 * @param id - The id of the triggered event.
 		 * @param entity - The entity reacting.
 		 * @param data - The type-specific event data.
 		 #/
-		declare function gameEventReact(name: string, id: number, entity: number, data: var[]): void;
+		declare function gameEventReact:CEventName(entity: number, data: var[]): void;
 		*/
-		rec->QueueEvent("gameEventReact", std::string(data), "");
+		
+		rec->QueueEvent(std::string("gameEventReact:") + data.name, std::string(data.argsData), "");
 	});
 
-	OnTriggerGameEventEmit.Connect([](std::string_view data)
+	OnTriggerGameEventEmit.Connect([](const GameEventData& data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();
 		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
 
-		/*NETEV gameEventEmit CLIENT
+		/*NETEV gameEventEmit:CEventName CLIENT
 		/#*
 		 * An event that is triggered when the game triggers an internal network event.
+		 * CEventName can be any event name that GTA 5 throws, e.g.: "gameEventEmit:CEventShockingCarCrash".
+		 * see: https://docs.fivem.net/docs/game-references/game-events/ for a list of known events.
 		 *
-		 * @param name - The name of the triggered event.
-		 * @param id - The id of the triggered event.
-		 * @param entities - The entities being alerted.
+		 * @param entities - The entities being alerted (can be empty).
 		 * @param data - The type-specific event data.
 		 #/
-		declare function gameEventEmit(name: string, id: number, entities: number[], data: var[]): void;
+		declare function gameEventEmit:CEventName(entities: number[], data: var[]): void;
 		*/
-		rec->QueueEvent("gameEventEmit", std::string(data), "");
+		rec->QueueEvent(std::string("gameEventEmit:") + data.name, std::string(data.argsData), "");
 	});
 
 	OnTriggerGameEvent.Connect([](const GameEventMetaData& data)

--- a/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
@@ -9,6 +9,44 @@
 
 static InitFunction initFunction([]
 {
+	OnTriggerGameEventReact.Connect([](const GameEventReactData& data)
+	{
+		auto resman = Instance<fx::ResourceManager>::Get();
+		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
+
+		/*NETEV gameEventReact CLIENT
+		/#*
+		 * An event that is triggered when the game triggers an internal network event.
+		 *
+		 * @param name - The name of the triggered event.
+		 * @param id - The id of the triggered event.
+		 * @param entity - The entity reacting.
+		 * @param data - The type-specific event data.
+		 #/
+		declare function gameEventReact(name: string, id: number, entity: number, data: var[]): void;
+		*/
+		rec->QueueEvent2("gameEventReact", {}, std::string(data.name), data.id, data.entity, data.arguments);
+	});
+
+	OnTriggerGameEventEmit.Connect([](const GameEventEmitData& data)
+	{
+		auto resman = Instance<fx::ResourceManager>::Get();
+		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
+
+		/*NETEV gameEventEmit CLIENT
+		/#*
+		 * An event that is triggered when the game triggers an internal network event.
+		 *
+		 * @param name - The name of the triggered event.
+		 * @param id - The id of the triggered event.
+		 * @param entities - The entities being alerted.
+		 * @param data - The type-specific event data.
+		 #/
+		declare function gameEventEmit(name: string, id: number, entities: number[], data: var[]): void;
+		*/
+		rec->QueueEvent2("gameEventEmit", {}, std::string(data.name), data.id, data.entities, data.arguments);
+	});
+
 	OnTriggerGameEvent.Connect([](const GameEventMetaData& data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();

--- a/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
@@ -9,7 +9,7 @@
 
 static InitFunction initFunction([]
 {
-	OnTriggerGameEventReact.Connect([](const GameEventReactData& data)
+	OnTriggerGameEventReact.Connect([](std::string_view data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();
 		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
@@ -25,10 +25,10 @@ static InitFunction initFunction([]
 		 #/
 		declare function gameEventReact(name: string, id: number, entity: number, data: var[]): void;
 		*/
-		rec->QueueEvent2("gameEventReact", {}, std::string(data.name), data.id, data.entity, data.arguments);
+		rec->QueueEvent("gameEventReact", std::string(data), "");
 	});
 
-	OnTriggerGameEventEmit.Connect([](const GameEventEmitData& data)
+	OnTriggerGameEventEmit.Connect([](std::string_view data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();
 		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
@@ -44,7 +44,7 @@ static InitFunction initFunction([]
 		 #/
 		declare function gameEventEmit(name: string, id: number, entities: number[], data: var[]): void;
 		*/
-		rec->QueueEvent2("gameEventEmit", {}, std::string(data.name), data.id, data.entities, data.arguments);
+		rec->QueueEvent("gameEventEmit", std::string(data), "");
 	});
 
 	OnTriggerGameEvent.Connect([](const GameEventMetaData& data)

--- a/code/components/gta-streaming-five/component.json
+++ b/code/components/gta-streaming-five/component.json
@@ -8,7 +8,8 @@
 		"gta:core",
 		"vfs:core",
 		"rage:formats",
-		"vendor:tbb"
+		"vendor:tbb",
+		"vendor:msgpack-c"
 	],
 	"provides": []
 }

--- a/code/components/gta-streaming-five/component.json
+++ b/code/components/gta-streaming-five/component.json
@@ -8,8 +8,8 @@
 		"gta:core",
 		"vfs:core",
 		"rage:formats",
-		"vendor:tbb",
-		"vendor:msgpack-c"
+		"vendor:msgpack-c",
+		"vendor:tbb"
 	],
 	"provides": []
 }

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -703,9 +703,15 @@ struct GameEventMetaData
 
 STREAMING_EXPORT extern fwEvent<const GameEventMetaData&> OnTriggerGameEvent;
 
-STREAMING_EXPORT extern fwEvent<std::string_view> OnTriggerGameEventReact;
+struct GameEventData
+{
+	const char* name;
+	std::string_view argsData;
+};
 
-STREAMING_EXPORT extern fwEvent<std::string_view> OnTriggerGameEventEmit;
+STREAMING_EXPORT extern fwEvent<const GameEventData&> OnTriggerGameEventReact;
+
+STREAMING_EXPORT extern fwEvent<const GameEventData&> OnTriggerGameEventEmit;
 
 struct DamageEventMetaData
 {

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -6,7 +6,6 @@
 #include <Pool.h>
 
 #include <boost/type_index/ctti_type_index.hpp>
-#include <msgpack.hpp>
 
 #include <directxmath.h>
 
@@ -704,25 +703,9 @@ struct GameEventMetaData
 
 STREAMING_EXPORT extern fwEvent<const GameEventMetaData&> OnTriggerGameEvent;
 
-struct GameEventReactData
-{
-	int32_t id;
-	const char* name;
-	uint32_t entity;
-	std::vector<msgpack::object> arguments;
-};
+STREAMING_EXPORT extern fwEvent<std::string_view> OnTriggerGameEventReact;
 
-STREAMING_EXPORT extern fwEvent<const GameEventReactData&> OnTriggerGameEventReact;
-
-struct GameEventEmitData
-{
-	int32_t id;
-	const char* name;
-	std::vector<uint32_t> entities;
-	std::vector<msgpack::object> arguments;
-};
-
-STREAMING_EXPORT extern fwEvent<const GameEventEmitData&> OnTriggerGameEventEmit;
+STREAMING_EXPORT extern fwEvent<std::string_view> OnTriggerGameEventEmit;
 
 struct DamageEventMetaData
 {

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -6,6 +6,7 @@
 #include <Pool.h>
 
 #include <boost/type_index/ctti_type_index.hpp>
+#include <msgpack.hpp>
 
 #include <directxmath.h>
 
@@ -696,12 +697,32 @@ STREAMING_EXPORT extern fwEvent<PopulationCreationState*> OnCreatePopulationPed;
 
 struct GameEventMetaData
 {
-	char name[256];
+	const char* name;
 	size_t numArguments;
-	uintptr_t arguments[48];
+	size_t arguments[48];
 };
 
 STREAMING_EXPORT extern fwEvent<const GameEventMetaData&> OnTriggerGameEvent;
+
+struct GameEventReactData
+{
+	int32_t id;
+	const char* name;
+	uint32_t entity;
+	std::vector<msgpack::object> arguments;
+};
+
+STREAMING_EXPORT extern fwEvent<const GameEventReactData&> OnTriggerGameEventReact;
+
+struct GameEventEmitData
+{
+	int32_t id;
+	const char* name;
+	std::vector<uint32_t> entities;
+	std::vector<msgpack::object> arguments;
+};
+
+STREAMING_EXPORT extern fwEvent<const GameEventEmitData&> OnTriggerGameEventEmit;
 
 struct DamageEventMetaData
 {

--- a/code/components/gta-streaming-five/src/GameEventHooks.cpp
+++ b/code/components/gta-streaming-five/src/GameEventHooks.cpp
@@ -111,9 +111,10 @@ void* HandleEventWrapReact(rage::fwEventGroup* group, rage::fwEvent* event)
 				{
 					const float* position = (const float*)(event + 8);
 					rage::fwEntity* entity = ((rage::fwEntity**)event)[13];
-					data.entity = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
+					uint32_t id = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
 
-					data.arguments.reserve(3);
+					data.arguments.reserve(4);
+					data.arguments.emplace_back(id);
 					data.arguments.emplace_back(position[0]);
 					data.arguments.emplace_back(position[1]);
 					data.arguments.emplace_back(position[2]);
@@ -125,14 +126,24 @@ void* HandleEventWrapReact(rage::fwEventGroup* group, rage::fwEvent* event)
 					// TODO: check how we will do this without a strcmp
 					if (strcmp(data.name + 15, "WalkIntoVehicle") == 0)
 					{
-						const float* position = (const float*)(event + 11);
+						const float* position = (const float*)(event + 5);
 						rage::fwEntity* entity = ((rage::fwEntity**)event)[8];
-						data.entity = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
+						uint32_t id = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
 
-						data.arguments.reserve(3);
+						data.arguments.reserve(4);
+						data.arguments.emplace_back(id);
 						data.arguments.emplace_back(position[0]);
 						data.arguments.emplace_back(position[1]);
 						data.arguments.emplace_back(position[2]);
+					}
+					else if (strcmp(data.name + 15, "GetRunOver") == 0)
+					{
+						const float* position = (const float*)(event + 10);
+						rage::fwEntity* entity = ((rage::fwEntity**)event)[6];
+						uint32_t id = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
+
+						data.arguments.emplace_back(id);
+						// doesn't seem there is a vector3, might have other info, speed, vector2?
 					}
 
 					break;
@@ -187,36 +198,6 @@ void* HandleEventWrapEmit(rage::fwEventGroup* group, rage::fwEvent* event)
 					data.arguments.emplace_back(position[0]);
 					data.arguments.emplace_back(position[1]);
 					data.arguments.emplace_back(position[2]);
-					break;
-				}
-				case 0x6169746e65746f50u: // "Potentia" little endian
-				{
-					// TODO: check how we will do this without a strcmp
-					if (strcmp(data.name + 15, "WalkIntoVehicle") == 0)
-					{
-						const float* position = (const float*)(event + 11);
-						rage::fwEntity* entity = ((rage::fwEntity**)event)[8];
-						uint32_t id = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
-
-						data.arguments.reserve(4);
-						data.arguments.emplace_back(id);
-						data.arguments.emplace_back(position[0]);
-						data.arguments.emplace_back(position[1]);
-						data.arguments.emplace_back(position[2]);
-					}
-					else if (strcmp(data.name + 15, "GetRunOver") == 0)
-					{
-						const float* position = (const float*)(event + 10);
-						rage::fwEntity* entity = ((rage::fwEntity**)event)[6];
-						uint32_t id = entity ? rage::fwScriptGuid::GetGuidFromBase(entity) : 0;
-
-						data.arguments.reserve(4);
-						data.arguments.emplace_back(id);
-						data.arguments.emplace_back(position[0]);
-						data.arguments.emplace_back(position[1]);
-						data.arguments.emplace_back(position[2]);
-					}
-
 					break;
 				}
 			}

--- a/code/components/handling-loader-five/component.json
+++ b/code/components/handling-loader-five/component.json
@@ -4,8 +4,7 @@
 	"dependencies": [
 		"fx[2]",
 		"scripting",
-		"gta:streaming:five",
-		"vendor:msgpack-c"
+		"gta:streaming:five"
 	],
 	"provides": []
 }

--- a/code/components/handling-loader-five/component.json
+++ b/code/components/handling-loader-five/component.json
@@ -4,7 +4,8 @@
 	"dependencies": [
 		"fx[2]",
 		"scripting",
-		"gta:streaming:five"
+		"gta:streaming:five",
+		"vendor:msgpack-c"
 	],
 	"provides": []
 }


### PR DESCRIPTION
This update will re-enable the hooking for the missing game events and retrieves all entities associated with it.

I've created separate scripting events that are being called, this, to allow fitting arguments to be passed to scripts and not to break existing listeners. They are called "gameEventEmit" and "gameEventReact" respectively as there are 3 game event versions; 1 that's already handled with "gameEventTriggered", 1 that sends an event to nearby entities (like when an event just occured), and the last 1 by who entities react to previous events (e.g.: CEventShockingDeadBody).

Events like CEventShocking*, CEventPotentialWalkIntoVehicle, and CEventPotentialGetRunOver already retrieve the world position.
To support more events' data retrieval we would need to analyze the event data and setup proper conversions.

Adding include/dependency : "vendor:msgpack-c" to 2 projects: gta-streaming-five and handling-loader-five. To allow this new event parser to send more types to scripts (e.g.: uint32 and float);