### PR TITLE
feat(extra-natives/five): add data URLs support to CreateRuntimeTextureFromImage

### DIFF
--- a/code/client/shared/Utils.cpp
+++ b/code/client/shared/Utils.cpp
@@ -231,7 +231,7 @@ fwString url_encode(const fwString &value)
 	return fwString(escaped.str().c_str());
 }
 
-bool UrlDecode(const std::string& in, std::string& out)
+bool UrlDecode(const std::string& in, std::string& out, bool replacePlus)
 {
 	out.clear();
 	out.reserve(in.size());
@@ -258,7 +258,7 @@ bool UrlDecode(const std::string& in, std::string& out)
 				return false;
 			}
 		}
-		else if (in[i] == '+')
+		else if (in[i] == '+' && replacePlus)
 		{
 			out += ' ';
 		}

--- a/code/client/shared/Utils.h
+++ b/code/client/shared/Utils.h
@@ -286,7 +286,7 @@ inline void LowerString(fwString& string)
 }
 
 fwString url_encode(const fwString &value);
-bool UrlDecode(const std::string& in, std::string& out);
+bool UrlDecode(const std::string& in, std::string& out, bool replacePlus = true);
 void CreateDirectoryAnyDepth(const char *path);
 
 void SetThreadName(int threadId, const char* threadName);

--- a/ext/native-decls/CreateRuntimeTextureFromImage.md
+++ b/ext/native-decls/CreateRuntimeTextureFromImage.md
@@ -8,12 +8,12 @@ apiset: client
 long CREATE_RUNTIME_TEXTURE_FROM_IMAGE(long txd, char* txn, char* fileName);
 ```
 
-Creates a runtime texture from the specified file in the current resource.
+Creates a runtime texture from the specified file in the current resource or a base64 data URL.
 
 ## Parameters
 * **txd**: A handle to the runtime TXD to create the runtime texture in.
 * **txn**: The name for the texture in the runtime texture dictionary.
-* **fileName**: The file name of an image to load. This should preferably be a PNG, and has to be specified as a `file` in the resource manifest.
+* **fileName**: The file name of an image to load or a base64 data URL. This should preferably be a PNG, and has to be specified as a `file` in the resource manifest.
 
 ## Return value
 A runtime texture handle.


### PR DESCRIPTION
Add support for creating runtime textures from base64 data URLs