### PR TITLE
tweak(debug-net/netgraph): Respect screen resolution

### DIFF
--- a/code/components/debug-net/src/NetDebug.cpp
+++ b/code/components/debug-net/src/NetDebug.cpp
@@ -243,10 +243,11 @@ NetOverlayMetricSink::NetOverlayMetricSink()
 			return;
 		}
 
-		auto& io = ImGui::GetIO();
+		int x, y;
+		GetGameResolution(x, y);
 
 		ImGui::SetNextWindowBgAlpha(0.0f);
-		ImGui::SetNextWindowPos(ImVec2(ImGui::GetMainViewport()->Pos.x + io.DisplaySize.x + g_netOverlayOffsetX, ImGui::GetMainViewport()->Pos.y + io.DisplaySize.y + g_netOverlayOffsetY), ImGuiCond_Once, ImVec2(1.0f, 1.0f));
+		ImGui::SetNextWindowPos(ImVec2(ImGui::GetMainViewport()->Pos.x + x + g_netOverlayOffsetX, ImGui::GetMainViewport()->Pos.y + y + g_netOverlayOffsetY), ImGuiCond_Always, ImVec2(1.0f, 1.0f));
 		ImGui::SetNextWindowSize(ImVec2(g_netOverlayWidth, g_netOverlayHeight));
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 
@@ -610,13 +611,6 @@ ImColor NetOverlayMetricSink::GetColorIndex(int index)
 
 void NetOverlayMetricSink::DrawBaseMetrics()
 {
-	// positioning
-	int x = GetOverlayLeft();
-	int y = GetOverlayTop() + (g_netOverlayHeight - 100) + 10;
-
-	CRGBA color(255, 255, 255);
-	CRect rect(x, y, x + (g_netOverlayWidth / 2), y + 100);
-
 	// collecting
 	int ping = m_ping;
 	int inPackets = m_lastInPackets;
@@ -632,9 +626,6 @@ void NetOverlayMetricSink::DrawBaseMetrics()
 	//
 	// second column
 	//
-
-	// positioning
-	rect.SetRect(rect.fX2, rect.fY1, rect.fX2 + (g_netOverlayWidth / 2), rect.fY2);
 
 	// collecting
 	int inBytes = m_lastInBytes;


### PR DESCRIPTION
**Summary:**
- Move the netgraph along the screen resolution if it ever changes. This should solve the following issue: 
- #955 

**Changes:**
- Changed `ConHost::OnDrawGui.Connect` to use internal screen resolution
instead via: `GetGameResolution`
- Removed some rectangle code in `NetOverlayMetricSink::DrawBaseMetrics`
which doesn't seem to be used.