### PR TITLE
feat(asi/five): add sh mode

### DIFF
--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -50,6 +50,7 @@ void DoPreLaunchTasks();
 void NVSP_DisableOnStartup();
 void SteamInput_Initialize();
 void XBR_EarlySelect();
+void SHMR_EarlySelect();
 bool ExecutablePreload_Init();
 void InitLogging();
 
@@ -378,6 +379,7 @@ int RealMain()
 	initState->ranPastInstaller = true;
 
 	XBR_EarlySelect();
+	SHMR_EarlySelect();
 #endif
 
 	// crossbuildruntime is safe from this point on

--- a/code/client/launcher/ShModeRuntime.cpp
+++ b/code/client/launcher/ShModeRuntime.cpp
@@ -1,0 +1,20 @@
+#include <StdInc.h>
+
+#if defined(LAUNCHER_PERSONALITY_MAIN)
+#include <CfxState.h>
+
+void SHMR_EarlySelect()
+{
+	auto state = CfxState::Get();
+	const auto realCli = (state->initCommandLine[0]) ? state->initCommandLine : GetCommandLineW();
+
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	auto shMode = GetPrivateProfileInt(L"Game", L"ShMode", 0, fpath.c_str());
+
+	if (shMode && !wcsstr(realCli, L"-sh"))
+	{
+		wcscat(state->initCommandLine, L"-sh");
+	}
+}
+
+#endif

--- a/code/client/shared/ShModeRuntime.h
+++ b/code/client/shared/ShModeRuntime.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifndef IS_FXSERVER
+#include <HostSharedData.h>
+#include <CfxState.h>
+
+#include <string_view>
+
+namespace shmr
+{
+bool IsShMode()
+{
+	static bool isShModeSet = false; 
+	static bool isShMode = false;
+
+	if (!isShModeSet)
+	{
+		auto sharedData = CfxState::Get();
+		std::wstring_view cli = (sharedData->initCommandLine[0]) ? sharedData->initCommandLine : GetCommandLineW();
+
+		if (cli.find(L"-sh") != std::wstring_view::npos)
+		{
+			isShMode = true;
+		}
+
+	}
+	return isShMode;
+}
+}
+#endif

--- a/code/components/asi-five/src/Component.cpp
+++ b/code/components/asi-five/src/Component.cpp
@@ -10,6 +10,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <CrossBuildRuntime.h>
+#include <ShModeRuntime.h>
 #include <filesystem>
 #include <wchar.h>
 
@@ -84,6 +85,13 @@ static bool IsCLRAssembly(const std::vector<uint8_t>& libraryBuffer)
 bool ComponentInstance::DoGameLoad(void* module)
 {
 	HookFunction::RunAll();
+
+	// sh mode is disabled, so we don't want to load any plugins
+	if (!shmr::IsShMode())
+	{
+		trace("sh mode disabled - skipping loading of .asi plugins\n");
+		return true;
+	}
 
 	try
 	{

--- a/code/components/glue/src/CrossBuildSwitch.cpp
+++ b/code/components/glue/src/CrossBuildSwitch.cpp
@@ -18,8 +18,9 @@ extern void RestartGameToOtherBuild(int build);
 
 static std::function<void(const std::string&)> g_submitFn;
 static bool g_cancelable;
-static bool g_canceled;
 static bool g_hadError;
+
+bool g_canceled;
 
 void PerformBuildSwitch(int build);
 

--- a/code/components/glue/src/ShModeSwitch.cpp
+++ b/code/components/glue/src/ShModeSwitch.cpp
@@ -1,0 +1,67 @@
+#include <StdInc.h>
+#include <CefOverlay.h>
+#include <json.hpp>
+
+static std::function<void(const std::string&)> g_submitFn;
+
+static bool g_cancelable;
+static bool g_hadError;
+
+// Someone should clean this up later, since this is a bit of a hack ( and may cause some bugs ) - we reference CrossBuildSwitch.cpp variable here.
+extern bool g_canceled;
+
+extern void RestartGameToSwitchShMode(bool shAllowed);
+
+void InitializeShModeSwitch(bool shAllowed)
+{
+
+	if (nui::HasMainUI())
+	{
+		auto j = nlohmann::json::object({
+		{ "enable", shAllowed },
+		});
+
+		nui::PostFrameMessage("mpMenu", fmt::sprintf(R"({ "type": "connectShModeSwitchRequest", "data": %s })", j.dump()));
+
+		g_submitFn = [shAllowed](const std::string& action)
+		{
+			if (action == "ok")
+			{
+				RestartGameToSwitchShMode(shAllowed);
+			}
+		};
+	}
+}
+
+bool SHMR_InterceptCardResponse(const nlohmann::json& j)
+{
+	if (g_submitFn)
+	{
+		auto jcp = j;
+
+		g_submitFn(jcp["data"]["action"]);
+		g_submitFn = {};
+
+		return true;
+	}
+
+	return false;
+}
+
+bool SHMR_InterceptCancelDefer()
+{
+	if (g_cancelable)
+	{
+		if (g_submitFn)
+		{
+			g_submitFn("cancel");
+			g_submitFn = {};
+		}
+
+		g_canceled = true;
+		g_cancelable = false;
+		return true;
+	}
+
+	return false;
+}

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -333,6 +333,8 @@ public:
 
 	fwEvent<int> OnRequestBuildSwitch;
 
+	fwEvent<bool> OnRequestShModeSwitch;
+
 	fwEvent<const char*> OnAttemptDisconnect;
 
 	fwEvent<NetAddress> OnInitReceived;

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -117,10 +117,14 @@
     "#Changelogs": "Change logs",
     "#Yes": "Yes",
 	"#No": "No",
-    "#BuildSwitch_Heading": "{{gameBrand}} needs to restart",
+    "#GameNeedsToRestart": "{{gameBrand}} needs to restart",
     "#BuildSwitch_Body": "The server you are joining requires a different game version ({{build}}). The game will close and restart shortly to change to this version and connect to the server.",
-    "#BuildSwitch_Cancel": "Cancel",
-    "#BuildSwitch_OK": "OK ({{seconds}})",
+    "#Cancel": "Cancel",
+    "#OK_WithSeconds": "OK ({{seconds}})",
+
+    "#ShMode_Enable": "The server you are joining requires scripthook mode to be enabled. The game will close and restart shortly to enable it and connect to the server.",
+    "#ShMode_Disable": "The server you are joining requires scripthook mode to be disabled. The game will close and restart shortly to disable it and connect to the server.",
+
 	"#EmptyServers_History": "Servers you have played on before will appear here. Check out the server list and join one now!",
 	"#EmptyServers_Favorites": "Your favorite servers will appear here, just click the star icon next to your favorite server!",
 	"#RentServer": "Rent a server",


### PR DESCRIPTION
This will allow anticheat team to do some "stricter" checks regarding
LoadLibrary based ( and similar ) injectors, cause when sh mode is
disabled, we won't load any "unwanted" files that might interact with
fivem stuff - a while ago duk said this would be good to add, so i did ;p

reopened it to cleanup commit history and other stuff