### PR TITLE
Increase CScriptEntityExtension pool size for RedM

### DIFF
--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -947,7 +947,7 @@
                 </Item>
                 <Item>
                   <PoolName>CScriptEntityExtension</PoolName>
-                  <PoolSize value="600"/>
+                  <PoolSize value="10000"/>
                 </Item>
                 <Item>
                   <PoolName>CScriptEntityIdExtension</PoolName>


### PR DESCRIPTION
Should resolve `CScriptEntityExtension` pool crashes.