### PR TITLE
Decrease state bag lock pressure

### DIFF
--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -581,17 +581,22 @@ void StateBagComponentImpl::AttachToObject(fx::ResourceManager* object)
 		decltype(m_erasureList) erasureList;
 
 		{
-			std::unique_lock _(m_erasureMutex);
-			erasureList = std::move(m_erasureList);
-		}
-
-		if (!erasureList.empty())
-		{
-			std::unique_lock lock(m_mapMutex);
-
-			for (const auto& id : erasureList)
+			if (!m_mapMutex.try_lock())
 			{
-				m_stateBags.erase(id);
+				return;
+			}
+
+			{
+				std::unique_lock _(m_erasureMutex);
+				erasureList = std::move(m_erasureList);
+			}
+
+			if (!erasureList.empty())
+			{
+				for (const auto& id : erasureList)
+				{
+					m_stateBags.erase(id);
+				}
 			}
 		}
 	},

--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -598,6 +598,8 @@ void StateBagComponentImpl::AttachToObject(fx::ResourceManager* object)
 					m_stateBags.erase(id);
 				}
 			}
+
+			m_mapMutex.unlock();
 		}
 	},
 	INT32_MIN);


### PR DESCRIPTION
Should help https://github.com/citizenfx/fivem/issues/1942

I add a new lock that handle target updates only
I also use a try lock for removal so it should release some pressure when there is a lot of entity despawning / state bag changes in the same time