### PR TITLE
tweak(clrcore): preparing v1 C# files for v2

### DIFF
--- a/code/client/clrcore/External/Audio.cs
+++ b/code/client/clrcore/External/Audio.cs
@@ -1,6 +1,13 @@
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum AudioFlag
 	{

--- a/code/client/clrcore/External/Blip.cs
+++ b/code/client/clrcore/External/Blip.cs
@@ -1,8 +1,16 @@
-using CitizenFX.Core.Native;
 using System;
 using System.Security;
 
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum BlipColor
 	{

--- a/code/client/clrcore/External/BoneID.cs
+++ b/code/client/clrcore/External/BoneID.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum Bone
 	{

--- a/code/client/clrcore/External/ButtonCombination.cs
+++ b/code/client/clrcore/External/ButtonCombination.cs
@@ -1,6 +1,10 @@
 using System;
 
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	/// <summary>
 	/// The Buttons enum used for creating <see cref="ButtonCombination"/>s

--- a/code/client/clrcore/External/Camera.cs
+++ b/code/client/clrcore/External/Camera.cs
@@ -1,7 +1,14 @@
 using System;
 using CitizenFX.Core.Native;
 
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum CameraShake
 	{

--- a/code/client/clrcore/External/Checkpoint.cs
+++ b/code/client/clrcore/External/Checkpoint.cs
@@ -1,7 +1,17 @@
 using System;
 using CitizenFX.Core.Native;
 
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using InputArgument = CitizenFX.Core.Native.Input.Primitive;
+
+namespace CitizenFX.FiveM
+#else
+using Color = System.Drawing.Color;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum CheckpointIcon
 	{
@@ -159,7 +169,7 @@ namespace CitizenFX.Core
 
 		public static implicit operator InputArgument(CheckpointCustomIcon icon)
 		{
-			return new InputArgument((int)icon.getValue());
+			return (InputArgument)(int)icon.getValue();
 		}
 
 		public static implicit operator byte(CheckpointCustomIcon icon)
@@ -341,16 +351,16 @@ namespace CitizenFX.Core
 		/// <summary>
 		/// Gets or sets the color of this <see cref="Checkpoint"/>.
 		/// </summary>
-		public System.Drawing.Color Color
+		public Color Color
 		{
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
 				if (memoryAddress == IntPtr.Zero)
 				{
-					return System.Drawing.Color.Transparent;
+					return Color.Transparent;
 				}
-				return System.Drawing.Color.FromArgb(MemoryAccess.ReadInt(memoryAddress + 80));
+				return Color.FromArgb(MemoryAccess.ReadInt(memoryAddress + 80));
 			}
 			set
 			{
@@ -365,16 +375,16 @@ namespace CitizenFX.Core
 		/// <summary>
 		/// Gets or sets the color of the icon in this <see cref="Checkpoint"/>.
 		/// </summary>
-		public System.Drawing.Color IconColor
+		public Color IconColor
 		{
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
 				if (memoryAddress == IntPtr.Zero)
 				{
-					return System.Drawing.Color.FromArgb(0, 0, 0, 0);
+					return Color.FromArgb(0, 0, 0, 0);
 				}
-				return System.Drawing.Color.FromArgb(MemoryAccess.ReadInt(memoryAddress + 84));
+				return Color.FromArgb(MemoryAccess.ReadInt(memoryAddress + 84));
 			}
 			set
 			{

--- a/code/client/clrcore/External/Controls.cs
+++ b/code/client/clrcore/External/Controls.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum Control
 	{

--- a/code/client/clrcore/External/DlcWeaponStructs.cs
+++ b/code/client/clrcore/External/DlcWeaponStructs.cs
@@ -1,9 +1,16 @@
 using System;
 using System.Runtime.InteropServices;
-using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+
 namespace CitizenFX.Core
+#endif
 {
 	[StructLayout(LayoutKind.Explicit, Size = 0x138)]
 	[SecurityCritical]
@@ -31,7 +38,11 @@ namespace CitizenFX.Core
 
 		public bool IsValid
 		{
+#if MONO_V2
+			get { return !API.IsDlcDataEmpty(unchecked((uint)validCheck)); }			
+#else
 			get { return !API.IsDlcDataEmpty(ref validCheck); }
+#endif
 		}
 
 		public WeaponHash Hash

--- a/code/client/clrcore/External/Element.cs
+++ b/code/client/clrcore/External/Element.cs
@@ -1,3 +1,5 @@
+#if !MONO_V2
+
 using System;
 using System.Drawing;
 using System.Collections.Generic;
@@ -327,3 +329,5 @@ namespace CitizenFX.Core.UI
 		}
 	}
 }
+
+#endif

--- a/code/client/clrcore/External/Entity.cs
+++ b/code/client/clrcore/External/Entity.cs
@@ -1,9 +1,18 @@
 using System;
 using System.Linq;
-using CitizenFX.Core.Native;
 using System.Security;
+using CitizenFX.Core.Native;
 
+#if MONO_V2
+using CitizenFX.Core;
+using CitizenFX.FiveM.Native;
+using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum ForceType
 	{
@@ -28,8 +37,13 @@ namespace CitizenFX.Core
 		/// <summary>
 		/// Gets the memory address where the <see cref="Entity"/> is stored in memory.
 		/// </summary>
+#if MONO_V2
+		internal IntPtr MemoryAddress
+#else
 		public IntPtr MemoryAddress
+#endif
 		{
+			[SecurityCritical]
 			get
 			{
 				// CFX-TODO
@@ -293,7 +307,7 @@ namespace CitizenFX.Core
 		}
 
 		/// <summary>
-		/// Gets this <see cref="Entity"/>s matrix which stores position and rotation information.
+		/// Gets this <see cref="Entity"/>'s matrix which stores position and rotation information.
 		/// </summary>
 		public Matrix Matrix
 		{
@@ -823,7 +837,7 @@ namespace CitizenFX.Core
 			}
 			set
 			{
-				API.SetEntityAlpha(Handle, value, 0); // p2 used to be false
+				API.SetEntityAlpha(Handle, value, default); // p2 used to be false
 			}
 		}
 		/// <summary>

--- a/code/client/clrcore/External/EntityBone.cs
+++ b/code/client/clrcore/External/EntityBone.cs
@@ -1,7 +1,14 @@
-using System;
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using InputArgument = CitizenFX.Core.Native.Input.Primitive;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class EntityBone
 	{
@@ -290,7 +297,7 @@ namespace CitizenFX.Core
 
 		public static implicit operator InputArgument(EntityBone entityBone)
 		{
-			return new InputArgument(entityBone.Index);
+			return (InputArgument)entityBone.Index;
 		}
 	}
 }

--- a/code/client/clrcore/External/EntityBoneCollection.cs
+++ b/code/client/clrcore/External/EntityBoneCollection.cs
@@ -1,8 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class EntityBoneCollection : IEnumerable<EntityBone>
 	{

--- a/code/client/clrcore/External/Euphoria.cs
+++ b/code/client/clrcore/External/Euphoria.cs
@@ -2,7 +2,11 @@ using System;
 using System.Collections.Generic;
 using CitizenFX.Core;
 
+#if MONO_V2
+namespace CitizenFX.FiveM.NaturalMotion
+#else
 namespace CitizenFX.Core.NaturalMotion
+#endif
 {
 	public sealed class Euphoria
 	{

--- a/code/client/clrcore/External/EuphoriaBase.cs
+++ b/code/client/clrcore/External/EuphoriaBase.cs
@@ -1,9 +1,16 @@
 using System;
 using System.Collections.Generic;
 using CitizenFX.Core;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM.NaturalMotion
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core.NaturalMotion
+#endif
 {
 	/// <summary>
 	/// A Base class for manually building a <see cref="NaturalMotion.Message"/>

--- a/code/client/clrcore/External/EuphoriaHelpers.cs
+++ b/code/client/clrcore/External/EuphoriaHelpers.cs
@@ -1,7 +1,11 @@
 using System;
 using CitizenFX.Core;
 
+#if MONO_V2
+namespace CitizenFX.FiveM.NaturalMotion
+#else
 namespace CitizenFX.Core.NaturalMotion
+#endif
 {
 	public enum ArmDirection
 	{

--- a/code/client/clrcore/External/Font.cs
+++ b/code/client/clrcore/External/Font.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM.UI
+#else
 namespace CitizenFX.Core.UI
+#endif
 {
 	public enum Font
 	{

--- a/code/client/clrcore/External/Interfaces.cs
+++ b/code/client/clrcore/External/Interfaces.cs
@@ -1,6 +1,13 @@
+#if MONO_V2
+using CitizenFX.Core;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public interface ISpatial
 	{
@@ -20,6 +27,7 @@ namespace CitizenFX.Core
 
 	public abstract class PoolObject : INativeValue, IDeletable
 	{
+#if !MONO_V2
 		protected PoolObject(int handle)
 		{
 			Handle = handle;
@@ -31,6 +39,16 @@ namespace CitizenFX.Core
 			get { return (ulong)Handle; }
 			set { Handle = unchecked((int)value); }
 		}
+#else
+		protected PoolObject(int handle) : base(unchecked((ulong)handle))
+		{ }
+
+		public int Handle
+		{
+			get => unchecked((int)m_nativeValue);
+			protected set => m_nativeValue = unchecked((ulong)value);
+		}
+#endif
 
 		public abstract bool Exists();
 

--- a/code/client/clrcore/External/MaterialHash.cs
+++ b/code/client/clrcore/External/MaterialHash.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum MaterialHash : uint
 	{

--- a/code/client/clrcore/External/Model.cs
+++ b/code/client/clrcore/External/Model.cs
@@ -1,10 +1,20 @@
 using System;
-using CitizenFX.Core.Native;
-using System.Security;
-using System.Threading.Tasks;
+
+#if MONO_V2
 using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+using TaskBool = CitizenFX.Core.Coroutine<bool>;
+using compat_i32_u32 = System.UInt32;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+using TaskBool = System.Threading.Tasks.Task<bool>;
+using compat_i32_u32 = System.Int32;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class Model : INativeValue, IEquatable<Model>
 	{
@@ -14,8 +24,15 @@ namespace CitizenFX.Core
 		}
 		public Model(int hash) : this()
 		{
+			Hash = (compat_i32_u32)hash;
+		}
+
+#if MONO_V2
+		public Model(uint hash) : this()
+		{
 			Hash = hash;
 		}
+#endif
 		public Model(string name) : this(Game.GenerateHash(name))
 		{
 		}
@@ -32,6 +49,9 @@ namespace CitizenFX.Core
 		/// <summary>
 		/// Gets the hash for this <see cref="Model"/>.
 		/// </summary>
+#if MONO_V2
+		public uint Hash { get => (uint)m_nativeValue; private set => m_nativeValue = value; }
+#else
 		public int Hash { get; private set; }
 
 		public override ulong NativeValue
@@ -45,6 +65,7 @@ namespace CitizenFX.Core
 				Hash = unchecked((int)value);
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Returns true if this <see cref="Model"/> is valid.
@@ -309,7 +330,7 @@ namespace CitizenFX.Core
 		/// </summary>
 		/// <param name="timeout">The time (in milliseconds) before giving up trying to load this <see cref="Model"/></param>
 		/// <returns><c>true</c> if this <see cref="Model"/> is loaded; otherwise, <c>false</c></returns>
-		public async Task<bool> Request(int timeout)
+		public async TaskBool Request(int timeout)
 		{
 			// Only request the model if it's not yet loaded.
 			if (!IsLoaded)
@@ -357,7 +378,7 @@ namespace CitizenFX.Core
 
 		public override int GetHashCode()
 		{
-			return Hash;
+			return (int)Hash;
 		}
 		public override string ToString()
 		{
@@ -387,7 +408,11 @@ namespace CitizenFX.Core
 
 		public static implicit operator int(Model source)
 		{
-			return source.Hash;
+			return (int)source.Hash;
+		}
+		public static implicit operator uint(Model source)
+		{
+			return (uint)source.Hash;
 		}
 		public static implicit operator PedHash(Model source)
 		{

--- a/code/client/clrcore/External/MpPedDataStructs.cs
+++ b/code/client/clrcore/External/MpPedDataStructs.cs
@@ -2,7 +2,11 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	/// <summary>
 	/// This is used to GET the data. The GetData() function returns the data into a usable struct for scripts to use safely.

--- a/code/client/clrcore/External/ParticleEffects.cs
+++ b/code/client/clrcore/External/ParticleEffects.cs
@@ -1,10 +1,19 @@
 using System;
 using System.Drawing;
 using CitizenFX.Core.Native;
-using Hash = CitizenFX.Core.Native.Hash;
-using System.Threading.Tasks;
+
+#if MONO_V2
+using CitizenFX.Core;
+using InputArgument = CitizenFX.Core.Native.Input.Primitive;
+using API = CitizenFX.FiveM.Native.Natives;
+using TaskBool = CitizenFX.Core.Coroutine<bool>;
+
+namespace CitizenFX.FiveM
+#else
+using TaskBool = System.Threading.Tasks.Task<bool>;
 
 namespace CitizenFX.Core
+#endif
 {
 	[Flags]
 	public enum InvertAxis
@@ -223,7 +232,7 @@ namespace CitizenFX.Core
 		/// </summary>
 		/// <param name="timeout">How long in milli-seconds should the game wait while the model hasnt been loaded before giving up</param>
 		/// <returns><c>true</c> if the <see cref="ParticleEffectsAsset"/> is Loaded; otherwise, <c>false</c></returns>
-		public async Task<bool> Request(int timeout)
+		public async TaskBool Request(int timeout)
 		{
 			if (!IsLoaded)
 			{
@@ -279,7 +288,7 @@ namespace CitizenFX.Core
 
 		public static implicit operator InputArgument(ParticleEffectsAsset asset)
 		{
-			return new InputArgument(asset._assetName);
+			return (InputArgument)asset._assetName;
 		}
 	}
 
@@ -538,7 +547,7 @@ namespace CitizenFX.Core
 		public static implicit operator InputArgument(ParticleEffect effect)
 		{
 			//we only need to worry about supplying a particle effect to a native, never returning one
-			return new InputArgument(effect.Handle);
+			return (InputArgument)effect.Handle;
 		}
 	}
 

--- a/code/client/clrcore/External/Ped.cs
+++ b/code/client/clrcore/External/Ped.cs
@@ -1,9 +1,18 @@
 using System;
 using CitizenFX.Core.Native;
-using CitizenFX.Core.NaturalMotion;
 using System.Security;
 
+#if MONO_V2
+using CitizenFX.Core;
+using CitizenFX.FiveM.Native;
+using CitizenFX.FiveM.NaturalMotion;
+using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.NaturalMotion;
 namespace CitizenFX.Core
+#endif
 {
 	public enum Gender
 	{
@@ -1578,10 +1587,18 @@ namespace CitizenFX.Core
 			API.SetPedResetFlag(Handle, flagID, true);
 		}
 
-		public Ped Clone(float heading = 0.0f)
+		[Obsolete("Parameter `float heading` is not used, use the parameter-less Clone() method instead")]
+		public Ped Clone(float heading = 0.0f) => Clone();
+
+		public Ped Clone()
 		{
-			return new Ped(API.ClonePed(Handle, heading, false, false));
+#if MONO_V2
+			return new Ped(API.ClonePed(Handle, API.NetworkGetEntityIsNetworked(Handle), false, false));
+#else
+			return new Ped(API.ClonePed(Handle, Convert.ToSingle(API.NetworkGetEntityIsNetworked(Handle)), false, false));
+#endif
 		}
+
 		/// <summary>
 		/// Determines whether this <see cref="Ped"/> exists.
 		/// </summary>

--- a/code/client/clrcore/External/PedBone.cs
+++ b/code/client/clrcore/External/PedBone.cs
@@ -1,6 +1,12 @@
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class PedBone : EntityBone
 	{

--- a/code/client/clrcore/External/PedBoneCollection.cs
+++ b/code/client/clrcore/External/PedBoneCollection.cs
@@ -1,9 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class PedBoneCollection : EntityBoneCollection, IEnumerable<PedBone>
 	{

--- a/code/client/clrcore/External/PedGroup.cs
+++ b/code/client/clrcore/External/PedGroup.cs
@@ -1,10 +1,18 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+using compat_i32_i64 = System.Int64;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
+using compat_i32_i64 = System.Int32;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum FormationType
 	{
@@ -92,7 +100,7 @@ namespace CitizenFX.Core
 		{
 			get
 			{
-				int unknBool = 0;
+				compat_i32_i64 unknBool = 0;
 				int count = 0;
 
 				API.GetGroupSize(Handle, ref unknBool, ref count);

--- a/code/client/clrcore/External/PedHash.cs
+++ b/code/client/clrcore/External/PedHash.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum PedHash : uint
 	{

--- a/code/client/clrcore/External/Pickup.cs
+++ b/code/client/clrcore/External/Pickup.cs
@@ -1,7 +1,15 @@
 using System;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum PickupType : uint
 	{

--- a/code/client/clrcore/External/PlayerList.cs
+++ b/code/client/clrcore/External/PlayerList.cs
@@ -3,14 +3,22 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 #if !IS_FXSERVER && !IS_RDR3 && !GTA_NY
 	public class PlayerList : IEnumerable<Player>
 	{
 		public const int MaxPlayers = 256;
+
+		public static PlayerList Players { get; } = new PlayerList();
 
 		public IEnumerator<Player> GetEnumerator()
 		{

--- a/code/client/clrcore/External/Prop.cs
+++ b/code/client/clrcore/External/Prop.cs
@@ -1,7 +1,12 @@
-using System;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public sealed class Prop : Entity
 	{

--- a/code/client/clrcore/External/RadioStation.cs
+++ b/code/client/clrcore/External/RadioStation.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum RadioStation
 	{

--- a/code/client/clrcore/External/Raycast.cs
+++ b/code/client/clrcore/External/Raycast.cs
@@ -1,7 +1,13 @@
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
 
 namespace CitizenFX.Core
+#endif
 {
 	public struct RaycastResult
 	{

--- a/code/client/clrcore/External/Relationship.cs
+++ b/code/client/clrcore/External/Relationship.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum Relationship
 	{

--- a/code/client/clrcore/External/RelationshipGroup.cs
+++ b/code/client/clrcore/External/RelationshipGroup.cs
@@ -1,8 +1,15 @@
 using System;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class RelationshipGroup : INativeValue, IEquatable<RelationshipGroup>
 	{

--- a/code/client/clrcore/External/Rope.cs
+++ b/code/client/clrcore/External/Rope.cs
@@ -1,8 +1,15 @@
 using System;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum RopeType
 	{

--- a/code/client/clrcore/External/Scaleform.cs
+++ b/code/client/clrcore/External/Scaleform.cs
@@ -1,9 +1,18 @@
 using System;
-using System.Drawing;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+using PointF = CitizenFX.Core.Vector2;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
+using System.Drawing;
 
 namespace CitizenFX.Core
+#endif
 {
 	public sealed class ScaleformArgumentTXD
 	{

--- a/code/client/clrcore/External/Screen.cs
+++ b/code/client/clrcore/External/Screen.cs
@@ -1,9 +1,16 @@
-using System;
-using System.Drawing;
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using PointF = CitizenFX.Core.Vector2;
+using Size = CitizenFX.Core.Size2;
+
+namespace CitizenFX.FiveM.UI
+#else
 using CitizenFX.Core.Native;
-using System.Security;
+using System.Drawing;
 
 namespace CitizenFX.Core.UI
+#endif
 {
 	public enum HudComponent
 	{

--- a/code/client/clrcore/External/Sprite.cs
+++ b/code/client/clrcore/External/Sprite.cs
@@ -1,3 +1,5 @@
+#if !MONO_V2
+
 using System;
 using System.IO;
 using System.Drawing;
@@ -213,10 +215,17 @@ namespace CitizenFX.Core.UI
 				return;
 			}
 
+#if MONO_V2
+			float scaleX = Size.X / screenWidth;
+			float scaleY = Size.Y / screenHeight;
+			float positionX = (Position.X + offset.X) / screenWidth;
+			float positionY = (Position.Y + offset.Y) / screenHeight;
+#else
 			float scaleX = Size.Width / screenWidth;
 			float scaleY = Size.Height / screenHeight;
 			float positionX = (Position.X + offset.Width) / screenWidth;
 			float positionY = (Position.Y + offset.Height) / screenHeight;
+#endif
 
 			if (!Centered)
 			{
@@ -228,3 +237,4 @@ namespace CitizenFX.Core.UI
 		}
 	}
 }
+#endif

--- a/code/client/clrcore/External/Style.cs
+++ b/code/client/clrcore/External/Style.cs
@@ -1,8 +1,15 @@
 using System;
 using System.Collections.Generic;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum PedComponents
 	{
@@ -126,7 +133,7 @@ namespace CitizenFX.Core
 				case PedHash.FreemodeFemale01:
 					return; //these models freeze when randomized
 			}
-			API.SetPedRandomComponentVariation(_ped.Handle, false);
+			API.SetPedRandomComponentVariation(_ped.Handle, default);
 		}
 		public void SetDefaultClothes()
 		{

--- a/code/client/clrcore/External/Tasks.cs
+++ b/code/client/clrcore/External/Tasks.cs
@@ -1,9 +1,17 @@
 using System;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using Task = CitizenFX.Core.Coroutine;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
-using System.Security;
 using System.Threading.Tasks;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum FiringPattern : uint
 	{

--- a/code/client/clrcore/External/Text.cs
+++ b/code/client/clrcore/External/Text.cs
@@ -1,3 +1,5 @@
+#if !MONO_V2
+
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -356,8 +358,13 @@ namespace CitizenFX.Core.UI
 				return;
 			}
 
+#if MONO_V2
+			float x = (Position.X + offset.X) / screenWidth;
+			float y = (Position.Y + offset.Y) / screenHeight;
+#else
 			float x = (Position.X + offset.Width) / screenWidth;
 			float y = (Position.Y + offset.Height) / screenHeight;
+#endif
 			float w = WrapWidth / screenWidth;
 
 			if (Shadow)
@@ -407,3 +414,4 @@ namespace CitizenFX.Core.UI
 		}
 	}
 }
+#endif

--- a/code/client/clrcore/External/Vehicle.cs
+++ b/code/client/clrcore/External/Vehicle.cs
@@ -1,12 +1,22 @@
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using CitizenFX.Core.Native;
-using System.Security;
-using System.Threading.Tasks;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using TaskPed = CitizenFX.Core.Coroutine<CitizenFX.FiveM.Ped>;
+using compat_i32_i64 = System.Int64;
+
+namespace CitizenFX.FiveM
+#else
+using System.Drawing;
+using TaskPed = System.Threading.Tasks.Task<CitizenFX.Core.Ped>;
+using compat_i32_i64 = System.Int32;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum CargobobHook
 	{
@@ -1430,7 +1440,7 @@ namespace CitizenFX.Core
 			Vector3 currentPosition = Position;
 			Vector3 newPosition = new Vector3();
 			float heading = 0f;
-			int unkn = 0;
+			compat_i32_i64 unkn = 0;
 
 			for (int i = 1; i < 40; i++)
 			{
@@ -1604,7 +1614,7 @@ namespace CitizenFX.Core
 			API.SetVehicleDamage(Handle, position.X, position.Y, position.Z, damageAmount, radius, false);
 		}
 
-		public async Task<Ped> CreatePedOnSeat(VehicleSeat seat, Model model)
+		public async TaskPed CreatePedOnSeat(VehicleSeat seat, Model model)
 		{
 			if (!IsSeatFree(seat))
 			{

--- a/code/client/clrcore/External/VehicleDoor.cs
+++ b/code/client/clrcore/External/VehicleDoor.cs
@@ -1,7 +1,12 @@
-using System;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 
 	public sealed class VehicleDoor

--- a/code/client/clrcore/External/VehicleDoorCollection.cs
+++ b/code/client/clrcore/External/VehicleDoorCollection.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
 
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum VehicleDoorIndex
 	{

--- a/code/client/clrcore/External/VehicleHash.cs
+++ b/code/client/clrcore/External/VehicleHash.cs
@@ -1,4 +1,8 @@
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum VehicleHash : uint
 	{

--- a/code/client/clrcore/External/VehicleMod.cs
+++ b/code/client/clrcore/External/VehicleMod.cs
@@ -1,11 +1,16 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Collections.ObjectModel;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 
 	public sealed class VehicleMod

--- a/code/client/clrcore/External/VehicleModCollection.cs
+++ b/code/client/clrcore/External/VehicleModCollection.cs
@@ -1,14 +1,21 @@
-using CitizenFX.Core;
-using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Drawing;
 using System.Linq;
-using System.Security;
-using System.Threading.Tasks;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using TaskBool = CitizenFX.Core.Coroutine<bool>;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+using System.Drawing;
+using TaskBool = System.Threading.Tasks.Task<bool>;
 
 namespace CitizenFX.Core
+#endif
 {
 	public enum VehicleModType
 	{
@@ -232,7 +239,7 @@ namespace CitizenFX.Core
 			API.SetVehicleModKit(_owner.Handle, 0);
 		}
 
-		public async Task<bool> RequestAdditionTextFile(int timeout = 1000)
+		public async TaskBool RequestAdditionTextFile(int timeout = 1000)
 		{
 			if (!API.HasThisAdditionalTextLoaded("mod_mnu", 10))
 			{

--- a/code/client/clrcore/External/VehicleToggleMod.cs
+++ b/code/client/clrcore/External/VehicleToggleMod.cs
@@ -1,7 +1,12 @@
-using System;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 
 	public sealed class VehicleToggleMod

--- a/code/client/clrcore/External/VehicleWheel.cs
+++ b/code/client/clrcore/External/VehicleWheel.cs
@@ -1,7 +1,12 @@
-using System;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 
 	public sealed class VehicleWheel

--- a/code/client/clrcore/External/VehicleWheelCollection.cs
+++ b/code/client/clrcore/External/VehicleWheelCollection.cs
@@ -2,7 +2,11 @@ using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
 
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public sealed class VehicleWheelCollection
 	{

--- a/code/client/clrcore/External/VehicleWindow.cs
+++ b/code/client/clrcore/External/VehicleWindow.cs
@@ -1,7 +1,12 @@
-using System;
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 
 	public sealed class VehicleWindow

--- a/code/client/clrcore/External/VehicleWindowCollection.cs
+++ b/code/client/clrcore/External/VehicleWindowCollection.cs
@@ -1,9 +1,16 @@
-using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum VehicleWindowIndex
 	{

--- a/code/client/clrcore/External/Weapon.cs
+++ b/code/client/clrcore/External/Weapon.cs
@@ -1,8 +1,18 @@
 using System;
-using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
+using compat_i32_u32 = System.UInt32;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+using compat_i32_u32 = System.Int32;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum WeaponTint
 	{
@@ -205,7 +215,7 @@ namespace CitizenFX.Core
 
 				if (!IsPresent)
 				{
-					return API.GetPedAmmoByType(_owner.Handle, (int)AmmoType);
+					return API.GetPedAmmoByType(_owner.Handle, (compat_i32_u32)AmmoType);
 				}
 
 				return API.GetAmmoInPedWeapon(_owner.Handle, (uint)Hash);
@@ -355,7 +365,7 @@ namespace CitizenFX.Core
 			{
 				WeaponComponent comp = Components.GetMk2CamoComponent((int)liveryID);
 				comp.Active = true;
-				API.N_0x9fe5633880ecd8ed(Game.PlayerPed.Handle, (int)Hash, (int)comp.ComponentHash, (int)colorID);
+				API.N_0x9fe5633880ecd8ed(Game.PlayerPed.Handle, (compat_i32_u32)Hash, (compat_i32_u32)comp.ComponentHash, (int)colorID);
 			}
 			else
 			{

--- a/code/client/clrcore/External/WeaponAsset.cs
+++ b/code/client/clrcore/External/WeaponAsset.cs
@@ -1,9 +1,19 @@
 using System;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+using TaskBool = CitizenFX.Core.Coroutine<bool>;
+
+namespace CitizenFX.FiveM
+#else
 using CitizenFX.Core.Native;
 using System.Threading.Tasks;
-using CitizenFX.Core;
+using TaskBool = System.Threading.Tasks.Task<bool>;
 
 namespace CitizenFX.Core
+#endif
 {
 	public class WeaponAsset : INativeValue, IEquatable<WeaponAsset>
 	{
@@ -48,7 +58,7 @@ namespace CitizenFX.Core
 		{
 			API.RequestWeaponAsset((uint)Hash, 31, 0);
 		}
-		public async Task<bool> Request(int timeout)
+		public async TaskBool Request(int timeout)
 		{
 			Request();
 

--- a/code/client/clrcore/External/WeaponCollection.cs
+++ b/code/client/clrcore/External/WeaponCollection.cs
@@ -1,9 +1,14 @@
-using CitizenFX.Core.Native;
-using System;
 using System.Collections.Generic;
-using System.Security;
+
+#if MONO_V2
+using API = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
+#endif
 {
 	public sealed class WeaponCollection
 	{

--- a/code/client/clrcore/External/WeaponComponent.cs
+++ b/code/client/clrcore/External/WeaponComponent.cs
@@ -1,8 +1,16 @@
-using System;
-using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using CitizenFX.FiveM.Native;
+using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum ComponentAttachmentPoint : uint
 	{

--- a/code/client/clrcore/External/WeaponComponentCollection.cs
+++ b/code/client/clrcore/External/WeaponComponentCollection.cs
@@ -1,10 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using CitizenFX.FiveM.Native;
+using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
+
+namespace CitizenFX.FiveM
+#else
+using CitizenFX.Core.Native;
+
 namespace CitizenFX.Core
+#endif
 {
 	public enum WeaponComponentHash : uint
 	{

--- a/code/client/clrcore/External/WeaponHash.cs
+++ b/code/client/clrcore/External/WeaponHash.cs
@@ -1,6 +1,8 @@
-using System;
-
+#if MONO_V2
+namespace CitizenFX.FiveM
+#else
 namespace CitizenFX.Core
+#endif
 {
 	public enum WeaponHash : uint
 	{

--- a/code/client/clrcore/External/World.cs
+++ b/code/client/clrcore/External/World.cs
@@ -1,13 +1,30 @@
 using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Drawing;
 using System.Linq;
-using System.Security;
-using System.Threading.Tasks;
+
+#if MONO_V2
+using CitizenFX.Core;
+using API = CitizenFX.FiveM.Native.Natives;
+using TaskPed = CitizenFX.Core.Coroutine<CitizenFX.FiveM.Ped>;
+using TaskPickup = CitizenFX.Core.Coroutine<CitizenFX.FiveM.Pickup>;
+using TaskProp = CitizenFX.Core.Coroutine<CitizenFX.FiveM.Prop>;
+using TaskVehicle = CitizenFX.Core.Coroutine<CitizenFX.FiveM.Vehicle>;
+using compat_i32_u32 = System.UInt32;
+using compat_i32_i64 = System.Int64;
+
+namespace CitizenFX.FiveM
+#else
+using System.Drawing;
+using TaskPed = System.Threading.Tasks.Task<CitizenFX.Core.Ped>;
+using TaskPickup = System.Threading.Tasks.Task<CitizenFX.Core.Pickup>;
+using TaskProp = System.Threading.Tasks.Task<CitizenFX.Core.Prop>;
+using TaskVehicle = System.Threading.Tasks.Task<CitizenFX.Core.Vehicle>;
+using compat_i32_u32 = System.Int32;
+using compat_i32_i64 = System.Int32;
 
 namespace CitizenFX.Core
+#endif
 {
 	class GTACalender : System.Globalization.GregorianCalendar
 	{
@@ -425,7 +442,7 @@ namespace CitizenFX.Core
 		{
 			get
 			{
-				switch (API.GetPrevWeatherTypeHashName())
+				switch (unchecked((int)API.GetPrevWeatherTypeHashName()))
 				{
 					case -1750463879:
 						return Weather.ExtraSunny;
@@ -479,7 +496,7 @@ namespace CitizenFX.Core
 		{
 			get
 			{
-				switch (API.GetNextWeatherTypeHashName())
+				switch (unchecked((int)API.GetNextWeatherTypeHashName()))
 				{
 					case -1750463879:
 						return Weather.ExtraSunny;
@@ -1284,7 +1301,7 @@ namespace CitizenFX.Core
 		/// <param name="position">The position to spawn the <see cref="Ped"/> at.</param>
 		/// <param name="heading">The heading of the <see cref="Ped"/>.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Ped"/> could not be spawned</remarks>
-		public static async Task<Ped> CreatePed(Model model, Vector3 position, float heading = 0f)
+		public static async TaskPed CreatePed(Model model, Vector3 position, float heading = 0f)
 		{
 			if (!model.IsPed || !await model.Request(1000))
 			{
@@ -1309,7 +1326,7 @@ namespace CitizenFX.Core
 		/// <param name="position">The position to spawn the <see cref="Vehicle"/> at.</param>
 		/// <param name="heading">The heading of the <see cref="Vehicle"/>.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Vehicle"/> could not be spawned</remarks>
-		public static async Task<Vehicle> CreateVehicle(Model model, Vector3 position, float heading = 0f)
+		public static async TaskVehicle CreateVehicle(Model model, Vector3 position, float heading = 0f)
 		{
 			if (!model.IsVehicle || !await model.Request(1000))
 			{
@@ -1325,7 +1342,7 @@ namespace CitizenFX.Core
 		/// <param name="position">The position to spawn the <see cref="Vehicle"/> at.</param>
 		/// <param name="heading">The heading of the <see cref="Vehicle"/>.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Vehicle"/> could not be spawned</remarks>
-		public static Task<Vehicle> CreateRandomVehicle(Vector3 position, float heading = 0f)
+		public static TaskVehicle CreateRandomVehicle(Vector3 position, float heading = 0f)
 		{
 			Array vehicleHashes = Enum.GetValues(typeof(VehicleHash));
 			Random random = new Random();
@@ -1362,7 +1379,7 @@ namespace CitizenFX.Core
 		/// <param name="dynamic">if set to <c>true</c> the <see cref="Prop"/> will have physics; otherwise, it will be static.</param>
 		/// <param name="placeOnGround">if set to <c>true</c> place the prop on the ground nearest to the <paramref name="position"/>.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
-		public static async Task<Prop> CreateProp(Model model, Vector3 position, bool dynamic, bool placeOnGround)
+		public static async TaskProp CreateProp(Model model, Vector3 position, bool dynamic, bool placeOnGround)
 		{
 			if (!await model.Request(1000))
 			{
@@ -1374,7 +1391,7 @@ namespace CitizenFX.Core
 				position.Z = GetGroundHeight(position);
 			}
 
-			return new Prop(API.CreateObject(model.Hash, position.X, position.Y, position.Z, true, true, dynamic));
+			return new Prop(API.CreateObject((compat_i32_u32)model.Hash, position.X, position.Y, position.Z, true, true, dynamic));
 		}
 		/// <summary>
 		/// Spawns a <see cref="Prop"/> of the given <see cref="Model"/> at the position specified.
@@ -1385,7 +1402,7 @@ namespace CitizenFX.Core
 		/// <param name="dynamic">if set to <c>true</c> the <see cref="Prop"/> will have physics; otherwise, it will be static.</param>
 		/// <param name="placeOnGround">if set to <c>true</c> place the prop on the ground nearest to the <paramref name="position"/>.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
-		public static async Task<Prop> CreateProp(Model model, Vector3 position, Vector3 rotation, bool dynamic, bool placeOnGround)
+		public static async TaskProp CreateProp(Model model, Vector3 position, Vector3 rotation, bool dynamic, bool placeOnGround)
 		{
 			Prop prop = await CreateProp(model, position, dynamic, placeOnGround);
 
@@ -1403,7 +1420,7 @@ namespace CitizenFX.Core
 		/// <param name="position">The position to spawn the <see cref="Prop"/> at.</param>
 		/// <param name="dynamic">if set to <c>true</c> the <see cref="Prop"/> will have physics; otherwise, it will be static.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
-		public static async Task<Prop> CreatePropNoOffset(Model model, Vector3 position, bool dynamic)
+		public static async TaskProp CreatePropNoOffset(Model model, Vector3 position, bool dynamic)
 		{
 			if (!await model.Request(1000))
 			{
@@ -1420,7 +1437,7 @@ namespace CitizenFX.Core
 		/// <param name="rotation">The rotation of the <see cref="Prop"/>.</param>
 		/// <param name="dynamic">if set to <c>true</c> the <see cref="Prop"/> will have physics; otherwise, it will be static.</param>
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
-		public static async Task<Prop> CreatePropNoOffset(Model model, Vector3 position, Vector3 rotation, bool dynamic)
+		public static async TaskProp CreatePropNoOffset(Model model, Vector3 position, Vector3 rotation, bool dynamic)
 		{
 			Prop prop = await CreatePropNoOffset(model, position, dynamic);
 
@@ -1432,7 +1449,7 @@ namespace CitizenFX.Core
 			return prop;
 		}
 
-		public static async Task<Pickup> CreatePickup(PickupType type, Vector3 position, Model model, int value)
+		public static async TaskPickup CreatePickup(PickupType type, Vector3 position, Model model, int value)
 		{
 			if (!await model.Request(1000))
 			{
@@ -1448,7 +1465,7 @@ namespace CitizenFX.Core
 
 			return new Pickup(handle);
 		}
-		public static async Task<Pickup> CreatePickup(PickupType type, Vector3 position, Vector3 rotation, Model model, int value)
+		public static async TaskPickup CreatePickup(PickupType type, Vector3 position, Vector3 rotation, Model model, int value)
 		{
 			if (!await model.Request(1000))
 			{
@@ -1464,7 +1481,7 @@ namespace CitizenFX.Core
 
 			return new Pickup(handle);
 		}
-		public static async Task<Prop> CreateAmbientPickup(PickupType type, Vector3 position, Model model, int value)
+		public static async TaskProp CreateAmbientPickup(PickupType type, Vector3 position, Model model, int value)
 		{
 			if (!await model.Request(1000))
 			{
@@ -1534,7 +1551,7 @@ namespace CitizenFX.Core
 		public static Rope AddRope(RopeType type, Vector3 position, Vector3 rotation, float length, float minLength, bool breakable)
 		{
 			API.RopeLoadTextures();
-			int unkPntr = 0;
+			compat_i32_i64 unkPntr = 0;
 			return new Rope(API.AddRope(position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, length, (int)type, length, minLength, 0.5f, false, false, true, 1.0f, breakable, ref unkPntr));
 		}
 

--- a/code/client/clrcore/Math/Color.cs
+++ b/code/client/clrcore/Math/Color.cs
@@ -33,9 +33,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-
 namespace System.Drawing 
 {
 	[Serializable]

--- a/code/client/clrcore/Math/GameMath.cs
+++ b/code/client/clrcore/Math/GameMath.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,35 +8,36 @@ namespace CitizenFX.Core
 {
     public class GameMath
     {
-        public static Vector3 DirectionToRotation(Vector3 dir, float roll)
+        public static Vector3 DirectionToRotation(Vector3 direction, float roll)
         {
-            dir = Vector3.Normalize(dir);
-            Vector3 rotval;
-            rotval.Z = -MathUtil.RadiansToDegrees((float)Math.Atan2(dir.X, dir.Y));
-            Vector3 rotpos = Vector3.Normalize(new Vector3(dir.Z, new Vector3(dir.X, dir.Y, 0.0f).Length(), 0.0f));
-            rotval.X = MathUtil.RadiansToDegrees((float)Math.Atan2(rotpos.X, rotpos.Y));
-            rotval.Y = roll;
-            return rotval;
+            direction = Vector3.Normalize(direction);
+            Vector3 rotpos = Vector3.Normalize(new Vector3(direction.Z, (float)Math.Sqrt(direction.X * direction.Y), 0.0f));
+			return new Vector3(
+				MathUtil.RadiansToDegrees((float)Math.Atan2(rotpos.X, rotpos.Y)),
+				roll,
+				-MathUtil.RadiansToDegrees((float)Math.Atan2(direction.X, direction.Y))
+			);
         }
-        public static Vector3 RotationToDirection(Vector3 Rotation)
+
+        public static Vector3 RotationToDirection(Vector3 rotation)
         {
-            float rotZ = MathUtil.DegreesToRadians(Rotation.Z);
-            float rotX = MathUtil.DegreesToRadians(Rotation.X);
+            float rotZ = MathUtil.DegreesToRadians(rotation.Z);
+            float rotX = MathUtil.DegreesToRadians(rotation.X);
             float multXY = Math.Abs((float)Math.Cos(rotX));
             return new Vector3((float)-Math.Sin(rotZ) * multXY, (float)Math.Cos(rotZ) * multXY, (float)Math.Sin(rotX));
         }
 
         public static float DirectionToHeading(Vector3 dir)
         {
-            dir.Z = 0.0f;
-            dir.Normalize();
-            return MathUtil.RadiansToDegrees((float)Math.Atan2(dir.X, dir.Y));
+			Vector2 dir2 = (Vector2)dir;
+			dir2.Normalize();
+            return MathUtil.RadiansToDegrees((float)Math.Atan2(dir2.X, dir2.Y));
         }
 
-        public static Vector3 HeadingToDirection(float Heading)
+        public static Vector3 HeadingToDirection(float heading)
         {
-            Heading = MathUtil.DegreesToRadians(Heading);
-            return new Vector3((float)-Math.Sin(Heading), (float)Math.Cos(Heading), 0.0f);
+            heading = MathUtil.DegreesToRadians(heading);
+            return new Vector3((float)-Math.Sin(heading), (float)Math.Cos(heading), 0.0f);
         }
     }
 }

--- a/code/client/clrcore/Math/MathUtil.cs
+++ b/code/client/clrcore/Math/MathUtil.cs
@@ -64,6 +64,11 @@ namespace CitizenFX.Core
         public const float TwoPi = (float)(2 * Math.PI);
 
         /// <summary>
+        /// Mathematical term for 2π, which is equivalent to 360 degrees.
+        /// </summary>
+        public const float Tau = (float)(2 * Math.PI);
+
+        /// <summary>
         /// A value specifying the approximation of π/2 which is 90 degrees.
         /// </summary>
         public const float PiOverTwo = (float)(Math.PI / 2);

--- a/code/client/clrcore/Math/Vector2.cs
+++ b/code/client/clrcore/Math/Vector2.cs
@@ -58,6 +58,7 @@ namespace CitizenFX.Core
 		/// A <see cref="CitizenFX.Core.Vector2"/> with all of its components set to zero.
 		/// </summary>
 		public static readonly Vector2 Zero = new Vector2();
+		public static readonly Vector2 Empty = new Vector2();
 
 		/// <summary>
 		/// The X unit <see cref="CitizenFX.Core.Vector2"/> (1, 0).
@@ -83,6 +84,16 @@ namespace CitizenFX.Core
 		/// The Y component of the vector.
 		/// </summary>
 		public float Y;
+
+		/// <summary>
+		/// Copies to a new instance of the <see cref="CitizenFX.Core.Vector2"/> struct.
+		/// </summary>
+		/// <param name="value">The value that will be assigned to all components.</param>
+		public Vector2(in Vector2 value)
+		{
+			X = value.X;
+			Y = value.Y;
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CitizenFX.Core.Vector2"/> struct.
@@ -1225,7 +1236,7 @@ namespace CitizenFX.Core
 		}
 
 		/// <summary>
-		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref SharpDX.Vector2,ref SharpDX.Vector2,out SharpDX.Vector2)"/>.
+		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref Vector2, ref Vector2, out Vector2)"/>.
 		/// </summary>
 		/// <param name="left">The first vector to multiply.</param>
 		/// <param name="right">The second vector to multiply.</param>

--- a/code/client/clrcore/Math/Vector3.cs
+++ b/code/client/clrcore/Math/Vector3.cs
@@ -1498,7 +1498,7 @@ namespace CitizenFX.Core
 		}
 
 		/// <summary>
-		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref SharpDX.Vector3,ref SharpDX.Vector3,out SharpDX.Vector3)"/>.
+		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref Vector3, ref Vector3, out Vector3)"/>.
 		/// </summary>
 		/// <param name="left">The first vector to multiply.</param>
 		/// <param name="right">The second vector to multiply.</param>

--- a/code/client/clrcore/Math/Vector4.cs
+++ b/code/client/clrcore/Math/Vector4.cs
@@ -1144,7 +1144,7 @@ namespace CitizenFX.Core
 		}
 
 		/// <summary>
-		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref SharpDX.Vector4,ref SharpDX.Vector4,out SharpDX.Vector4)"/>.
+		/// Multiplies a vector with another by performing component-wise multiplication equivalent to <see cref="Multiply(ref Vector4, ref Vector4, out Vector4)"/>.
 		/// </summary>
 		/// <param name="left">The first vector to multiply.</param>
 		/// <param name="right">The second vector to multiply.</param>

--- a/code/client/clrcore/Math/v2/Color.cs
+++ b/code/client/clrcore/Math/v2/Color.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CitizenFX.Core
+{
+	[StructLayout(LayoutKind.Explicit)]
+	public struct Color : IEquatable<Color>
+	{
+
+		/// <summary>
+		/// Get the blue channel of this color
+		/// </summary>
+		[FieldOffset(0)] public byte B;
+
+		/// <summary>
+		/// Get the green channel of this color
+		/// </summary>
+		[FieldOffset(1)] public byte G;
+
+		/// <summary>
+		/// Get the red channel of this color
+		/// </summary>
+		[FieldOffset(2)] public byte R;
+
+		/// <summary>
+		/// Get the alpha/translucency channel of this color
+		/// </summary>
+		[FieldOffset(3)] public byte A;
+
+		// Overlapping helper fields
+		// this will skip C#'s requirement to initialize these fields (they already are by above fields)
+		[FieldOffset(0)] private unsafe fixed byte values[4];
+		[FieldOffset(0)] private unsafe fixed uint argb[1];
+
+		public readonly static Color Black = new Color(0xFF000000);
+		public readonly static Color White = new Color(0xFFFFFFFF);
+
+		public readonly static Color Red = new Color(0xFFFF0000);
+		public readonly static Color Green = new Color(0xFF00FF00);
+		public readonly static Color Blue = new Color(0xFF0000FF);
+		public readonly static Color Transparent = new Color(0x00000000);
+
+		/// <summary>
+		/// Create a fully opaque color by individual given channels
+		/// </summary>
+		/// <param name="r">red</param>
+		/// <param name="g">green</param>
+		/// <param name="b">blue</param>
+		public unsafe Color(byte r, byte g, byte b)
+		{
+			A = 0xFF;
+			R = r;
+			G = g;
+			B = b;
+		}
+
+		/// <summary>
+		/// Create a color by individual given channels
+		/// </summary>
+		/// <param name="a">alpha/translucency</param>
+		/// <param name="r">red</param>
+		/// <param name="g">green</param>
+		/// <param name="b">blue</param>
+		public unsafe Color(byte a, byte r, byte g, byte b)
+		{
+			A = a;
+			R = r;
+			G = g;
+			B = b;
+		}
+
+		/// <summary>
+		/// Create a color with an unsinged integer
+		/// </summary>
+		/// <param name="argb">argb values</param>
+		public unsafe Color(uint argb) : this() => this.argb[0] = argb;
+
+		/// <summary>
+		/// Create a color with a signed integer
+		/// </summary>
+		/// <param name="argb">argb values</param>
+		public unsafe Color(int argb) : this() => this.argb[0] = (uint)argb;
+
+		/// <summary>
+		/// Get or set the channel at the specified index
+		/// </summary>
+		/// <remarks>Does <paramref name="index"/> % 4 internally as it's faster than a boundary check</remarks>
+		/// <param name="index">channel to get the value for</param>
+		/// <returns></returns>
+		public unsafe byte this[int index]
+		{
+			get => this[(uint)index];
+			set => this[(uint)index] = value;
+		}
+
+		/// <summary>
+		/// Get or set the channel at the specified index
+		/// </summary>
+		/// <remarks>Does <paramref name="index"/> % 4 internally as it's faster than a boundary check</remarks>
+		/// <param name="index">channel to get the value for</param>
+		/// <returns></returns>
+		public unsafe byte this[uint index]
+		{
+#if !OS_LINUX
+			get => values[index % 4];
+			set => values[index % 4] = value;
+#else // compiler wants it pinned for some reason, compiles into a few extra ops
+			get { fixed (byte* v = values) return v[index % 4]; }
+			set { fixed (byte* v = values) v[index % 4] = value; }
+#endif
+		}
+
+		public static unsafe explicit operator uint(in Color color) => color.argb[0];
+		public static unsafe explicit operator int(in Color color) => (int)color.argb[0];
+
+		[Obsolete("use `new Color(byte, byte, byte, byte)` instead")]
+		internal static Color FromArgb(byte a, byte r, byte g, byte b) => new Color(a, r, g, b);
+
+		[Obsolete("use `new Color(byte, byte, byte)` instead")]
+		internal static Color FromArgb(int r, int g, int b) => new Color((byte)r, (byte)g, (byte)b);
+
+		[Obsolete("use `new Color(int)` instead")]
+		internal static Color FromArgb(int argb) => new Color(argb);
+
+		[Obsolete("use `(int)color` instead")]
+#if !OS_LINUX
+		internal unsafe int ToArgb() => (int)argb[0];
+
+		public override unsafe string ToString() => $"Color({values[0]}, {values[1]}, {values[2]}, {values[3]})";
+#else // compiler wants it pinned for some reason, compiles into a few extra ops
+		internal unsafe int ToArgb() { fixed(uint* p = argb) return (int)p[0]; }
+
+		public override unsafe string ToString() { fixed(uint* p = argb) return $"Color({p[0]}, {p[1]}, {p[2]}, {p[3]})"; }
+#endif
+
+		public unsafe bool Equals(Color other) => (uint)this == (uint)other;
+	}
+}

--- a/code/client/clrcore/Math/v2/Size2.cs
+++ b/code/client/clrcore/Math/v2/Size2.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CitizenFX.Core
+{
+	/// <summary>
+	/// Used for integer sizes with width and height values
+	/// </summary>
+	[StructLayout(LayoutKind.Explicit)]
+	public struct Size2 : IEquatable<Size2>
+	{
+		[FieldOffset(0)] private int width;
+		[FieldOffset(4)] private int height;
+
+		// Overlapping helper fields
+		// this will skip C#'s requirement to initialize these fields (they already are by above fields)
+		[FieldOffset(0)] private unsafe fixed int values[2];
+
+		/// <summary>
+		/// Get or set the width of this element
+		/// </summary>
+		public int Width { get => width; set => width = value; }
+
+		/// <summary>
+		/// Get or set the height of this element
+		/// </summary>
+		public int Height { get => height; set => height = value; }
+
+		public static readonly Size2 Zero = new Size2(0, 0);
+		public static readonly Size2 One = new Size2(1, 1);
+		public static readonly Size2 Min = new Size2(int.MinValue, int.MinValue);
+		public static readonly Size2 Max = new Size2(int.MaxValue, int.MaxValue);
+
+		/// <summary>
+		/// Create a new Size2 with both Width and Height set to <paramref name="value"/>
+		/// </summary>
+		/// <param name="value">value for both width and height</param>
+		public Size2(int value)
+		{
+			this.width = value;
+			this.height = value;
+		}
+
+		/// <summary>
+		/// Create a new Size2 with specified width and height values
+		/// </summary>
+		/// <param name="width">width of the Size2</param>
+		/// <param name="height">height of the Size2</param>
+		public Size2(int width, int height)
+		{
+			this.width = width;
+			this.height = height;
+		}
+
+		/// <summary>
+		/// Get or set the value at the specified index.
+		/// </summary>
+		/// <remarks>Does <paramref name="index"/> % 2 internally as it's faster than a boundary check</remarks>
+		/// <param name="index">0 for Width and 1 for Height.</param>
+		/// <returns>value in either component</returns>
+		public int this[int index]
+		{
+			get => this[(uint)index];
+			set => this[(uint)index] = value;
+		}
+
+		/// <summary>
+		/// Get or set the value at the specified index.
+		/// </summary>
+		/// <remarks>Does <paramref name="index"/> % 2 internally as it's faster than a boundary check</remarks>
+		/// <param name="index">0 for Width and 1 for Height.</param>
+		/// <returns>value in either component</returns>
+		public unsafe int this[uint index]
+		{
+#if !OS_LINUX
+			get => values[index % 2];
+			set => values[index % 2] = value;
+#else // compiler wants it pinned for some reason, compiles into a few extra ops
+			get { fixed (int* v = values) return v[index % 2]; }
+			set { fixed (int* v = values) v[index % 2] = value; }
+#endif
+		}
+
+		public static Size2 operator +(in Size2 left, in Size2 right) => new Size2(left.width + right.width, left.height + right.height);
+		public static Size2 operator -(in Size2 left, in Size2 right) => new Size2(left.width - right.width, left.height - right.height);
+		public static Size2 operator *(in Size2 left, in Size2 right) => new Size2(left.width * right.width, left.height * right.height);
+		public static Size2 operator /(in Size2 left, in Size2 right) => new Size2(left.width / right.width, left.height / right.height);
+
+		public static Size2 operator +(in Size2 left, int right) => new Size2(left.width + right, left.height + right);
+		public static Size2 operator -(in Size2 left, int right) => new Size2(left.width - right, left.height - right);
+		public static Size2 operator *(in Size2 left, int right) => new Size2(left.width * right, left.height * right);
+		public static Size2 operator /(in Size2 left, int right) => new Size2(left.width / right, left.height / right);
+
+		public static bool operator ==(in Size2 left, in Size2 right) => left.width == right.width && left.height == right.height;
+		public static bool operator !=(in Size2 left, in Size2 right) => left.width != right.width || left.height != right.height;
+
+		public bool Equals(Size2 other) => this == other;
+		public override bool Equals(object other) => other is Size2 v2 && Equals(v2);
+
+		public override int GetHashCode() => unchecked((width * 397) ^ height);
+	}
+}

--- a/code/client/clrcore/MonoScriptRuntime.cs
+++ b/code/client/clrcore/MonoScriptRuntime.cs
@@ -140,7 +140,9 @@ namespace CitizenFX.Core
 		[SecuritySafeCritical]
 		public int HandlesFile(string filename, IScriptHostWithResourceData metadata)
 		{
-			return (filename.EndsWith(".net.dll") ? 1 : 0);
+			metadata.GetNumResourceMetaData("mono_rt2", out IntPtr enableV2);
+			// enableV2 should be null to be v1, i.e.: this runtime
+			return enableV2 == IntPtr.Zero && filename.EndsWith(".net.dll") ? 1 : 0;
 		}
 
 		[SecuritySafeCritical]

--- a/code/client/clrcore/Server/Entity.cs
+++ b/code/client/clrcore/Server/Entity.cs
@@ -3,6 +3,10 @@ using System.Linq;
 using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using API = CitizenFX.Server.Native.Natives;
+#endif
+
 namespace CitizenFX.Core
 {
 	public abstract class Entity : PoolObject, IEquatable<Entity>, ISpatial
@@ -109,7 +113,7 @@ namespace CitizenFX.Core
 		{
 			get
 			{
-				return API.GetEntityModel(this.Handle);
+				return unchecked((int)API.GetEntityModel(this.Handle));
 			}
 		}
 

--- a/code/client/clrcore/Server/Interfaces.cs
+++ b/code/client/clrcore/Server/Interfaces.cs
@@ -1,5 +1,9 @@
 using CitizenFX.Core.Native;
 
+#if MONO_V2
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+#endif
+
 namespace CitizenFX.Core
 {
 	public interface ISpatial

--- a/code/client/clrcore/Server/Ped.cs
+++ b/code/client/clrcore/Server/Ped.cs
@@ -2,6 +2,10 @@ using System;
 using CitizenFX.Core.Native;
 using System.Security;
 
+#if MONO_V2
+using API = CitizenFX.Server.Native.Natives;
+#endif
+
 namespace CitizenFX.Core
 {
 	public sealed class Ped : Entity

--- a/code/client/clrcore/Server/ServerWrappers.cs
+++ b/code/client/clrcore/Server/ServerWrappers.cs
@@ -5,7 +5,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+#if MONO_V2
+using static CitizenFX.Server.Native.Natives;
+#else
 using static CitizenFX.Core.Native.API;
+#endif
 
 namespace CitizenFX.Core
 {
@@ -49,6 +53,9 @@ namespace CitizenFX.Core
 
 		public void TriggerEvent(string eventName, params object[] args)
 		{
+#if MONO_V2
+			CoreNatives.TriggerClientEventInternal(eventName, m_handle, args);
+#else
 			var argsSerialized = MsgPackSerializer.Serialize(args);
 
 			unsafe
@@ -58,10 +65,14 @@ namespace CitizenFX.Core
 					Function.Call(Hash.TRIGGER_CLIENT_EVENT_INTERNAL, eventName, m_handle, serialized, argsSerialized.Length);
 				}
 			}
+#endif
 		}
 
 		public void TriggerLatentEvent(string eventName, int bytesPerSecond, params object[] args)
 		{
+#if MONO_V2
+			CoreNatives.TriggerLatentClientEventInternal(eventName, m_handle, args, bytesPerSecond);
+#else
 			var argsSerialized = MsgPackSerializer.Serialize(args);
 
 			unsafe
@@ -71,6 +82,7 @@ namespace CitizenFX.Core
 					Function.Call(Hash.TRIGGER_LATENT_CLIENT_EVENT_INTERNAL, eventName, m_handle, serialized, argsSerialized.Length, bytesPerSecond);
 				}
 			}
+#endif
 		}
 
 		protected bool Equals(Player other) => string.Equals(Handle, other.Handle);


### PR DESCRIPTION
* Update game related C# files,
   * v2 changes to use namespace `CitizenFX.FiveM`,
   * Other updates to make these files work for both runtimes without changing V1's API,
   * Moved `PlayerList` to `External` as it was disabled for any non-FiveM product,
   * Removed some unused using directives.
* Some math clean up, increasing performance slightly,
* Added `Game.GenerateHashASCII(string)` which is around 6.5 times faster than `Game.GenerateHash(string)`.

Prerequisite to mono_rt2