### PR TITLE
feat(scripting/state): add GET_PLAYER_SERVER_ID_FROM_PED

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1748,6 +1748,18 @@ static void Init()
 
 		context.SetResult(player);
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_SERVER_ID_FROM_PED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (entity->type == fx::sync::NetObjEntityType::Player)
+		{
+			if (auto owner = entity->GetClient())
+			{
+				return owner->GetNetId();
+			}
+		}
+		return (uint32_t)0;
+	}));
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/GetPlayerServerIdFromPed.md
+++ b/ext/native-decls/GetPlayerServerIdFromPed.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+---
+
+## GET_PLAYER_SERVER_ID_FROM_PED 
+
+```c
+int GET_PLAYER_SERVER_ID_FROM_PED(Ped ped);
+```
+
+## Parameters
+- **ped**: The ped to get the server id of.
+
+## Return value
+Returns the players server id, or 0 if the ped didn't exist, or if it wasn't a player ped


### PR DESCRIPTION
This was a native I remember complaining about not existing a while ago and makes working with certain checkable events easier to work with (i.e. weaponDamageEvent and the sort)

This is meant to function somewhat like `NetworkGetPlayerIndexFromPed` does on the client