### PR TITLE
fix(scripting-mono): attach mono thread

### DIFF
--- a/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHost.cpp
@@ -269,6 +269,7 @@ static void InitMono()
 	// initializes the mono runtime
 	fx::mono::MonoComponentHostShared::Initialize();
 
+	mono_thread_attach(mono_get_root_domain());
 	g_rootDomain = mono_get_root_domain();
 
 	mono_add_internal_call("CitizenFX.Core.GameInterface::PrintLog", reinterpret_cast<void*>(GI_PrintLogCall));


### PR DESCRIPTION
Sentry showing symptoms that are equivalent to the mono v1 environment being in a detached thread state, e.g.: missing `mono_thread_attach` or `mono_thread_detach`.