### PR TITLE
Increase atDScriptObjectNode pool size for RedM

### DIFF
--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -1598,7 +1598,7 @@
                 </Item>
                 <Item>
                   <PoolName>atDScriptObjectNode</PoolName>
-                  <PoolSize value="500"/>
+                  <PoolSize value="10000"/>
                 </Item>
                 <Item>
                   <PoolName>CRemoteScriptArgs</PoolName>


### PR DESCRIPTION
This should resolve `rage::scriptHandler::atDScriptObjectNode` pool overflow crashes.