### PR TITLE
fix(scripting): no-op REGISTER_SCRIPT_WITH_AUDIO

### DIFF
--- a/code/components/rage-scripting-five/src/scrEngine.cpp
+++ b/code/components/rage-scripting-five/src/scrEngine.cpp
@@ -467,6 +467,7 @@ scrEngine::NativeHandler GetNativeHandlerDo(uint64_t origHash, uint64_t hash)
 					BLOCK_NATIVE(0x8EF07E15701D61ED);
 					BLOCK_NATIVE(0x933D6A9EEC1BACD0);
 					BLOCK_NATIVE(0x213AEB2B90CBA7AC);
+					BLOCK_NATIVE(0xC6ED9D5092438D91);
 				}
 
 				g_fastPathMap[NativeHash{ origHash }] = handler;


### PR DESCRIPTION
According to fivem native docs - "This native does absolutely nothing,
just a nullsub" so we'll just disable it, as it's proven to be useful
for shady "anticheats"