### PR TITLE
Update scheduler.lua

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -304,7 +304,7 @@ function AddEventHandler(eventName, eventRoutine)
 end
 
 function RemoveEventHandler(eventData)
-	if not eventData.key and not eventData.name then
+	if not eventData or not eventData.key or not eventData.name then
 		error('Invalid event data passed to RemoveEventHandler()', 2)
 	end
 


### PR DESCRIPTION
When passing nil as eventData to RemoveEventHandler, scheduler.lua errors out with a nil value error, this should prevent that and trigger the "Invalid event data" error from inside the function instead.