### PR TITLE
tweak(converter/rdr3): Add more bounds type to rdr3->five converter

### DIFF
--- a/code/components/rage-formats-x/include/convert/phBound_rdr3_five.h
+++ b/code/components/rage-formats-x/include/convert/phBound_rdr3_five.h
@@ -169,10 +169,30 @@ namespace rage
 				outPolys[i].poly.triangleArea = calculateArea(outPolys[i]);
 				outPolys[i].type = 0;
 			}
-			else
-			{
-				printf("unhandled primitive type %d\n", inPolys[i].type);
-				__debugbreak();
+			else if (inPolys[i].type == 1)
+			{ // Sphere
+				outPolys[i].sphere.index = inPolys[i].sphere.index;
+				outPolys[i].sphere.radius = inPolys[i].sphere.radius;
+				outPolys[i].type = 1;
+			}
+			else if (inPolys[i].type == 2)
+			{ // Capsule
+				outPolys[i].capsule.index = inPolys[i].capsule.index;
+				outPolys[i].capsule.indexB = inPolys[i].capsule.indexB;
+				outPolys[i].capsule.length = inPolys[i].capsule.length;
+				outPolys[i].type = 2;
+			}
+			else if (inPolys[i].type == 3)
+			{ // Box
+				memcpy(&outPolys[i].box.indices, &inPolys[i].box.indices, sizeof(inPolys[i].box.indices));
+				outPolys[i].type = 3;
+			}
+			else if (inPolys[i].type == 4)
+			{ // Cylinder
+				outPolys[i].capsule.index = inPolys[i].capsule.index;
+				outPolys[i].capsule.indexB = inPolys[i].capsule.indexB;
+				outPolys[i].capsule.length = inPolys[i].capsule.length;
+				outPolys[i].type = 4;
 			}
 		}
 

--- a/code/components/rage-formats-x/include/phBound.h
+++ b/code/components/rage-formats-x/include/phBound.h
@@ -901,26 +901,39 @@ public:
 
 		struct  
 		{
-			uint16_t type; // 1
+#ifdef RAGE_FORMATS_GAME_RDR3
 			uint16_t index;
-
-			float radius;
-		} sphere;
-
-		struct  
-		{
+			uint16_t type;
+#else
 			uint16_t type; // 2
 			uint16_t index;
+#endif
+			float radius;
+			uint32_t unk0;
+			uint32_t unk1;
+		} sphere;
 
+		struct
+		{
+#ifdef RAGE_FORMATS_GAME_RDR3
+			uint16_t index;
+			uint16_t type;
+#else
+			uint16_t type; // 1
+			uint16_t index;
+#endif
 			float length;
-			int16_t indexB;
+			uint16_t indexB;
+			uint16_t unk0;
+			uint32_t unk1;
 		} capsule;
 
-		struct  
+		struct
 		{
 			uint32_t type; // 3
 
-			int16_t indices[4];
+			uint16_t indices[4];
+			uint32_t unk0;
 		} box;
 
 		struct  


### PR DESCRIPTION
Allow us to edit and edit bounds, but five->rdr3 make game crash, somehow triangles are corrupted when converted back in rsc8