### PR TITLE
fix(clrcore-v2): teething troubles

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -3,14 +3,43 @@ using System;
 namespace CitizenFX.Core
 {
 	[Flags]
-	public enum Binding { None = 0x0, Local = 0x1, Remote = 0x2, All = Local | Remote }
+	public enum Binding
+	{
+		/// <summary>
+		/// No one can call this
+		/// </summary>
+		None = 0x0,
 
+		/// <summary>
+		/// Server only accepts server calls, client only client calls
+		/// </summary>
+		Local = 0x1,
+
+		/// <summary>
+		/// Server only accepts client calls, client only server calls
+		/// </summary>
+		Remote = 0x2,
+
+		/// <summary>
+		/// Accept all incoming calls
+		/// </summary>
+		All = Local | Remote
+	}
+
+	/// <summary>
+	/// Schedule this method to run on the first frame when this <see cref="BaseScript"/> is loaded
+	/// </summary>
+	/// <remarks>Only works on <see cref="BaseScript"/> inherited class methods</remarks>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class TickAttribute : Attribute
 	{
 		public TickAttribute() { }
 	}
 
+	/// <summary>
+	/// Register this method to listen for the given <see cref="Command"/> when this <see cref="BaseScript"/> is loaded
+	/// </summary>
+	/// <remarks>Only works on <see cref="BaseScript"/> inherited class methods</remarks>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class CommandAttribute : Attribute
 	{
@@ -23,6 +52,10 @@ namespace CitizenFX.Core
 		}
 	}
 
+	/// <summary>
+	/// Register this method to listen for the given <see cref="Event"/> when this <see cref="BaseScript"/> is loaded
+	/// </summary>
+	/// <remarks>Only works on <see cref="BaseScript"/> inherited class methods</remarks>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class EventHandlerAttribute : Attribute
 	{
@@ -35,6 +68,10 @@ namespace CitizenFX.Core
 		}
 	}
 
+	/// <summary>
+	/// Register this method to listen for the given <see cref="Export"/> when this <see cref="BaseScript"/> is loaded
+	/// </summary>
+	/// <remarks>Only works on <see cref="BaseScript"/> inherited class methods</remarks>
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class ExportAttribute : Attribute
 	{
@@ -46,4 +83,8 @@ namespace CitizenFX.Core
 			Binding = binding;
 		}
 	}
+
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public class SourceAttribute : Attribute
+	{ }
 }

--- a/code/client/clrcore-v2/Debug.cs
+++ b/code/client/clrcore-v2/Debug.cs
@@ -45,6 +45,7 @@ namespace CitizenFX.Core
 		/// <param name="exc">the thrown exception in question</param>
 		/// <param name="func">the DynFunc that was being executed</param>
 		/// <returns>true if we should still print/log it</returns>
