### PR TITLE
Various streaming fixes and tweaks for RedM

### DIFF
--- a/code/components/gta-streaming-five/include/Streaming.h
+++ b/code/components/gta-streaming-five/include/Streaming.h
@@ -198,6 +198,8 @@ public:
 		{
 #ifdef GTA_FIVE
 			static_assert(offsetof(Manager, NumPendingRequests) == 0x1E0);
+#elif IS_RDR3
+			static_assert(offsetof(Manager, moduleMgr) == 144);
 #endif
 		}
 
@@ -238,8 +240,10 @@ public:
 		StreamingListEntry* RequestListHead;
 		StreamingListEntry* RequestListTail;
 
-#ifndef IS_RDR3
+#ifdef GTA_FIVE
 		char pad2[368 - 40];
+#elif IS_RDR3
+		char pad2[32];
 #endif
 
 		strStreamingModuleMgr moduleMgr;

--- a/code/components/gta-streaming-rdr3/src/Streaming.cpp
+++ b/code/components/gta-streaming-rdr3/src/Streaming.cpp
@@ -26,7 +26,7 @@ static hook::cdecl_stub<bool(void*, uint32_t, int)> g_releaseSystemObject([]()
 
 static hook::cdecl_stub<streaming::strStreamingModule**(void*, uint32_t)> g_getStreamingModule([]()
 {
-	return hook::get_pattern("44 0F B7 51 10 45 33 C9 4C 8B 59 08", 0);
+	return hook::get_pattern("44 0F B7 51 10 45 33 C9 4C 8B 59 08", -4);
 });
 
 static hook::cdecl_stub<int(const char*)> g_getStreamingExtIndex([]()


### PR DESCRIPTION
- Fixed custom map data files unloading disconnection crash (`REDM-2D`).
- Backported `DLC_ITYP_REQUEST` proxy mounter.
- Fixed some related patterns and structs.