### PR TITLE
fix(sdk): .ts to .js for built files in manifest

### DIFF
--- a/ext/sdk/resources/sdk-root/shell/src/resource-templates/ts/scaffolder.ts
+++ b/ext/sdk/resources/sdk-root/shell/src/resource-templates/ts/scaffolder.ts
@@ -10,8 +10,8 @@ export default class TsScaffolder implements ResourceTemplateScaffolder {
   protected readonly fsService: FsService;
 
   async scaffold({ manifest, resourceName, resourcePath }: ResourceTemplateScaffolderArgs) {
-    manifest.clientScripts.push('dist/client.ts');
-    manifest.serverScripts.push('dist/server.ts');
+    manifest.clientScripts.push('dist/client.js');
+    manifest.serverScripts.push('dist/server.js');
 
     manifest.fxdkWatchCommands.push([
       "yarn",
@@ -63,9 +63,8 @@ export default class TsScaffolder implements ResourceTemplateScaffolder {
 }
 
 function getIgnore(): string {
-  return `client/
-server/
-node_modules/
+  return `client/*
+server/*
 package.json
 build.js
 `;


### PR DESCRIPTION
Fixes the oops on the manifest trying to use .ts files instead of .js files

The syntax supported by `.fxdkignore` isn't one to one with `.gitignore`, thus the need to use a wildcard after the directory ignore.