### PR TITLE
fix(ext/cfx-ui): expand languages without country

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -17,13 +17,19 @@ export function registerMpMenuIntlService(container: ServicesContainer) {
 
 @injectable()
 class MpMenuIntlService implements IIntlService {
-  readonly systemLocale = mpMenu.systemLanguages[0] || 'en-US';
-  readonly systemLocaleCountry = (() => {
-    const [language, country] = this.systemLocale.split('-');
+  readonly systemLocale = (() => {
+    const systemLocale = mpMenu.systemLanguages[0] || 'en-US';
+    const [language, country] = systemLocale.split('-');
 
     if (!country) {
-      return language.toUpperCase();
+      // Windows has some locales such as `pl` which should expand to `pl-PL`
+      return `${language.toLowerCase()}-${language.toUpperCase()}`;
     }
+
+    return country.toUpperCase();
+  })();
+  readonly systemLocaleCountry = (() => {
+    const [_, country] = this.systemLocale.split('-');
 
     return country.toUpperCase();
   })();


### PR DESCRIPTION
Countries such as `pl` would match the non-expanded locale code in the home page server list only, instead of the consistent (and suggested) locale code `pl-PL`.

This fix makes locale codes without country expand to the language code as country, which *should* be the only case in which these occur in the OS.

