### PR TITLE
Set real drawable name when doing five->rdr3 drawable conversion

### DIFF
--- a/code/components/rage-formats-x/include/convert/gtaDrawable_five_rdr3.h
+++ b/code/components/rage-formats-x/include/convert/gtaDrawable_five_rdr3.h
@@ -864,8 +864,6 @@ inline void ConvertBaseDrawable(five::rmcDrawable* drawable, rdr3::gtaDrawable* 
 			lodGroup.SetDrawBucketMask(i, oldLodGroup.GetDrawBucketMask(i));
 		}
 	}
-
-	out->SetName("drawable_from_redm_exporter_see_redm.gg.#dr");
 }
 
 template<>
@@ -880,6 +878,15 @@ rdr3::gtaDrawable* convert(five::gtaDrawable* drawable)
 		auto newBound = convert<rdr3::phBound*>(bound);
 		out->SetBound(newBound);
 	}
+
+	auto name = std::string(drawable->GetName());
+
+	if (name.find("redm.net") == std::string::npos)
+	{
+		name = "redm.net_" + name;
+	}
+
+	out->SetName(name.c_str());
 
 	return out;
 }


### PR DESCRIPTION
Should help with debugging converted assets in-game.