### PR TITLE
fix(ext/cfx-ui): adaptive card inline action style fix

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyConnectingModal/AdaptiveCardPresenter/AdaptiveCardPresenter.module.scss
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyConnectingModal/AdaptiveCardPresenter/AdaptiveCardPresenter.module.scss
@@ -125,7 +125,8 @@
       }
     }
 
-    :global(.ac-pushButton) {
+    :global(.ac-pushButton),
+    :global(.ac-inlineActionButton) {
       gap: ui.offset('small');
 
       @include ui.def('height', ui.control-height('normal'));


### PR DESCRIPTION
This fixes inline actions on adaptive card inputs showing as a white box.

Before:
![1673105009](https://user-images.githubusercontent.com/23743032/211158329-9786ebfe-e616-408d-b79f-deefeab555a3.png)
After:
![1673105129](https://user-images.githubusercontent.com/23743032/211158330-5f32578a-6f64-4e57-b211-5772af0fdca7.png)
