### PR TITLE
Update data file types count for FiveM b2545

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -872,7 +872,11 @@ static int LookupDataFileType(const std::string& type)
 #ifdef GTA_FIVE
 	int typesCount = 0xC9;
 
-	if (xbr::IsGameBuildOrGreater<2189>())
+	if (xbr::IsGameBuildOrGreater<2545>())
+	{
+		typesCount = 0xCE;
+	}
+	else if (xbr::IsGameBuildOrGreater<2189>())
 	{
 		typesCount = 0xCB;
 	}


### PR DESCRIPTION
This change will allow to mount new data file types introduced in b2545:
`CARCOLS_GEN9_FILE`
`CARMODCOLS_GEN9_FILE`
`COMMUNITY_STATS_FILE`