### PR TITLE
tweak(citizen-devtools): improve monitor performance

### DIFF
--- a/code/components/citizen-devtools/include/ResourceMonitor.h
+++ b/code/components/citizen-devtools/include/ResourceMonitor.h
@@ -147,6 +147,7 @@ namespace fx
 	class DEVTOOLS_EXPORT ResourceMonitor
 	{
 	public:
+		// TODO: use an std::string_view to remove the unnecesary copy, and make use of correct spelling
 		using ResourceDatas = std::vector<std::tuple<std::string, double, double, int64_t, int64_t, std::shared_ptr<const TickMetrics<64, 200>>, double, std::shared_ptr<const TickMetrics<64, 200>>>>;
 
 	public:

--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -227,7 +227,7 @@ static HookFunction hookFunctionGameTime([]()
 
 			if (th)
 			{
-				th->push_front(fmt::sprintf("%s: activated", resourceName));
+				th->push_front(resourceName + ": activated");
 			}
 		},
 		INT32_MIN);


### PR DESCRIPTION
This will lessen the impact of the current Resource Monitor by removing a noticeable part of the ScRT pre- and post-run overhead.

Rundown of some changes:

* ResourceMonitor
  - Removed the `std::unordered_multiset`, really slow for what they do, notoriously so.
  - Repurposed the `tbb::concurrent_unordered_map` to take on the multiset's function.
  - Only uses a single stopwatch per resource.
  - Some branch prediction optimizations.
  - Proper and more performant math changes.
* String formatting is at least twice as slow as a simple concatenation.

I've been running these changes for months while working on another project, have had no issues.