### PR TITLE
Block to rewrite natives

### DIFF
--- a/code/components/scripting-gta/src/ScriptEngine.cpp
+++ b/code/components/scripting-gta/src/ScriptEngine.cpp
@@ -222,6 +222,9 @@ namespace fx
 
 	void ScriptEngine::RegisterNativeHandler(uint64_t nativeIdentifier, TNativeHandler function)
 	{
+		if (g_registeredHandlers[nativeIdentifier]) {
+			return false;	
+		}
 		g_registeredHandlers[nativeIdentifier] = function;
 
 		if (!launch::IsSDK())


### PR DESCRIPTION
The cheats register a second time the natives to be able to falsify the results So I made sure that if it's declared once you can't declare it a second time