### PR TITLE
feat(citizen-server-impl): GET_GAME_POOL parity

### DIFF
--- a/ext/native-decls/GetGamePool.md
+++ b/ext/native-decls/GetGamePool.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 ---
 ## GET_GAME_POOL
 


### PR DESCRIPTION
Adds GET_GAME_POOL native to FXServer as mentioned in https://github.com/citizenfx/fivem/issues/1270. 
I have only been able to test it on FiveM as I do not have RedM currently installed.