### PR TITLE
Fix missed data size calculator function hook for RedM

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -2023,6 +2023,7 @@ static HookFunction hookFunction([]()
 	// also patch sync data size calculator allowing more bits
 	{
 		auto sizeCalculatorVtable = hook::get_address<uintptr_t*>(hook::get_pattern("B8 BF FF 00 00 48 8B CF 66 21 87", 27));
+		g_origSyncDataSizeCalculatorSerializePlayerIndex = (decltype(g_origSyncDataSizeCalculatorSerializePlayerIndex))sizeCalculatorVtable[25];
 		hook::put(&sizeCalculatorVtable[25], (uintptr_t)SyncDataSizeCalculatorSerializePlayerIndex);
 	}
 #endif


### PR DESCRIPTION
Fixes bug introduced in #1329 breaking non-OneSync servers.