### PR TITLE
tweak(scripting-mono-v2): use core scheduler

### DIFF
--- a/code/client/clrcore-v2/Coroutine/Coroutine.cs
+++ b/code/client/clrcore-v2/Coroutine/Coroutine.cs
@@ -182,12 +182,12 @@ namespace CitizenFX.Core
 			return coroutine;
 		}
 
-		internal static Coroutine WaitUntil(uint time)
+		internal static Coroutine WaitUntil(ulong time)
 		{
 			var coroutine = new Coroutine();
 			Action action = () => coroutine.GetAwaiter().SetResult();
 
-			if (time <= Scheduler.TimeNow) // e.g.: Coroutine.Wait(0u) or Coroutine.Delay(0u)
+			if (time <= Scheduler.CurrentTime) // e.g.: Coroutine.Wait(0u) or Coroutine.Delay(0u)
 				Scheduler.Schedule(action);
 			else
 				Scheduler.Schedule(action, time);
@@ -195,9 +195,9 @@ namespace CitizenFX.Core
 			return coroutine;
 		}
 
-		internal static Coroutine Wait(uint delay) => WaitUntil(Scheduler.TimeNow + delay);
+		internal static Coroutine Wait(ulong delay) => WaitUntil(Scheduler.CurrentTime + delay);
 
-		internal static Coroutine Delay(uint delay) => WaitUntil(Scheduler.TimeNow + delay);
+		internal static Coroutine Delay(ulong delay) => WaitUntil(Scheduler.CurrentTime + delay);
 	}
 
 	public interface ICoroutineAwaiter {}

--- a/code/client/clrcore-v2/Coroutine/Scheduler.cs
+++ b/code/client/clrcore-v2/Coroutine/Scheduler.cs
@@ -6,12 +6,24 @@ namespace CitizenFX.Core
 {
 	public class Scheduler
 	{
-		internal static uint TimeNow { get; private set; }
+		/// <summary>
+		/// Current time of this scheduler
+		/// </summary>
+		public static ulong CurrentTime { get; internal set; }
+
+		/// <summary>
+		/// Thread onto which all coroutines will run and be put back to
+		/// </summary>
 		internal static Thread MainThread { get; private set; }
 
-		private static LinkedList<Tuple<uint, Action>> s_queue = new LinkedList<Tuple<uint, Action>>();
+		/// <summary>
+		/// Current time of the scheduler, set per frame.
+		/// </summary>
+		private static LinkedList<Tuple<ulong, Action>> s_queue = new LinkedList<Tuple<ulong, Action>>();
 
-		// optimized non ordering
+		/// <summary>
+		/// Double buffered array for non-ordered scheduling
+		/// </summary>
 		private static List<Action> s_nextFrame = new List<Action>();
 		private static List<Action> s_nextFrameProcessing = new List<Action>();
 
@@ -20,6 +32,10 @@ namespace CitizenFX.Core
 			MainThread = Thread.CurrentThread;
 		}
 
+		/// <summary>
+		/// Schedule an action to be run on the next frame
+		/// </summary>
+		/// <param name="coroutine">Action to execute</param>
 		public static void Schedule(Action coroutine)
 		{
 			if (coroutine != null)
@@ -33,7 +49,12 @@ namespace CitizenFX.Core
 				throw new ArgumentNullException(nameof(coroutine));
 		}
 
-		public static void Schedule(Action coroutine, uint time)
+		/// <summary>
+		/// Schedule an action to be run at the first frame at or after the specified time
+		/// </summary>
+		/// <param name="coroutine">Action to execute</param>
+		/// <param name="time">Time when it should be executed, see <see cref="CurrentTime"/></param>
+		public static void Schedule(Action coroutine, ulong time)
 		{
 			if (coroutine != null)
 			{
@@ -44,21 +65,24 @@ namespace CitizenFX.Core
 					{
 						if (time < it.Value.Item1)
 						{
-							s_queue.AddBefore(it, new Tuple<uint, Action>(time, coroutine));
+							s_queue.AddBefore(it, new Tuple<ulong, Action>(time, coroutine));
 							return;
 						}
 					}
 
-					s_queue.AddLast(new Tuple<uint, Action>(time, coroutine));
+					s_queue.AddLast(new Tuple<ulong, Action>(time, coroutine));
 				}
 			}
 			else
 				throw new ArgumentNullException(nameof(coroutine));
 		}
 
+		/// <summary>
+		/// Execute all scheduled coroutines
+		/// </summary>
 		internal static void Update()
 		{
-			uint timeNow = TimeNow = (uint)Environment.TickCount;
+			ulong timeNow = CurrentTime;
 
 			// all next frame coroutines
 			{
@@ -106,6 +130,24 @@ namespace CitizenFX.Core
 						return;
 				}
 			}
