### PR TITLE
Update LegitimacyNUI version

### DIFF
--- a/code/components/ros-patches-five/src/LegitimacyNui.cpp
+++ b/code/components/ros-patches-five/src/LegitimacyNui.cpp
@@ -420,7 +420,7 @@ function RGSC_GET_TITLE_ID()
 function RGSC_GET_VERSION_INFO()
 {
 	return JSON.stringify({
-		Version: '2.0.3.7',
+		Version: '2.1.6.5',
 		TitleVersion: ''
 	});
 }


### PR DESCRIPTION
This PR fixes the error below (version changed to the minimum version required)
![image](https://user-images.githubusercontent.com/92888450/234386115-3bc10177-23ed-41af-bb57-0779b4157805.png)