### PR TITLE
Add support for b2612 in vish compat

### DIFF
--- a/code/components/scripthookv/src/VishCompat.cpp
+++ b/code/components/scripthookv/src/VishCompat.cpp
@@ -269,6 +269,7 @@ enum eGameVersion : int
 	VER_1_0_2189_0_NOSTEAM = 64,
 	VER_1_0_2372_0_NOSTEAM = 70,
 	VER_1_0_2545_0_NOSTEAM = 72,
+	VER_1_0_2612_1_NOSTEAM = 74,
 };
 
 // ScriptHookV uses incremental numbers instead of build
@@ -280,6 +281,7 @@ DLL_EXPORT eGameVersion getGameVersion()
 	if (xbr::IsGameBuild<2189>()) return VER_1_0_2189_0_NOSTEAM;
 	if (xbr::IsGameBuild<2372>()) return VER_1_0_2372_0_NOSTEAM;
 	if (xbr::IsGameBuild<2545>()) return VER_1_0_2545_0_NOSTEAM;
+	if (xbr::IsGameBuild<2612>()) return VER_1_0_2612_1_NOSTEAM;
 
 	return VER_1_0_1604_0_NOSTEAM; // Default build
 }


### PR DESCRIPTION
Mainly just `getGameVersion`.