### PR TITLE
feat(extra-natives/five): dashboard getter natives

### DIFF
--- a/ext/native-decls/GetVehicleDashboardBoost.md
+++ b/ext/native-decls/GetVehicleDashboardBoost.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_BOOST
+
+```c
+float GET_VEHICLE_DASHBOARD_BOOST();
+```

--- a/ext/native-decls/GetVehicleDashboardFuel.md
+++ b/ext/native-decls/GetVehicleDashboardFuel.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_FUEL
+
+```c
+float GET_VEHICLE_DASHBOARD_FUEL();
+```

--- a/ext/native-decls/GetVehicleDashboardLights.md
+++ b/ext/native-decls/GetVehicleDashboardLights.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_LIGHTS
+
+```c
+int GET_VEHICLE_DASHBOARD_LIGHTS();
+```
+
+Gets the state of the player vehicle's dashboard lights as a bit set
+	indicator_left = 1
+	indicator_right = 2
+	handbrakeLight = 4
+	engineLight = 8
+	ABSLight = 16
+	gasLight = 32
+	oilLight = 64
+	headlights = 128
+	highBeam = 256
+	batteryLight = 512

--- a/ext/native-decls/GetVehicleDashboardOilPressure.md
+++ b/ext/native-decls/GetVehicleDashboardOilPressure.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_OIL_PRESSURE
+
+```c
+float GET_VEHICLE_DASHBOARD_OIL_PRESSURE();
+```

--- a/ext/native-decls/GetVehicleDashboardOilTemp.md
+++ b/ext/native-decls/GetVehicleDashboardOilTemp.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_OIL_TEMP
+
+```c
+float GET_VEHICLE_DASHBOARD_OIL_TEMP();
+```

--- a/ext/native-decls/GetVehicleDashboardRPM.md
+++ b/ext/native-decls/GetVehicleDashboardRPM.md
@@ -1,0 +1,13 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_RPM
+
+```c
+float GET_VEHICLE_DASHBOARD_RPM();
+```
+
+
+## Return value
+float 0 to ~1.1 representing the angle of the rpm gauge on the player's vehicle dashboard

--- a/ext/native-decls/GetVehicleDashboardTemp.md
+++ b/ext/native-decls/GetVehicleDashboardTemp.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_TEMP
+
+```c
+float GET_VEHICLE_DASHBOARD_TEMP();
+```

--- a/ext/native-decls/GetVehicleDashboardVacuum.md
+++ b/ext/native-decls/GetVehicleDashboardVacuum.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_VACUUM
+
+```c
+float GET_VEHICLE_DASHBOARD_VACUUM();
+```

--- a/ext/native-decls/GetVehicleDashboardWaterTemp.md
+++ b/ext/native-decls/GetVehicleDashboardWaterTemp.md
@@ -1,0 +1,9 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_DASHBOARD_WATER_TEMP
+
+```c
+float GET_VEHICLE_DASHBOARD_WATER_TEMP();
+```


### PR DESCRIPTION
Set of natives that get the state of the local player's current vehicle's dashboard.
Tested on b2699. The research was done so long ago I don't expect this struct or pattern has or ever will change.

Based on [ikt's GTAVDashHook](https://github.com/E66666666/GTAVDashHook)

I'm not sure how to handle allowing setting values without setting the entire struct so setters are omitted for now.