### PR TITLE
fix(mumble): fix server crash when using MumbleSetPlayerMuted or MumbleIsPlayerMuted

### DIFF
--- a/code/components/voip-server-mumble/src/client.cpp
+++ b/code/components/voip-server-mumble/src/client.cpp
@@ -118,7 +118,7 @@ bool Client_is_player_muted(int serverId)
 	{
 		client_t* c;
 		c = list_get_entry(itr, client_t, node);
-		if (strstr(c->username, convertedServerId.c_str()))
+		if (c->username && strstr(c->username, convertedServerId.c_str()))
 		{
 			return c->mute;
 		}
@@ -133,7 +133,7 @@ void Client_set_player_muted(int serverId, bool muted)
 	{
 		client_t* c;
 		c = list_get_entry(itr, client_t, node);
-		if (strstr(c->username, convertedServerId.c_str())) {
+		if (c->username && strstr(c->username, convertedServerId.c_str())) {
 			c->mute = muted;
 			break;
 		}


### PR DESCRIPTION
- fixes https://forum.cfx.re/t/fxserver-crashes-when-mumble-native-mumble-set-player-muted-is-invoked-sporadic/4838208

Fixes oversight in #1087

Getting/Setting a player muted would result in a crash if you manage to hit it right when a client is getting initialized and their username is still null.