### PR TITLE
Timecycle editor and extra natives for FiveM

### DIFF
--- a/code/components/devtools-five/component.json
+++ b/code/components/devtools-five/component.json
@@ -4,8 +4,10 @@
 	"dependencies": [
 		"fx[2]",
 		"vendor:imgui",
+		"vendor:tinyxml2-dll",
 		"conhost",
 		"gta:core",
+		"gta:game",
 		"gta:streaming",
 		"gta:mission-cleanup",
 		"citizen:resources:core",

--- a/code/components/devtools-five/include/TimecycleEditor.h
+++ b/code/components/devtools-five/include/TimecycleEditor.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <StdInc.h>
+#include <Timecycle.h>
+
+class SelectedTimecycle
+{
+private:
+	rage::tcModifier* m_selection;
+	std::map<int, rage::tcModData> m_cachedMods;
+	std::set<int> m_disabled;
+
+public:
+	void RestoreVar(int index);
+	void RemoveVar(int index);
+	void DisableVar(int index);
+	void EnableVar(int index);
+	void UpdateVars();
+	bool IsVarDisabled(int index);
+	rage::tcModData* GetVar(int index);
+	std::map<int, rage::tcModData>& GetVars();
+
+	void SetModifier(rage::tcModifier* mod);
+	void ResetModifier();
+	bool HasModifier();
+	rage::tcModifier* GetModifier();
+};

--- a/code/components/devtools-five/src/TimecycleEditor.cpp
+++ b/code/components/devtools-five/src/TimecycleEditor.cpp
@@ -1,0 +1,843 @@
+#include <StdInc.h>
+#include <CoreConsole.h>
+#include <ConsoleHost.h>
+#include <GameInit.h>
+#include <HostSharedData.h>
+#include <tinyxml2.h>
+#include <TimecycleEditor.h>
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_API DLL_IMPORT
+
+#include <imgui.h>
+#include <imgui_internal.h>
+
+void SelectedTimecycle::RestoreVar(int index)
+{
+	if (!m_selection)
+	{
+		return;
+	}
+
+	if (auto it = m_cachedMods.find(index); it != m_cachedMods.end())
+	{
+		for (auto& modData : GetModifier()->m_modData)
+		{
+			if (modData.m_index == index)
+			{
+				modData.m_value1 = it->second.m_value1;
+				modData.m_value2 = it->second.m_value2;
+			}
+		}
+	}
+}
+
+void SelectedTimecycle::RemoveVar(int index)
+{
+	if (auto& it = m_cachedMods.find(index); it != m_cachedMods.end())
+	{
+		m_cachedMods.erase(index);
+		m_disabled.erase(index);
+	}
+}
+
+void SelectedTimecycle::DisableVar(int index)
+{
+	if (!IsVarDisabled(index))
+	{
+		m_disabled.insert(index);
+	}
+}
+
+void SelectedTimecycle::EnableVar(int index)
+{
+	if (IsVarDisabled(index))
+	{
+		m_disabled.erase(index);
+	}
+}
+
+void SelectedTimecycle::UpdateVars()
+{
+	if (!m_selection)
+	{
+		return;
+	}
+
+	for (auto& modData : GetModifier()->m_modData)
+	{
+		if (auto& it = m_cachedMods.find(modData.m_index); it == m_cachedMods.end())
+		{
+			m_cachedMods.insert({ modData.m_index, modData });
+		}
+	}
+}
+
+bool SelectedTimecycle::IsVarDisabled(int index)
+{
+	return m_disabled.find(index) != m_disabled.end();
+}
+
+rage::tcModData* SelectedTimecycle::GetVar(int index)
+{
+	if (auto it = m_cachedMods.find(index); it != m_cachedMods.end())
+	{
+		return &it->second;
+	}
+
+	return nullptr;
+}
+
+void SelectedTimecycle::SetModifier(rage::tcModifier* mod)
+{
+	if (mod != GetModifier() && GetModifier() != nullptr)
+	{
+		for (auto index : m_disabled)
+		{
+			RestoreVar(index);
+		}
+	}
+
+	ResetModifier();
+
+	m_selection = mod;
+
+	UpdateVars();
+}
+
+void SelectedTimecycle::ResetModifier()
+{
+	m_disabled.clear();
+	m_cachedMods.clear();
+	m_selection = nullptr;
+}
+
+std::map<int, rage::tcModData>& SelectedTimecycle::GetVars()
+{
+	return m_cachedMods;
+}
+
+bool SelectedTimecycle::HasModifier()
+{
+	return GetModifier() != nullptr;
+}
+
+rage::tcModifier* SelectedTimecycle::GetModifier()
+{
+	if (m_selection != nullptr)
+	{
+		if (m_selection->m_modData.m_offset == nullptr)
+		{
+			ResetModifier();
+		}
+	}
+
+	return m_selection;
+}
+
+static SelectedTimecycle CurrentTimecycle;
+
+// copy pasted from "CloneDebug.cpp"
+static bool Splitter(bool split_vertically, float thickness, float* size1, float* size2, float min_size1, float min_size2, float splitter_long_axis_size = -1.0f)
+{
+	using namespace ImGui;
+	ImGuiContext& g = *GImGui;
+	ImGuiWindow* window = g.CurrentWindow;
+	ImGuiID id = window->GetID("##Splitter");
+	ImRect bb;
+	bb.Min = window->DC.CursorPos + (split_vertically ? ImVec2(*size1, 0.0f) : ImVec2(0.0f, *size1));
+	bb.Max = bb.Min + CalcItemSize(split_vertically ? ImVec2(thickness, splitter_long_axis_size) : ImVec2(splitter_long_axis_size, thickness), 0.0f, 0.0f);
+	return SplitterBehavior(bb, id, split_vertically ? ImGuiAxis_X : ImGuiAxis_Y, size1, size2, min_size1, min_size2, 0.0f);
+}
+
+static InitFunction initFunction([]()
+{
+#ifndef _DEBUG
+	if (!launch::IsSDK() && !launch::IsSDKGuest())
+	{
+		return;
+	}
+#endif
+
+	static constexpr size_t kMaxBufferSize = 256;
+	static char g_editorSearchNameBuffer[kMaxBufferSize];
+	static char g_editorSearchParamBuffer[kMaxBufferSize];
+	static char g_editorDetailNameBuffer[kMaxBufferSize];
+	static char g_editorDetailFilterBuffer[kMaxBufferSize];
+	static char g_editorDetailDropDownBuffer[kMaxBufferSize];
+	static bool g_editorApplySelectedTimecycle = false;
+	static tinyxml2::XMLPrinter g_editorTimecycleOutput;
+
+	static bool timecycleEditorEnabled;
+	static ConVar<bool> timecycleEditorVar("timecycleeditor", ConVar_Archive | ConVar_UserPref, false, &timecycleEditorEnabled);
+
+	ConHost::OnShouldDrawGui.Connect([](bool* should)
+	{
+		*should = *should || timecycleEditorEnabled;
+	});
+
+	ConHost::OnDrawGui.Connect([]()
+	{
+		if (!timecycleEditorEnabled)
+		{
+			return;
+		}
+
+		auto tcVarInfos = TheTimecycleManager->GetConfigVarInfos();
+		if (!tcVarInfos)
+		{
+			return;
+		}
+
+		auto tcManager = TheTimecycleManager->GetGameManager();
+		if (!tcManager)
+		{
+			return;
+		}
+
+		if (!Instance<ICoreGameInit>::Get()->GetGameLoaded() || Instance<ICoreGameInit>::Get()->HasVariable("gameKilled"))
+		{
+			return;
+		}
+
+		ImGui::SetNextWindowSizeConstraints(ImVec2(1020.0f, 400.0f), ImVec2(1920.0f, 2000.0f));
+
+		if (ImGui::Begin("Timecycle Editor", &timecycleEditorEnabled))
+		{
+			static float treeSize = 400.f;
+			static float detailSize = 600.f;
+
+			Splitter(true, 8.0f, &treeSize, &detailSize, 8.0f, 8.0f);
+
+			if (ImGui::BeginChild("tree", ImVec2(treeSize, -1.0f), true))
+			{
+				// controls
+				ImGui::Text("Search timecycle:");
+
+				ImGui::Columns(2);
+				ImGui::SetColumnWidth(0, 90.0f);
+
+				ImGui::Text("By name");
+				ImGui::SameLine();
+				ImGui::NextColumn();
+
+				ImGui::InputText("##controls_search_name", g_editorSearchNameBuffer, kMaxBufferSize);
+				ImGui::NextColumn();
+
+				ImGui::Text("By param");
+				ImGui::SameLine();
+				ImGui::NextColumn();
+
+				ImGui::InputText("##controls_search_param", g_editorSearchParamBuffer, kMaxBufferSize);
+				ImGui::NextColumn();
+
+				ImGui::Separator();
+				ImGui::EndColumns();
+
+				if (auto scriptData = TheTimecycleManager->GetScriptData())
+				{
+					if (scriptData->m_primaryModifierIndex != -1)
+					{
+						auto modifier = TheTimecycleManager->GetTimecycleByIndex(scriptData->m_primaryModifierIndex);
+						auto tcName = modifier ? TheTimecycleManager->GetTimecycleName(*modifier).c_str() : "INVALID";
+						ImGui::Text("Primary modifier: %s", tcName);
+
+						ImGui::DragFloat(va("##primary-strength"), &scriptData->m_primaryModifierStrength, 0.05f, -10.0f, 10.0f, "%.3f", 1.0f);
+
+						ImGui::SameLine();
+
+						if (ImGui::Button("Clear"))
+						{
+							scriptData->m_primaryModifierIndex = -1;
+						}
+					}
+					else
+					{
+						ImGui::Text("Primary modifier: NONE");
+					}
+
+					ImGui::Separator();
+
+					if (scriptData->m_transitionModifierIndex != -1)
+					{
+						auto modifier = TheTimecycleManager->GetTimecycleByIndex(scriptData->m_transitionModifierIndex);
+						auto tcName = modifier ? TheTimecycleManager->GetTimecycleName(*modifier).c_str() : "INVALID";
+						ImGui::Text("Transition modifier: %s", tcName);
+
+						ImGui::DragFloat(va("##transition-strength"), &scriptData->m_transitionModifierStrength, 0.05f, -10.0f, 10.0f, "%.3f", 1.0f);
+
+						ImGui::SameLine();
+
+						if (ImGui::Button("Clear"))
+						{
+							scriptData->m_transitionModifierIndex = -1;
+						}
+					}
+					else
+					{
+						ImGui::Text("Transition modifier: NONE");
+					}
+
+					ImGui::Separator();
+
+					if (scriptData->m_extraModifierIndex != -1)
+					{
+						auto modifier = TheTimecycleManager->GetTimecycleByIndex(scriptData->m_extraModifierIndex);
+						auto tcName = modifier ? TheTimecycleManager->GetTimecycleName(*modifier).c_str() : "INVALID";
+						ImGui::Text("Extra modifier: %s", tcName);
+
+						ImGui::SameLine();
+
+						if (ImGui::Button("Clear"))
+						{
+							scriptData->m_extraModifierIndex = -1;
+						}
+					}
+					else
+					{
+						ImGui::Text("Extra modifier: NONE");
+					}
+
+					ImGui::Separator();
+
+					if (ImGui::Checkbox("Apply selected", &g_editorApplySelectedTimecycle))
+					{
+						if (g_editorApplySelectedTimecycle)
+						{
+							if (auto modifier = CurrentTimecycle.GetModifier())
+							{
+								scriptData->m_primaryModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
+							}
+						}
+					}
+				}
+
+				if (ImGui::BeginChild("list", ImVec2(-1.0f, -1.0f), false))
+				{
+					ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, ImGui::GetFontSize());
+
+					bool drawnAny = false;
+
+					for (auto modifier : tcManager->m_modifiers)
+					{
+						if (!modifier)
+						{
+							continue;
+						}
+
+						bool isSelected = (CurrentTimecycle.GetModifier() == modifier);
+						auto& modifierName = TheTimecycleManager->GetTimecycleName(*modifier);
+
+						if (!isSelected)
+						{
+							if (strlen(g_editorSearchNameBuffer) > 0 && strstr(modifierName.c_str(), g_editorSearchNameBuffer) == NULL)
+							{
+								continue;
+							}
+
+							if (strlen(g_editorSearchParamBuffer) > 0)
+							{
+								bool hasModData = TheTimecycleManager->DoesTimecycleHasModData(*modifier, std::string(g_editorSearchParamBuffer), true);
+
+								if (!hasModData)
+								{
+									continue;
+								}
+							}
+						}
+
+						if (ImGui::TreeNodeEx(modifier,
+							ImGuiTreeNodeFlags_Leaf | ((isSelected) ? ImGuiTreeNodeFlags_Selected : 0),
+							"%s", modifierName.c_str()))
+						{
+							if (ImGui::IsItemClicked())
+							{
+								g_editorTimecycleOutput.ClearBuffer();
+								TheTimecycleManager->EnsureTimecycleBackup(*modifier);
+								CurrentTimecycle.SetModifier(modifier);
+								strcpy(g_editorDetailNameBuffer, modifierName.c_str());
+
+								if (g_editorApplySelectedTimecycle)
+								{
+									auto modifier = CurrentTimecycle.GetModifier();
+									auto scriptData = TheTimecycleManager->GetScriptData();
+
+									if (scriptData && modifier != nullptr)
+									{
+										scriptData->m_primaryModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
+									}
+								}
+							}
+
+							ImGui::TreePop();
+						}
+
+						drawnAny = true;
+					}
+
+					ImGui::PopStyleVar();
+
+					if (!drawnAny && (strlen(g_editorSearchNameBuffer) > 0 || strlen(g_editorSearchParamBuffer) > 0))
+					{
+						ImGui::Text("No timecycles found");
+
+						if (ImGui::Button("Clear search query"))
+						{
+							memset(g_editorSearchNameBuffer, 0, kMaxBufferSize);
+							memset(g_editorSearchParamBuffer, 0, kMaxBufferSize);
+						}
+					}
+				}
+
+				ImGui::EndChild();
+			}
+
+			ImGui::EndChild();
+			ImGui::SameLine();
+
+			bool showOutput = g_editorTimecycleOutput.CStrSize() > 1;
+
+			if (showOutput && ImGui::BeginChild("output", ImVec2(-1.0f, -1.0f), true))
+			{
+				if (ImGui::Button("Close"))
+				{
+					g_editorTimecycleOutput.ClearBuffer();
+				}
+
+				ImGui::SameLine();
+				ImGui::Text("Select and copy using CTRL+C");
+				ImGui::Separator();
+
+				auto output = g_editorTimecycleOutput.CStr();
+				ImGui::InputTextMultiline("##xml_output", (char*)output, g_editorTimecycleOutput.CStrSize(), ImVec2(-1.0f, -1.0f));
+			}
+			else if (ImGui::BeginChild("detail", ImVec2(-1.0f, -1.0f), true))
+			{
+				ImGui::Columns(2);
+				ImGui::SetColumnWidth(0, 100.0f);
+
+				ImGui::Text("Name");
+				ImGui::SameLine();
+				ImGui::NextColumn();
+
+				ImGui::InputText("##detail_name", g_editorDetailNameBuffer, kMaxBufferSize);
+
+				if (auto tc = CurrentTimecycle.GetModifier())
+				{
+					ImGui::SameLine();
+					ImGui::Text("(index: %d)", TheTimecycleManager->GetTimecycleIndex(tc->m_nameHash));
+				}
+
+				ImGui::NextColumn();
+
+				ImGui::Text("Controls");
+				ImGui::SameLine();
+				ImGui::NextColumn();
+
+				if (ImGui::Button("Create"))
+				{
+					auto nameLength = strlen(g_editorDetailNameBuffer);
+
+					if (nameLength >= 2 && nameLength <= 128)
+					{
+						auto newName = std::string(g_editorDetailNameBuffer);
+
+						auto created = TheTimecycleManager->CreateTimecycle(newName);
+						if (created != nullptr)
+						{
+							CurrentTimecycle.SetModifier(created);
+							memset(g_editorDetailNameBuffer, 0, kMaxBufferSize);
+						}
+					}
+				}
+
+				auto modifier = CurrentTimecycle.GetModifier();
+
+				if (modifier != nullptr)
+				{
+					ImGui::SameLine();
+
+					if (ImGui::Button("Rename"))
+					{
+						auto nameLength = strlen(g_editorDetailNameBuffer);
+
+						if (nameLength >= 2 && nameLength <= 128)
+						{
+							auto newName = std::string(g_editorDetailNameBuffer);
+							auto newHash = HashString(newName);
+
+							TheTimecycleManager->RenameTimecycle(*modifier, newName);
+						}
+					}
+
+					ImGui::SameLine();
+
+					if (ImGui::Button("Clone"))
+					{
+						auto nameLength = strlen(g_editorDetailNameBuffer);
+
+						if (nameLength >= 2 && nameLength <= 128)
+						{
+							auto cloned = TheTimecycleManager->CloneTimecycle(*modifier, std::string(g_editorDetailNameBuffer));
+							if (cloned != nullptr)
+							{
+								CurrentTimecycle.SetModifier(cloned);
+								memset(g_editorDetailNameBuffer, 0, kMaxBufferSize);
+							}
+						}
+					}
+
+					ImGui::SameLine();
+
+					if (ImGui::Button("Delete"))
+					{
+						TheTimecycleManager->RemoveTimecycle(*modifier);
+						CurrentTimecycle.ResetModifier();
+					}
+
+					ImGui::SameLine();
+
+					if (ImGui::Button("Generate XML"))
+					{
+						auto timecycle = CurrentTimecycle.GetModifier();
+						auto tcName = TheTimecycleManager->GetTimecycleName(*timecycle).c_str();
+
+						tinyxml2::XMLDocument document;
+
+						auto rootElement = document.NewElement("timecycle_modifier_data");
+						rootElement->SetAttribute("version", "1.000000");
+
+						auto modElement = document.NewElement("modifier");
+						modElement->SetAttribute("name", tcName);
+						modElement->SetAttribute("numMods", timecycle->m_modData.GetCount());
+						modElement->SetAttribute("userFlags", 0);
+
+						for (auto& modData : timecycle->m_modData)
+						{
+							if (auto varInfo = TheTimecycleManager->GetConfigVarInfo(modData.m_index))
+							{
+								auto varElement = document.NewElement(varInfo->m_name);
+								varElement->SetText(va("%.3f %.3f", modData.m_value1, modData.m_value2));
+								modElement->InsertEndChild(varElement);
+							}
+						}
+
+						rootElement->InsertEndChild(modElement);
+						document.InsertEndChild(rootElement);
+
+						g_editorTimecycleOutput.ClearBuffer();
+						g_editorTimecycleOutput.PushHeader(false, true);
+						document.Print(&g_editorTimecycleOutput);
+					}
+
+					if (CurrentTimecycle.HasModifier()) // as it may be deleted at this point
+					{
+						CurrentTimecycle.UpdateVars();
+
+						ImGui::NextColumn();
+						ImGui::Text("Filter");
+						ImGui::SameLine();
+
+						ImGui::NextColumn();
+						ImGui::InputText("##detail_filter_param", g_editorDetailFilterBuffer, kMaxBufferSize);
+						ImGui::SameLine();
+
+						if (ImGui::Button("Clear"))
+						{
+							memset(g_editorDetailFilterBuffer, 0, kMaxBufferSize);
+						}
+
+						if (auto scriptData = TheTimecycleManager->GetScriptData())
+						{
+							ImGui::NextColumn();
+							ImGui::Text("Apply");
+							ImGui::SameLine();
+
+							ImGui::NextColumn();
+
+							if (ImGui::Button("As primary"))
+							{
+								scriptData->m_primaryModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
+							}
+
+							ImGui::SameLine();
+
+							if (ImGui::Button("As transition"))
+							{
+								scriptData->m_transitionModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
+								scriptData->m_transitionModifierSpeed = 0.1f;
+								scriptData->m_transitionModifierStrength = 0.0f;
+							}
+
+							ImGui::SameLine();
+
+							if (ImGui::Button("As extra"))
+							{
+								scriptData->m_extraModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
+							}
+						}
+
+						ImGui::NextColumn();
+						ImGui::Text("Variable");
+						ImGui::SameLine();
+
+						ImGui::NextColumn();
+						ImGui::InputText("##input", g_editorDetailDropDownBuffer, kMaxBufferSize);
+						ImGui::SameLine();
+
+						static bool isOpen = false;
+						bool isFocused = ImGui::IsItemFocused();
+						isOpen |= ImGui::IsItemActive();
+
+						if (isOpen)
+						{
+							ImGui::SetNextWindowPos({ ImGui::GetItemRectMin().x, ImGui::GetItemRectMax().y });
+							ImGui::SetNextWindowSize({ ImGui::GetItemRectSize().x, 450.0f });
+
+							if (ImGui::Begin("##popup", &isOpen, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_Tooltip))
+							{
+								ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
+								isFocused |= ImGui::IsWindowFocused();
+
+								for (int i = 0; i < TheTimecycleManager->GetConfigVarInfoCount(); i++)
+								{
+									if (strstr(tcVarInfos[i].m_name, g_editorDetailDropDownBuffer) == NULL)
+									{
+										continue;
+									}
+
+									bool addedParam = false;
+
+									// do not add params that already in the list of this timecycle
+									for (auto modData : modifier->m_modData)
+									{
+										if (modData.m_index == tcVarInfos[i].m_index)
+										{
+											addedParam = true;
+											break;
+										}
+									}
+
+									if (addedParam)
+									{
+										continue;
+									}
+
+									if (ImGui::Selectable(tcVarInfos[i].m_name) || (ImGui::IsItemFocused() && ImGui::IsKeyPressedMap(ImGuiKey_Enter)))
+									{
+										strcpy(g_editorDetailDropDownBuffer, tcVarInfos[i].m_name);
+										isOpen = false;
+									}
+								}
+							}
+
+							ImGui::End();
+							isOpen &= isFocused;
+						}
+
+						if (ImGui::Button("Add"))
+						{
+							if (TheTimecycleManager->AddTimecycleModData(*modifier, std::string(g_editorDetailDropDownBuffer)))
+							{
+								memset(g_editorDetailDropDownBuffer, 0, kMaxBufferSize);
+							}
+						}
+
+						ImGui::SameLine();
+
+						if (ImGui::Button("Clear"))
+						{
+							memset(g_editorDetailDropDownBuffer, 0, kMaxBufferSize);
+						}
+
+						ImGui::Separator();
+
+						ImGui::Columns(6);
+						ImGui::Text("Var");
+						ImGui::NextColumn();
+						ImGui::Text("Name");
+						ImGui::NextColumn();
+						ImGui::Text("Default");
+						ImGui::NextColumn();
+						ImGui::Text("Value 1");
+						ImGui::NextColumn();
+						ImGui::Text("Value 2");
+						ImGui::NextColumn();
+						ImGui::Text("");
+						ImGui::NextColumn();
+
+#define COLUMN_CLAMP_WIDTH(index, min, max)               \
+	if (min > 0.0f && ImGui::GetColumnWidth(index) < min) \
+		ImGui::SetColumnWidth(index, min);                \
+	if (max > 0.0f && ImGui::GetColumnWidth(index) > max) \
+		ImGui::SetColumnWidth(index, max);
+
+						COLUMN_CLAMP_WIDTH(0, 50.0f, 80.0f);
+						COLUMN_CLAMP_WIDTH(1, 300.0f, -1.0f);
+						COLUMN_CLAMP_WIDTH(2, 100.0f, -1.0f);
+						COLUMN_CLAMP_WIDTH(3, 125.0f, -1.0f);
+						COLUMN_CLAMP_WIDTH(4, 125.0f, -1.0f);
+						COLUMN_CLAMP_WIDTH(5, 100.0f, 120.0f);
+
+#undef COLUMN_CLAMP_WIDTH
+
+						bool drawnAny = false;
+
+						// delayed mod data removing queue to not mutate map when drawing stuff
+						std::set<int> removeQueue;
+
+						for (auto& [index, modData] : CurrentTimecycle.GetVars())
+						{
+							if (modData.m_index == -1 || modData.m_index > TheTimecycleManager->GetConfigVarInfoCount())
+							{
+								continue; // invalid?
+							}
+
+							auto& varInfo = tcVarInfos[index];
+
+							if (strlen(g_editorDetailFilterBuffer) > 0 && strstr(varInfo.m_name, g_editorDetailFilterBuffer) == NULL)
+							{
+								continue;
+							}
+
+							bool isSearched = (strlen(g_editorSearchParamBuffer) > 0 && strstr(varInfo.m_name, g_editorSearchParamBuffer) != NULL);
+
+							ImGui::Text("%d", varInfo.m_index);
+							ImGui::NextColumn();
+
+							if (isSearched)
+							{
+								ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(81, 179, 236, 255));
+							}
+
+							ImGui::Text("%s", varInfo.m_name);
+
+							if (isSearched)
+							{
+								ImGui::PopStyleColor();
+							}
+
+							ImGui::NextColumn();
+							ImGui::Text("%f", varInfo.m_value);
+							ImGui::NextColumn();
+
+							bool nulled = (varInfo.m_value == 0.0f);
+							float min = nulled ? -1.0f : ((varInfo.m_value > 0.0f) ? -varInfo.m_value : varInfo.m_value) * 10.0f;
+							float max = nulled ? 1.0f : ((varInfo.m_value > 0.0f) ? varInfo.m_value : -varInfo.m_value) * 10.0f;
+							float step = nulled ? 0.02f : (varInfo.m_value / 20.0f);
+
+							bool isVarEnabled = !CurrentTimecycle.IsVarDisabled(index);
+							auto actualData = TheTimecycleManager->GetTimecycleModData(*modifier, index);
+							auto dataSource = (isVarEnabled) ? actualData : &modData;
+
+							if (!isVarEnabled)
+							{
+								ImGui::BeginDisabled();
+							}
+
+							if (ImGui::DragFloat(va("##%x-%d-1", modifier->m_nameHash, index), &modData.m_value1, step, min, max, "%.3f", 1.0f))
+							{
+								if (dataSource == actualData)
+								{
+									actualData->m_value1 = modData.m_value1;
+								}
+							}
+
+							ImGui::NextColumn();
+
+							if (ImGui::DragFloat(va("##%x-%d-2", modifier->m_nameHash, index), &modData.m_value2, step, min, max, "%.3f", 1.0f))
+							{
+								if (dataSource == actualData)
+								{
+									actualData->m_value2 = modData.m_value2;
+								}
+							}
+
+							ImGui::NextColumn();
+
+							if (!isVarEnabled)
+							{
+								ImGui::EndDisabled();
+							}
+
+							if (ImGui::Checkbox(va("##%x-%d-check", modifier->m_nameHash, index), &isVarEnabled))
+							{
+								if (isVarEnabled)
+								{
+									if (TheTimecycleManager->AddTimecycleModData(*modifier, std::string(varInfo.m_name)))
+									{
+										CurrentTimecycle.EnableVar(index);
+
+										auto addedData = TheTimecycleManager->GetTimecycleModData(*modifier, index);
+										addedData->m_value1 = modData.m_value1;
+										addedData->m_value2 = modData.m_value2;
+									}
+								}
+								else
+								{
+									if (TheTimecycleManager->RemoveTimecycleModData(*modifier, modData))
+									{
+										CurrentTimecycle.DisableVar(index);
+									}
+								}
+							}
+
+							ImGui::SameLine();
+
+							if (ImGui::Button(va("Delete##%x-%d-del", modifier->m_nameHash, index)))
+							{
+								if (TheTimecycleManager->RemoveTimecycleModData(*modifier, std::string(varInfo.m_name)))
+								{
+									removeQueue.insert(varInfo.m_index);
+								}
+							}
+
+							ImGui::NextColumn();
+
+							drawnAny = true;
+						}
+
+						ImGui::Columns();
+
+						if (!drawnAny && strlen(g_editorDetailFilterBuffer) > 0)
+						{
+							ImGui::Text("No parameters found");
+
+							if (ImGui::Button("Clear filter query"))
+							{
+								memset(g_editorDetailFilterBuffer, 0, kMaxBufferSize);
+							}
+						}
+
+						for (auto index : removeQueue)
+						{
+							CurrentTimecycle.RemoveVar(index);
+						}
+					}
+				}
+				else
+				{
+					ImGui::Separator();
+				}
+			}
+
+			ImGui::EndChild();
+		}
+
+		ImGui::End();
+	});
+
+	OnKillNetworkDone.Connect([=]()
+	{
+		CurrentTimecycle.ResetModifier();
+
+		memset(g_editorSearchNameBuffer, 0, kMaxBufferSize);
+		memset(g_editorSearchParamBuffer, 0, kMaxBufferSize);
+		memset(g_editorDetailNameBuffer, 0, kMaxBufferSize);
+		memset(g_editorDetailFilterBuffer, 0, kMaxBufferSize);
+		memset(g_editorDetailDropDownBuffer, 0, kMaxBufferSize);
+
+		g_editorApplySelectedTimecycle = false;
+		g_editorTimecycleOutput.ClearBuffer();
+	});
+});

