### PR TITLE
tweak(glue/net/launcher/asi-five): Add sh mode

### DIFF
--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -50,6 +50,7 @@ void DoPreLaunchTasks();
 void NVSP_DisableOnStartup();
 void SteamInput_Initialize();
 void XBR_EarlySelect();
+void SHMR_EarlySelect();
 bool ExecutablePreload_Init();
 void InitLogging();
 
@@ -378,6 +379,7 @@ int RealMain()
 	initState->ranPastInstaller = true;
 
 	XBR_EarlySelect();
+	SHMR_EarlySelect();
 #endif
 
 	// crossbuildruntime is safe from this point on

--- a/code/client/launcher/ShModeLaunch.cpp
+++ b/code/client/launcher/ShModeLaunch.cpp
@@ -1,0 +1,22 @@
+#include <StdInc.h>
+
+#if defined(LAUNCHER_PERSONALITY_MAIN)
+#include <CfxState.h>
+
+void SHMR_EarlySelect()
+{
+	auto state = CfxState::Get();
+	const auto realCli = (state->initCommandLine[0]) ? state->initCommandLine : GetCommandLineW();
+
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	auto shMode = GetPrivateProfileInt(L"Game", L"ShMode", 0, fpath.c_str());
+
+	if (shMode && !wcsstr(realCli, L"sh"))
+	{
+		wcscat(state->initCommandLine, L"sh");
+	}
+
+}
+
+
+#endif

--- a/code/client/shared/ShModeLaunch.cpp
+++ b/code/client/shared/ShModeLaunch.cpp
@@ -1,0 +1,22 @@
+#include <StdInc.h>
+
+#if defined(LAUNCHER_PERSONALITY_MAIN)
+#include <CfxState.h>
+
+void SHMR_EarlySelect()
+{
+	auto state = CfxState::Get();
+	const auto realCli = (state->initCommandLine[0]) ? state->initCommandLine : GetCommandLineW();
+
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	auto shMode = GetPrivateProfileInt(L"Game", L"ShMode", 0, fpath.c_str());
+
+	if (shMode && !wcsstr(realCli, L"sh"))
+	{
+		wcscat(state->initCommandLine, L"sh");
+	}
+
+}
+
+
+#endif

--- a/code/client/shared/ShModeLaunch.h
+++ b/code/client/shared/ShModeLaunch.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifndef IS_FXSERVER
+#include <HostSharedData.h>
+#include <CfxState.h>
+
+#include <string_view>
+
+#endif
+
+namespace shmr
+{
+bool IsShMode()
+{
+#ifndef IS_FXSERVER
+	static bool isShModeSet = false; 
+	static bool isShMode = false;
+
+	if (!isShModeSet)
+	{
+		auto sharedData = CfxState::Get();
+		std::wstring_view cli = (sharedData->initCommandLine[0]) ? sharedData->initCommandLine : GetCommandLineW();
+
+		if (cli.find(L"sh") != std::wstring_view::npos)
+		{
+			isShMode = true;
+		}
+
+	}
+	return isShMode;
+#else
+	return false;
+#endif
+}
+}

--- a/code/components/asi-five/src/Component.cpp
+++ b/code/components/asi-five/src/Component.cpp
@@ -10,6 +10,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <CrossBuildRuntime.h>
+#include <ShModeLaunch.h>
 #include <filesystem>
 #include <wchar.h>
 
