### PR TITLE
fix(server/impl): Use rfind for GET_PLAYER_IDENTIFIER_BY_TYPE

### DIFF
--- a/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
@@ -59,7 +59,7 @@ static void CreatePlayerCommands()
 
 		for (int i = 0; i < identifiers.size(); ++i)
 		{
-			if (identifiers[i].find(identifierType) != std::string::npos)
+			if (identifiers[i].rfind(identifierType, 0) != std::string::npos)
 			{
 				return identifiers[i].c_str();
 			}


### PR DESCRIPTION
This solution seems a bit more correct, this searches only the start of the string, this shouldn't actually be a problem for now, but could avoid future issues in the case an identifier name would occur in the identifier itself.

This is also a bit more performant than the other solution.