### PR TITLE
feat(nui): media key controls

### DIFF
--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -80,7 +80,7 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		const frame = document.createElement('iframe');
 		frame.name = frameName;
 		frame.style.visibility = 'hidden';
-		frame.allow = 'microphone *; camera *;';
+		frame.allow = 'microphone *; camera *; encrypted-media *;';
 		frame.src = frameUrl;
 		frame.tabIndex = -1;
 


### PR DESCRIPTION
Allow iframes to access media keys and make use of extended keyboard features to control existing audio context.

An example of how this would be used is a music player could be controlled via keyboard play/pause/etc buttons. I.e. in-game radio, phone, menu music, etc.