### PR TITLE
feat(discord): support newlines in SET_RICH_PRESENCE

### DIFF
--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -69,6 +69,11 @@ static void UpdatePresence()
 			g_richPresenceValues[7]
 		);
 
+		if (!g_richPresenceOverride.empty())
+		{
+			formattedRichPresence = g_richPresenceOverride;
+		}
+
 		auto lineOff = formattedRichPresence.find_first_of("\n");
 
 		std::string line1 = formattedRichPresence.substr(0, lineOff);
@@ -77,11 +82,6 @@ static void UpdatePresence()
 		if (lineOff != std::string::npos)
 		{
 			line2 = formattedRichPresence.substr(lineOff + 1);
-		}
-
-		if (!g_richPresenceOverride.empty())
-		{
-			line2 = g_richPresenceOverride;
 		}
 
 		if (g_discordAppId != g_lastDiscordAppId) 


### PR DESCRIPTION
This was requested by @Keyinator in response to @SaSiNO97 being angry
at there being a bug (citizenfx/fivem#1362) leading to the wrong line
being overridden from their viewpoint of 'correct line', curiously about
a day after this bug actually got fixed on the 'Latest' update channel.

At the risk of leading to another complaint at this code (unchanged ever
since 4fc76ead5e0e3336caba31f5327403225512ce1f except for a bug since
ce4d89e1a9770ab0810560f3bfdb0a2d161ac218 that got fixed within a day of
being reported as broken in citizenfx/fivem#1362) 'changing again', this
changes the override to replace the formatted string and not one of the
lines.

It does make one wonder why the override was targeting a line instead of
the full string, and it could indeed be likely that this was due to said
line duplication bug that got fixed before.