### PR TITLE
tweak(scripting/v8): Add missing LocalPlayer state bag alias

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -126,6 +126,7 @@ declare function NewStateBag(name: string) : StateBagInterface;
 declare function Entity(entity: number): EntityInterface
 declare var GlobalState : StateBagInterface
 declare function Player(entity: number|string): EntityInterface
+declare var LocalPlayer : EntityInterface
 
 declare var exports: any;
 

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -686,6 +686,10 @@ const EXT_LOCALFUNCREF = 11;
 		return ent;
 	};
 
+	if (!isDuplicityVersion) {
+		global.LocalPlayer = Player(-1);
+	}
+
 	/*
 	BEGIN
 	https://github.com/errwischt/stacktrace-parser/blob/0121cc6e7d57495437818676f6b69be7d34c2fa7/src/stack-trace-parser.js


### PR DESCRIPTION
As title says, this PR add missing `LocalPlayer` alias for `Player(-1)` in V8 script runtime.

Like in Lua scrt https://github.com/citizenfx/fivem/blob/6e1f04ed2739b3927a77fb437b4338a23d187efa/data/shared/citizen/scripting/lua/scheduler.lua#L1079-L1081