### PR TITLE
Return nullptr if object player owner wasn't found in RDR3

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -588,6 +588,10 @@ CNetGamePlayer* netObject__GetPlayerOwner(rage::netObject* object)
 			return player;
 		}
 
+#ifdef IS_RDR3
+		return nullptr;
+#endif
+
 		EnsurePlayer31();
 		return g_player31;
 	}
@@ -604,7 +608,9 @@ static uint8_t netObject__GetPlayerOwnerId(rage::netObject* object)
 		return g_origGetOwnerPlayerId(object);
 	}
 
-	return netObject__GetPlayerOwner(object)->physicalPlayerIndex();
+	auto owner = netObject__GetPlayerOwner(object);
+
+	return owner ? owner->physicalPlayerIndex() : 0xFF;
 }
 
 static CNetGamePlayer*(*g_origGetPendingPlayerOwner)(rage::netObject*);
@@ -757,7 +763,9 @@ static void PassObjectControlStub(CNetGamePlayer* player, rage::netObject* netOb
 		return g_origPassObjectControl(player, netObject, a3);
 	}
 
-	if (player->physicalPlayerIndex() == netObject__GetPlayerOwner(netObject)->physicalPlayerIndex())
+	auto owner = netObject__GetPlayerOwner(netObject);
+
+	if (!owner || player->physicalPlayerIndex() == owner->physicalPlayerIndex())
 	{
 		return;
 	}
@@ -4398,7 +4406,7 @@ static InitFunction initFunction([]()
 		}
 
 		auto owner = netObject__GetPlayerOwner(netObj);
-		context.SetResult<int>(owner->physicalPlayerIndex());
+		context.SetResult<int>(owner ? owner->physicalPlayerIndex() : 0xFF);
 	});
 
 #ifdef ONESYNC_CLONING_NATIVES

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -728,11 +728,14 @@ static bool _isPlayerTalking(void* mgr, char* playerData)
 		if (netObj)
 		{
 			// actually: netobj owner
-			auto index = netObject__GetPlayerOwner(netObj)->physicalPlayerIndex();
-
-			if (g_talkers.test(index) || o_talkers.test(index))
+			if (auto owner = netObject__GetPlayerOwner(netObj))
 			{
-				return true;
+				auto index = owner->physicalPlayerIndex();
+
+				if (g_talkers.test(index) || o_talkers.test(index))
+				{
+					return true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
See `rage::netObject::GetPlayerOwner`. Experimental change - might cause more issues than it was meant to fix, but still would be useful for diagnosis of the specific group of crashes. Shouldn't affect FiveM in any case.

:BlessRNG: