### PR TITLE
feat(extra-natives/five): add GET_WORLD_COORD_FROM_SCREEN_COORD

### DIFF
--- a/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
@@ -1,0 +1,43 @@
+#include <StdInc.h>
+
+#include <ScriptEngine.h>
+
+#include <GamePrimitives.h>
+
+struct scrVector
+{
+	float x;
+	int _pad;
+	float y;
+	int _pad2;
+	float z;
+	int _pad3;
+};
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_WORLD_COORD_FROM_SCREEN_COORD", [](fx::ScriptContext& context)
+	{
+		float screenX = context.GetArgument<float>(0);
+		float screenY = context.GetArgument<float>(1);
+
+		using namespace DirectX;
+		rage::Vec3V start = Unproject((*g_viewportGame)->viewport, rage::Vec3V{ screenX, screenY, 0.0f });
+		rage::Vec3V end = Unproject((*g_viewportGame)->viewport, rage::Vec3V{ screenX, screenY, 1.0f });
+
+		auto startVector = XMLoadFloat3((XMFLOAT3*)&start);
+		auto endVector = XMLoadFloat3((XMFLOAT3*)&end);
+		auto normalVector = XMVector3Normalize(XMVectorSubtract(endVector, startVector));
+
+		scrVector* worldOut = context.GetArgument<scrVector*>(2);
+		scrVector* normalOut = context.GetArgument<scrVector*>(3);
+
+		worldOut->x = start.x;
+		worldOut->y = start.y;
+		worldOut->z = start.z;
+
+		normalOut->x = XMVectorGetX(normalVector);
+		normalOut->y = XMVectorGetY(normalVector);
+		normalOut->z = XMVectorGetZ(normalVector);
+	});
+});

--- a/ext/native-decls/GetWorldCoordFromScreenCoord.md
+++ b/ext/native-decls/GetWorldCoordFromScreenCoord.md
@@ -1,0 +1,44 @@
+---
+ns: CFX
+apiset: client
+---
+
+## GET_WORLD_COORD_FROM_SCREEN_COORD
+
+```c
+void GET_WORLD_COORD_FROM_SCREEN_COORD(float screenX, float screenY, Vector3* worldVector, Vector3* normalVector);
+```
+
+Converts a screen coordinate into its relative world coordinate.
+
+## Examples
+
+```lua
+CreateThread(function()
+  while true do
+    local screenX = GetDisabledControlNormal(0, 239)
+    local screenY = GetDisabledControlNormal(0, 240)
+
+    local world, normal = GetWorldCoordFromScreenCoord(screenX, screenY)
+
+    local depth = 10
+
+    local target = world + normal * depth
+
+    DrawSphere(target.x, target.y, target.z, 0.5, 255, 0, 0, 0.5)
+
+    Wait(0)
+  end
+end)
+```
+
+## Parameters
+
+- **screenX**: A screen horizontal axis coordinate (0.0 - 1.0).
+- **screenY**: A screen vertical axis coordinate (0.0 - 1.0).
+- **worldVector**: The world coord vector pointer.
+- **normalVector**: The screen normal vector pointer.
+
+## Return value
+
+A Vector3 representing the world coordinates relative to the specified screen coordinates and a screen plane normal Vector3 (normalised).


### PR DESCRIPTION
This functionality is often provided by the platform on game engines and some SA modifications, also, there are a lot of snippets implementing it out there, so I imagine that it would be a good addition to the platform.

I chose the native name and "namespace" grouping based on the `GET_SCREEN_COORD_FROM_WORLD_COORD` native.

The initial idea was to return just the world coords relative to the screen coords, but I realized that to suit the most common use case, which I imagine is mouse picking, the native would also need to return the normal vector.

If this is not the right way to do it, let me know and I'll make the necessary changes.