### PR TITLE
fix(native-decls): Update some Convar natives (GET_CONVAR, GET_CONVAR_INT and SET_CONVAR_REPLICATED)

### DIFF
--- a/ext/native-decls/GetConvar.md
+++ b/ext/native-decls/GetConvar.md
@@ -8,9 +8,18 @@ apiset: shared
 char* GET_CONVAR(char* varName, char* default_);
 ```
 
+Can be used to get a console variable of type `char*`, for example a string.
+
+## Examples
+```lua
+if GetConvar('voice_useNativeAudio', 'false') == 'true' then
+    Citizen.Trace('Native Audio is enabled.')
+end
+```
 
 ## Parameters
-* **varName**: 
-* **default_**: 
+* **varName**: The console variable to look up.
+* **default_**: The default value to set if none is found.
 
 ## Return value
+Returns the convar value if it can be found, otherwise it returns the assigned `default`.

--- a/ext/native-decls/GetConvarInt.md
+++ b/ext/native-decls/GetConvarInt.md
@@ -8,9 +8,19 @@ apiset: shared
 int GET_CONVAR_INT(char* varName, int default_);
 ```
 
+Can be used to get a console variable casted back to `int` (an integer value).
+
+
+## Examples
+```lua
+if GetConvarInt('remainingRounds', 0) < 900 then
+    Citizen.Trace("Less than 900 rounds remaining...")
+end
+```
 
 ## Parameters
-* **varName**: 
-* **default_**: 
+* **varName**: The console variable to look up.
+* **default_**: The default value to set if none is found (variable not set using [SET_CONVAR](#_0x341B16D2), or not accessible).
 
 ## Return value
+Returns the convar value if it can be found, otherwise it returns the assigned `default`.

--- a/ext/native-decls/SetConvarReplicated.md
+++ b/ext/native-decls/SetConvarReplicated.md
@@ -8,8 +8,14 @@ apiset: server
 void SET_CONVAR_REPLICATED(char* varName, char* value);
 ```
 
+Used to replicate a server variable onto clients.
+
+## Examples
+```lua
+SetConvarReplicated('voice_useNativeAudio', 'true')
+```
 
 ## Parameters
-* **varName**: 
-* **value**: 
+* **varName**: The console variable name.
+* **value**: The value to set for the given console variable.
 


### PR DESCRIPTION
Update `GetConvar`, `GetConvarInt` and `SetConvarReplicated` natives. 
Mainly provides descriptions and usage examples.