### PR TITLE
feat(extra-natives-five): DISABLE_VEHICLE_PASSENGER_IDLE_CAMERA

### DIFF
--- a/ext/native-decls/DisableVehiclePassengerIdleCamera.md
+++ b/ext/native-decls/DisableVehiclePassengerIdleCamera.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## DISABLE_VEHICLE_PASSENGER_IDLE_CAMERA
+
+```c
+void DISABLE_VEHICLE_PASSENGER_IDLE_CAMERA(BOOL state);
+```
+
+Disables the game's afk camera that starts panning around after 30 seconds of inactivity(While riding in a car as a passenger)
+
+## Parameters
+* **state**: On/Off


### PR DESCRIPTION
The original natives(InvalidateVehicleIdleCam, InvalidateIdleCam) loop over all the cameras (~19), look for a specific hashtype, and then update the afk-timer. For InvalidateVehicleIdleCam, this was a hash used by camCinematicInTrainContext and camCinematicInVehicleContext

Funny enough there is also a `camCinematicInVehicleMultiplayerPassengerContext` that is unrelated...