### PR TITLE
Custom colors for vehicle xenon lights

### DIFF
--- a/ext/native-decls/ClearVehicleXenonLightsCustomColor.md
+++ b/ext/native-decls/ClearVehicleXenonLightsCustomColor.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## CLEAR_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR
+
+```c
+void CLEAR_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle);
+```
+
+Removes vehicle xenon lights custom RGB color.
+
+## Parameters
+* **vehicle**: The vehicle handle.

--- a/ext/native-decls/GetVehicleXenonLightsCustomColor.md
+++ b/ext/native-decls/GetVehicleXenonLightsCustomColor.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR
+
+```c
+BOOL GET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle, int* red, int* green, int* blue);
+```
+
+Returns vehicle xenon lights custom RGB color values. Do note this native doesn't return non-RGB colors that was set with [_SET_VEHICLE_XENON_LIGHTS_COLOR](#_0xE41033B25D003A07).
+
+## Parameters
+* **vehicle**: The vehicle handle.
+* **red**: Red color (0-255).
+* **green**: Green color (0-255).
+* **blue**: Blue color (0-255).
+
+## Return value
+A boolean indicating if vehicle have custom xenon lights RGB color.

--- a/ext/native-decls/SetVehicleXenonLightsCustomColor.md
+++ b/ext/native-decls/SetVehicleXenonLightsCustomColor.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR
+
+```c
+void SET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle, int red, int green, int blue);
+```
+
+Sets custom vehicle xenon lights color, allowing to use RGB palette. The game will ignore lights color set by [_SET_VEHICLE_XENON_LIGHTS_COLOR](#_0xE41033B25D003A07) when custom color is active. This native is not synced between players. Requires xenon lights mod to be set on vehicle.
+
+## Parameters
+* **vehicle**: The vehicle handle.
+* **red**: Red color (0-255).
+* **green**: Green color (0-255).
+* **blue**: Blue color (0-255).
+
+## Examples
+```lua
+local vehicle = GetVehiclePedIsUsing(PlayerPedId())
+if DoesEntityExist(vehicle) then
+  -- Toggle xenon lights mod.
+  ToggleVehicleMod(vehicle, 22, true)
+
+  -- Set pink lights color.
+  SetVehicleXenonLightsCustomColor(vehicle, 244, 5, 82)
+end
+```


### PR DESCRIPTION
This PR implementing natives allowing to use custom (RGB) color for vehicles with xenon lights.

```c
void SET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle, int red, int green, int blue);
BOOL GET_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle, int* red, int* green, int* blue);
void CLEAR_VEHICLE_XENON_LIGHTS_CUSTOM_COLOR(Vehicle vehicle);
```

![image](https://user-images.githubusercontent.com/10367215/185748643-21668740-3d7b-4ff0-ba9e-3874cdecb80f.png)

Testing script: https://pastebin.com/3BUWSm9a