### PR TITLE
fix(steam): only update game name on change

### DIFF
--- a/code/components/steam/src/SteamComponent.cpp
+++ b/code/components/steam/src/SteamComponent.cpp
@@ -640,11 +640,15 @@ void SteamComponent::SetRichPresenceValue(int idx, const std::string& value)
 {
 	assert(idx >= 0 && idx < _countof(m_richPresenceValues));
 
+	// special case for 0 as we use that for the server name suffix.
+	// we should only launch a new Steam child if the game name changes.
+	bool updateGameName = (idx == 0 && m_richPresenceValues[0] != value);
+
 	m_richPresenceValues[idx] = value;
 
 	m_richPresenceChanged = true;
 
-	if (idx == 0)
+	if (updateGameName)
 	{
 		static HostSharedData<CfxPresenceState> gameData("PresenceState");
 		gameData->needRefresh = true;


### PR DESCRIPTION
This PR fixes #1397 by only launching the Steam child if the name has actually changed.

The Steam component *should* be refactored at a later date to use the `OnRichPresenceSetTemplate` and `OnRichPresenceSetValue` events however, that requires a dependency inversion (`net` <-> `steam`) which is out-of-scope for this PR.