### PR TITLE
fix(server/impl): apply all state bag changes on startup

### DIFF
--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -233,6 +233,12 @@ namespace fx
 						m_mainThreadCallbacks->Run();
 					}));
 
+					// run remaining callbacks before we remove this callback list
+					if (m_mainThreadCallbacks)
+					{
+						m_mainThreadCallbacks->Run();
+					}
+
 					m_mainThreadCallbacks = std::make_unique<CallbackListUv>(mainData->callbackAsync);
 					m_mainThreadCallbacks->AttachToThread();
 


### PR DESCRIPTION
* Fixes issue where a set of state bag changes (and potentially other callbacks) on start up were simply discarded.

fixes #1384 