### PR TITLE
Fix conceptual error

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -319,7 +319,7 @@ function RemoveEventHandler(eventData)
 end
 
 local ignoreNetEvent = {
-	'__cfx_internal:commandFallback'
+	['__cfx_internal:commandFallback'] = true
 }
 
 function RegisterNetEvent(eventName, cb)


### PR DESCRIPTION
There is a conceptual error in the scheduler, Lua doesnt support the `not table[key]` for arrays