### PR TITLE
fix(net/five): correct targets for precreated state bags

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -143,7 +143,7 @@ public:
 	//
 	// Marks a given prefix as 'safe to pre-create'.
 	//
-	virtual void AddSafePreCreatePrefix(std::string_view idPrefix) = 0;
+	virtual void AddSafePreCreatePrefix(std::string_view idPrefix, bool useParentTargets) = 0;
 
 	//
 	// An event handling a state bag value change.

--- a/code/components/citizen-resources-gta/src/EntityStateBags.cpp
+++ b/code/components/citizen-resources-gta/src/EntityStateBags.cpp
@@ -18,7 +18,7 @@ public:
 		{
 			auto sbac = fx::ResourceManager::GetCurrent()->GetComponent<fx::StateBagComponent>();
 			m_scriptGuid = scriptGuid;
-			m_stateBag = sbac->RegisterStateBag(fmt::sprintf("localEntity:%d", scriptGuid));
+			m_stateBag = sbac->RegisterStateBag(fmt::sprintf("localEntity:%d", scriptGuid), false);
 		}
 	}
 

--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -442,8 +442,8 @@ void CloneManagerLocal::BindNetLibrary(NetLibrary* netLibrary)
 	m_globalBag = sbac->RegisterStateBag("global", true);
 
 	sbac->RegisterTarget(0);
-	sbac->AddSafePreCreatePrefix("entity:");
-	sbac->AddSafePreCreatePrefix("player:");
+	sbac->AddSafePreCreatePrefix("entity:", true);
+	sbac->AddSafePreCreatePrefix("player:", true);
 	sbac->SetGameInterface(this);
 
 	m_netLibrary->AddReliableHandler(


### PR DESCRIPTION
* Precreated state bags will get the proper targets on creation

Could be the cause of #1700 and several reports on Discord, but unable to test as I can't reproduce it.