### PR TITLE
tweak(game/five): increase CWeaponComponentInfo limit

### DIFF
--- a/code/components/gta-streaming-five/src/PatchWeaponLimits.cpp
+++ b/code/components/gta-streaming-five/src/PatchWeaponLimits.cpp
@@ -40,7 +40,7 @@ struct PatternPair
 };
 
 // should be synced with CWeaponComponentInfo in gameconfig.xml
-constexpr int kNumWeaponComponentInfos = 1024;
+constexpr int kNumWeaponComponentInfos = 2048;
 
 static CWeaponComponentInfo** weaponComponentInfoCollection;
 

--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -382,7 +382,7 @@
 						</Item>
 						<Item>
 							<PoolName>CWeaponComponentInfo</PoolName>
-							<PoolSize value="1024"/>
+							<PoolSize value="2048"/>
 						</Item>
 						<Item>
 							<PoolName>phInstGta</PoolName>


### PR DESCRIPTION
Increased to resolve getting a pool error when adding a lot of weapon components.