### PR TITLE
feat(gamestate/server): add SetEntityIgnoreRequestControlFilter native

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -742,6 +742,7 @@ struct SyncEntityState
 	uint32_t creationToken;
 	uint32_t routingBucket = 0;
 	float overrideCullingRadius = 0.0f;
+	bool ignoreRequestControlFilter = false;
 
 	std::shared_mutex guidMutex;
 	eastl::bitset<roundToWord(MAX_CLIENTS)> relevantTo;

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -6546,6 +6546,17 @@ inline bool RequestControlHandler(fx::ServerGameState* sgs, const fx::ClientShar
 		}
 	}
 
+	// if the entity is set to ignore the policy, allow
+	if (entity->ignoreRequestControlFilter)
+	{
+		return true;
+	}
+
+	if constexpr (Mode == RequestControlFilterMode::FilterAll)
+	{
+		return false;
+	}
+
 	// if we need to, check if the entity is player-controlled
 	// for now, this means a vehicle that's occupied by a player.
 	// in the future, we could track e.g. attachment state or pending component control
@@ -6643,13 +6654,6 @@ std::function<bool()> fx::ServerGameState::GetRequestControlEventHandler(const f
 	{
 		return {};
 	}
-	else if (g_requestControlFilterState == RequestControlFilterMode::FilterAll)
-	{
-		return []
-		{
-			return false;
-		};
-	}
 
 	uint32_t objectId = 0;
 	rl::MessageBuffer msg;
@@ -6673,6 +6677,8 @@ std::function<bool()> fx::ServerGameState::GetRequestControlEventHandler(const f
 					return &fx::RequestControlHandler<RequestControlFilterMode::FilterPlayer>;
 				case RequestControlFilterMode::FilterPlayerSettled:
 					return &fx::RequestControlHandler<RequestControlFilterMode::FilterPlayerSettled>;
+				case RequestControlFilterMode::FilterAll:
+					return &fx::RequestControlHandler<RequestControlFilterMode::FilterAll>;
 			}
 		}();
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1295,6 +1295,17 @@ static void Init()
 		return true;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_IGNORE_REQUEST_CONTROL_FILTER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (context.GetArgumentCount() > 1)
+		{
+			bool ignore = context.GetArgument<bool>(1);
+			entity->ignoreRequestControlFilter = ignore;
+		}
+
+		return true;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_ROUTING_BUCKET", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
 	{
 		// get the current resource manager

--- a/ext/native-decls/SetEntityIgnoreRequestControlFilter.md
+++ b/ext/native-decls/SetEntityIgnoreRequestControlFilter.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_ENTITY_IGNORE_REQUEST_CONTROL_FILTER
+
+```c
+void SET_ENTITY_IGNORE_REQUEST_CONTROL_FILTER(Entity entity, bool ignore);
+```
+
+It allows to flag an entity to ignore the request control filter policy.
+
+## Parameters
+* **entity**: The entity handle to ignore the request control filter.
+* **ignore**: Define if the entity ignores the request control filter policy.


### PR DESCRIPTION
This will allow to use _sv_filterRequestControl_ but still allow to cover some edge cases that would discourage people from using it.
I believe that this will help with the adoption of _sv_filterRequestControl_ and especially _sv_filterRequestControl 4_.
