### PR TITLE
feat(gta/core): dynamic pool resizing

### DIFF
--- a/code/client/shared/atPool.h
+++ b/code/client/shared/atPool.h
@@ -1,18 +1,30 @@
 #pragma once
 
+struct atPoolFlags
+{
+	uint8_t generation : 7;
+	uint8_t isFree : 1;
+};
+
+struct atPoolStats
+{
+	uint32_t numEntries : 30;
+	uint32_t unk : 2;
+};
+
 class atPoolBase
 {
-protected:
+public:
 #if IS_RDR3
 	int8_t* m_unk;
 #endif
-	char* m_data;
-	int8_t* m_flags;
-	uint32_t m_count;
+	char*    m_data;
+	atPoolFlags* m_flags;
+	int32_t  m_count;
 	uint32_t m_entrySize;
-	uint32_t m_pad;
-	uint32_t m_pad2;
-	uint32_t m_bitCount;
+	int32_t  m_freeList;
+	int32_t  m_lastAlloc;
+	atPoolStats m_poolStats;
 
 private:
 	struct VirtualDtorBase
@@ -24,7 +36,7 @@ public:
 	template<typename T>
 	T* GetAt(int index) const
 	{
-		if (m_flags[index] < 0)
+		if (m_flags[index].isFree)
 		{
 			return nullptr;
 		}
@@ -38,7 +50,7 @@ public:
 		int index = handle >> 8;
 		int8_t flag = handle & 0xFF;
 
-		if (m_flags[index] < 0 || m_flags[index] != flag)
+		if (m_flags[index].isFree || m_flags[index].generation != flag)
 		{
 			return nullptr;
 		}
@@ -49,14 +61,14 @@ public:
 	size_t GetCountDirect()
 	{
 		// R* code does << 2 >> 2, but that makes no sense
-		return m_bitCount & 0x3FFFFFFF;
+		return m_poolStats.numEntries;
 	}
 
 	size_t GetCount()
 	{
-		size_t count = std::count_if(m_flags, m_flags + m_count, [] (int8_t flag)
+		size_t count = std::count_if(m_flags, m_flags + m_count, [](atPoolFlags flag)
 		{
-			return (flag >= 0);
+			return !flag.isFree;
 		});
 
 		return count;
@@ -76,13 +88,17 @@ public:
 	{
 		for (int i = 0; i < m_count; i++)
 		{
-			if (m_flags[i] >= 0)
+			if (!m_flags[i].isFree)
 			{
 				delete GetAt<VirtualDtorBase>(i);
 			}
 		}
 	}
 };
+
+static_assert(offsetof(atPoolBase, m_poolStats) == 0x20);
+static_assert(offsetof(atPoolBase, m_freeList) == 0x18);
+static_assert(offsetof(atPoolBase, m_count) == 0x10);
 
 template<typename T>
 class atPool : public atPoolBase

--- a/code/components/gta-core-five/src/PoolManagement.cpp
+++ b/code/components/gta-core-five/src/PoolManagement.cpp
@@ -717,6 +717,8 @@ static HookFunction hookFunction([] ()
 	{
 		trace("Enabling pool hacks!!\n");
 		MH_CreateHook(hook::get_call(hook::get_pattern("C7 ? ? 10 00 00 00 C7 ? ? 00 00 00 40 E8", 14)), InitPoolStub, (void**)&g_origInitPool);
+
+		AddCrashometry("poolhacks_enabled", "true");
 	}
 
 	auto registerAssetPools = [&](hook::pattern& patternMatch, int callOffset, int nameOffset)


### PR DESCRIPTION
A very preliminary attempt at abusing virtual memory to allow for dynamically-"resizable" pools. At the moment eligible pools need to be manually specified with a hash and size/growth policies.

Can be enabled by passing `-poolhacks` as a command line option.

Note that there's still a fixed upper limit, but it can be raised much higher because the actual memory is only committed on an as-needed basis.

Ideally we get this working with the `TxdStore` pool but that needs me to either:
1. Hardcode its location somehow
2. Figure out how to exclude pre-allocated pools from pool hackery and have reasonable defaults