### PR TITLE
tweak(ext/cfx-ui): Enable NUI in-process GPU option for RedM

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
@@ -165,8 +165,6 @@ const GAME_GAME_SETTINGS = new Map<string, ISetting.AnySetting>([
     description: $L('#Settings_InProcessGpuDesc'),
 
     ...convarAccessorsBoolean('nui_useInProcessGpu'),
-
-    visible: onlyForFiveM,
   }],
   ['streamingProgress', {
     type: 'checkbox',


### PR DESCRIPTION
From my tests, it seems safe to add this option to the redm menu (previously only available as a command). Tested on dx12 and Vulkan on AMD GPU
[nui_useInProcessGpu  true](https://streamable.com/jve44a)
[nui_useInProcessGpu  false](https://streamable.com/tofwp0)