### PR TITLE
feat(rdr3): enable PRI_OPTIONAL_LOW props

### DIFF
--- a/code/components/gta-streaming-rdr3/src/MiscStuff.cpp
+++ b/code/components/gta-streaming-rdr3/src/MiscStuff.cpp
@@ -1,0 +1,25 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <MinHook.h>
+
+int32_t* ms_entityLevelCap = NULL; //rage::fwMapData::ms_entityLevelCap
+static void(*g_function)();
+static void hk_function()
+{
+	// doing this because game keeps setting rage::fwMapData::ms_entityLevelCap to PRI_OPTIONAL_MEDIUM
+	if (!g_function)
+	{
+		return g_function();
+	}
+
+	hook::put<int32_t>(ms_entityLevelCap, 0x03); 
+}
+
+static HookFunction hookFunction([]()
+{
+    	ms_entityLevelCap = hook::get_address<int32_t*>(hook::get_pattern<uint8_t>("0F 45 C2 89 05 ? ? ? ? 89 05", 0xB));
+
+		MH_Initialize();
+		MH_CreateHook((hook::get_call((hook::get_pattern("0F 47 C7 88 05", 0x9)))), hk_function, reinterpret_cast<void**>(&g_function));
+		MH_EnableHook(MH_ALL_HOOKS);
+})


### PR DESCRIPTION
in RDR3 props with priority level PRI_OPTIONAL_LOW props are not loaded by default, just like it was in GTA5 this PR fixes that.

in both GTA5 and RDR2 `rage::fwMapData::ms_entityLevelCap` is `PRI_OPTIONAL_LOW ` by default. but in `CGameWorld::Init` `rage::fwMapData::ms_entityLevelCap` is set to `PRI_OPTIONAL_MEDIUM ` you guys have set it to `PRI_OPTIONAL_LOW ` in GTA5. I did the same in RDR2. here is a comparison:
![b5pEb1672829306](https://user-images.githubusercontent.com/97910292/210703201-88e450d7-844a-41a1-a4ff-c670a9b93043.jpg)
