### PR TITLE
tweak(gameconfig): up TxdStore limit to 105500

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -458,7 +458,7 @@
 						</Item>
 						<Item>
 							<PoolName>TxdStore</PoolName>
-							<PoolSize value="85500"/>
+							<PoolSize value="105500"/>
 						</Item>
 						<Item>
 							<PoolName>CNetObjVehicle</PoolName>


### PR DESCRIPTION
This fixes a crash for NVE users who most likely installed every mod provided, alongside having a server with a lot of streamed content

This was tested on 1604 and 2545 and didn't cause any crashes while fixing the Pool crash