### PR TITLE
Fix missing comma in PatchFilterDLC.cpp

### DIFF
--- a/code/components/gta-core-five/src/PatchFilterDLC.cpp
+++ b/code/components/gta-core-five/src/PatchFilterDLC.cpp
@@ -64,7 +64,7 @@ static std::unordered_set<std::string> g_badFiles{
 	"dlc_mpSum2_g9ec:/common/data/effects/peds/first_person.meta",
 	"dlc_mpSum2_g9ecCRC:/common/data/pedalternatevariations.meta",
 
-	"dlc_mpChristmas3_G9EC:/x64/levels/mpChristmas3_G9EC/vehiclemods/entity3hsw_mods.rpf"
+	"dlc_mpChristmas3_G9EC:/x64/levels/mpChristmas3_G9EC/vehiclemods/entity3hsw_mods.rpf",
 	"dlc_mpChristmas3_G9EC:/x64/levels/mpChristmas3_G9EC/vehiclemods/issi8hsw_mods.rpf"
 };
 


### PR DESCRIPTION
Without the comma, it concatenates the string with the string on the next line.