### PR TITLE
tweak(server): state bags can now be created by clients and replicated

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -78,6 +78,19 @@ public:
 	// Sets the owning peer ID.
 	//
 	virtual void SetOwningPeer(std::optional<int> peer) = 0;
+	
+	//
+	// Enable or disable immediate replication of this state bag's changes.
+	// If enabled it'll send the state bag update immediatly (old behavior).
+	// If disabled then new replicating state bag changes are queued, use SendQueuedUpdates() to send them.
+	// #TODO: potentially remove this once the throttling system is in place
+	//
+	virtual void EnableImmediateReplication(bool enabled) = 0;
+
+	//
+	// Will send all queued replicating state bag updates to all targets, see EnableImmediateReplication(bool).
+	//
+	virtual void SendQueuedUpdates() = 0;
 
 	//
 	// Gets data for a key.
@@ -97,8 +110,9 @@ public:
 
 	//
 	// Should be called when receiving a state bag control packet.
+	// arg: outBagNameName; if given (!= nullptr) and if the state bag wasn't found then this string will contain the bag name, otherwise outBagNameName is unchanged.
 	//
-	virtual void HandlePacket(int source, std::string_view data) = 0;
+	virtual void HandlePacket(int source, std::string_view data, std::string* outBagNameName = nullptr) = 0;
 
 	//
 	// Gets a state bag by an identifier. Returns an empty shared_ptr if not found.

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -824,6 +824,7 @@ struct SyncCommandState
 	rl::MessageBuffer cloneBuffer;
 	std::function<void(bool finalFlush)> flushBuffer;
 	std::function<void(size_t)> maybeFlushBuffer;
+	std::vector<std::shared_ptr<fx::StateBag>> syncStateBags;
 	uint64_t frameIndex;
 	fx::ClientSharedPtr client;
 	bool hadTime;
@@ -838,6 +839,7 @@ struct SyncCommandState
 		cloneBuffer.SetCurrentBit(0);
 		flushBuffer = {};
 		maybeFlushBuffer = {};
+		syncStateBags.clear();
 		frameIndex = 0;
 		client = {};
 		hadTime = false;


### PR DESCRIPTION
* Any client that owns an entity can now create its replicating state bags on the server.
* Clients will queue their state bag changes and send them after getting an ACK from the server (meaning the server now knows of the entity).
* State bag updates to clients are now being sent after the clone creation packets.
* State bag updates are not being sent to clients that just got a call to remove the associated entities.

resolves #1335 
resolves #1304 