### PR TITLE
Fix RedM reconnection issues and crashes

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -3947,13 +3947,13 @@ public:
 	{
 		if (!g_initedTimeSync)
 		{
+			// we don't want to use cloud time
+			m_useCloudTime = false;
+
 			g_origInitializeTime(this, _getConnectionManager(), 1, nullptr, 0, nullptr, 7, 2000, 60000);
 
 			// to make the game not try to get time from us
 			m_connectionMgr = nullptr;
-
-			// we don't want to use cloud time
-			m_useCloudTime = false;
 
 			g_initedTimeSync = true;
 
@@ -4470,6 +4470,11 @@ static InitFunction initFunction([]()
 		{
 			em->ClearEvents();
 		}
+#endif
+
+#ifdef IS_RDR3
+		// RDR3 doesn't restart netTimeSync after disconnecting from a server with enabled onesync
+		g_initedTimeSync = false;
 #endif
 
 		g_events.clear();

--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -737,12 +737,12 @@ static CNetGamePlayer* AllocateNetPlayer(void* mgr)
 #ifdef GTA_FIVE
 	void* plr = malloc(xbr::IsGameBuildOrGreater<2372>() ? 704 : xbr::IsGameBuildOrGreater<2060>() ? 688 : 672);
 #elif IS_RDR3
-	void* plr = malloc(2784);
+	void* plr = malloc(xbr::IsGameBuildOrGreater<1436>() ? 2736 : 2784);
 #endif
 
 	auto player = _netPlayerCtor(plr);
 
-	// in RDR3 game wants CNetworkPlayerMgr pointer in CNetGamePlayer
+	// RDR3 wants CNetworkPlayerMgr pointer in CNetGamePlayer
 #ifdef IS_RDR3
 	*(rage::netPlayerMgrBase**)((uint64_t)player + 288) = g_playerMgr;
 #endif
@@ -3340,7 +3340,7 @@ std::string GetType(void* d)
 
 	}
 #elif IS_RDR3
-	std::string typeName = fmt::sprintf("%p", *(void**)self);
+	std::string typeName = fmt::sprintf("%p", (void*)hook::get_unadjusted(*(void**)self));
 #endif
 
 	return typeName;

--- a/code/components/gta-net-rdr3/include/netObject.h
+++ b/code/components/gta-net-rdr3/include/netObject.h
@@ -55,8 +55,10 @@ public:
 	uint8_t nextOwnerId; // +70
 	uint8_t isRemote; // +71
 	uint8_t wantsToDelete : 1; // +72
+	uint8_t unk1 : 1;
+	uint8_t unk2 : 1;
+	uint8_t shouldNotBeDeleted : 1;
 	char pad_3[3]; // +73;
-	uint8_t shouldNotBeDeleted : 1; // +76
 	char pad_4[3];
 	char pad_5[32];
 	uint32_t creationAckedPlayers; // +112

--- a/code/components/gta-net-rdr3/src/netObject.cpp
+++ b/code/components/gta-net-rdr3/src/netObject.cpp
@@ -3,6 +3,7 @@
 #include <Hooking.h>
 #include <netObject.h>
 #include <netSyncTree.h>
+#include <GameInit.h>
 #include <CrossBuildRuntime.h>
 
 #include <atPool.h>
@@ -48,6 +49,13 @@ netObject* CreateCloneObject(NetObjEntityType type, uint16_t objectId, uint8_t a
 
 static HookFunction hookFunction([]()
 {
+	OnKillNetworkDone.Connect([=]()
+	{
+		// clear cached validate pools
+		std::fill(std::begin(validatePools), std::end(validatePools), nullptr);
+	},
+	1000);
+
 	if (xbr::IsGameBuildOrGreater<1491>())
 	{
 		auto location = hook::get_pattern<char>("7F 2B 41 B9 B8 0A 00 00 C7", 61);


### PR DESCRIPTION
This set of commits will hopefully resolve all the issues and crashes related to reconnect on OneSync servers after disconnection. Was only tested locally with CL2.