### PR TITLE
fix(scripting/v8): correct return value for proxy setter

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -594,7 +594,8 @@ const EXT_LOCALFUNCREF = 11;
 
 			set(_, k, v) {
 				const payload = msgpack_pack(v);
-				return SetStateBagValue(es, k, payload, payload.length, isDuplicityVersion);
+				SetStateBagValue(es, k, payload, payload.length, isDuplicityVersion);
+				return true; // If the set() method returns false, and the assignment happened in strict-mode code, a TypeError will be thrown.
 			},
 		});
 	};


### PR DESCRIPTION
* Fixes: `TypeError: 'set' on proxy: trap returned falsish for key`

Additional info:
On Proxies: If the set() method returns false, and the assignment happened in strict-mode code, a TypeError will be thrown.