### PR TITLE
feat(streaming-five): Add support for other Game Events (fixed)

### DIFF
--- a/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameEventFunctions.cpp
@@ -9,6 +9,27 @@
 
 static InitFunction initFunction([]
 {
+	OnTriggerGameEventExt.Connect([](const GameEventData& data)
+	{
+		auto resman = Instance<fx::ResourceManager>::Get();
+		auto rec = resman->GetComponent<fx::ResourceEventManagerComponent>();
+
+		/*NETEV CEventName CLIENT
+		/#*
+		 * An event that is triggered when the game triggers an internal network event.
+		 * CEventName can be any event name that GTA 5 throws, e.g.: "CEventShockingCarCrash".
+		 * see: https://docs.fivem.net/docs/game-references/game-events/ for a list of known events.
+		 *
+		 * @param entities - All entities receiving/emitting the event, can be empty.
+		 * @param eventEntity - Entity the event is related to.
+		 * @param data - Extra event data.
+		 #/
+		declare function CEventName(entities: number[], eventEntity: number, data: var[]): void;
+		*/
+		
+		rec->QueueEvent(std::string(data.name), std::string(data.argsData), "");
+	});
+
 	OnTriggerGameEvent.Connect([](const GameEventMetaData& data)
 	{
 		auto resman = Instance<fx::ResourceManager>::Get();

--- a/code/components/gta-streaming-five/component.json
+++ b/code/components/gta-streaming-five/component.json
@@ -8,6 +8,7 @@
 		"gta:core",
 		"vfs:core",
 		"rage:formats",
+		"vendor:msgpack-c",
 		"vendor:tbb"
 	],
 	"provides": []

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -696,12 +696,20 @@ STREAMING_EXPORT extern fwEvent<PopulationCreationState*> OnCreatePopulationPed;
 
 struct GameEventMetaData
 {
-	char name[256];
+	const char* name;
 	size_t numArguments;
-	uintptr_t arguments[48];
+	size_t arguments[48];
 };
 
 STREAMING_EXPORT extern fwEvent<const GameEventMetaData&> OnTriggerGameEvent;
+
+struct GameEventData
+{
+	const char* name;
+	std::string_view argsData;
+};
+
+STREAMING_EXPORT extern fwEvent<const GameEventData&> OnTriggerGameEventExt;
 
 struct DamageEventMetaData
 {


### PR DESCRIPTION
This update will re-enable the hooking for the missing game events and retrieves all entities associated with it.

- Better design that follows the game's event system, which fixes the crashing of previous version https://github.com/citizenfx/fivem/pull/1195.
- All events will now get the associated entity, even those missing in previous version.
- Previous Emit/React versions merged, event names are now the same as the game event name itself, e.g.: "CEventShockingSeenNiceCar".
- Right now only CEventShocking* reads the position of the event and puts it in the args parameter.

Example usage (Lua):
```lua
AddEventHandler("CEventShockingGunshotFired", function(entities, eventEntity, args)
	print("CEventShockingGunshotFired", json.encode(entities), eventEntity, json.encode(args));
end);
```