### PR TITLE
fix(server): entity state bag sync with nearby players

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -123,7 +123,7 @@ public:
 	// Registers a state bag for the specified identifier. The pointer returned should be
 	// the *only* reference, every reference kept internally should be weak.
 	//
-	virtual std::shared_ptr<StateBag> RegisterStateBag(std::string_view id) = 0;
+	virtual std::shared_ptr<StateBag> RegisterStateBag(std::string_view id, bool useParentTargets = false) = 0;
 
 	//
 	// Sets the game interface for sending network packets.

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -869,7 +869,6 @@ struct SyncCommandState
 	rl::MessageBuffer cloneBuffer;
 	std::function<void(bool finalFlush)> flushBuffer;
 	std::function<void(size_t)> maybeFlushBuffer;
-	std::vector<std::shared_ptr<fx::StateBag>> syncStateBags;
 	uint64_t frameIndex;
 	fx::ClientSharedPtr client;
 	bool hadTime;
@@ -884,7 +883,6 @@ struct SyncCommandState
 		cloneBuffer.SetCurrentBit(0);
 		flushBuffer = {};
 		maybeFlushBuffer = {};
-		syncStateBags.clear();
 		frameIndex = 0;
 		client = {};
 		hadTime = false;


### PR DESCRIPTION
* Fixed state bag changes being sent to players that are not in the same network scope.
   - State bags no longer being sent to everyone when their target list is empty.
   - Global state bag will still send to everyone (old behavior).
* Fixed state bag changes not being sent to players in the same network scope.
* Removed queueing of state bag's target registration, as this became obsolete.

Seems like the issues were (primarily) pre-existing errors that came to light with enabling clients to create state bags.

fixes #1691