### PR TITLE
fix(scripting/lua): print error and allow nil returns on ref funcs

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -491,7 +491,7 @@ Citizen.SetCallRefRoutine(function(refId, argsSerialized)
 	local ref = refPtr.func
 
 	local err
-	local retvals
+	local retvals = false
 	local cb = {}
 	
 	local di = debug_getinfo(ref)
@@ -506,16 +506,14 @@ Citizen.SetCallRefRoutine(function(refId, argsSerialized)
 		end
 
 		if cb.cb then
-			cb.cb(retvals or false, err)
+			cb.cb(retvals, err)
+		elseif err then
+			Citizen.Trace(err)
 		end
 	end, ('ref call [%s[%d..%d]]'):format(di.short_src, di.linedefined, di.lastlinedefined))
 
 	if not waited then
 		if err then
-			if err ~= '' then
-				Citizen.Trace(err)
-			end
-			
 			return msgpack_pack(nil)
 		end
 


### PR DESCRIPTION
* Errors coming from async ref functions were either sent to the callback or ignored, this muted errors that came from commands as described in #1809, this change will output them if no callback is present.
* Fixes cases where `false` is returned for any false-like value, even if e.g.: `nil` was expected. The fallback value `false`  is still used in case of an error.

resolves #1809