### PR TITLE
Added missing SetVehicleCurrentGear native declaration

### DIFF
--- a/ext/native-decls/SetVehicleCurrentGear.md
+++ b/ext/native-decls/SetVehicleCurrentGear.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_VEHICLE_CURRENT_GEAR
+
+```c
+void SET_VEHICLE_CURRENT_GEAR(Vehicle vehicle, int gear);
+```
+
+
+## Parameters
+* **vehicle**: 
+* **gear**: 


### PR DESCRIPTION
I found this native in the code but not on the native documentation, so this pull request adds it.