+		[SecuritySafeCritical]
 		internal static bool ShouldWeLogDynFuncError(Exception exc, DynFunc func)
 		{
 			return exc.TargetSite != func.Method

--- a/code/client/clrcore-v2/Interop/ExportsManager.cs
+++ b/code/client/clrcore-v2/Interop/ExportsManager.cs
@@ -25,7 +25,7 @@ namespace CitizenFX.Core
 			if (s_exports.TryGetValue(eventName, out var export) && (export.Item2 & origin) != 0)
 			{
 				if (args == null)
-					args = MsgPackDeserializer.DeserializeArray(argsSerialized, serializedSize, sourceString);
+					args = MsgPackDeserializer.DeserializeArray(argsSerialized, serializedSize, origin == Binding.Remote ? sourceString : null);
 
 				if (origin == Binding.Local)
 				{

--- a/code/client/clrcore-v2/Interop/ExternalsManager.cs
+++ b/code/client/clrcore-v2/Interop/ExternalsManager.cs
@@ -36,7 +36,7 @@ namespace CitizenFX.Core
 			{
 				if (eventName == RpcRequestName)
 				{
-					args = MsgPackDeserializer.DeserializeArguments(argsSerialized, serializedSize, sourceString, true);
+					args = MsgPackDeserializer.DeserializeArguments(argsSerialized, serializedSize, origin == Binding.Remote ? sourceString : null);
 					if (args.Length > 3 && args[2] is string requestId)
 					{
 						ulong rid = Convert.ToUInt64(requestId);

--- a/code/client/clrcore-v2/Interop/MsgPackDeserializer.cs
+++ b/code/client/clrcore-v2/Interop/MsgPackDeserializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -160,9 +161,9 @@ namespace CitizenFX.Core
 			throw new InvalidOperationException($"Tried to decode invalid MsgPack type {type}");
 		}
 
-		private Dictionary<string, object> ReadMap(uint length)
+		private IDictionary<string, object> ReadMap(uint length)
 		{
-			var retobject = new Dictionary<string, object>();
+			var retobject = new ExpandoObject() as IDictionary<string, object>;
 
 			for (var i = 0; i < length; i++)
 			{
@@ -205,7 +206,7 @@ namespace CitizenFX.Core
 		private unsafe double ReadDouble()
 		{
 			var v = ReadUInt64();
-			return *(float*)&v;
+			return *(double*)&v;
 		}
 
 		private unsafe byte ReadByte()
@@ -281,10 +282,11 @@ namespace CitizenFX.Core
 			{
 				case 10: // remote funcref
 				case 11: // local funcref
+					var refFunc = ReadString(length);
 					return m_netSource is null
-						? _LocalFunction.Create(ReadString(length))
+						? _LocalFunction.Create(refFunc)
 #if REMOTE_FUNCTION_ENABLED
-						: _RemoteFunction.Create(ReadString(length), m_netSource);
+						: _RemoteFunction.Create(refFunc, m_netSource);
 #else
 						: null;
 #endif

--- a/code/client/clrcore-v2/Native/CustomNativeInvoker.cs
+++ b/code/client/clrcore-v2/Native/CustomNativeInvoker.cs
@@ -28,6 +28,7 @@ namespace CitizenFX.Core.Native
 			/// Keeps adding arguments onto the argument stack, will recurse when arguments need to be fixed.
 			/// This approach is 10x faster than the v1 approach in combination with CString
 			/// </summary>
+			[SecurityCritical]
 			internal unsafe void PushPinAndInvoke()
 			{
 				while (m_offset < m_length)
@@ -53,6 +54,7 @@ namespace CitizenFX.Core.Native
 			}
 		}
 
+		[SecuritySafeCritical]
 		public static unsafe T Call<T>(ulong hash, params Argument[] arguments)
 		{
 			ulong* __data = stackalloc ulong[32];
@@ -60,12 +62,14 @@ namespace CitizenFX.Core.Native
 			return (T)ScriptContext.GetResult(typeof(T), __data, hash);
 		}
 
+		[SecuritySafeCritical]
 		public static unsafe void Call(ulong hash, params Argument[] arguments)
 		{
 			ulong* __data = stackalloc ulong[32];
 			InvokeInternal(__data, hash, arguments);
 		}
 
+		[SecurityCritical]
 		private static unsafe void InvokeInternal(ulong* data, ulong nativeHash, Argument[] args)
 		{
 			CustomInvocation invoker = default;

--- a/code/client/clrcore-v2/Native/Native.cs
+++ b/code/client/clrcore-v2/Native/Native.cs
@@ -177,8 +177,8 @@ namespace CitizenFX.Core.Native
 		
 		[SecurityCritical] public static unsafe implicit operator Argument(void* v) => new Input.Primitive((ulong)v);
 
-		internal abstract unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx);
-		internal virtual unsafe void PullNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
+		[SecurityCritical] internal abstract unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx);
+		[SecurityCritical] internal virtual unsafe void PullNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			=> ctx.m_offset++;
 	}
 
@@ -194,6 +194,7 @@ namespace CitizenFX.Core.Native
 			public Primitive(ulong value) => this.m_nativeValue = value;
 			public Primitive() { }
 
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				ctx.m_ctx.functionDataPtr[ctx.m_ctx.numArguments++] = m_nativeValue;
@@ -205,6 +206,8 @@ namespace CitizenFX.Core.Native
 			private CitizenFX.Core.CString m_cstr;
 
 			internal CString(CitizenFX.Core.CString value) => m_cstr = value;
+
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				fixed (byte* ptr = m_cstr?.value)
@@ -228,6 +231,7 @@ namespace CitizenFX.Core.Native
 				z = N64.Val(v.Z);
 			}
 
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				ulong* data = ctx.m_ctx.functionDataPtr + ctx.m_ctx.numArguments;
@@ -238,6 +242,7 @@ namespace CitizenFX.Core.Native
 				data[2] = z;
 			}
 
+			[SecurityCritical]
 			internal override unsafe void PullNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 				=> ctx.m_offset += 3;
 		}
@@ -265,6 +270,7 @@ namespace CitizenFX.Core.Native
 				w = N64.Val(v.W);
 			}
 
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				ulong* data = ctx.m_ctx.functionDataPtr + ctx.m_ctx.numArguments;
@@ -297,11 +303,13 @@ namespace CitizenFX.Core.Native
 			public static implicit operator float(Primitive v) => N64.To_float(v.m_nativeValue);
 			public static implicit operator double(Primitive v) => N64.To_double(v.m_nativeValue);
 
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				ctx.m_ctx.functionDataPtr[ctx.m_ctx.numArguments++] = m_nativeValue;
 			}
