### PR TITLE
gameconfig: increase FragmentStore

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -278,7 +278,7 @@
 						</Item>
 						<Item>
 							<PoolName>FragmentStore</PoolName>
-							<PoolSize value="48000"/>
+							<PoolSize value="96000"/>
 						</Item>
 						<Item>
 							<PoolName>GamePlayerBroadcastDataHandler_Remote</PoolName>


### PR DESCRIPTION
This increases FragmentStore from 48000 to 96000 so more vehicle modkits can be streamed.