### PR TITLE
Resolve runtime texture unloading crash on b2802

### DIFF
--- a/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
+++ b/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
@@ -49,6 +49,11 @@
 
 using Microsoft::WRL::ComPtr;
 
+static hook::cdecl_stub<rage::five::pgDictionary<rage::grcTexture>*(void*, int)> textureDictionaryCtor([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 8B F8 EB 02 33 FF 4C 8D 3D"));
+});
+
 class RuntimeTex
 {
 public:
@@ -251,7 +256,9 @@ RuntimeTxd::RuntimeTxd(const char* name)
 		if (!entry.handle)
 		{
 			m_name = name;
-			m_txd = new rage::five::pgDictionary<rage::grcTexture>();
+
+			void* memoryStub = rage::GetAllocator()->Allocate(sizeof(rage::five::pgDictionary<rage::grcTexture>), 16, 0);
+			m_txd = textureDictionaryCtor(memoryStub, 1);
 
 			streaming::strAssetReference ref;
 			ref.asset = m_txd;

--- a/code/components/gta-streaming-five/include/Streaming.h
+++ b/code/components/gta-streaming-five/include/Streaming.h
@@ -79,14 +79,14 @@ public:
 		XBR_VIRTUAL_DTOR(strStreamingModule)
 
 #ifdef IS_RDR3
-		virtual void m_8() = 0;
+		XBR_VIRTUAL_METHOD(void, m_8, ())
 
-		virtual void m_10() = 0;
+		XBR_VIRTUAL_METHOD(void, m_10, ())
 
 		//
 		// Creates a new asset for `name`, or returns the existing index in this module for it.
 		//
-		virtual uint32_t* FindSlotFromHashKey(uint32_t* id, uint32_t name) = 0;
+		XBR_VIRTUAL_METHOD(uint32_t*, FindSlotFromHashKey, (uint32_t* id, uint32_t name))
 #elif GTA_FIVE
 		//
 		// Creates a new asset for `name`, or returns the existing index in this module for it.


### PR DESCRIPTION
Fixes #1756
Add forgotten `XBR_VIRTUAL_METHOD` for RDR3.