### PR TITLE
Add SET_WATER_AREA_CLIP_RECT & Fix LOAD_WATER_FROM_PATH path handling

### DIFF
--- a/code/components/extra-natives-five/src/WaterExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WaterExtraNatives.cpp
@@ -677,11 +677,20 @@ static HookFunction initFunction([]()
 			return;
 		}
 
-		auto filePath = resource->GetPath() + "/" + context.GetArgument<const char*>(1);
+		std::string filePath = resource->GetPath();
+
+		// Make sure path separator exists or add it before combining path with file name
+		char c = filePath[filePath.length() - 1];
+		if (c != '/' && c != '\\')
+			filePath += '/';
+
+		filePath += context.GetArgument<const char*>(1);
+
 		fwRefContainer<vfs::Stream> stream = vfs::OpenRead(filePath);
 
 		if (!stream.GetRef())
 		{
+			trace("unable to find water file at %s\n", filePath.c_str());
 			context.SetResult(false);
 			return;
 		}

--- a/ext/native-decls/SetWaterAreaClipRect.md
+++ b/ext/native-decls/SetWaterAreaClipRect.md
@@ -1,0 +1,28 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_WATER_AREA_CLIP_RECT
+
+```c
+void SET_WATER_AREA_CLIP_RECT(int minX, int minY, int maxX, int maxY);
+```
+
+Sets world clip boundaries for water quads file (water.xml, water_heistisland.xml)
+Used internally by LOAD_GLOBAL_WATER_FILE
+
+## Examples
+
+```lua
+SetWaterAreaClipRect(-4000, -4000, 4500, 8000)
+```
+
+## Parameters
+* **minX**: 
+* **minY**: 
+* **maxX**: 
+* **maxY**: 
+
+```
+Supported Builds: 2189+
+```


### PR DESCRIPTION
Added **SET_WATER_AREA_CLIP_RECT** - allows to place custom water file outside playable area
Fixed **LOAD_WATER_FROM_PATH** - wasn't handling path separator correctly, creating invalid paths like 'water_handler//water.xml' (two slashes instead of single one)