### PR TITLE
feat(extra-natives/five): Add GET_ALL_VEHICLE_MODELS native

### DIFF
--- a/code/components/extra-natives-five/src/ModelListNatives.cpp
+++ b/code/components/extra-natives-five/src/ModelListNatives.cpp
@@ -1,0 +1,51 @@
+#include <StdInc.h>
+#include <Hooking.h>
+
+#include <ScriptEngine.h>
+#include <ScriptSerialization.h>
+
+static uint32_t(*initVehicleArchetype)(const char* name, bool a2, unsigned int a3);
+
+static void(*g_origArchetypeDtor)(fwArchetype* at);
+
+// Use a map of hashes and names for optimization purposes
+// We just hash it on registration instead of needing to rehash it when checking for it every deregistration
+static std::unordered_map<uint32_t, std::string> g_vehicles;
+
+static uint32_t initVehicleArchetype_stub(const char* name, bool a2, unsigned int a3)
+{
+	g_vehicles.insert({ HashString(name), name });
+	return initVehicleArchetype(name, a2, a3);
+}
+
+static void ArchetypeDtorHook(fwArchetype* at)
+{
+	g_vehicles.erase(at->hash);
+	g_origArchetypeDtor(at);
+}
+
+static HookFunction hookFunction([]()
+{
+	//hook for vehicle registering
+	{
+		auto location = hook::get_pattern<char>("E8 ? ? ? ? 48 8B 4D E0 48 8B 11");
+		hook::set_call(&initVehicleArchetype, location);
+		hook::call(location, initVehicleArchetype_stub);
+	}
+	// hook to catch deregistration of vehicles
+	{
+		auto location = hook::get_pattern("E8 ? ? ? ? 80 7B 60 01 74 39"); // Taken from StreamingFreeTests.cpp
+		hook::set_call(&g_origArchetypeDtor, location);
+		hook::call(location, ArchetypeDtorHook);
+	}
+	fx::ScriptEngine::RegisterNativeHandler("GET_ALL_VEHICLE_MODELS", [](fx::ScriptContext& context)
+	{
+		// its redundant and possibly confusing to give both hashes and names, so just give the names.
+		std::vector<std::string_view> models;
+		for (const auto& pair : g_vehicles)
+		{
+			models.push_back(pair.second);
+		}
+		context.SetResult(fx::SerializeObject(models));
+	});
+});

--- a/ext/native-decls/GetAllVehicleModels.md
+++ b/ext/native-decls/GetAllVehicleModels.md
@@ -1,0 +1,32 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_ALL_VEHICLE_MODELS
+
+```c
+object GET_ALL_VEHICLE_MODELS();
+```
+
+Returns all registered vehicle model names, including non-dlc vehicles and custom vehicles in no particular order.
+
+**Example output**
+
+```
+	["dubsta", "dubsta2", "dubsta3", "myverycoolcar", "sultan", "sultanrs", ...]
+```
+
+This native will not return vehicles that are unregistered (i.e from a resource being stopped) during runtime.
+
+## Examples
+
+```lua
+RegisterCommand("spawnrandomcar", function()
+	local vehicles = GetAllVehicleModels()
+	local veh = vehicles[math.random(1, #vehicles)]
+	RequestModel(veh)
+	repeat Wait(0) until HasModelLoaded(veh)
+	local veh = CreateVehicle(veh, GetEntityCoords(PlayerPedId()), GetEntityHeading(PlayerPedId(), true, false)
+	SetPedIntoVehicle(PlayerPedId(), veh, -1)
+end)
+```


### PR DESCRIPTION
This native returns all vehicle models that are registered, it also will be unregister any vehicles in resources that get stopped.

This is my first PR relating to C++. I can't promise its perfect.

Test command:

```lua
RegisterCommand("spawnrandomcar", function()
	local vehicles = GetAllVehicleModels()
	local veh = vehicles[math.random(1, #vehicles)]
	RequestModel(veh)
	repeat Wait(0) until HasModelLoaded(veh)
	local veh = CreateVehicle(veh, GetEntityCoords(PlayerPedId()), GetEntityHeading(PlayerPedId(), true, false)
	SetPedIntoVehicle(PlayerPedId(), veh, -1)
end)
```