-
+			
+			[SecurityCritical]
 			internal override unsafe void PullNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				m_nativeValue = ctx.m_ctx.functionDataPtr[ctx.m_offset++];
@@ -319,6 +327,7 @@ namespace CitizenFX.Core.Native
 			public static implicit operator Core.Vector4(Vector4 v) => v.m_vector;
 			public static implicit operator Core.Quaternion(Vector4 v) => new Core.Quaternion(v.m_vector.X, v.m_vector.Y, v.m_vector.Z, v.m_vector.W);
 
+			[SecurityCritical]
 			internal override unsafe void PushNativeValue(ref CustomNativeInvoker.CustomInvocation ctx)
 			{
 				fixed (Core.Vector4* ptr = &m_vector)

--- a/code/client/clrcore-v2/Native/NativeTypes.cs
+++ b/code/client/clrcore-v2/Native/NativeTypes.cs
@@ -10,6 +10,8 @@ namespace CitizenFX.Core.Native
 
 		public static unsafe ulong Val(int v) => *(uint*)&v;
 		public static unsafe ulong Val(uint v) => v;
+		public static unsafe ulong Val(long v) => *(ulong*)&v;
+		public static unsafe ulong Val(ulong v) => v;
 		public static unsafe ulong Val(float v) => *(uint*)&v;
 		public static unsafe ulong Val(double v) => *(ulong*)&v;
 		public static unsafe ulong Val(bool v) => *(byte*)&v;

--- a/code/client/clrcore-v2/Remote.cs
+++ b/code/client/clrcore-v2/Remote.cs
@@ -8,23 +8,28 @@ namespace CitizenFX.Core
 
 		internal Remote(string playerId)
 		{
-			if (playerId.StartsWith("net:"))
+			if (!string.IsNullOrEmpty(playerId))
 			{
-				playerId = playerId.Substring(4);
-			}
-			else if (playerId.StartsWith("internal-net:"))
-			{
-				playerId = playerId.Substring(13);
-			}
+				if (playerId.StartsWith("net:"))
+				{
+					playerId = playerId.Substring(4);
+				}
+				else if (playerId.StartsWith("internal-net:"))
+				{
+					playerId = playerId.Substring(13);
+				}
 
-			m_playerId = playerId;
+				m_playerId = playerId;
+			}
+			else
+				m_playerId = null;
 		}
 
 		internal Remote(Binding binding, string playerId) : this(playerId)
 		{
 		}
 
-		public static implicit operator bool(Remote remote) => remote.m_playerId != null;
+		internal static bool IsRemoteInternal(Remote remote) => remote.m_playerId != null;
 
 		internal string GetPlayerHandle() => m_playerId;
 
@@ -36,9 +41,12 @@ namespace CitizenFX.Core
 
 		internal Remote(bool isServer) => m_isServer = isServer;
 
-		public static implicit operator bool(Remote remote) => remote.m_isServer;
+		internal static bool IsRemoteInternal(Remote remote) => remote.m_isServer;
 
 		public override string ToString() => $"Remote({m_isServer})";
 #endif
+		public bool IsRemote => IsRemoteInternal(this);
+
+		public static implicit operator bool(Remote remote) => IsRemoteInternal(remote);
 	}
 }

--- a/code/client/clrcore-v2/Shared/Player.cs
+++ b/code/client/clrcore-v2/Shared/Player.cs
@@ -15,7 +15,7 @@ namespace CitizenFX.Shared
 		/// <summary>
 		/// Gets the handle of this player
 		/// </summary>
