### PR TITLE
Make player/resource/tag filters in cfx-ui respect uppercase 

### DIFF
--- a/ext/cfx-ui/src/cfx/common/pages/ServerDetailsPage/ServerDetailsPage.tsx
+++ b/ext/cfx-ui/src/cfx/common/pages/ServerDetailsPage/ServerDetailsPage.tsx
@@ -187,7 +187,7 @@ export const ServerDetailsPage = observer(function Details(props: ServerDetailsP
                         items={server.players}
                         seeAllTitle={$L('#ServerDetail_Players_ShowAll')}
                         renderPreviewItem={playerRenderer}
-                        itemMatchesFilter={(filter, item) => item.name.toLowerCase().includes(filter)}
+                        itemMatchesFilter={(filter, item) => item.name.toLowerCase().includes(filter.toLowerCase())}
                       />
                     )}
 
@@ -198,7 +198,7 @@ export const ServerDetailsPage = observer(function Details(props: ServerDetailsP
                         items={displayResources}
                         seeAllTitle={$L('#ServerDetail_Resources_ShowAll')}
                         renderPreviewItem={identity}
-                        itemMatchesFilter={(filter, item) => item.toLowerCase().includes(filter)}
+                        itemMatchesFilter={(filter, item) => item.toLowerCase().includes(filter.toLowerCase())}
                       />
                     )}
 
@@ -209,7 +209,7 @@ export const ServerDetailsPage = observer(function Details(props: ServerDetailsP
                         items={server.tags}
                         renderPreviewItem={identity}
                         seeAllTitle={$L('#ServerDetail_Tags_ShowAll')}
-                        itemMatchesFilter={(filter, item) => item.toLowerCase().includes(filter)}
+                        itemMatchesFilter={(filter, item) => item.toLowerCase().includes(filter.toLowerCase())}
                       />
                     )}
                   </Flex>


### PR DESCRIPTION
Previously, when trying to search with an uppercase query, you wouldn't get a result.
This PR fixes this behaviour.

Before this PR:

https://user-images.githubusercontent.com/23613354/223552956-705f79f2-39a6-4fb5-b271-f03139edf10e.mp4

After this PR:

https://user-images.githubusercontent.com/23613354/223552991-bef302d8-5742-46fc-b51c-7b4af71d8d10.mp4


