### PR TITLE
tweak(scripting/csharp): add blip cone function

### DIFF
--- a/code/client/clrcore/External/Blip.cs
+++ b/code/client/clrcore/External/Blip.cs
@@ -3,7 +3,9 @@ using System.Security;
 
 #if MONO_V2
 using CitizenFX.Core;
+using CitizenFX.FiveM.Native;
 using API = CitizenFX.FiveM.Native.Natives;
+using Function = CitizenFX.FiveM.Native.Natives;
 
 namespace CitizenFX.FiveM
 #else
@@ -480,6 +482,34 @@ namespace CitizenFX.Core
 		public void RemoveNumberLabel()
 		{
 			API.HideNumberOnBlip(Handle);
+		}
+
+		/// <summary>
+		/// Adds a cone for this <see cref="Blip"/>
+		/// </summary>
+		/// <param name="halfAngle">'Width' of the cone (0.0f - pi)</param>
+		/// <param name="distance">Distance of the cone</param>
+		/// <param name="heading">Heading of the cone in radians (degrees * pi / 180)</param>
+		/// <param name="color">Color of the cone (see <see href="https://docs.fivem.net/docs/game-references/hud-colors/">hud colors</see>/></param>
+		/// <param name="unk0">Unknown at this time</param>
+		/// <param name="unk1">Unknown at this time</param>
+		/// <param name="unk2">Unknown at this time</param>
+		/// <param name="unk3">Unknown at this time</param>
+		public void ShowCone(float halfAngle, float distance, float heading, int color, float unk0 = -1.0f, float unk1 = 1.0f, float unk2 = 1.0f, int unk3 = 1)
+		{
+			// SETUP_FAKE_CONE_DATA
+			Function.Call((Hash)0xF83D0FEBE75E62C9, Handle, unk0, unk1, halfAngle, unk2, distance, heading, unk3, color);
+			API.SetBlipShowCone(Handle, true);
+		}
+
+		/// <summary>
+		/// Removes the cone for this <see cref="Blip"/>
+		/// </summary>
+		public void HideCone()
+		{
+			// REMOVE_FAKE_CONE_DATA
+			Function.Call((Hash)0x35A3CD97B2C0A6D2, Handle);
+			API.SetBlipShowCone(Handle, false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This function will add a cone to the blip (see picture).  This can be used for for example camera's or whatever you like!

![image](https://user-images.githubusercontent.com/80054446/230181162-6b07134e-b45a-43ab-95b8-ad609b83919d.png)

The following code snippet is an example of how you can use the 'new' function.

```cs
using System;
using CitizenFX.Core;
using CitizenFX.Core.Native;
using static CitizenFX.Core.Native.API;

namespace TEST
{
    public class Class1 : BaseScript
    {
        public Class1() 
        {
            RegisterCommand("testblip", new Action<int, List<object>, string>(async (src, args, raw) =>
            {
                int hash = (uint)GetHashKey("ch_prop_ch_cctv_cam_02a");

                RequestModel(hash);

                while (!HasModelLoaded(hash)) await Delay(10);

                Vector3 v = GetEntityCoords(Game.PlayerPed.Handle, true);
                int obj = CreateObject(GetHashKey("ch_prop_ch_cctv_cam_02a"), v.X, v.Y, v.Z, false, false, false);

                while (!DoesEntityExist(obj)) await Delay(10);

                Blip blip = new Blip(AddBlipForEntity(obj));

                blip.AddCone(1.2f, 8.2f, 3.0f, 1);

                await Delay(3000);

                blip.RemoveCone();

                DeleteObject(ref obj);
            }), false);
        }
    }
}
```