-		public uint Handle => uint.Parse(m_handle);
+		public int Handle => int.Parse(m_handle);
 #else
 	public abstract class Player : Core.Native.Input.Primitive
 	{

--- a/code/client/clrcore/Server/ServerWrappers.cs
+++ b/code/client/clrcore/Server/ServerWrappers.cs
@@ -16,6 +16,11 @@ namespace CitizenFX.Core
 #if MONO_V2
 	public class Player	: Shared.Player
 	{
+		internal Player(Remote remote)
+		{
+			m_handle = remote.GetPlayerHandle();
+		}
+
 #else
 	public class Player
 	{

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -34,7 +34,7 @@ const wchar_t* const MonoComponentHostShared::s_platformAssemblies[] = {
 	L"CitizenFX.Core.dll",
 	//L"CitizenFX.Core.Client.dll",
 	L"CitizenFX." PRODUCT_NAME ".dll",
-	L"CitizenFX." PRODUCT_NAME ".NativesImpl.dll",
+	L"CitizenFX." PRODUCT_NAME ".NativeImpl.dll",
 };
 #endif
 

--- a/ext/natives/codegen_out_cs_v2.lua
+++ b/ext/natives/codegen_out_cs_v2.lua
@@ -521,6 +521,8 @@ local function PrintNativeMethod(native)
 	io.stdout:write(t2, '[System.Security.SecuritySafeCritical]\n', t2, 'public static unsafe ', retType, ' ',
 		(hasResult and retType:gsub('ref ', '')..'_' or 'void_'), native.hash, '(')
 	
+	local monoStackBugFix = true;
+	
 	-- write parameters and append argument string for the ulong stack
 	local argn, fixed, stack = 0, '', ''
 	local comma, argSize = '', #native.arguments
@@ -529,7 +531,13 @@ local function PrintNativeMethod(native)
 		local name, wrapperType, asPointer = ToNonLanguageName(arg.name), GetWrapperType(arg.type, arg.pointer == true)
 		
 		io.stdout:write(comma, wrapperType[2][1]:gsub('{0}', name), '')
-		stack = stack .. comma .. wrapperType[2][2]:gsub('{0}', name)
+		
+		local stackValue = wrapperType[2][2]:gsub('{0}', name)
+		if stackValue ~= '0' then
+			monoStackBugFix = false
+		end
+		
+		stack = stack .. comma .. stackValue
 		
 		if wrapperType[2][3] then fixed = fixed..t3..wrapperType[2][3]:gsub('{0}', name)..'\n' end
 		
@@ -549,17 +557,23 @@ local function PrintNativeMethod(native)
 		comma = ', '
 	end
 	
-	io.stdout:write(')\n', t2, '{\n', fixed, t3, '{\n', t4, 'ulong* __data = stackalloc ulong[] { ', stack)
-	
-	-- make sure there's enough room to store the return types
 	local resultSize = hasResult and (wrapRetType.typeSize or 1) or -1
-	while argn < resultSize do
-		io.stdout:write(comma, '0')
-		comma, argn = ', ', argn + 1
+	if monoStackBugFix then
+		io.stdout:write(')\n', t2, '{\n', fixed, t3, '{\n', t4, 'ulong* __data = stackalloc ulong[', math.max(resultSize, argn), '];\n')
+	else
+		io.stdout:write(')\n', t2, '{\n', fixed, t3, '{\n', t4, 'ulong* __data = stackalloc ulong[] { ', stack)
+		
+		-- make sure there's enough room to store the return types
+		while argn < resultSize do
+			io.stdout:write(comma, '0')
+			comma, argn = ', ', argn + 1
+		end
+		
+		io.stdout:write(' };\n')
 	end
 	
 	-- invoke native
-	io.stdout:write(' };\n', t4, 'ScriptContext.InvokeNative')
+	io.stdout:write(t4, 'ScriptContext.InvokeNative')
 	if writeVector3Out then io.stdout:write('OutVec3') end -- will call the Vector3 copy function, required to pass on the values
 	io.stdout:write('(ref s_', native.hash, ', ', native.hash, ', __data, ', argn, ');\n')
 


### PR DESCRIPTION
\* This PR does not activate the mono v2 runtime.

Crashes still present
* Sporadic SIGSEGV on resource stop, experienced by early test group but reason is still unknown. Requires a repro to properly investigate.

Coroutine & Scheduler
* Coroutines will force themselves back onto the main thread.
* Scheduler added locks for scheduling
* Scheduler null checks new coroutines

MsgPackDeserializer
* Fix wrong reinterpretation for double
* Read string even if not used
* Return maps as `ExpandoObject`s

DynFunc
* Fix `ShouldWeLogDynFuncError(...)` apparently `Exception.TargetSite` is `SecurityCritical` on mono
* Make it safe to create `DynFunc`'s from `Action<T...>` and `Func<T..., R>`
* Value type support
* `Remote` replaced with `SourceAttribute` flag
   - `FiveM.Player` or any other constructible from `Remote` type is accepted
   - `bool` and `Remote` are also still valid types

Natives
* Add `N64.Val` for `long` and `ulong`
* Fix CAS issues with custom native invocation
* Workaround fix for a mono bug where it wasn't properly accounting for `localloc` stack sizes

Events
* Remove internal events checks on server, use `Binding.Local` to filter out incorrect client invocations of these
* Event exception code clean up
* Consider `internal-net` as `Remote.Local` but with `Remote` reference
* Documented Binding values
* Event code clean up
* Send event strings as the current domain

Host (C++)
* Enable environment pushing
* Use non MONO_ENTER_GC_UNSAFE domain unloading
* Create objects on resource's app domain

Other
* Fix CitizenFX.<Game>.NativeImpl.dll typo, for trusted assemblies
* Player Handle wrong type for shared library
* Remote player string null check
* Fix server `Remote` constructor