### PR TITLE
fix(streaming/five): unload and reload original ytyp

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1346,8 +1346,6 @@ public:
 
 	virtual void UnloadDataFile(CDataFileMgr::DataFile* entry) override
 	{
-		CDataFileMount::sm_Interfaces[174]->UnloadDataFile(entry);
-
 		std::string baseName = ParseBaseName(entry);
 
 		uint32_t slotId;
@@ -1372,6 +1370,8 @@ public:
 				}
 			}
 		}
+
+		CDataFileMount::sm_Interfaces[174]->UnloadDataFile(entry);
 	}
 };
 


### PR DESCRIPTION
Fixes an issue where if you disconnect (not quit) and rejoin, .ytyp files wouldn't load properly and result into lower LOD map models being shown in the world.

Tested and gives expected results:
- Different .ytyp files (extracted from GTA V directly),
- Altered properties of archetypes in .ytyp files,
- Connect, disconnect, connect, disconnect, connect,
- Connect, disconnect, start single player,
- Altered properties of archetypes in .ytyp files,
- Connect, disconnect, unloading the resource with an altered .ytyp, connect,
- Above but: loading resource with an altered .ytyp

resolves #1340