### PR TITLE
tweak(server/launcher): POPCNT missing on VMs.

### DIFF
--- a/code/server/launcher/src/Main.cpp
+++ b/code/server/launcher/src/Main.cpp
@@ -36,8 +36,20 @@ int main(int argc, char* argv[])
 		fmt::printf("The Cfx.re Platform Server requires support for x86-64-v2 instructions (such as POPCNT).\n");
 		fmt::printf("Your current CPU (\"%s\") does not appear to support this. Supported CPUs include most CPUs from around 2010 or newer.\n", x86info.brand_string);
 		fmt::printf("\n");
-		fmt::printf("Exiting.\n");
-		return 1;
+		
+		std::string brand_string_l;
+
+		brand_string_l.resize(x86info.brand_string.size());
+		std::transform(x86info.brand_string.begin(),x86info.brand_string.end(), brand_string_l.begin(), ::tolower);
+		
+		if (brand_string_l.find("kvm") != std::string::npos || brand_string_l.find("virtual") != std::string::npos || brand_string_l.find("qemu") != std::string::npos) {
+			fmt::printf("Your processor has been detected as virtualized. If your server crashes with the illegal instruction reason, it is very likely that it is not supported. Contact your administrator to check if your CPU is compatible.\n\n")
+			
+			std::this_thread::sleep_for(std::chrono::milliseconds(5000)); // Sleep instead of MessageBox for user convenience.
+		} else {
+			fmt::printf("Exiting.\n");
+			return 1;
+		}
 	}
 #endif
 


### PR DESCRIPTION
The detection of the POPCNT instruction may give a false negative on virtualized systems even though the processor has the instruction.