### PR TITLE
Add getter for SET_ENTITY_ONLY_DAMAGED_BY_RELATIONSHIP_GROUP

### DIFF
--- a/code/components/extra-natives-five/src/EntityExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/EntityExtraNatives.cpp
@@ -36,4 +36,23 @@ static InitFunction initFunction([]()
 
 		context.SetResult<bool>(result);
 	});
+
+	/* original setter is SET_ENTITY_ONLY_DAMAGED_BY_RELATIONSHIP_GROUP, perhaps this is for entities too? */
+	fx::ScriptEngine::RegisterNativeHandler("CAN_ENTITY_ONLY_BE_DAMAGED_BY_A_RELATIONSHIP_GROUP", [](fx::ScriptContext& context)
+	{
+		bool result = false;
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+
+		if (entity)
+		{
+			auto address = (char*)entity;
+			DWORD flag = *(DWORD*)(address + 0x188);
+			result = (flag & (1 << 12)) != 0;
+
+			if (auto relationshipHashPtr = context.GetArgument<int*>(1))
+				*relationshipHashPtr = *reinterpret_cast<int*>(address + 0x194);
+		}
+
+		context.SetResult<bool>(result);
+	});
 });

--- a/ext/native-decls/CanEntityOnlyBeDamagedByARelationshipGroup.md
+++ b/ext/native-decls/CanEntityOnlyBeDamagedByARelationshipGroup.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+---
+## CAN_ENTITY_ONLY_BE_DAMAGED_BY_A_RELATIONSHIP_GROUP
+
+```c
+bool CAN_ENTITY_ONLY_BE_DAMAGED_BY_A_RELATIONSHIP_GROUP(Entity entity, int* relationshipHash);
+```
+
+A getter for [SET_ENTITY_ONLY_DAMAGED_BY_RELATIONSHIP_GROUP](#_0x7022BD828FA0B082).
+
+## Examples
+
+```lua
+local ped = PlayerPedId()
+
+SetEntityOnlyDamagedByRelationshipGroup(ped, true, 1337) -- often used as 'stealthy' invincible  
+local retval, relationshipHash = CanEntityOnlyBeDamagedByARelationshipGroup(ped)
+print(retval, relationshipHash)-- retval: true, relationshipHash: 1337
+
+SetEntityOnlyDamagedByRelationshipGroup(ped, false, 0)
+local retval, relationshipHash = CanEntityOnlyBeDamagedByARelationshipGroup(ped)
+print(retval, relationshipHash)-- retval: false, relationshipHash: 0
+```
+
+## Parameters
+* **entity**: The entity to get the relationship damage status.
+* **relationshipHash**: The relationshipHash out value.


### PR DESCRIPTION
While looking through some cheat menus so I can detect some features, I discovered they all mostly use SetEntityOnlyDamagedByRelationshipGroup to give themselves Invincibility, and apparently they are claiming it as 'stealth' invincible. There is no native yet for Server developers to check for this flag, so I decided to make it and ask for a pull request.