### PR TITLE
tweak(clr): dont remove eventhandler on exception

### DIFF
--- a/code/client/clrcore/EventHandlerDictionary.cs
+++ b/code/client/clrcore/EventHandlerDictionary.cs
@@ -114,8 +114,6 @@ namespace CitizenFX.Core
                 catch (Exception e)
                 {
                     Debug.WriteLine("Error invoking callback for event {0}: {1}", m_eventName, e.ToString());
-
-                    m_callbacks.Remove(callback);
                 }
             }
         }


### PR DESCRIPTION
For now, if an exception is thrown inside an event handler callback, this callback is removed the event handlers list.
Im not sure if its a bug or feature, but it forces me (im pretty sure not just me) to create some custom workarounds like this

https://gist.github.com/lurkmorr228/d4c4a2d1cef428adeb9dd9c9597ce2cc