### PR TITLE
Skip tunable checks for some natives on b1436 in RedM

### DIFF
--- a/code/components/gta-core-rdr3/src/GameInitRage.cpp
+++ b/code/components/gta-core-rdr3/src/GameInitRage.cpp
@@ -257,10 +257,13 @@ static HookFunction hookFunctionNet([]()
 	hook::jump(hook::get_pattern("84 C0 74 04 32 C0 EB 0E 4C 8B C7 48 8B D6", -0x1D), ReturnTrueAndForcePedMPFlag);
 	hook::jump(hook::get_pattern("40 8A F2 48 8B F9 E8 ? ? ? ? 84 C0 74", -0x12), ReturnTrueAndForcePedMPFlag);
 
-	// nop checks used for not syncing some "unwanted" metaped components
 	if (xbr::IsGameBuildOrGreater<1436>())
 	{
+		// nop checks used for not syncing some "unwanted" metaped components
 		hook::nop(hook::get_pattern("8B 40 18 3D CC E2 69 9D"), 0x2F);
+
+		// skip tunable checks for explosion/fire related natives
+		hook::jump(hook::get_pattern("B9 BD C5 AF E3 BA B2 A0 A7 92", -0x14), Return1);
 	}
 
 	//hook::jump(0x1406B50E8, LogStubLog1);


### PR DESCRIPTION
Original report: https://forum.cfx.re/t/explosion-natives-no-longer-working-after-1436-31-update/4888502