### PR TITLE
tweak(scripting/lua): Citizen.Await promise handling

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -160,7 +160,7 @@ const EXT_LOCALFUNCREF = 11;
 								cb([v], null);
 						}).catch(err => {
 							if (cb != null)
-								cb(null, err);
+								cb(null, err.message)
 						});
 					}}]);
 				}


### PR DESCRIPTION
I was having a look at Citizen.Await / promises and noticed some weird hack, despite promises exposing state and value (maybe based on some old code?). I didn't experience any unexpected behaviour with this change to the implementation.

Change to main.js returns the actual error message, rather than an empty object in the Lua runtime.
![image](https://user-images.githubusercontent.com/65407488/147406024-e0e86534-a66d-463d-82b8-06f606756ccb.png)
![image](https://user-images.githubusercontent.com/65407488/147406099-fda49f24-1678-47f3-8fcf-7fabfe2d4f7f.png)

