### PR TITLE
fix(ext/cfx-ui): was adding servers that aren't the right game

### DIFF
--- a/ext/cfx-ui/src/app/servers/servers.service.ts
+++ b/ext/cfx-ui/src/app/servers/servers.service.ts
@@ -124,7 +124,7 @@ export class ServersService {
 
 			this.requestEvent
 				.subscribe(url => {
-					this.worker.postMessage({ type: 'queryServers', url: url + `streamRedir/` });
+					this.worker.postMessage({ type: 'queryServers', url: url + `streamRedir/`, gameName: gameService.gameName });
 				});
 		}
 

--- a/ext/cfx-ui/src/app/servers/workers/servers.worker.ts
+++ b/ext/cfx-ui/src/app/servers/workers/servers.worker.ts
@@ -560,9 +560,8 @@ function queryServers(e: MessageEvent) {
 						serverTagsWorker.addServerTags(server);
 						serverTagsWorker.addLocaleIndex(server);
 						serverAutoCompleteWorker.addAutocompleteIndex(server);
+						cachedServers[server.EndPoint] = server.Data;
 					}
-
-					cachedServers[server.EndPoint] = server.Data;
 				}
 
 				postMessage({ type: 'addServers', servers });

--- a/ext/cfx-ui/src/app/servers/workers/servers.worker.ts
+++ b/ext/cfx-ui/src/app/servers/workers/servers.worker.ts
@@ -556,9 +556,11 @@ function queryServers(e: MessageEvent) {
 						server.Data.vars.sv_projectDesc = filterProjectDesc(server.Data.vars.sv_projectDesc);
 					}
 
-					serverTagsWorker.addServerTags(server);
-					serverTagsWorker.addLocaleIndex(server);
-					serverAutoCompleteWorker.addAutocompleteIndex(server);
+					if (server?.Data?.vars?.gamename == e.data.gameName) {
+						serverTagsWorker.addServerTags(server);
+						serverTagsWorker.addLocaleIndex(server);
+						serverAutoCompleteWorker.addAutocompleteIndex(server);
+					}
 
 					cachedServers[server.EndPoint] = server.Data;
 				}


### PR DESCRIPTION
*Fixes the problem that caused us to have data from other games as well, e.g.:*

On rdr3, I have the tags for gta5 and of course there are not so many server on redm:
![eg](https://user-images.githubusercontent.com/42467470/166080965-071aa41b-6dc8-4282-87c6-07acfa7fc75a.png)

With this PR we now add the server to the workers *only* if it is the **same** game.
Result:
![2](https://user-images.githubusercontent.com/42467470/166081232-2155f428-e653-4d0d-b94a-383d07c6fd46.png)

