### PR TITLE
tweak(native-decl): set the proper return type

### DIFF
--- a/ext/native-decls/SetStateBagValue.md
+++ b/ext/native-decls/SetStateBagValue.md
@@ -5,7 +5,7 @@ apiset: shared
 ## SET_STATE_BAG_VALUE
 
 ```c
-void SET_STATE_BAG_VALUE(char* bagName, char* keyName, char* valueData, int valueLength, BOOL replicated);
+BOOL SET_STATE_BAG_VALUE(char* bagName, char* keyName, char* valueData, int valueLength, BOOL replicated);
 ```
 
 Internal function for setting a state bag value.


### PR DESCRIPTION
After the introduction of https://github.com/citizenfx/fivem/commit/ce964dd76086bcfb2d4e8e6f7f36433c8d35b199 SET_STATE_BAG_VALUE will always return 0 instead of its proper return type.