### PR TITLE
fix(ext/natives): Fix long results for natives

### DIFF
--- a/ext/natives/codegen_out_native_lua.lua
+++ b/ext/natives/codegen_out_native_lua.lua
@@ -194,7 +194,11 @@ local function printTypeSetter(type, native, retval)
 	elseif type.nativeType == 'string' then
 		argType = template:format("const char*", retval)
 	elseif type.nativeType == 'int' then
-		argType = template:format("int32_t", retval)
+		if type.subType == 'long' then
+			argType = template:format("int64_t", retval)
+		else
+			argType = template:format("int32_t", retval)
+		end
 	elseif type.nativeType == 'float' then
 		argType = template:format("float", retval)
 	elseif type.nativeType == 'bool' then


### PR DESCRIPTION
This was set correctly in "parseArgumentType" from this post: https://forum.cfx.re/t/native-dui-handle-not-working-with-lua-5-4-and-fxv2-oal/4822448/2

but I noticed it still didn't work and figured it's because the PushObject call is still in int32_t as seen below:
```c
	int64_t retval = nCtx.GetResult<int64_t>();
	LuaArgumentParser::PushObject<int32_t>(L, retval);
```

Changing this to also return a int64_t should fix this issue.