### PR TITLE
Implement worldhorizon (farlods) rendering toggle native

### DIFF
--- a/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
@@ -4,6 +4,8 @@
 
 #include <GamePrimitives.h>
 
+#include <Hooking.h>
+
 struct scrVector
 {
 	float x;
@@ -13,6 +15,21 @@ struct scrVector
 	float z;
 	int _pad3;
 };
+
+struct WorldhorizonManager
+{
+	char m_unknown;
+	char m_disableRendering;
+
+	// etc...
+};
+
+static WorldhorizonManager* g_worldhorizonMgr;
+
+static HookFunction hookFunction([]()
+{
+	g_worldhorizonMgr = hook::get_address<WorldhorizonManager*>(hook::get_pattern("83 C8 FF 48 8D 0D ? ? ? ? 89 44 24 38", 6));
+});
 
 static InitFunction initFunction([]()
 {
@@ -39,5 +56,15 @@ static InitFunction initFunction([]()
 		normalOut->x = XMVectorGetX(normalVector);
 		normalOut->y = XMVectorGetY(normalVector);
 		normalOut->z = XMVectorGetZ(normalVector);
+	});
+	
+	fx::ScriptEngine::RegisterNativeHandler("DISABLE_WORLDHORIZON_RENDERING", [](fx::ScriptContext& context)
+	{
+		auto flag = context.GetArgument<bool>(0);
+
+		if (g_worldhorizonMgr)
+		{
+			g_worldhorizonMgr->m_disableRendering = flag;
+		}
 	});
 });

--- a/ext/native-decls/DisableWorldhorizonRendering.md
+++ b/ext/native-decls/DisableWorldhorizonRendering.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+---
+## DISABLE_WORLDHORIZON_RENDERING
+
+```c
+void DISABLE_WORLDHORIZON_RENDERING(BOOL state);
+```
+
+Disables the game's world horizon lods rendering (see `farlods.#dd`).
+Using the island hopper natives might also affect this state.
+
+## Parameters
+* **state**: On/Off


### PR DESCRIPTION
Implementing a native allowing to disable farlods/worldhorizon rendering (see `farlods.#dd` / `farlods_guarma.#dd`). Available in both FiveM and RedM. This might be useful for custom maps and cases when using island hoppers is not an option.

```c
void DISABLE_WORLDHORIZON_RENDERING(BOOL state);
```
