### PR TITLE
tweak(scripting/v8): improve exports typings

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -128,7 +128,14 @@ declare var GlobalState : StateBagInterface
 declare function Player(entity: number|string): EntityInterface
 declare var LocalPlayer : EntityInterface
 
-declare var exports: any;
+interface CitizenExports {
+    (exportKey: string | number, exportFunction: Function): void;
+    [resourceName: string] : {
+        [exportKey: string | number]: Function
+    };
+}
+
+declare var exports: CitizenExports;
 
 declare var source: number;
 


### PR DESCRIPTION
This change allows us to use the advantage of TypeScript's interface extending to add better typings for known exports in a project.

As the interface will be available globally, I called it `CitizenExports` to prevent conflict with other packages.

For example, you could do the following in a TypeScript module file to extend the exports interface:

```ts
declare global {
  interface CitizenExports {
    coolResource: {
      doSomething(parameter: string): void;
    }
  }
}
```

Then in another file, you would get the auto complete:

```ts
global.exports.coolResource.doSomething('Snaily');
```