### PR TITLE
feat(convars): add GET_CONVAR_FLOAT

### DIFF
--- a/code/components/citizen-resources-client/src/ConsoleScriptFunctions.cpp
+++ b/code/components/citizen-resources-client/src/ConsoleScriptFunctions.cpp
@@ -60,4 +60,25 @@ static InitFunction initFunction([]()
 			context.SetResult(atoi(var->GetValue().c_str()));
 		}
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_CONVAR_FLOAT", [](fx::ScriptContext& context)
+	{
+		// get the server's console context
+		auto consoleContext = console::GetDefaultContext();
+
+		// get the variable manager
+		auto varMan = consoleContext->GetVariableManager();
+
+		// get the variable
+		auto var = varMan->FindEntryRaw(context.CheckArgument<const char*>(0));
+
+		if (!var)
+		{
+			context.SetResult<float>(context.GetArgument<float>(1));
+		}
+		else
+		{
+			context.SetResult<float>(atof(var->GetValue().c_str()));
+		}
+	});
 });

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -1397,6 +1397,33 @@ static InitFunction initFunction2([]()
 		}
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_CONVAR_FLOAT", [](fx::ScriptContext& context)
+	{
+		// get the current resource manager
+		auto resourceManager = fx::ResourceManager::GetCurrent();
+
+		// get the owning server instance
+		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+
+		// get the server's console context
+		auto consoleContext = instance->GetComponent<console::Context>();
+
+		// get the variable manager
+		auto varMan = consoleContext->GetVariableManager();
+
+		// get the variable
+		auto var = varMan->FindEntryRaw(context.CheckArgument<const char*>(0));
+
+		if (!var)
+		{
+			context.SetResult<float>(context.GetArgument<float>(1));
+		}
+		else
+		{
+			context.SetResult<float>(atof(var->GetValue().c_str()));
+		}
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_CONVAR", [](fx::ScriptContext& context)
 	{
 		// get the current resource manager

--- a/ext/native-decls/GetConvarFloat.md
+++ b/ext/native-decls/GetConvarFloat.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: shared
+---
+## GET_CONVAR_FLOAT
+
+```c
+float GET_CONVAR_FLOAT(char* varName, float default_);
+```
+
+
+## Parameters
+* **varName**: 
+* **default_**: 
+
+## Return value
+The convar value as a float, or if the convar isn't set, the default value


### PR DESCRIPTION
Currently, there's no way to get a convar as a float

This leads to some really hacking solutions (like [here](https://github.com/AvarianKnight/pma-voice/blob/f908bcc628d0cebc9668f933a200808cd2921e2c/client/main.lua#L6))