### PR TITLE
tweak(mumble/server): security improvements

### DIFF
--- a/code/components/voip-server-mumble/src/ServerMumbleVoice.cpp
+++ b/code/components/voip-server-mumble/src/ServerMumbleVoice.cpp
@@ -50,7 +50,9 @@ static InitFunction initFunction([]()
 	{
 		int serverId = context.GetArgument<int>(0);
 
-		context.SetResult<bool>(Client_is_player_muted(serverId));
+		auto client = Client_get_from_player(serverId);
+
+		context.SetResult<bool>(client->mute);
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_PLAYER_MUTED", [](fx::ScriptContext& context)
@@ -58,6 +60,8 @@ static InitFunction initFunction([]()
 		int serverId = context.GetArgument<int>(0);
 		bool toggle = context.GetArgument<bool>(1);
 
-		Client_set_player_muted(serverId, toggle);
+		auto client = Client_get_from_player(serverId);
+
+		client->mute = toggle;
 	});
 });

--- a/code/components/voip-server-mumble/src/client.cpp
+++ b/code/components/voip-server-mumble/src/client.cpp
@@ -110,34 +110,20 @@ int Client_getfds(struct pollfd *pollfds)
 	return 0;
 }
 
-bool Client_is_player_muted(int serverId)
+client_t *Client_get_from_player(int serverId)
 {
 	auto convertedServerId = fmt::sprintf("[%d]", serverId);
 	struct dlist *itr, *save;
-	list_iterate_safe(itr, save, &clients)
-	{
+	list_iterate_safe(itr, save, &clients) {
 		client_t* c;
 		c = list_get_entry(itr, client_t, node);
 		if (c->username && strstr(c->username, convertedServerId.c_str()))
 		{
-			return c->mute;
+			return c;
 		}
 	}
-}
 
-void Client_set_player_muted(int serverId, bool muted)
-{
-	auto convertedServerId = fmt::sprintf("[%d]", serverId);
-	struct dlist *itr, *save;
-	list_iterate_safe(itr, save, &clients)
-	{
-		client_t* c;
-		c = list_get_entry(itr, client_t, node);
-		if (c->username && strstr(c->username, convertedServerId.c_str())) {
-			c->mute = muted;
-			break;
-		}
-	}
+	return NULL;
 }
 
 void Client_janitor()

--- a/code/components/voip-server-mumble/src/client.h
+++ b/code/components/voip-server-mumble/src/client.h
@@ -117,8 +117,7 @@ typedef struct {
 
 void Client_init();
 int Client_getfds(struct pollfd *pollfds);
-bool Client_is_player_muted(int serverId);
-void Client_set_player_muted(int serverId, bool muted);
+client_t *Client_get_from_player(int serverId);
 void Client_janitor();
 int Client_add(fwRefContainer<net::TcpServerStream> stream, client_t** client);
 int Client_read_fd(int fd);


### PR DESCRIPTION
This PR features a bunch of improvements addressing mumble server abuses (unwanted users connecting from the official mumble client trolling legit users).
- Admin password can now be provided without being connected this allows us to disconnect no-admin users not responding to some criteria.
- Disconnect users connecting from the official mumble client without an admin password set.
- Disconnect admins who are providing a server id in username field, this help prevent unwanted behaviour with natives or future implementations.
- Disconnect non-admin users who are providing no server id or a server id already used in username field.