### PR TITLE
feat(scripting-mono): enable mono v2 runtime

### DIFF
--- a/data/client/components.json
+++ b/data/client/components.json
@@ -51,6 +51,7 @@
 	"gta:game:five",
 	"handling-loader:five",
 	"citizen:scripting:mono",
+	"citizen:scripting:mono-v2",
 	"devtools:five",
 	"tool:vehrec",
 	"extra-natives:five",

--- a/data/server/components.json
+++ b/data/server/components.json
@@ -20,6 +20,7 @@
   "scripting:server",
   "svadhesive",
   "citizen:scripting:mono",
+  "citizen:scripting:mono-v2",
   "citizen:scripting:v8node",
   "voip-server:mumble",
   "http-client"

--- a/data/server_windows/components.json
+++ b/data/server_windows/components.json
@@ -22,6 +22,7 @@
   "scripting:server",
   "svadhesive",
   "citizen:scripting:mono",
+  "citizen:scripting:mono-v2",
   "citizen:scripting:v8node",
   "voip-server:mumble",
   "http-client",


### PR DESCRIPTION
* Will enable the mono v2 runtime on FiveM and Server
  - Resources can use this runtime by defining `mono_rt2 'Prerelease expiring 2023-06-30. See https://aka.cfx.re/mono-rt2-preview for info.'` in their `fxmanifest.lua` file,
  - User's C# assemblies need to be compiled against the `v2/` assemblies.
* RedM needs some internal native changes before it'll be activated,
* Replace mono_rt2 check with an expiration date and informative value.

Final commit for publishing mono_rt2