@@ -84,6 +85,13 @@ static bool IsCLRAssembly(const std::vector<uint8_t>& libraryBuffer)
 bool ComponentInstance::DoGameLoad(void* module)
 {
 	HookFunction::RunAll();
+
+
+	if (!shmr::IsShMode())
+	{
+		trace("Skipping .asi file loading - sh mode disabled \n");
+		return true;
+	}
 
 	try
 	{

--- a/code/components/glue/src/CrossBuildSwitch.cpp
+++ b/code/components/glue/src/CrossBuildSwitch.cpp
@@ -18,8 +18,9 @@ extern void RestartGameToOtherBuild(int build);
 
 static std::function<void(const std::string&)> g_submitFn;
 static bool g_cancelable;
-static bool g_canceled;
 static bool g_hadError;
+
+bool g_canceled;
 
 void PerformBuildSwitch(int build);
 

--- a/code/components/glue/src/ShModeSwitch.cpp
+++ b/code/components/glue/src/ShModeSwitch.cpp
@@ -1,0 +1,70 @@
+#include <StdInc.h>
+#include <CefOverlay.h>
+#include <json.hpp>
+
+static std::function<void(const std::string&)> g_submitFn;
+
+static bool g_cancelable;
+static bool g_hadError;
+
+// Someone should clean this up later, since this is a bit of a hack ( and may cause some bugs ) - we reference CrossBuildSwitch.cpp variable here.
+extern bool g_canceled;
+
+extern void RestartGameToSwitchShMode(bool shAllowed);
+
+void InitializeShModeSwitch(bool shAllowed)
+{
+
+	if (nui::HasMainUI())
+	{
+		auto j = nlohmann::json::object({ { "enable", shAllowed },
+		});
+
+		nui::PostFrameMessage("mpMenu", fmt::sprintf(R"({ "type": "connectShModeSwitchRequest", "data": %s })", j.dump()));
+
+		g_submitFn = [shAllowed](const std::string& action)
+		{
+			if (action == "ok")
+			{
+				RestartGameToSwitchShMode(shAllowed);
+			}
+		};
+
+	}
+
+}
+
+bool SHMR_InterceptCardResponse(const nlohmann::json& j)
+{
+	if (g_submitFn)
+	{
+		auto jcp = j;
+
+		g_submitFn(jcp["data"]["action"]);
+		g_submitFn = {};
+
+		return true;
+	}
+
+	return false;
+}
+
+bool SHMR_InterceptCancelDefer()
+{
+	if (g_cancelable)
+	{
+		if (g_submitFn)
+		{
+			g_submitFn("cancel");
+			g_submitFn = {};
+		}
+
+		g_canceled = true;
+		g_cancelable = false;
+		return true;
+	}
+
+	return false;
+}
+
+

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -333,6 +333,8 @@ public:
 
 	fwEvent<int> OnRequestBuildSwitch;
 
+	fwEvent<bool> OnRequestShModeSwitch;
+
 	fwEvent<const char*> OnAttemptDisconnect;
 
 	fwEvent<NetAddress> OnInitReceived;

--- a/ext/cfx-ui/src/app/game.service.ts
+++ b/ext/cfx-ui/src/app/game.service.ts
@@ -98,6 +98,9 @@ export abstract class GameService {
 	buildSwitchTimeout;
 	buildSwitchUItimeouts = [];
 
+	shModeSwitchTimeout;
+	shModeSwitchUITimeouts = [];
+
 	get systemLanguages(): string[] {
 		return ['en-us'];
 	}
@@ -440,6 +443,11 @@ export class CfxGameService extends GameService {
 							this.invokeBuildSwitch(
 								this.lastServer, event.data.data.title, event.data.data.content));
 						break;
+					case 'connectShModeSwitchRequest':
+						this.zone.run(() =>
+							this.invokeShModeSwitchRequest(
+								this.lastServer, event.data.data.enable));
+						break;
 					case 'serverAdd':
 						if (event.data.addr in this.pingList) {
 							this.pingListEvents.push([event.data.addr, event.data.ping]);
@@ -642,7 +650,7 @@ export class CfxGameService extends GameService {
 				gameBrand = 'FiveM';
 			}
 
-			const heading = new TextBlock(this.translation.translate('#BuildSwitch_Heading', { build, gameBrand }));
+			const heading = new TextBlock(this.translation.translate('#GameNeedsToRestart', { build, gameBrand }));
 			heading.size = TextSize.ExtraLarge;
 			card.addItem(heading);
 
@@ -652,12 +660,12 @@ export class CfxGameService extends GameService {
 
 			const cancelAction = new SubmitAction();
 			cancelAction.data = { action: 'cancel' };
-			cancelAction.title = this.translation.translate('#BuildSwitch_Cancel');
+			cancelAction.title = this.translation.translate('#Cancel');
 
 			const okAction = new SubmitAction();
 			okAction.data = { action: 'ok' };
 			okAction.style = 'positive';
-			okAction.title = this.translation.translate('#BuildSwitch_OK', { seconds });
+			okAction.title = this.translation.translate('#OK_WithSeconds', { seconds });
 
 			const actionSet = new ActionSet();
 			actionSet.addAction(cancelAction);
@@ -722,6 +730,79 @@ export class CfxGameService extends GameService {
 			server: server,
 			card: JSON.stringify(card.toJSON())
 		});
+	}
+
+	protected invokeShModeSwitchRequest(server: Server, enable: boolean) {
+		this.card = true;
+
+		const presentCard = (seconds: number) => {
+			if (!this.card) {
+				return;
+			}
+
+			const card = new AdaptiveCard();
+			card.version = new Version(1, 0);
+
+			let gameBrand = 'CitizenFX';
+
+			if (this.gameName === 'rdr3') {
+				gameBrand = 'RedM';
+			} else if (this.gameName === 'gta5') {
+				gameBrand = 'FiveM';
+			}
+
+			let zero = 0;
+
+			const heading = new TextBlock(this.translation.translate('#GameNeedsToRestart', { zero, gameBrand }));
+			heading.size = TextSize.ExtraLarge;
+			card.addItem(heading);
+			
+			const msgLabel = enable ? "#ShMode_Enable" : "#ShMode_Disable";
+
+			const body = new TextBlock(this.translation.translate(msgLabel, { zero, seconds }));
+			body.wrap = true;
+			card.addItem(body);
+
+			const cancelAction = new SubmitAction();
+			cancelAction.data = { action: 'cancel' };
+			cancelAction.title = this.translation.translate('#Cancel');
+
+			const okAction = new SubmitAction();
+			okAction.data = { action: 'ok' };
+			okAction.style = 'positive';
+			okAction.title = this.translation.translate('#OK_WithSeconds', { seconds });
+
+			const actionSet = new ActionSet();
+			actionSet.addAction(cancelAction);
+			actionSet.addAction(okAction);
+			card.addItem(actionSet);
+
+			this.connectCard.emit({
+				server: server,
+				card: JSON.stringify(card.toJSON())
+			});
+		};
+
+		this.shModeSwitchUITimeouts.forEach(clearTimeout);
+        this.shModeSwitchUITimeouts.length = 0;
+
+		for (let i = 0; i < 10; i++) {
+			const msec = (10 - i) * 1000;
+			const sec = i;
+
+            this.shModeSwitchUITimeouts.push(setTimeout(() => presentCard(sec), msec));
+		}
+
+        if (this.shModeSwitchTimeout) {
+            clearTimeout(this.buildSwitchTimeout);
+        }
+        this.shModeSwitchTimeout = setTimeout(() => {
+			if (this.card) {
+				this.submitCardResponse({
+					action: 'ok'
+				});
+			}
+		}, 10000);
 	}
 
 	get systemLanguages(): string[] {

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -117,10 +117,14 @@
     "#Changelogs": "Change logs",
     "#Yes": "Yes",
 	"#No": "No",
-    "#BuildSwitch_Heading": "{{gameBrand}} needs to restart",
+    "#GameNeedsToRestart": "{{gameBrand}} needs to restart",
     "#BuildSwitch_Body": "The server you are joining requires a different game version ({{build}}). The game will close and restart shortly to change to this version and connect to the server.",
-    "#BuildSwitch_Cancel": "Cancel",
-    "#BuildSwitch_OK": "OK ({{seconds}})",
+    "#Cancel": "Cancel",
+    "#OK_WithSeconds": "OK ({{seconds}})",
+
+    "#ShMode_Enable": "The server you are joining requires scripthook mode to be enabled. The game will close and restart shortly to enable it and connect to the server.",
+    "#ShMode_Disable": "The server you are joining requires scripthook mode to be disabled. The game will close and restart shortly to disable it and connect to the server.",
+
 	"#EmptyServers_History": "Servers you have played on before will appear here. Check out the server list and join one now!",
 	"#EmptyServers_Favorites": "Your favorite servers will appear here, just click the star icon next to your favorite server!",
 	"#RentServer": "Rent a server",


### PR DESCRIPTION
** THIS CODE IS A POC AND NEEDS TO BE CORRECTED **

Why?

While conversating with duk about preventing people from abusing LoadLibrary / LdrLoadDll based injectors, he said that scripthook functionality makes it harder to implement since it's loading user provided .asi files ( aka renamed .dll's ) . This commit adds "sh" start paremeter and functionality that will ask user to restart their game in order to enable/disable ( and store that setting in CitizenFX.ini file ) sh mode to play on server that doesn't match our current sh mode - this should allow adhesive developers to implement mitigations against injectors more easily.

** Known bugs **

While testing that feature i encountered one UI related bug where it randomly changes dialog message. ( i decided to leave this for someone that actually knows webdev stuff to fix - i quickly copy-pasted already existing implementation of already existing game build switch UI dialog just to get going )

How to reproduce:

- Connect to a server that will request sh mode change
- Press cancel button
- Connect to a server that will request build switch
- UI should now randomly change displayed message from #BuildSwitch_Body to #ShMode_Enable/Disable

- Timer is also bugged

** Additional info **

Yes i know i probably broke some project conventions by using wrong function/variable/namespace names or placing new files in wrong directories, but i leave it for project maintainer to fix.