### PR TITLE
fix(extra-natives-five): translucency issue with ped headshots

### DIFF
--- a/code/components/extra-natives-five/src/NuiTxdSource.cpp
+++ b/code/components/extra-natives-five/src/NuiTxdSource.cpp
@@ -21,6 +21,10 @@
 
 #include <DirectXTex/DirectXTex.h>
 
+#include <CrossBuildRuntime.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
 namespace WRL = Microsoft::WRL;
 
 class NuiTxdResourceHandler;
@@ -312,6 +316,16 @@ static InitFunction initFunction([]()
 	}, -500);
 });
 
+__int64(__fastcall* g_origAlterPedHeadshotTransparentPSConstants_Hook)(__m128*, __m128*);
+
+// Since b2189's shader changes `RegisterPedheadshotTransparent`'s texture colors are in the [0 .. 0.6] range, let's inverse it
+// Sets	PS constant buffer 3rd and 4th? (unchecked) float4/vec4/__m128 values, where the 3rd is referred to as `GeneralParams0`
+__int64 __fastcall AlterPedHeadshotTransparentPSConstants_Hook(__m128* a3, __m128* a4)
+{
+	*a3 = _mm_set1_ps(1.f / 0.6f); // *a3 is stack allocated
+	return g_origAlterPedHeadshotTransparentPSConstants_Hook(a3, a4);
+}
+
 static HookFunction hookFunction([]()
 {
 	OnGrcCreateDevice.Connect([]()
@@ -319,4 +333,11 @@ static HookFunction hookFunction([]()
 		nui::RegisterSchemeHandlerFactory("http", "nui-img", Instance<NUISchemeHandlerFactory>::Get());
 		nui::RegisterSchemeHandlerFactory("https", "nui-img", Instance<NUISchemeHandlerFactory>::Get());
 	});
+
+	if (xbr::IsGameBuildOrGreater<2189>())
+	{
+		g_origAlterPedHeadshotTransparentPSConstants_Hook = hook::trampoline(
+			hook::get_pattern("48 8D 4D F7 0F 29 4D F7 0F 29 45 E7", 0xC),
+			AlterPedHeadshotTransparentPSConstants_Hook);
+	}
 });


### PR DESCRIPTION
Compensate for changes that were made to a blit shader since b2189, which was mapping colors into the [0 .. 0.6] range. This rendered textures made by `RegisterPedheadshotTransparent` half-ish translucent and unwanted.

Tested on builds: 2189, 2372, 2545, 2612, 2699, 2802.

resolves: #1697