+		}
+
+		/// <summary>
+		/// Time in milliseconds when the next action needs to be activated
+		/// </summary>
+		/// <returns>Delay in milliseconds or ~0ul (<see cref="ulong.MaxValue"/>) if there's nothing to run</returns>
+		internal static ulong NextTaskTime()
+		{
+			if (s_nextFrame.Count != 0)
+			{
+				return CurrentTime;
+			}
+			else if (s_queue.Count != 0)
+			{
+				return s_queue.First.Value.Item1;
+			}
+			
+			return ulong.MaxValue;
 		}
 	}
 }

--- a/code/components/citizen-scripting-mono-v2/include/MonoScriptRuntime.h
+++ b/code/components/citizen-scripting-mono-v2/include/MonoScriptRuntime.h
@@ -21,7 +21,8 @@
 
 namespace fx::mono
 {
-class MonoScriptRuntime : public fx::OMClass<MonoScriptRuntime, IScriptRuntime, IScriptFileHandlingRuntime, IScriptTickRuntime, IScriptEventRuntime, IScriptRefRuntime, IScriptMemInfoRuntime, /*IScriptStackWalkingRuntime,*/ IScriptDebugRuntime, IScriptProfiler>
+class MonoScriptRuntime : public fx::OMClass<MonoScriptRuntime, IScriptRuntime, IScriptFileHandlingRuntime, IScriptTickRuntimeWithBookmarks,
+	IScriptEventRuntime, IScriptRefRuntime, IScriptMemInfoRuntime, /*IScriptStackWalkingRuntime,*/ IScriptDebugRuntime, IScriptProfiler>
 {
 private:
 	int m_instanceId;
@@ -29,25 +30,27 @@ private:
 	std::string m_resourceName;
 	MonoDomain* m_appDomain;
 	int32_t m_appDomainId;
+
+	// Direct host access
+	IScriptHost* m_scriptHost;
 	IScriptHostWithResourceData* m_resourceHost;
 	IScriptHostWithManifest* m_manifestHost;
+	IScriptHostWithBookmarks* m_bookmarkHost;
 
 	fx::OMPtr<IScriptRuntimeHandler> m_handler;
-
-	// OM
-	IScriptHost* m_scriptHost;
 	fx::Resource* m_parentObject;
 	IDebugEventListener* m_debugListener;
 	std::unordered_map<std::string, int> m_scriptIds;
+	uint64_t m_scheduledTime = ~uint64_t(0);
 
 	// method targets
 	Method m_loadAssembly;
 
-	// method thunks, these are for calls that require perfomance
-	Thunk<void(bool profiling)> m_tick;
-	Thunk<void(MonoString* eventName, const char* argsSerialized, uint32_t serializedSize, MonoString* sourceId)> m_triggerEvent;
+	// method thunks, these are for calls that require performance
+	Thunk<uint32_t(uint64_t gameTime, bool profiling)> m_tick;
+	Thunk<uint32_t(MonoString* eventName, const char* argsSerialized, uint32_t serializedSize, MonoString* sourceId, uint64_t gameTime, bool profiling)> m_triggerEvent;
 
-	Thunk<void(int32_t refIndex, char* argsSerialized, uint32_t argsSize, char** retvalSerialized, uint32_t* retvalSize)> m_callRef;
+	Thunk<uint32_t(int32_t refIndex, char* argsSerialized, uint32_t argsSize, char** retvalSerialized, uint32_t* retvalSize, uint64_t gameTime, bool profiling)> m_callRef;
 	Thunk<void(int32_t refIndex, int32_t* newRefIdx)> m_duplicateRef = nullptr;
 	Thunk<void(int32_t refIndex)> m_removeRef = nullptr;
 
@@ -72,7 +75,9 @@ public:
 
 	NS_DECL_ISCRIPTFILEHANDLINGRUNTIME;
 
-	NS_DECL_ISCRIPTTICKRUNTIME;
+	NS_DECL_ISCRIPTTICKRUNTIMEWITHBOOKMARKS;
+
+	void ScheduleTick(uint64_t timeMilliseconds);
 
 	NS_DECL_ISCRIPTEVENTRUNTIME;
 
@@ -91,5 +96,14 @@ inline MonoScriptRuntime::MonoScriptRuntime()
 {
 	m_instanceId = rand();
 	m_name = "ScriptDomain_" + std::to_string(m_instanceId);
+}
+
+inline void MonoScriptRuntime::ScheduleTick(uint64_t timeMilliseconds)
+{
+	if (timeMilliseconds < m_scheduledTime)
+	{
+		m_scheduledTime = timeMilliseconds;
+		m_bookmarkHost->ScheduleBookmark(this, 0, timeMilliseconds * 1000); // positive values are expected to me microseconds and absolute
+	}
 }
 }


### PR DESCRIPTION
Schedule tick calls with the core scheduler, aka Bookmark system or tick-less.
* Removes unnecessary mono-environment-switching costs when there's nothing to execute,
* Renamed parameters and added documentation on the `Scheduler`'s functions.