### PR TITLE
Fix Netgraph's imgui window displaying a scrollbar  

### DIFF
--- a/code/components/debug-net/src/NetDebug.cpp
+++ b/code/components/debug-net/src/NetDebug.cpp
@@ -262,7 +262,7 @@ NetOverlayMetricSink::NetOverlayMetricSink()
 		ImGui::SetNextWindowSize(ImVec2(g_netOverlayWidth, g_netOverlayHeight));
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 
-		if (ImGui::Begin("NetGraph", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize))
+		if (ImGui::Begin("NetGraph", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar))
 		{
 			// draw the graph
 			DrawGraph();


### PR DESCRIPTION
When I enabled NetGraph i noticed that netgraph displays a unintended scrollbar on certain resolutions. Adding the "ImGuiWindowFlags_NoScrollbar" flag to the netgraph imgui window will resolve this issue.
![image](https://user-images.githubusercontent.com/79093941/182004494-52b033fa-703d-4b8c-9e6e-eae7873dab10.png)
