### PR TITLE
feat: add trigger event native for multiple targets

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -368,6 +368,13 @@ if isDuplicityVersion then
 
 		return TriggerClientEventInternal(eventName, playerId, payload, payload:len())
 	end
+
+	function TriggerClientsEvent(eventName, playersId, ...)
+		local payload = msgpack_pack_args(...)
+		local playersIdPayload = msgpack_pack(playersId)
+
+		return TriggerClientsEventInternal(eventName, playersIdPayload, playersIdPayload:len(), payload, payload:len())
+	end
 	
 	function TriggerLatentClientEvent(eventName, playerId, bps, ...)
 		local payload = msgpack_pack_args(...)

--- a/ext/native-decls/TriggerClientsEventInternal.md
+++ b/ext/native-decls/TriggerClientsEventInternal.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: server
+---
+## TRIGGER_CLIENTS_EVENT_INTERNAL
+
+```c
+void TRIGGER_CLIENTS_EVENT_INTERNAL(char* eventName, char* targetPayload, int targetPayloadLength, char* eventPayload, int payloadLength);
+```
+
+The backing function for TriggerClientsEvent.
+
+## Parameters
+* **eventName**: 
+* **targetPayload**: 
+* **targetPayloadLength**: 
+* **eventPayload**: 
+* **payloadLength**: 
+


### PR DESCRIPTION
The goal of this native is to be able to send an event to a specific list of players ensuring that only the relevant players will get it, without having to serialize the payload at every call or sending it to all players.

Example (lua):
```lua
local targets = { "1", "3" }
TriggerClientsEvent("cancelTrade", targets, { example = 0 })
```
If you have a better name to suggest for this native share it :)