### PR TITLE
Add PerformHttpRequest to v8 using promises

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -108,6 +108,15 @@ declare function emitNet(eventName: string, target: number|string, ...args: any[
 declare function TriggerClientEvent(eventName: string, target: number|string, ...args: any[]): void
 declare function TriggerLatentClientEvent(eventName: string, target: number|string, bps: number, ...args: any[]): void
 
+interface CFXHttpResponse {
+    status: number;
+    body?: string;
+    headers: Record<string, string>;
+    errorData?: string;
+}
+
+declare function PerformHttpRequest(url: string, method: string, data: string|object, headers: object, options: any): Promise<CFXHttpResponse>
+
 declare function removeEventListener(eventName: string, callback: Function): void
 
 declare function setTimeout<T extends any[]>(callback: (...args: T) => void, ms?: number, ...args: T): CitizenTimer;


### PR DESCRIPTION
The http/https module has too much boilerplate, often requiring installing a module like axios or node-fetch, this pull request will provide an easy wrapper to do HTTP Requests using promises.