### PR TITLE
Fix null reference exception in model.cs

### DIFF
--- a/code/client/clrcore/External/Model.cs
+++ b/code/client/clrcore/External/Model.cs
@@ -404,11 +404,14 @@ namespace CitizenFX.Core
 
 		public static bool operator ==(Model left, Model right)
 		{
-			return left.Equals(right);
+  			if (left == null)
+    			return right == null;
+
+  			return left.Equals(right);
 		}
 		public static bool operator !=(Model left, Model right)
 		{
-			return !left.Equals(right);
+			return !(left==right);
 		}
 	}
 }

--- a/code/client/clrcore/External/Model.cs
+++ b/code/client/clrcore/External/Model.cs
@@ -404,10 +404,7 @@ namespace CitizenFX.Core
 
 		public static bool operator ==(Model left, Model right)
 		{
-  			if (left == null)
-    			return right == null;
-
-  			return left.Equals(right);
+  			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 		}
 		public static bool operator !=(Model left, Model right)
 		{


### PR DESCRIPTION
A bug was causing null reference exception if null was == (or !=) compared to another model.
The issue has been fixed by firstly checking if the left side is null, and if so performing a null check on the right side.

This is a pr related to:
#1312 