--- a/code/components/devtools-five/src/TimecycleEditor.cpp
+++ b/code/components/devtools-five/src/TimecycleEditor.cpp
@@ -425,7 +425,7 @@ static InitFunction initFunction([]()
 				if (auto tc = CurrentTimecycle.GetModifier())
 				{
 					ImGui::SameLine();
-					ImGui::Text("(index: %d)", TheTimecycleManager->GetTimecycleIndex(tc->m_nameHash));
+					ImGui::Text("(index: %d)", TheTimecycleManager->GetTimecycleIndex(*tc));
 				}
 
 				ImGui::NextColumn();

--- a/code/components/extra-natives-five/src/TimecycleNatives.cpp
+++ b/code/components/extra-natives-five/src/TimecycleNatives.cpp
@@ -1,0 +1,246 @@
+#include <StdInc.h>
+#include <ScriptEngine.h>
+#include <Timecycle.h>
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_STRENGTH", [=](fx::ScriptContext& context)
+	{
+		float result = 0.0f;
+
+		if (auto scriptData = TheTimecycleManager->GetScriptData())
+		{
+			result = scriptData->m_primaryModifierStrength;
+		}
+
+		context.SetResult<float>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_NAME_BY_INDEX", [=](fx::ScriptContext& context)
+	{
+		const char* result = "";
+
+		auto index = context.GetArgument<int>(0);
+
+		if (auto tc = TheTimecycleManager->GetTimecycleByIndex(index))
+		{
+			result = TheTimecycleManager->GetTimecycleName(*tc).c_str();
+		}
+
+		context.SetResult<const char*>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_INDEX_BY_NAME", [=](fx::ScriptContext& context)
+	{
+		int result = -1;
+
+		auto name = context.CheckArgument<const char*>(0);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(HashString(name)))
+		{
+			result = TheTimecycleManager->GetTimecycleIndex(*tc);
+		}
+
+		context.SetResult<int>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_COUNT", [=](fx::ScriptContext& context)
+	{
+		int result = 0;
+
+		if (auto tcManager = TheTimecycleManager->GetGameManager())
+		{
+			result = tcManager->m_modifiers.GetCount();
+		}
+
+		context.SetResult<int>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_VAR_COUNT", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<int>(TheTimecycleManager->GetConfigVarInfoCount());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_VAR_NAME_BY_INDEX", [=](fx::ScriptContext& context)
+	{
+		const char* result = "";
+
+		auto index = context.GetArgument<int>(0);
+		
+		if (auto varInfo = TheTimecycleManager->GetConfigVarInfo(index))
+		{
+			result = varInfo->m_name;
+		}
+
+		context.SetResult<const char*>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_VAR_DEFAULT_VALUE_BY_INDEX", [=](fx::ScriptContext& context)
+	{
+		float result = 0.0f;
+
+		auto index = context.GetArgument<int>(0);
+
+		if (auto varInfo = TheTimecycleManager->GetConfigVarInfo(index))
+		{
+			result = varInfo->m_value;
+		}
+
+		context.SetResult<float>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_VAR_COUNT", [=](fx::ScriptContext& context)
+	{
+		int result = 0;
+
+		auto tcName = context.CheckArgument<const char*>(0);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			result = tc->m_modData.GetCount();
+		}
+
+		context.SetResult<int>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_VAR_NAME_BY_INDEX", [=](fx::ScriptContext& context)
+	{
+		const char* result = "";
+
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto varIndex = context.GetArgument<int>(1);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			if (auto modData = TheTimecycleManager->GetTimecycleModDataByIndex(*tc, varIndex))
+			{
+				if (auto varInfo = TheTimecycleManager->GetConfigVarInfo(modData->m_index))
+				{
+					result = varInfo->m_name;
+				}
+			}
+		}
+
+		context.SetResult<const char*>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TIMECYCLE_MODIFIER_VAR", [=](fx::ScriptContext& context)
+	{
+		bool result = false;
+
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto varName = context.GetArgument<const char*>(1);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			if (auto modData = TheTimecycleManager->GetTimecycleModData(*tc, varName))
+			{
+				*context.GetArgument<float*>(2) = modData->m_value1;
+				*context.GetArgument<float*>(3) = modData->m_value2;
+				result = true;
+			}
+		}
+
+		context.SetResult<bool>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_TIMECYCLE_MODIFIER_VAR", [=](fx::ScriptContext& context)
+	{
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto varName = context.CheckArgument<const char*>(1);
+		auto value1 = context.GetArgument<float>(2);
+		auto value2 = context.GetArgument<float>(3);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			if (!TheTimecycleManager->DoesTimecycleHasModData(*tc, varName))
+			{
+				TheTimecycleManager->AddTimecycleModData(*tc, varName);
+			}
+
+			TheTimecycleManager->SetTimecycleModData(*tc, std::string(varName), value1, value2);
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_TIMECYCLE_MODIFIER_HAS_VAR", [=](fx::ScriptContext& context)
+	{
+		bool result = false;
+
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto varName = context.CheckArgument<const char*>(1);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			result = TheTimecycleManager->DoesTimecycleHasModData(*tc, varName);
+		}
+
+		context.SetResult<bool>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("REMOVE_TIMECYCLE_MODIFIER_VAR", [=](fx::ScriptContext& context)
+	{
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto varName = context.CheckArgument<const char*>(1);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			if (TheTimecycleManager->DoesTimecycleHasModData(*tc, varName))
+			{
+				TheTimecycleManager->RemoveTimecycleModData(*tc, varName);
+			}
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("CREATE_TIMECYCLE_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		int result = -1;
+
+		auto tcName = context.CheckArgument<const char*>(0);
+		auto nameLength = strlen(tcName);
+		
+		if (nameLength >= 2 && nameLength <= 128)
+		{
+			if (!TheTimecycleManager->HasTimecycleWithName(tcName))
+			{
+				if (auto tc = TheTimecycleManager->CreateTimecycle(tcName))
+				{
+					result = TheTimecycleManager->GetTimecycleIndex(*tc);
+				}
+			}
+		}
+
+		context.SetResult<int>(result);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("REMOVE_TIMECYCLE_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		auto tcName = context.CheckArgument<const char*>(0);
+
+		if (auto tc = TheTimecycleManager->GetTimecycle(tcName))
+		{
+			TheTimecycleManager->RemoveTimecycle(*tc);
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("CLONE_TIMECYCLE_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		int result = -1;
+
+		auto origName = context.CheckArgument<const char*>(0);
+		auto cloneName = context.CheckArgument<const char*>(1);
+		auto nameLength = strlen(cloneName);
+
+		if (nameLength >= 2 && nameLength <= 128)
+		{
+			if (auto source = TheTimecycleManager->GetTimecycle(origName))
+			{
+				if (auto clone = TheTimecycleManager->CloneTimecycle(*source, cloneName))
+				{
+					result = TheTimecycleManager->GetTimecycleIndex(*clone);
+				}
+			}
+		}
+
+		context.SetResult<int>(result);
+	});
+});

--- a/code/components/gta-game-five/include/Timecycle.h
+++ b/code/components/gta-game-five/include/Timecycle.h
@@ -1,0 +1,149 @@
+#pragma once
+#include <StdInc.h>
+#include <sysAllocator.h>
+#include <atArray.h>
+
+#ifdef COMPILING_GTA_GAME_FIVE
+#define GTA_GAME_EXPORT DLL_EXPORT
+#else
+#define GTA_GAME_EXPORT DLL_IMPORT
+#endif
+
+namespace rage
+{
+// TODO: atBinaryMap proper implementation
+template<typename TValue = void*>
+class atBinaryMap : public rage::sysUseAllocator
+{
+public:
+	struct DataPair : rage::sysUseAllocator
+	{
+		uint32_t m_hash;
+		TValue m_value;
+	};
+
+public:
+	bool m_isSorted;
+	atArray<DataPair> m_array;
+};
+
+struct tcModData : rage::sysUseAllocator
+{
+	int m_index;
+	float m_value1;
+	float m_value2;
+};
+
+struct tcModifier : rage::sysUseAllocator
+{
+	atArray<tcModData> m_modData;
+	uint32_t m_nameHash;
+	atArray<tcModData*>* m_varMap; // +24, seems to be related to "rage::tcModifier::RemoveVarMap"
+	uint32_t m_userFlags; // +32, attribute from xml
+	uint32_t m_unk;
+};
+
+struct tcVarInfo
+{
+	int m_index;
+	char pad[4];
+	char* m_name;
+	float m_value;
+	char end[12];
+};
+
+struct tcConfig // see "rage::tcManager::Init"
+{
+	static int* ms_numVars;
+	static tcVarInfo** ms_pVarInfos;
+};
+
+class tcManager
+{
+private:
+	char pad[0x40];
+
+public:
+	atArray<tcModifier*> m_modifiers;
+	atBinaryMap<tcModifier*> m_modifiersMap; // map for fast lookup?
+	// etc...
+
+public:
+	static tcManager* ms_Instance;
+};
+
+int* tcConfig::ms_numVars;
+tcVarInfo** tcConfig::ms_pVarInfos;
+tcManager* tcManager::ms_Instance;
+}
+
+struct TimecycleScriptData // probably not even a struct, but seems consistent between game builds
+{
+	uint32_t m_primaryModifierIndex; // (GET/SET)_TIMECYCLE_MODIFIER
+	float m_primaryModifierStrength;
+	uint32_t m_transitionModifierIndex; // (GET/SET)_TRANSITION_TIMECYCLE_MODIFIER
+	float m_transitionModifierStrength;
+	float m_transitionModifierSpeed; // second arg of (GET/SET)_TRANSITION_TIMECYCLE_MODIFIER
+	char pad[24];
+	uint32_t m_extraModifierIndex; // _SET_EXTRA_TIMECYCLE_MODIFIER
+};
+
+class TimecycleManager
+{
+private:
+	std::map<uint32_t, std::string> m_originalNames; // names that were gathered from data files
+	std::map<uint32_t, std::string> m_customNames; // names of custom timecycles that were created in code
+	std::map<uint32_t, rage::tcModifier*> m_modifiersBackup; // backups of original modifiers
+
+public:
+	GTA_GAME_EXPORT std::string& GetTimecycleName(const uint32_t hash);
+	GTA_GAME_EXPORT std::string& GetTimecycleName(const rage::tcModifier& modifier);
+	GTA_GAME_EXPORT rage::tcModifier* GetTimecycle(const uint32_t hash);
+	GTA_GAME_EXPORT rage::tcModifier* GetTimecycle(const std::string& name);
+	GTA_GAME_EXPORT rage::tcModifier* GetTimecycleByIndex(const uint32_t index);
+	GTA_GAME_EXPORT rage::tcModifier* CreateTimecycle(const std::string& newName);
+	GTA_GAME_EXPORT rage::tcModifier* CloneTimecycle(rage::tcModifier& modifier, const std::string& cloneName);
+	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const int index);
+	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModDataByIndex(rage::tcModifier& modifier, const int index);
+	GTA_GAME_EXPORT bool AddTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
+	GTA_GAME_EXPORT bool AddTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	GTA_GAME_EXPORT bool SetTimecycleModData(rage::tcModifier& modifier, std::string& paramName, const float value1, const float value2);
+	GTA_GAME_EXPORT bool SetTimecycleModData(rage::tcModifier& modifier, const int index, const float value1, const float value2);
+	GTA_GAME_EXPORT bool RemoveTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
+	GTA_GAME_EXPORT bool RemoveTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	GTA_GAME_EXPORT bool RenameTimecycle(rage::tcModifier& modifier, const std::string& newName);
+	GTA_GAME_EXPORT bool DoesTimecycleHasModData(rage::tcModifier& modifier, const std::string& paramName, bool search = false);
+	GTA_GAME_EXPORT bool DoesTimecycleHasModData(rage::tcModifier& modifier, const int index);
+	GTA_GAME_EXPORT int GetTimecycleIndex(const rage::tcModifier& modifier);
+	GTA_GAME_EXPORT int GetTimecycleIndex(const std::string& name);
+	GTA_GAME_EXPORT int GetTimecycleIndex(const uint32_t hash);
+	GTA_GAME_EXPORT void EnsureTimecycleBackup(const rage::tcModifier& modifier);
+	GTA_GAME_EXPORT void RemoveTimecycle(rage::tcModifier& modifier);
+
+public:
+	void RevertChanges();
+	void HandleTimecycleLoaded(const uint32_t hash, const std::string& name);
+	void HandleTimecycleUnloaded(const uint32_t hash);
+	void RemoveTimecycleBackup(const uint32_t hash);
+	void AddCustomTimecycleName(const uint32_t hash, const std::string& name);
+	void RemoveCustomTimecycleName(const uint32_t hash);
+	void RemoveTimecycle(const uint32_t hash);
+	bool IsTimecycleBackedUp(const rage::tcModifier& modifier);
+	bool IsCustomTimecycle(const rage::tcModifier& modifier);
+
+public:
+	static GTA_GAME_EXPORT rage::tcManager* GetGameManager(); // get pointer to instance of RAGE timecycle manager
+	static GTA_GAME_EXPORT TimecycleScriptData* GetScriptData(); // get "script" data, seems to be struct that is used in natives
+	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfo(const std::string& paramName, bool search = false);
+	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfo(const int index);
+	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfos();
+	static GTA_GAME_EXPORT int GetConfigVarInfoCount();
+	static GTA_GAME_EXPORT bool HasTimecycleWithName(const std::string& paramName);
+
+private:
+	static void AddTimecycleToList(rage::tcModifier& modifier, bool sort = true);
+	static void SortTimecycleMap();
+};
+
+extern GTA_GAME_EXPORT TimecycleManager* TheTimecycleManager;

--- a/code/components/gta-game-five/include/Timecycle.h
+++ b/code/components/gta-game-five/include/Timecycle.h
@@ -1,13 +1,8 @@
 #pragma once
-#include <StdInc.h>
+#include "ComponentExport.h"
+
 #include <sysAllocator.h>
 #include <atArray.h>
-
-#ifdef COMPILING_GTA_GAME_FIVE
-#define GTA_GAME_EXPORT DLL_EXPORT
-#else
-#define GTA_GAME_EXPORT DLL_IMPORT
-#endif
 
 namespace rage
 {
@@ -88,7 +83,7 @@ struct TimecycleScriptData // probably not even a struct, but seems consistent b
 	uint32_t m_extraModifierIndex; // _SET_EXTRA_TIMECYCLE_MODIFIER
 };
 
-class TimecycleManager
+class COMPONENT_EXPORT(GTA_GAME_FIVE) TimecycleManager
 {
 private:
 	std::map<uint32_t, std::string> m_originalNames; // names that were gathered from data files
@@ -96,54 +91,52 @@ private:
 	std::map<uint32_t, rage::tcModifier*> m_modifiersBackup; // backups of original modifiers
 
 public:
-	GTA_GAME_EXPORT std::string& GetTimecycleName(const uint32_t hash);
-	GTA_GAME_EXPORT std::string& GetTimecycleName(const rage::tcModifier& modifier);
-	GTA_GAME_EXPORT rage::tcModifier* GetTimecycle(const uint32_t hash);
-	GTA_GAME_EXPORT rage::tcModifier* GetTimecycle(const std::string& name);
-	GTA_GAME_EXPORT rage::tcModifier* GetTimecycleByIndex(const uint32_t index);
-	GTA_GAME_EXPORT rage::tcModifier* CreateTimecycle(const std::string& newName);
-	GTA_GAME_EXPORT rage::tcModifier* CloneTimecycle(rage::tcModifier& modifier, const std::string& cloneName);
-	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
-	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const int index);
-	GTA_GAME_EXPORT rage::tcModData* GetTimecycleModDataByIndex(rage::tcModifier& modifier, const int index);
-	GTA_GAME_EXPORT bool AddTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
-	GTA_GAME_EXPORT bool AddTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
-	GTA_GAME_EXPORT bool SetTimecycleModData(rage::tcModifier& modifier, std::string& paramName, const float value1, const float value2);
-	GTA_GAME_EXPORT bool SetTimecycleModData(rage::tcModifier& modifier, const int index, const float value1, const float value2);
-	GTA_GAME_EXPORT bool RemoveTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
-	GTA_GAME_EXPORT bool RemoveTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
-	GTA_GAME_EXPORT bool RenameTimecycle(rage::tcModifier& modifier, const std::string& newName);
-	GTA_GAME_EXPORT bool DoesTimecycleHasModData(rage::tcModifier& modifier, const std::string& paramName, bool search = false);
-	GTA_GAME_EXPORT bool DoesTimecycleHasModData(rage::tcModifier& modifier, const int index);
-	GTA_GAME_EXPORT int GetTimecycleIndex(const rage::tcModifier& modifier);
-	GTA_GAME_EXPORT int GetTimecycleIndex(const std::string& name);
-	GTA_GAME_EXPORT int GetTimecycleIndex(const uint32_t hash);
-	GTA_GAME_EXPORT void EnsureTimecycleBackup(const rage::tcModifier& modifier);
-	GTA_GAME_EXPORT void RemoveTimecycle(rage::tcModifier& modifier);
-
-public:
+	const std::string& GetTimecycleName(const rage::tcModifier& modifier);
+	rage::tcModifier* GetTimecycle(const uint32_t hash);
+	rage::tcModifier* GetTimecycle(const std::string& name);
+	rage::tcModifier* GetTimecycleByIndex(const uint32_t index);
+	rage::tcModifier* CreateTimecycle(const std::string& newName);
+	rage::tcModifier* CloneTimecycle(rage::tcModifier& modifier, const std::string& cloneName);
+	rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	rage::tcModData* GetTimecycleModData(rage::tcModifier& modifier, const int index);
+	rage::tcModData* GetTimecycleModDataByIndex(rage::tcModifier& modifier, const int index);
+	bool AddTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	bool SetTimecycleModData(rage::tcModifier& modifier, std::string& paramName, const float value1, const float value2);
+	bool RemoveTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
+	bool RemoveTimecycleModData(rage::tcModifier& modifier, const std::string& paramName);
+	bool RenameTimecycle(rage::tcModifier& modifier, const std::string& newName);
+	bool DoesTimecycleHasModData(rage::tcModifier& modifier, const std::string& paramName, bool search = false);
+	int GetTimecycleIndex(const rage::tcModifier& modifier);
+	void EnsureTimecycleBackup(const rage::tcModifier& modifier);
+	void RemoveTimecycle(rage::tcModifier& modifier);
 	void RevertChanges();
 	void HandleTimecycleLoaded(const uint32_t hash, const std::string& name);
 	void HandleTimecycleUnloaded(const uint32_t hash);
-	void RemoveTimecycleBackup(const uint32_t hash);
+
+	static rage::tcManager* GetGameManager(); // get pointer to instance of RAGE timecycle manager
+	static TimecycleScriptData* GetScriptData(); // get "script" data, seems to be struct that is used in natives
+	static rage::tcVarInfo* GetConfigVarInfo(const std::string& paramName, bool search = false);
+	static rage::tcVarInfo* GetConfigVarInfo(const int index);
+	static rage::tcVarInfo* GetConfigVarInfos();
+	static int GetConfigVarInfoCount();
+	static bool HasTimecycleWithName(const std::string& paramName);
+
+private:
+	const std::string& GetTimecycleName(const uint32_t hash);
+	bool AddTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData);
+	bool DoesTimecycleHasModData(rage::tcModifier& modifier, const int index);
+	bool IsTimecycleBackedUp(const rage::tcModifier& modifier);
+	bool IsCustomTimecycle(const rage::tcModifier& modifier);
+	bool SetTimecycleModData(rage::tcModifier& modifier, const int index, const float value1, const float value2);
+	int GetTimecycleIndex(const std::string& name);
+	int GetTimecycleIndex(const uint32_t hash);
 	void AddCustomTimecycleName(const uint32_t hash, const std::string& name);
 	void RemoveCustomTimecycleName(const uint32_t hash);
 	void RemoveTimecycle(const uint32_t hash);
-	bool IsTimecycleBackedUp(const rage::tcModifier& modifier);
-	bool IsCustomTimecycle(const rage::tcModifier& modifier);
+	void RemoveTimecycleBackup(const uint32_t hash);
 
-public:
-	static GTA_GAME_EXPORT rage::tcManager* GetGameManager(); // get pointer to instance of RAGE timecycle manager
-	static GTA_GAME_EXPORT TimecycleScriptData* GetScriptData(); // get "script" data, seems to be struct that is used in natives
-	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfo(const std::string& paramName, bool search = false);
-	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfo(const int index);
-	static GTA_GAME_EXPORT rage::tcVarInfo* GetConfigVarInfos();
-	static GTA_GAME_EXPORT int GetConfigVarInfoCount();
-	static GTA_GAME_EXPORT bool HasTimecycleWithName(const std::string& paramName);
-
-private:
 	static void AddTimecycleToList(rage::tcModifier& modifier, bool sort = true);
 	static void SortTimecycleMap();
 };
 
-extern GTA_GAME_EXPORT TimecycleManager* TheTimecycleManager;
+extern COMPONENT_EXPORT(GTA_GAME_FIVE) TimecycleManager* TheTimecycleManager;

--- a/code/components/gta-game-five/src/Timecycle.cpp
+++ b/code/components/gta-game-five/src/Timecycle.cpp
@@ -17,7 +17,7 @@ TimecycleScriptData* TimecycleManager::GetScriptData()
 	return g_timeCycleScriptData;
 };
 
-std::string& TimecycleManager::GetTimecycleName(uint32_t hash)
+const std::string& TimecycleManager::GetTimecycleName(uint32_t hash)
 {
 	if (auto& it = m_originalNames.find(hash); it != m_originalNames.end())
 	{
@@ -29,10 +29,11 @@ std::string& TimecycleManager::GetTimecycleName(uint32_t hash)
 		return it->second;
 	}
 
-	assert(false && va("Failed to find timecycle name for %X", hash));
+	static std::string fallback = "INVALID";
+	return fallback;
 }
 
-std::string& TimecycleManager::GetTimecycleName(const rage::tcModifier& modifier)
+const std::string& TimecycleManager::GetTimecycleName(const rage::tcModifier& modifier)
 {
 	return GetTimecycleName(modifier.m_nameHash);
 }
@@ -151,7 +152,7 @@ rage::tcModifier* TimecycleManager::GetTimecycle(const std::string& name)
 		return nullptr;
 	}
 
-	return TimecycleManager::GetTimecycle(HashString(name));
+	return GetTimecycle(HashString(name));
 }
 
 rage::tcModifier* TimecycleManager::GetTimecycle(const uint32_t hash)
@@ -360,7 +361,7 @@ void TimecycleManager::RemoveTimecycle(const uint32_t hash)
 	}
 
 	// ensure we're not using this timecycle when removing it
-	if (auto scriptData = TimecycleManager::GetScriptData())
+	if (auto scriptData = GetScriptData())
 	{
 		if (index == scriptData->m_primaryModifierIndex)
 		{

--- a/code/components/gta-game-five/src/Timecycle.cpp
+++ b/code/components/gta-game-five/src/Timecycle.cpp
@@ -1,0 +1,767 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <Timecycle.h>
+#include <GameInit.h>
+
+static TimecycleScriptData* g_timeCycleScriptData;
+
+rage::tcManager* TimecycleManager::GetGameManager()
+{
+	assert(rage::tcManager::ms_Instance);
+	return rage::tcManager::ms_Instance;
+};
+
+TimecycleScriptData* TimecycleManager::GetScriptData()
+{
+	return g_timeCycleScriptData;
+};
+
+std::string& TimecycleManager::GetTimecycleName(uint32_t hash)
+{
+	if (auto& it = m_originalNames.find(hash); it != m_originalNames.end())
+	{
+		return it->second;
+	}
+
+	if (auto& it = m_customNames.find(hash); it != m_customNames.end())
+	{
+		return it->second;
+	}
+
+	assert(false && va("Failed to find timecycle name for %X", hash));
+}
+
+std::string& TimecycleManager::GetTimecycleName(const rage::tcModifier& modifier)
+{
+	return GetTimecycleName(modifier.m_nameHash);
+}
+
+rage::tcVarInfo* TimecycleManager::GetConfigVarInfo(const std::string& paramName, bool search)
+{
+	if (strlen(paramName.c_str()) == 0)
+	{
+		return nullptr;
+	}
+
+	if (auto tcVarInfos = *rage::tcConfig::ms_pVarInfos)
+	{
+		for (int i = 0; i < GetConfigVarInfoCount(); i++)
+		{
+			auto& varInfo = tcVarInfos[i];
+
+			if (search && strstr(varInfo.m_name, paramName.c_str()) != NULL)
+			{
+				return &varInfo;
+			}
+			else if (!search && strcmp(varInfo.m_name, paramName.c_str()) == NULL)
+			{
+				return &varInfo;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+rage::tcVarInfo* TimecycleManager::GetConfigVarInfo(const int paramIndex)
+{
+	if (auto tcVarInfos = *rage::tcConfig::ms_pVarInfos)
+	{
+		for (int i = 0; i < GetConfigVarInfoCount(); i++)
+		{
+			auto& varInfo = tcVarInfos[i];
+
+			if (varInfo.m_index == paramIndex)
+			{
+				return &varInfo;
+			}
+		}
+	}
+
+	return nullptr;
+}
+rage::tcVarInfo* TimecycleManager::GetConfigVarInfos()
+{
+	return *rage::tcConfig::ms_pVarInfos;
+}
+
+rage::tcModData* TimecycleManager::GetTimecycleModDataByIndex(rage::tcModifier& modifier, const int index)
+{
+	if (index < modifier.m_modData.GetCount())
+	{
+		return &modifier.m_modData[index];
+	}
+
+	return nullptr;
+}
+
+rage::tcModData* TimecycleManager::GetTimecycleModData(rage::tcModifier& modifier, const std::string& paramName)
+{
+	if (auto tcVarInfos = *rage::tcConfig::ms_pVarInfos)
+	{
+		for (auto& modData : modifier.m_modData)
+		{
+			if (modData.m_index == -1 || modData.m_index > GetConfigVarInfoCount())
+			{
+				continue; // invalid?
+			}
+
+			auto& varInfo = tcVarInfos[modData.m_index];
+
+			if (strcmp(varInfo.m_name, paramName.c_str()) == NULL)
+			{
+				return &modData;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+rage::tcModData* TimecycleManager::GetTimecycleModData(rage::tcModifier& modifier, const int paramIndex)
+{
+	for (auto& modData : modifier.m_modData)
+	{
+		if (modData.m_index == paramIndex)
+		{
+			return &modData;
+		}
+	}
+
+	return nullptr;
+}
+
+rage::tcModifier* TimecycleManager::GetTimecycleByIndex(const uint32_t index)
+{
+	auto tcManager = GetGameManager();
+
+	if (tcManager && index < tcManager->m_modifiers.GetCount())
+	{
+		return tcManager->m_modifiers[index];
+	}
+
+	return nullptr;
+}
+
+rage::tcModifier* TimecycleManager::GetTimecycle(const std::string& name)
+{
+	if (name.length() == 0)
+	{
+		return nullptr;
+	}
+
+	return TimecycleManager::GetTimecycle(HashString(name));
+}
+
+rage::tcModifier* TimecycleManager::GetTimecycle(const uint32_t hash)
+{
+	auto tcManager = GetGameManager();
+
+	for (int i = 0; i < tcManager->m_modifiers.GetCount(); i++)
+	{
+		if (tcManager->m_modifiers[i]->m_nameHash == hash)
+		{
+			return tcManager->m_modifiers[i];
+		}
+	}
+
+	return nullptr;
+}
+
+rage::tcModifier* TimecycleManager::CreateTimecycle(const std::string& newName)
+{
+	if (auto tcManager = rage::tcManager::ms_Instance)
+	{
+		auto nameHash = HashString(newName);
+
+		for (auto modifier : tcManager->m_modifiers)
+		{
+			if (modifier->m_nameHash == nameHash)
+			{
+				return nullptr;
+			}
+		}
+
+		auto created = new rage::tcModifier();
+		created->m_modData = atArray<rage::tcModData>(8);
+		created->m_nameHash = nameHash;
+		created->m_varMap = nullptr;
+		created->m_userFlags = 0;
+
+		AddCustomTimecycleName(nameHash, newName);
+		AddTimecycleToList(*created);
+
+		return created;
+	}
+
+	return nullptr;
+}
+
+rage::tcModifier* TimecycleManager::CloneTimecycle(rage::tcModifier& modifier, const std::string& cloneName)
+{
+	auto tcManager = GetGameManager();
+	auto nameHash = HashString(cloneName);
+
+	for (auto modifier : tcManager->m_modifiers)
+	{
+		if (modifier->m_nameHash == nameHash)
+		{
+			return nullptr;
+		}
+	}
+
+	auto clone = new rage::tcModifier();
+	clone->m_modData = atArray(modifier.m_modData);
+	clone->m_nameHash = nameHash;
+	clone->m_varMap = nullptr; // we don't need this I believe
+	clone->m_userFlags = modifier.m_userFlags;
+
+	AddCustomTimecycleName(nameHash, cloneName);
+	AddTimecycleToList(*clone);
+
+	return clone;
+}
+
+void TimecycleManager::RevertChanges()
+{
+	/*
+		Reverting process:
+		1. Find all indexes of custom timecycles.
+		2. Remove all custom timecycles from tcManager.
+		3. Iterate over backups and find actually changed timecycles.
+		4. Remove changed timecycles from tcManager.
+		5. Restore removed timecycles from backup.
+		6. Sort tcModifier map in tcManager.
+		7. Clear backup map and custom names.
+	*/
+
+	auto tcManager = GetGameManager();
+
+	std::vector<int> arrayIndexes{};
+	std::vector<int> mapIndexes{};
+
+	// find custom timecycles and save array indexes
+	for (auto& entry : m_customNames)
+	{
+		for (int i = 0; i < tcManager->m_modifiers.GetCount(); i++)
+		{
+			if (tcManager->m_modifiers[i]->m_nameHash == entry.first)
+			{
+				arrayIndexes.push_back(i);
+			}
+		}
+
+		for (int i = 0; i < tcManager->m_modifiersMap.m_array.GetCount(); i++)
+		{
+			if (tcManager->m_modifiersMap.m_array[i].m_hash == entry.first)
+			{
+				mapIndexes.push_back(i);
+			}
+		}
+	}
+
+	// remove custom timecycles from array and map
+	for (auto index : arrayIndexes)
+	{
+		tcManager->m_modifiers.Remove(index);
+	}
+
+	for (auto index : mapIndexes)
+	{
+		tcManager->m_modifiersMap.m_array.Remove(index);
+	}
+
+	// find all modifiers from backup that actually were changed or removed
+	// remove them from the game array and then restore from backup
+	std::list<rage::tcModifier*> modifiersToRestore;
+
+	for (auto& backup : m_modifiersBackup)
+	{
+		bool isModified = false;
+
+		if (auto tc = GetTimecycle(backup.first))
+		{
+			if (tc->m_modData.GetCount() != backup.second->m_modData.GetCount())
+			{
+				isModified = true;
+				// trace("%s: %X changed not the array size (cur %d) vs (bak %d)\n", __FUNCTION__, backup.second->m_nameHash, tc->m_modData.GetCount(), backup.second->m_modData.GetCount());
+			}
+			else
+			{
+				// search for any change in modData
+				for (int i = 0; i < tc->m_modData.GetCount(); i++)
+				{
+					auto& current = tc->m_modData[i];
+					auto& stored = backup.second->m_modData[i];
+
+					if (current.m_index != stored.m_index || current.m_value1 != stored.m_value1 || current.m_value2 != stored.m_value2)
+					{
+						// trace("%s: %X changed data (cur %d %f %f) vs (was %d %f %f)\n", __FUNCTION__, backup.second->m_nameHash, current.m_index, current.m_value1, current.m_value2, stored.m_index, stored.m_value1, stored.m_value2);
+						isModified = true;
+						break;
+					}
+				}
+			}
+		}
+		else
+		{
+			// there potentially can be cases when we're still storing backup of an
+			// unloaded timecycle, make sure we won't restore stuff in such a scenario
+			if (m_originalNames.find(backup.first) != m_originalNames.end())
+			{
+				// trace("%s: %X was removed\n", __FUNCTION__, backup.second->m_nameHash);
+				isModified = true;
+			}
+		}
+
+		if (isModified)
+		{
+			modifiersToRestore.push_back(backup.second);
+			RemoveTimecycle(backup.first);
+		}
+	}
+
+	// add original modifiers back
+	for (auto backup : modifiersToRestore)
+	{
+		AddTimecycleToList(*backup, false);
+	}
+
+	// sort timecycle modifier map after all the mess
+	SortTimecycleMap();
+
+	// clear custom timecycle names
+	m_customNames.clear();
+
+	// clear backups map
+	m_modifiersBackup.clear();
+}
+
+void TimecycleManager::SortTimecycleMap()
+{
+	auto tcManager = GetGameManager();
+
+	std::sort(tcManager->m_modifiersMap.m_array.begin(), tcManager->m_modifiersMap.m_array.end(), [](const auto& left, const auto& right)
+	{
+		return (left.m_hash < right.m_hash);
+	});
+
+	tcManager->m_modifiersMap.m_isSorted = true;
+}
+
+void TimecycleManager::RemoveTimecycle(const uint32_t hash)
+{
+	auto index = GetTimecycleIndex(hash);
+
+	if (index == -1)
+	{
+		return;
+	}
+
+	// ensure we're not using this timecycle when removing it
+	if (auto scriptData = TimecycleManager::GetScriptData())
+	{
+		if (index == scriptData->m_primaryModifierIndex)
+		{
+			scriptData->m_primaryModifierIndex = -1;
+		}
+
+		if (index == scriptData->m_extraModifierIndex)
+		{
+			scriptData->m_extraModifierIndex = -1;
+		}
+
+		if (index == scriptData->m_transitionModifierIndex)
+		{
+			scriptData->m_transitionModifierIndex = -1;
+		}
+	}
+
+	auto tcManager = GetGameManager();
+
+	delete tcManager->m_modifiers[index];
+	tcManager->m_modifiers.Remove(index);
+
+	for (int i = 0; i < tcManager->m_modifiersMap.m_array.GetCount(); i++)
+	{
+		if (tcManager->m_modifiersMap.m_array[i].m_value->m_nameHash == hash)
+		{
+			tcManager->m_modifiersMap.m_array.Remove(i);
+			break;
+		}
+	}
+
+	RemoveCustomTimecycleName(hash);
+}
+
+void TimecycleManager::RemoveTimecycle(rage::tcModifier& modifier)
+{
+	RemoveTimecycle(modifier.m_nameHash);
+}
+
+void TimecycleManager::AddTimecycleToList(rage::tcModifier& modifier, bool sort)
+{
+	auto tcManager = GetGameManager();
+
+	// expand modifiers array by 16 if reached size
+	{
+		if (tcManager->m_modifiers.GetCount() >= tcManager->m_modifiers.GetSize())
+		{
+			tcManager->m_modifiers.Expand(tcManager->m_modifiers.GetCount() + 16);
+		}
+
+		// add to the modifiers array
+		tcManager->m_modifiers.Set(tcManager->m_modifiers.GetCount(), &modifier);
+	}
+
+	// add timecycle to the modifiers map and sort it
+	{
+		if (tcManager->m_modifiersMap.m_array.GetCount() >= tcManager->m_modifiersMap.m_array.GetSize())
+		{
+			tcManager->m_modifiersMap.m_array.Expand(tcManager->m_modifiersMap.m_array.GetCount() + 16);
+		}
+
+		auto dataPair = new rage::atBinaryMap<rage::tcModifier*>::DataPair();
+		dataPair->m_hash = modifier.m_nameHash;
+		dataPair->m_value = &modifier;
+
+		tcManager->m_modifiersMap.m_array.Set(tcManager->m_modifiersMap.m_array.GetCount(), *dataPair);
+		tcManager->m_modifiersMap.m_isSorted = false;
+
+		if (sort)
+		{
+			std::sort(tcManager->m_modifiersMap.m_array.begin(), tcManager->m_modifiersMap.m_array.end(), [](const auto& left, const auto& right)
+			{
+				return (left.m_hash < right.m_hash);
+			});
+
+			tcManager->m_modifiersMap.m_isSorted = true;
+		}
+	}
+}
+
+void TimecycleManager::EnsureTimecycleBackup(const rage::tcModifier& modifier)
+{
+	if (IsCustomTimecycle(modifier) || IsTimecycleBackedUp(modifier))
+	{
+		return;
+	}
+
+	auto backup = new rage::tcModifier();
+	backup->m_nameHash = modifier.m_nameHash;
+	backup->m_modData = atArray<rage::tcModData>(modifier.m_modData);
+	backup->m_userFlags = 0;
+	backup->m_varMap = nullptr;
+
+	m_modifiersBackup[modifier.m_nameHash] = backup;
+}
+
+bool TimecycleManager::IsTimecycleBackedUp(const rage::tcModifier& modifier)
+{
+	return m_modifiersBackup.find(modifier.m_nameHash) != m_modifiersBackup.end();
+}
+
+bool TimecycleManager::IsCustomTimecycle(const rage::tcModifier& modifier)
+{
+	return m_originalNames.find(modifier.m_nameHash) == m_originalNames.end();
+}
+
+bool TimecycleManager::HasTimecycleWithName(const std::string& name)
+{
+	auto tcManager = GetGameManager();
+	auto nameHash = HashString(name);
+
+	for (int i = 0; i < tcManager->m_modifiers.GetCount(); i++)
+	{
+		if (tcManager->m_modifiers[i]->m_nameHash == nameHash)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void TimecycleManager::HandleTimecycleLoaded(const uint32_t hash, const std::string& name)
+{
+	m_originalNames[hash] = name;
+}
+
+void TimecycleManager::HandleTimecycleUnloaded(const uint32_t hash)
+{
+	m_originalNames.erase(hash);
+
+	RemoveTimecycleBackup(hash);
+}
+
+void TimecycleManager::RemoveTimecycleBackup(const uint32_t hash)
+{
+	if (auto it = m_modifiersBackup.find(hash); it != m_modifiersBackup.end())
+	{
+		m_modifiersBackup.erase(it);
+	}
+}
+
+void TimecycleManager::AddCustomTimecycleName(const uint32_t hash, const std::string& name)
+{
+	m_customNames[hash] = name;
+}
+
+void TimecycleManager::RemoveCustomTimecycleName(const uint32_t hash)
+{
+	m_customNames.erase(hash);
+}
+
+bool TimecycleManager::DoesTimecycleHasModData(rage::tcModifier& modifier, const std::string& paramName, bool search)
+{
+	if (auto varInfo = GetConfigVarInfo(paramName, search))
+	{
+		return DoesTimecycleHasModData(modifier, varInfo->m_index);
+	}
+
+	return false;
+}
+
+bool TimecycleManager::DoesTimecycleHasModData(rage::tcModifier& modifier, const int index)
+{
+	for (auto& entry : modifier.m_modData)
+	{
+		if (entry.m_index == index)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool TimecycleManager::SetTimecycleModData(rage::tcModifier& modifier, std::string& paramName, const float value1, const float value2)
+{
+	if (auto varInfo = GetConfigVarInfo(paramName))
+	{
+		return SetTimecycleModData(modifier, varInfo->m_index, value1, value2);
+	}
+
+	return false;
+}
+
+bool TimecycleManager::SetTimecycleModData(rage::tcModifier& modifier, const int index, const float value1, const float value2)
+{
+	EnsureTimecycleBackup(modifier);
+
+	for (auto& entry : modifier.m_modData)
+	{
+		if (entry.m_index == index)
+		{
+			entry.m_value1 = value1;
+			entry.m_value2 = value2;
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool TimecycleManager::AddTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData)
+{
+	for (auto& entry : modifier.m_modData)
+	{
+		if (modData.m_index == entry.m_index)
+		{
+			return false;
+		}
+	}
+
+	EnsureTimecycleBackup(modifier);
+
+	if (modifier.m_modData.GetCount() >= modifier.m_modData.GetSize())
+	{
+		modifier.m_modData.Expand(modifier.m_modData.GetSize() + 16);
+	}
+
+	modifier.m_modData.Set(modifier.m_modData.GetCount(), modData);
+
+	std::sort(modifier.m_modData.begin(), modifier.m_modData.end(), [](const auto& left, const auto& right)
+	{
+		return (left.m_index < right.m_index);
+	});
+
+	return true;
+}
+
+bool TimecycleManager::AddTimecycleModData(rage::tcModifier& modifier, const std::string& paramName)
+{
+	if (auto varInfo = GetConfigVarInfo(paramName))
+	{
+		auto modData = new rage::tcModData();
+		modData->m_index = varInfo->m_index;
+		modData->m_value1 = varInfo->m_value;
+		modData->m_value2 = 0.0f;
+
+		return AddTimecycleModData(modifier, *modData);
+	}
+
+	return false;
+}
+
+bool TimecycleManager::RemoveTimecycleModData(rage::tcModifier& modifier, const rage::tcModData& modData)
+{
+	EnsureTimecycleBackup(modifier);
+
+	for (int i = 0; i < modifier.m_modData.GetCount(); i++)
+	{
+		if (modifier.m_modData[i].m_index == modData.m_index)
+		{
+			modifier.m_modData.Remove(i);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool TimecycleManager::RemoveTimecycleModData(rage::tcModifier& modifier, const std::string& paramName)
+{
+	if (auto modData = GetTimecycleModData(modifier, paramName))
+	{
+		return RemoveTimecycleModData(modifier, *modData);
+	}
+
+	return false;
+}
+
+bool TimecycleManager::RenameTimecycle(rage::tcModifier& modifier, const std::string& newName)
+{
+	auto newHash = HashString(newName);
+
+	if (modifier.m_nameHash == newHash)
+	{
+		return true;
+	}
+
+	EnsureTimecycleBackup(modifier);
+
+	auto& modifiersMap = rage::tcManager::ms_Instance->m_modifiersMap;
+
+	for (auto it = modifiersMap.m_array.begin(); it != modifiersMap.m_array.end(); ++it)
+	{
+		if (it->m_hash == modifier.m_nameHash)
+		{
+			it->m_hash = newHash;
+			it->m_value->m_nameHash = newHash;
+
+			modifiersMap.m_isSorted = false;
+
+			break;
+		}
+	}
+
+	if (!modifiersMap.m_isSorted)
+	{
+		std::sort(modifiersMap.m_array.begin(), modifiersMap.m_array.end(), [](const auto& left, const auto& right)
+		{
+			return (left.m_hash < right.m_hash);
+		});
+
+		modifiersMap.m_isSorted = true;
+	}
+
+	AddCustomTimecycleName(newHash, newName);
+
+	return modifier.m_nameHash != newHash;
+}
+
+int TimecycleManager::GetTimecycleIndex(const rage::tcModifier& modifier)
+{
+	return GetTimecycleIndex(modifier.m_nameHash);
+}
+
+int TimecycleManager::GetTimecycleIndex(const std::string& name)
+{
+	auto nameHash = HashString(name);
+	return GetTimecycleIndex(nameHash);
+}
+
+int TimecycleManager::GetTimecycleIndex(const uint32_t hash)
+{
+	auto tcManager = GetGameManager();
+
+	for (int i = 0; i < tcManager->m_modifiers.GetCount(); i++)
+	{
+		if (tcManager->m_modifiers[i]->m_nameHash == hash)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int TimecycleManager::GetConfigVarInfoCount()
+{
+	return *rage::tcConfig::ms_numVars;
+}
+
+static TimecycleManager TCManager;
+TimecycleManager* TheTimecycleManager = &TCManager;
+
+static uint32_t (*g_origTimecycleComputeHashLoad)(int, char*);
+static uint32_t TimecycleComputeHashLoad(int ns, char* name)
+{
+	auto hash = g_origTimecycleComputeHashLoad(ns, name);
+	TCManager.HandleTimecycleLoaded(hash, std::string(name));
+	return hash;
+}
+
+static uint32_t (*g_origTimecycleComputeHashUnload)(int, char*);
+static uint32_t TimecycleComputeHashUnload(int ns, char* name)
+{
+	auto hash = g_origTimecycleComputeHashUnload(ns, name);
+	TCManager.HandleTimecycleUnloaded(hash);
+	return hash;
+}
+
+static HookFunction hookFunction([]()
+{
+	OnKillNetworkDone.Connect([=]()
+	{
+		TCManager.RevertChanges();
+	});
+
+	static_assert(sizeof(rage::tcModData) == 0xC);
+	static_assert(sizeof(rage::tcVarInfo) == 0x20);
+	static_assert(sizeof(rage::tcModifier) == 0x28);
+	static_assert(sizeof(rage::atBinaryMap<void*>) == 0x18);
+
+	{
+		auto location = hook::get_pattern<char>("7E 6E 45 33 F6");
+		rage::tcConfig::ms_numVars = hook::get_address<int*>(location - 6, 2, 6);
+		rage::tcConfig::ms_pVarInfos = hook::get_address<rage::tcVarInfo**>(location + 5, 3, 7);
+	}
+
+	{
+		auto location = hook::get_pattern<char>("48 C1 E0 03 41 80 E1 01 C6 44 24 20 00", 19);
+		rage::tcManager::ms_Instance = hook::get_address<rage::tcManager*>(location, 3, 7);
+	}
+
+	{
+		auto location = hook::get_pattern<char>("48 89 7B 10 8B 05 ? ? ? ? 83 F8 FF 74 13");
+		g_timeCycleScriptData = hook::get_address<TimecycleScriptData*>(location + 6);
+	}
+
+	{
+		auto location = hook::get_pattern("48 8B 50 08 E8 ? ? ? ? B9", 4);
+
+		hook::set_call(&g_origTimecycleComputeHashLoad, location);
+		hook::call(location, TimecycleComputeHashLoad);
+	}
+
+	{
+		auto location = hook::get_pattern("48 8B 50 08 E8 ? ? ? ? 48 8D 54 24", 4);
+
+		hook::set_call(&g_origTimecycleComputeHashUnload, location);
+		hook::call(location, TimecycleComputeHashUnload);
+	}
+});

--- a/ext/native-decls/CloneTimecycleModifier.md
+++ b/ext/native-decls/CloneTimecycleModifier.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## CLONE_TIMECYCLE_MODIFIER
+
+```c
+int CLONE_TIMECYCLE_MODIFIER(char* sourceModifierName, char* clonedModifierName);
+```
+
+## Examples
+
+```lua
+local sourceName = "underwater"
+local cloneName = "my_awesome_timecycle"
+
+local clonedIndex = CloneTimecycleModifier(sourceName, cloneName)
+if clonedIndex ~= -1 then
+  SetTimecycleModifier(cloneName)
+end
+```
+
+## Parameters
+* **sourceModifierName**: The source timecycle name.
+* **clonedModifierName**: The clone timecycle name, must be unique.
+
+## Return value
+The cloned timecycle modifier index, or -1 if failed.

--- a/ext/native-decls/CreateTimecycleModifier.md
+++ b/ext/native-decls/CreateTimecycleModifier.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## CREATE_TIMECYCLE_MODIFIER
+
+```c
+int CREATE_TIMECYCLE_MODIFIER(char* modifierName);
+```
+
+Create a clean timecycle modifier. See [`SET_TIMECYCLE_MODIFIER_VAR`](#_0x6E0A422B) to add variables.
+
+## Examples
+
+```lua
+local modifierName = "my_awesome_timecycle"
+local createdIndex = CreateTimecycleModifier(modifierName)
+
+if createdIndex ~= -1 then
+  SetTimecycleModifier(modifierName)
+end
+```
+
+## Parameters
+* **modifierName**: The new timecycle name, must be unique.
+
+## Return value
+The created timecycle modifier index, or -1 if failed.

--- a/ext/native-decls/DoesTimecycleModifierHasVar.md
+++ b/ext/native-decls/DoesTimecycleModifierHasVar.md
@@ -1,0 +1,36 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DOES_TIMECYCLE_MODIFIER_HAS_VAR
+
+```c
+BOOL DOES_TIMECYCLE_MODIFIER_HAS_VAR(char* modifierName, char* varName);
+```
+
+## Examples
+
+```lua
+local modifierName = "superDARK"
+local varName = "postfx_noise"
+
+if DoesTimecycleModifierHasVar(modifierName, varName) then
+  local success, value1, value2 = GetTimecycleModifierVar(modifierName, varName)
+
+  if success then
+    print(string.format("[%s] removed var %s with values: %f %f", modifierName, varName, value1, value2))
+    RemoveTimecycleModifierVar(modifierName, varName)
+  end
+else
+    SetTimecycleModifierVar(modifierName, varName, 1.0, 1.0)
+    print(string.format("[%s] created var %s", modifierName, varName))
+end
+```
+
+## Parameters
+* **modifierName**: The name of timecycle modifier.
+* **varName**: The name of timecycle variable.
+
+## Return value
+Whether or not variable by name was found on the specified timecycle modifier.

--- a/ext/native-decls/GetTimecycleModifierCount.md
+++ b/ext/native-decls/GetTimecycleModifierCount.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_COUNT
+
+```c
+int GET_TIMECYCLE_MODIFIER_COUNT();
+```
+
+## Examples
+
+```lua
+local count = GetTimecycleModifierCount()
+print("we have  " .. count .. "timecycle modifiers loaded")
+```
+
+## Return value
+Returns the amount of timecycle modifiers loaded.

--- a/ext/native-decls/GetTimecycleModifierIndexByName.md
+++ b/ext/native-decls/GetTimecycleModifierIndexByName.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_INDEX_BY_NAME
+
+```c
+int GET_TIMECYCLE_MODIFIER_INDEX_BY_NAME(char* modifierName);
+```
+
+## Examples
+
+```lua
+local modifierIndex = GetTimecycleModifierIndexByName("underwater")
+local currentIndex = GetTimecycleModifierIndex()
+
+if currentIndex ~= -1 and currentIndex == modifierIndex then
+  print("we're actually using 'underwater' timecycle!")
+end
+```
+
+## Parameters
+* **modifierName**: The timecycle modifier name.
+
+## Return value
+The timecycle modifier index.

--- a/ext/native-decls/GetTimecycleModifierNameByIndex.md
+++ b/ext/native-decls/GetTimecycleModifierNameByIndex.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_NAME_BY_INDEX
+
+```c
+char* GET_TIMECYCLE_MODIFIER_NAME_BY_INDEX(int modifierIndex);
+```
+
+## Examples
+
+```lua
+local modifierIndex = GetTimecycleModifierIndex()
+
+if modifierIndex ~= -1 then
+  local modifierName = GetTimecycleModifierNameByIndex(modifierIndex)
+  print("current timecycle name is " .. modifierName)
+end
+```
+
+## Parameters
+* **modifierIndex**: The timecycle modifier index.
+
+## Return value
+The timecycle modifier name.

--- a/ext/native-decls/GetTimecycleModifierStrength.md
+++ b/ext/native-decls/GetTimecycleModifierStrength.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_STRENGTH
+
+```c
+float GET_TIMECYCLE_MODIFIER_STRENGTH();
+```
+
+A getter for [SET_TIMECYCLE_MODIFIER_STRENGTH](#_0x82E7FFCD5B2326B3).
+
+## Return value
+Returns current timecycle modifier strength.

--- a/ext/native-decls/GetTimecycleModifierVar.md
+++ b/ext/native-decls/GetTimecycleModifierVar.md
@@ -1,0 +1,36 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_VAR
+
+```c
+BOOL GET_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName, float* value1, float* value2);
+```
+
+## Examples
+
+```lua
+local modifierName = "superDARK"
+local varName = "postfx_noise"
+
+if DoesTimecycleModifierHasVar(modifierName, varName) then
+  local success, value1, value2 = GetTimecycleModifierVar(modifierName, varName)
+
+  if success then
+    print(string.format("[%s] removed var %s with values: %f %f", modifierName, varName, value1, value2))
+    RemoveTimecycleModifierVar(modifierName, varName)
+  end
+else
+    SetTimecycleModifierVar(modifierName, varName, 1.0, 1.0)
+    print(string.format("[%s] created var %s", modifierName, varName))
+end
+```
+
+## Parameters
+* **modifierName**: The name of timecycle modifier.
+* **varName**: The name of timecycle variable.
+
+## Return value
+Whether or not variable by name was found on the specified timecycle modifier.

--- a/ext/native-decls/GetTimecycleModifierVarCount.md
+++ b/ext/native-decls/GetTimecycleModifierVarCount.md
@@ -1,0 +1,30 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_VAR_COUNT
+
+```c
+int GET_TIMECYCLE_MODIFIER_VAR_COUNT(char* modifierName);
+```
+
+## Examples
+
+```lua
+local varCount = GetTimecycleModifierVarCount("underwater")
+
+if varCount ~= 0 then
+  for index = 0, varCount - 1 do
+    local varName = GetTimecycleModifierVarNameByIndex(index)
+
+    print(string.format("[%d] %s", index, varName))
+  end
+end
+```
+
+## Parameters
+* **modifierName**: The timecycle modifier name.
+
+## Return value
+The amount of variables used on a specified timecycle modifier.

--- a/ext/native-decls/GetTimecycleModifierVarNameByIndex.md
+++ b/ext/native-decls/GetTimecycleModifierVarNameByIndex.md
@@ -1,0 +1,31 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_MODIFIER_VAR_COUNT
+
+```c
+char* GET_TIMECYCLE_MODIFIER_VAR_COUNT(char* modifierName, int modifierVarIndex);
+```
+
+## Examples
+
+```lua
+local varCount = GetTimecycleModifierVarCount("underwater")
+
+if varCount ~= 0 then
+  for index = 0, varCount - 1 do
+    local varName = GetTimecycleModifierVarNameByIndex(index)
+
+    print(string.format("[%d] %s", index, varName))
+  end
+end
+```
+
+## Parameters
+* **modifierName**: The name of timecycle modifier.
+* **modifierVarIndex**: The index of a variable on the specified timecycle modifier.
+
+## Return value
+The name of a variable by index.

--- a/ext/native-decls/GetTimecycleVarCount.md
+++ b/ext/native-decls/GetTimecycleVarCount.md
@@ -1,0 +1,30 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_VAR_COUNT
+
+```c
+int GET_TIMECYCLE_VAR_COUNT();
+```
+
+Returns the amount of variables available to be applied on timecycle modifiers.
+
+## Examples
+
+```lua
+local varCount = GetTimecycleVarCount()
+
+if varCount ~= 0 then
+  for index = 0, varCount - 1 do
+    local varName = GetTimecycleVarNameByIndex(index)
+    local varDefault = GetTimecycleVarDefaultValueByIndex(index)
+
+    print(string.format("[%d] %s (%f)", index, varName, varDefault))
+  end
+end
+```
+
+## Return value
+The amount of available variables for timecycle modifiers.

--- a/ext/native-decls/GetTimecycleVarDefaultValueByIndex.md
+++ b/ext/native-decls/GetTimecycleVarDefaultValueByIndex.md
@@ -1,0 +1,33 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_VAR_DEFAULT_VALUE_BY_INDEX
+
+```c
+float GET_TIMECYCLE_VAR_DEFAULT_VALUE_BY_INDEX(int varIndex);
+```
+
+See [GET_TIMECYCLE_VAR_COUNT](#_0x838B34D8).
+
+## Examples
+
+```lua
+local varCount = GetTimecycleVarCount()
+
+if varCount ~= 0 then
+  for index = 0, varCount - 1 do
+    local varName = GetTimecycleVarNameByIndex(index)
+    local varDefault = GetTimecycleVarDefaultValueByIndex(index)
+
+    print(string.format("[%d] %s (%f)", index, varName, varDefault))
+  end
+end
+```
+
+## Parameters
+* **varIndex**: The index of variable.
+
+## Return value
+The default value of a timecycle variable.

--- a/ext/native-decls/GetTimecycleVarNameByIndex.md
+++ b/ext/native-decls/GetTimecycleVarNameByIndex.md
@@ -1,0 +1,33 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TIMECYCLE_VAR_NAME_BY_INDEX
+
+```c
+char* GET_TIMECYCLE_VAR_NAME_BY_INDEX(int varIndex);
+```
+
+See [GET_TIMECYCLE_VAR_COUNT](#_0x838B34D8).
+
+## Examples
+
+```lua
+local varCount = GetTimecycleVarCount()
+
+if varCount ~= 0 then
+  for index = 0, varCount - 1 do
+    local varName = GetTimecycleVarNameByIndex(index)
+    local varDefault = GetTimecycleVarDefaultValueByIndex(index)
+
+    print(string.format("[%d] %s (%f)", index, varName, varDefault))
+  end
+end
+```
+
+## Parameters
+* **varIndex**: The index of variable.
+
+## Return value
+The name of a timecycle variable.

--- a/ext/native-decls/RemoveTimecycleModifier.md
+++ b/ext/native-decls/RemoveTimecycleModifier.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REMOVE_TIMECYCLE_MODIFIER
+
+```c
+void REMOVE_TIMECYCLE_MODIFIER(char* modifierName);
+```
+
+## Examples
+
+```lua
+local modifierName = "my_awesome_timecycle"
+RemoveTimecycleModifier(modifierName)
+```
+
+## Parameters
+* **modifierName**: The timecycle modifier name.

--- a/ext/native-decls/RemoveTimecycleModifierVar.md
+++ b/ext/native-decls/RemoveTimecycleModifierVar.md
@@ -1,0 +1,33 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REMOVE_TIMECYCLE_MODIFIER_VAR
+
+```c
+void REMOVE_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName);
+```
+
+## Examples
+
+```lua
+local modifierName = "superDARK"
+local varName = "postfx_noise"
+
+if DoesTimecycleModifierHasVar(modifierName, varName) then
+  local success, value1, value2 = GetTimecycleModifierVar(modifierName, varName)
+
+  if success then
+    print(string.format("[%s] removed var %s with values: %f %f", modifierName, varName, value1, value2))
+    RemoveTimecycleModifierVar(modifierName, varName)
+  end
+else
+    SetTimecycleModifierVar(modifierName, varName, 1.0, 1.0)
+    print(string.format("[%s] created var %s", modifierName, varName))
+end
+```
+
+## Parameters
+* **modifierName**: The name of timecycle modifier.
+* **varName**: The name of timecycle variable.

--- a/ext/native-decls/SetTimecycleModifierVar.md
+++ b/ext/native-decls/SetTimecycleModifierVar.md
@@ -1,0 +1,35 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_TIMECYCLE_MODIFIER_VAR
+
+```c
+void SET_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName, float value1, float value2);
+```
+
+## Examples
+
+```lua
+local modifierName = "superDARK"
+local varName = "postfx_noise"
+
+if DoesTimecycleModifierHasVar(modifierName, varName) then
+  local success, value1, value2 = GetTimecycleModifierVar(modifierName, varName)
+
+  if success then
+    print(string.format("[%s] removed var %s with values: %f %f", modifierName, varName, value1, value2))
+    RemoveTimecycleModifierVar(modifierName, varName)
+  end
+else
+    SetTimecycleModifierVar(modifierName, varName, 1.0, 1.0)
+    print(string.format("[%s] created var %s", modifierName, varName))
+end
+```
+
+## Parameters
+* **modifierName**: The name of timecycle modifier.
+* **varName**: The name of timecycle variable.
+* **value1**: The first value of variable.
+* **value2**: The second value of variable.


### PR DESCRIPTION
A set of natives allowing people to create, modify and test timecycles in runtime:
```cpp
 // Getter for SET_TIMECYCLE_MODIFIER_STRENGTH
float GET_TIMECYCLE_MODIFIER_STRENGTH();

// Getting all available modifiers
int GET_TIMECYCLE_MODIFIER_COUNT();
char* GET_TIMECYCLE_MODIFIER_NAME_BY_INDEX(int modifierIndex);
int GET_TIMECYCLE_MODIFIER_INDEX_BY_NAME(char* modifierName);

// Manipulating modifiers
int CREATE_TIMECYCLE_MODIFIER(char* modifierName); // returns -1 if failed to create
int CLONE_TIMECYCLE_MODIFIER(char* sourceModifierName, char* clonedModifierName); // returns -1 if failed to clone
void REMOVE_TIMECYCLE_MODIFIER(char* modifierName);

// Getting all available timecycle vars and their default values
int GET_TIMECYCLE_VAR_COUNT();
char* GET_TIMECYCLE_VAR_NAME_BY_INDEX(int varIndex);
float GET_TIMECYCLE_VAR_DEFAULT_VALUE_BY_INDEX(int varIndex);

// Getting all timecycle vars within modifier
int GET_TIMECYCLE_MODIFIER_VAR_COUNT(char* modifierName);
char* GET_TIMECYCLE_MODIFIER_VAR_NAME_BY_INDEX(char* modifierName, int modifierVarIndex);

// Manipulating timecycle vars within modifier
BOOL GET_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName, float* value1, float* value2);
void SET_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName, float value1, float value2);
BOOL DOES_TIMECYCLE_MODIFIER_HAS_VAR(char* modifierName, char* varName);
void REMOVE_TIMECYCLE_MODIFIER_VAR(char* modifierName, char* varName);
```

The new runtime timecycle editor only available in FxDK mode (`timecycleeditor 1` cmd):

https://user-images.githubusercontent.com/10367215/230184958-fb4a16f6-4b0c-411b-90ce-b83a2e019d52.mp4

Going to be backported on RedM soon as well.