### PR TITLE
fix(build-tools): mono v2 rdr3 and Linux server folder fix

### DIFF
--- a/code/premake5.lua
+++ b/code/premake5.lua
@@ -575,7 +575,7 @@ if _OPTIONS['game'] ~= 'launcher' then
 		cstargets 'v2'
 	end
 		
-	if _OPTIONS['game'] ~= 'server' then
+	if _OPTIONS['game'] ~= 'server' and  _OPTIONS['game'] ~= 'rdr3' then -- remove rdr3 check when its natives are fixed
 		do csproject ("CitizenFX."..program.publicName..".NativeImpl")
 			clr 'Unsafe'
 			files { 'client/clrcore-v2/Native/'..program.cSharp.nativesFile }

--- a/code/tools/ci/build_server_2.sh
+++ b/code/tools/ci/build_server_2.sh
@@ -87,7 +87,7 @@ EOF
 #endif
 EOF
 	
-	lua5.3 codegen.lua inp/natives_global.lua cs_v2 server > /src/code/client/clrcore-v2/Natives/NativesServer.cs
+	lua5.3 codegen.lua inp/natives_global.lua cs_v2 server > /src/code/client/clrcore-v2/Native/NativesServer.cs
 
 	lua5.3 codegen.lua inp/natives_global.lua rpc server > /opt/cfx-server/citizen/scripting/rpc_natives.json
 fi


### PR DESCRIPTION
* Disable mono v2 natives and game libraries for rdr3,
* Use renamed `Native` folder on Linux builds.