### PR TITLE
fix(extra-natives/five): GetWeaponDamageModifier

### DIFF
--- a/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
@@ -329,7 +329,7 @@ static HookFunction hookFunction([]()
 
 		if (auto weapon = getWeaponFromHash(context))
 		{
-			damageModifier = *(uint16_t*)(weapon + WeaponDamageModifierOffset);
+			damageModifier = *(float*)(weapon + WeaponDamageModifierOffset);
 		}
 
 		context.SetResult<float>(damageModifier);


### PR DESCRIPTION
Resolve a typo on GetWeaponDamageModifier's native getter. The function was dereferencing and casting to a type of uint16_t when it should have been a float.

This should resolve issue #1638