### PR TITLE
feat(devtools): add a server version of neteventlog

### DIFF
--- a/code/components/citizen-devtools/src/NetEventLog.cpp
+++ b/code/components/citizen-devtools/src/NetEventLog.cpp
@@ -1,11 +1,11 @@
 #include <StdInc.h>
 
-#ifndef IS_FXSERVER
 #include <ResourceEventComponent.h>
 #include <ResourceManager.h>
 
+#ifndef IS_FXSERVER
 #include <NetLibrary.h>
-
+#endif
 #include <boost/circular_buffer.hpp>
 
 #include <ConsoleHost.h>
@@ -18,17 +18,27 @@ struct EventLogEntry
 	std::string eventName;
 	size_t payloadSize;
 	bool out;
+	std::optional<std::string> eventSource;
 };
 
-static boost::circular_buffer<EventLogEntry> g_eventLog(150);
+static boost::circular_buffer<EventLogEntry> g_eventLog(
+	// We want a bigger buffer on the server because it will send/receive *a lot* more events, and 150 will quickly get filled
+#if IS_FXSERVER
+	600
+#else
+	150
+#endif
+);
 static std::mutex g_eventLogMutex;
 
-static void EventLog_Add(const std::string& eventName, size_t payloadSize, bool out)
+static void EventLog_Add(const std::string& eventName, size_t payloadSize, bool out, std::optional<std::string> eventSource = std::nullopt)
 {
 	EventLogEntry eve;
 	eve.eventName = eventName;
 	eve.payloadSize = payloadSize;
 	eve.out = out;
+	// this should always be nullopt on client
+	eve.eventSource = eventSource;
 
 	std::unique_lock<std::mutex> lock(g_eventLogMutex);
 	g_eventLog.push_front(std::move(eve));
@@ -55,13 +65,24 @@ static InitFunction initFunction([]()
 
 		if (ImGui::Begin("Network Event Log", &eventLogEnabled))
 		{
-			ImGui::Columns(3);
+			// If we're on the server we're going to have the "Sender/Receiver" field so we need an extra column
+			ImGui::Columns(
+#ifdef IS_FXSERVER
+				4
+#else
+				3
+#endif
+			);
 
 			{
 				ImGui::Text("Dir");
 				ImGui::NextColumn();
 				ImGui::Text("Name");
 				ImGui::NextColumn();
+#ifdef IS_FXSERVER
+				ImGui::Text("Sender/Receiver");
+				ImGui::NextColumn();
+#endif
 				ImGui::Text("Size");
 				ImGui::NextColumn();
 
@@ -69,10 +90,21 @@ static InitFunction initFunction([]()
 
 				for (auto& entry : g_eventLog)
 				{
-					ImGui::Text((entry.out) ? "C->S" : "S->C");
+
+					ImGui::Text(
+#ifndef IS_FXSERVER
+						(entry.out) ? "C->S" : "S->C"
+#else
+						(entry.out) ? "S->C" : "C->S"
+#endif
+					);
 					ImGui::NextColumn();
 					ImGui::Text("%s", entry.eventName.c_str());
 					ImGui::NextColumn();
+#if IS_FXSERVER
+					ImGui::Text("%s", entry.eventSource.value_or("server").c_str());
+					ImGui::NextColumn();
+#endif
 					ImGui::Text("%lld B", entry.payloadSize);
 					ImGui::NextColumn();
 				}
@@ -92,11 +124,23 @@ static InitFunction initFunction([]()
 		{
 			if (eventSource.find("net:") == 0)
 			{
+#if IS_FXSERVER
+				EventLog_Add(eventName, eventPayload.size(), false, std::optional{ eventSource.substr(4) });
+#else
 				EventLog_Add(eventName, eventPayload.size(), false);
+#endif
+				
 			}
 		});
+
+		eventManager->OnClientEventTriggered.Connect([](const std::string_view& eventName, size_t& eventSize, const std::optional<std::string_view>& eventTarget)
+		{
+			EventLog_Add(std::string{ eventName }, eventSize, true, std::string{ eventTarget.value_or("-1") });
+		});
+
 	}, INT32_MAX);
 
+#ifndef IS_FXSERVER
 	NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary* library)
 	{
 		library->OnTriggerServerEvent.Connect([](const std::string& eventName, const std::string& eventPayload)
@@ -104,5 +148,6 @@ static InitFunction initFunction([]()
 			EventLog_Add(eventName, eventPayload.size(), true);
 		});
 	});
-});
 #endif
+});
+

--- a/code/components/citizen-resources-core/include/ResourceEventComponent.h
+++ b/code/components/citizen-resources-core/include/ResourceEventComponent.h
@@ -130,6 +130,9 @@ public:
 	//
 	fwEvent<const std::string&, const std::string&, const std::string&> OnQueueEvent;
 
+	// Arguments: eventName, eventPayloadSize, eventSource
+	fwEvent<const std::string_view&, size_t&, const std::optional<std::string_view>&> OnClientEventTriggered;
+
 	//
 	// Triggers an event immediately. Returns a value indicating whether the event was not canceled.
 	//

--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -99,6 +99,7 @@ public:
 
 		m_instance->GetComponent<console::Context>()->AddToBuffer(R"(
 devgui_convar "Tools/Performance/Resource Monitor" resmon
+devgui_convar "Tools/Network/Network Event Log" netEventLog
 devgui_convar "Tools/Network/State/Network Object Viewer" netobjviewer
 devgui_convar "Tools/Network/State/Player List" svplayerlist
 )");

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -1133,6 +1133,11 @@ void fx::ServerEventComponent::TriggerClientEvent(const std::string_view& eventN
 			client->SendPacket(0, outBuffer, NetPacketType_Reliable);
 		});
 	}
+
+	auto manager = fx::ResourceManager::GetCurrent();
+	auto eventManager = manager->GetComponent<fx::ResourceEventManagerComponent>();
+
+	eventManager->OnClientEventTriggered(eventName, dataLen, targetSrc);
 }
 
 static InitFunction initFunction2([]()


### PR DESCRIPTION
This was long a long requested feature and might be useful for optimization, or finding exploits in resources

Tips on how this code might be cleaner would be appreciated, but I'm not sure if there is a way :\