### PR TITLE
fix(scripting-mono): set mono's path as Unicode

### DIFF
--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -52,7 +52,7 @@ _MonoProfiler MonoComponentHostShared::s_monoProfiler;
 bool SetEnvironmentVariableNarrow(const char* key, const char* value)
 {
 #ifdef _WIN32
-	return SetEnvironmentVariableA(key, value);
+	return SetEnvironmentVariableW(ToWide(key).c_str(), ToWide(value).c_str());
 #else
 	// POSIX doesn't copy our strings with putenv, setenv does
 	return setenv(key, value, true) == 0;


### PR DESCRIPTION
Should fix the following problems:
 * "Failed to create environment, hresult 80070002",
 * System.IO.FileNotFoundException: Could not load file or assembly 'CitizenFX.Core, ...`.