### PR TITLE
feat(nui): midi API access

### DIFF
--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -80,7 +80,7 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		const frame = document.createElement('iframe');
 		frame.name = frameName;
 		frame.style.visibility = 'hidden';
-		frame.allow = 'microphone *; camera *;';
+		frame.allow = 'microphone *; camera *; midi *;';
 		frame.src = frameUrl;
 		frame.tabIndex = -1;
 


### PR DESCRIPTION
This is to allow navigator.requestMIDIAccess() and be able to connect a real keyboard for a piano resource.

navigator.requestMIDIAccess({sysex: true}) will still be blocked so it should be safe :)