### PR TITLE
fix(extra-natives/five): Crosshair convars init

### DIFF
--- a/code/components/extra-natives-five/src/DrawImNatives.cpp
+++ b/code/components/extra-natives-five/src/DrawImNatives.cpp
@@ -3236,29 +3236,29 @@ static InitFunction initFunctionSceneExperiment([]()
 });
 #endif
 
+static ConVar<bool> crosshair("cl_customCrosshair", ConVar_Archive, false);
+static ConVar<int> cl_crosshaircolor("cl_crosshaircolor", ConVar_Archive, 1);
+static ConVar<float> cl_crosshairgap("cl_crosshairgap", ConVar_Archive, 1);
+static ConVar<float> cl_crosshairsize("cl_crosshairsize", ConVar_Archive, 5);
+static ConVar<float> cl_crosshairthickness("cl_crosshairthickness", ConVar_Archive, 0.5f);
+static ConVar<int> cl_crosshaircolor_r("cl_crosshaircolor_r", ConVar_Archive, 50);
+static ConVar<int> cl_crosshaircolor_g("cl_crosshaircolor_g", ConVar_Archive, 250);
+static ConVar<int> cl_crosshaircolor_b("cl_crosshaircolor_b", ConVar_Archive, 50);
+static ConVar<int> cl_crosshairalpha("cl_crosshairalpha", ConVar_Archive, 200);
+static ConVar<int> cl_crosshairstyle("cl_crosshairstyle", ConVar_Archive, 0);
+static ConVar<float> cl_crosshair_dynamic_splitdist("cl_crosshair_dynamic_splitdist", ConVar_Archive, 7.f);
+static ConVar<bool> cl_crosshairusealpha("cl_crosshairusealpha", ConVar_Archive, true);
+static ConVar<bool> cl_crosshair_drawoutline("cl_crosshair_drawoutline", ConVar_Archive, true);
+static ConVar<float> cl_crosshair_outlinethickness("cl_crosshair_outlinethickness", ConVar_Archive, 1.f);
+static ConVar<bool> cl_crosshairdot("cl_crosshairdot", ConVar_Archive, true);
+static ConVar<float> cl_crosshair_dynamic_splitalpha_innermod("cl_crosshair_dynamic_splitalpha_innermod", ConVar_Archive, 1.f);
+static ConVar<float> cl_crosshair_dynamic_splitalpha_outermod("cl_crosshair_dynamic_splitalpha_outermod", ConVar_Archive, 0.5f);
+static ConVar<float> cl_crosshair_dynamic_maxdist_splitratio("cl_crosshair_dynamic_maxdist_splitratio", ConVar_Archive, 0.35f);
+
 static void DoCrosshairDraw()
 {
 	// a hacky custom crosshair (no game integration yet)
 	// taken from ipfs://QmV2XyHMEnG73yevDZXJ4e7PFzQ6RvGqhUnjtmCcaxpqFE (also on github)
-	static ConVar<bool> crosshair("cl_customCrosshair", ConVar_Archive, false);
-	static ConVar<int> cl_crosshaircolor("cl_crosshaircolor", ConVar_Archive, 1);
-	static ConVar<float> cl_crosshairgap("cl_crosshairgap", ConVar_Archive, 1);
-	static ConVar<float> cl_crosshairsize("cl_crosshairsize", ConVar_Archive, 5);
-	static ConVar<float> cl_crosshairthickness("cl_crosshairthickness", ConVar_Archive, 0.5f);
-	static ConVar<int> cl_crosshaircolor_r("cl_crosshaircolor_r", ConVar_Archive, 50);
-	static ConVar<int> cl_crosshaircolor_g("cl_crosshaircolor_g", ConVar_Archive, 250);
-	static ConVar<int> cl_crosshaircolor_b("cl_crosshaircolor_b", ConVar_Archive, 50);
-	static ConVar<int> cl_crosshairalpha("cl_crosshairalpha", ConVar_Archive, 200);
-	static ConVar<int> cl_crosshairstyle("cl_crosshairstyle", ConVar_Archive, 0);
-	static ConVar<float> cl_crosshair_dynamic_splitdist("cl_crosshair_dynamic_splitdist", ConVar_Archive, 7.f);
-	static ConVar<bool> cl_crosshairusealpha("cl_crosshairusealpha", ConVar_Archive, true);
-	static ConVar<bool> cl_crosshair_drawoutline("cl_crosshair_drawoutline", ConVar_Archive, true);
-	static ConVar<float> cl_crosshair_outlinethickness("cl_crosshair_outlinethickness", ConVar_Archive, 1.f);
-	static ConVar<bool> cl_crosshairdot("cl_crosshairdot", ConVar_Archive, true);
-	static ConVar<float> cl_crosshair_dynamic_splitalpha_innermod("cl_crosshair_dynamic_splitalpha_innermod", ConVar_Archive, 1.f);
-	static ConVar<float> cl_crosshair_dynamic_splitalpha_outermod("cl_crosshair_dynamic_splitalpha_outermod", ConVar_Archive, 0.5f);
-	static ConVar<float> cl_crosshair_dynamic_maxdist_splitratio("cl_crosshair_dynamic_maxdist_splitratio", ConVar_Archive, 0.35f);
-
 	static auto m_flCrosshairDistance = 1.0f;
 
 	if (!crosshair.GetValue())


### PR DESCRIPTION
Resolve an issue with crosshair convar init state:

Currently, crosshair convars are inited from DoCrosshairDraw's method. This method gets called when the game is done loading, thus overriding any replicated cvars the server is sending via 'setr' unless the client were to rejoin said server without fully closing the client via 'quit'.

To resolve this, we move these convars out of the method.

Looks a bit weird to have all these console variables init'd like this in the global scope, but it resolves the issue. I guess a better solution would be to have these variables declared as a shared pointer and then initializing them in an init method like other things do i.e. `g_use3dAudio` or `g_handbrakeCamConvar`.

If that's a better way to do it, let me know and I'll modify the PR, thanks!