### PR TITLE
feat(clrcore-v2): global events and BaseScript instantiation control

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -84,7 +84,36 @@ namespace CitizenFX.Core
 		}
 	}
 
+
+	/// <summary>
+	/// When used in events it'll be filled with the caller (source) of this event
+	/// </summary>
+	/// <example>
+	///		Shared libraries
+	///		<code>[Source] Remote remote</code>
+	///	</example>
+	/// <example>
+	///		Server libraries
+	///		<code>[Source] Player player</code>
+	/// </example>
+	/// <example>
+	///		Shared libraries
+	///		<code>[Source] bool isRemote</code>
+	/// </example>
 	[AttributeUsage(AttributeTargets.Parameter)]
 	public class SourceAttribute : Attribute
 	{ }
+
+	/// <summary>
+	/// Explicitly enable or disable <see cref="BaseScript" /> instantiation when this resource is starting.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class)]
+	public class EnableOnLoadAttribute : Attribute
+	{
+		public bool Enable { get; }
+		public EnableOnLoadAttribute(bool enable)
+		{
+			Enable = enable;
+		}
+	}
 }

--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -138,6 +138,7 @@ namespace CitizenFX.Core
 
 		#region Events Handlers
 		internal void RegisterEventHandler(string eventName, DynFunc deleg, Binding binding = Binding.Local) => EventHandlers[eventName].Add(deleg, binding);
+		internal void UnregisterEventHandler(string eventName, DynFunc deleg) => EventHandlers[eventName].Remove(deleg);
 		#endregion
 
 		#region Script loading

--- a/code/client/clrcore-v2/Interop/Events.cs
+++ b/code/client/clrcore-v2/Interop/Events.cs
@@ -9,6 +9,45 @@ namespace CitizenFX.Core
 #if IS_FXSERVER
 		public static readonly CString AllPlayers = "-1";
 #endif
+
+		/// <summary>
+		/// Register an event handler
+		/// </summary>
+		/// <remarks>Be aware this will keep <paramref name="handler"/>.Target object alive once registered, unless it's of type <see cref="BaseScript"/></remarks>
+		/// <param name="eventName">name to listen for</param>
+		/// <param name="handler">delegate to call once triggered</param>
+		/// <param name="binding">limit calls to certain sources, e.g.: server only, client only</param>
+		public static void RegisterEventHandler(string eventName, DynFunc handler, Binding binding = Binding.Local)
+		{
+			if (handler.Target is BaseScript script)
+			{
+				// these should stay with their owner
+				script.RegisterEventHandler(eventName, handler, binding);
+			}
+			else
+			{
+				EventsManager.AddEventHandler(eventName, handler, binding);
+			}
+		}
+
+		/// <summary>
+		/// Unregister an event handler
+		/// </summary>
+		/// <param name="eventName">name to remove event for</param>
+		/// <param name="handler">delegate to remove</param>
+		public static void UnregisterEventHandler(string eventName, DynFunc handler)
+		{
+			if (handler.Target is BaseScript script)
+			{
+				// these should stay with their owner
+				script.UnregisterEventHandler(eventName, handler);
+			}
+			else
+			{
+				EventsManager.RemoveEventHandler(eventName, handler);
+			}
+		}
+
 		public static void TriggerEvent(string eventName, params object[] args)
 			=> CoreNatives.TriggerEventInternal(eventName, args);
 

--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -116,6 +116,11 @@ namespace CitizenFX.Core
 			}
 		}
 
+		/// <summary>
+		/// Register an event handler
+		/// </summary>
+		/// <param name="deleg">delegate to call once triggered</param>
+		/// <param name="binding">limit calls to certain sources, e.g.: server only, client only</param>
 		public EventHandlerSet Add(DynFunc deleg, Binding binding = Binding.Local)
 		{
 			m_handlers.Add(deleg);
@@ -123,6 +128,10 @@ namespace CitizenFX.Core
 			return this;
 		}
 
+		/// <summary>
+		/// Unregister an event handler
+		/// </summary>
+		/// <param name="deleg">delegate to remove</param>
 		public EventHandlerSet Remove(Delegate deleg)
 		{
 			int index = m_handlers.FindIndex(cur => deleg.Equals(cur));
@@ -134,25 +143,38 @@ namespace CitizenFX.Core
 			return this;
 		}
 
+		/// <summary>
+		/// Register an event handler
+		/// </summary>
+		/// <remarks>Will add it as <see cref="Binding.Local"/>, use <see cref="Add(DynFunc, Binding)"/> to explicitly set the binding.</remarks>
+		/// <param name="entry">this event handler set</param>
+		/// <param name="deleg">delegate to register</param>
+		/// <returns>itself</returns>
 		public static EventHandlerSet operator +(EventHandlerSet entry, DynFunc deleg) => entry.Add(deleg);
 
+		/// <summary>
+		/// Unregister an event handler
+		/// </summary>
+		/// <param name="entry">this event handler set</param>
+		/// <param name="deleg">delegate to register</param>
+		/// <returns>itself</returns>
 		public static EventHandlerSet operator -(EventHandlerSet entry, DynFunc deleg) => entry.Remove(deleg);
 
 		/// <summary>
-		/// Backwards compatibility
+		/// Register an event handler
 		/// </summary>
-		/// <param name="entry"></param>
-		/// <param name="deleg"></param>
-		/// <returns></returns>
-		[Obsolete("This is slow, use += Func.Create<T..., Ret>(method) instead.", false)]
-		public static EventHandlerSet operator +(EventHandlerSet entry, Delegate deleg) => entry.Add((remote, args) => deleg.DynamicInvoke(args));
+		/// <remarks>Will add it as <see cref="Binding.Local"/>, use <see cref="Add(DynFunc, Binding)"/> to explicitly set the binding.</remarks>
+		/// <param name="entry">this event handler set</param>
+		/// <param name="deleg">delegate to register</param>
+		/// <returns>itself</returns>
+		public static EventHandlerSet operator +(EventHandlerSet entry, Delegate deleg) => entry.Add(Func.Create(deleg.Target, deleg.Method));
 
 		/// <summary>
-		/// Backwards compatibility
+		/// Unregister an event handler
 		/// </summary>
-		/// <param name="entry"></param>
-		/// <param name="deleg"></param>
-		/// <returns></returns>
+		/// <param name="entry">this event handler set</param>
+		/// <param name="deleg">delegate to register</param>
+		/// <returns>itself</returns>
 		public static EventHandlerSet operator -(EventHandlerSet entry, Delegate deleg) => entry.Remove(deleg);
 	}
 }

--- a/code/client/clrcore-v2/ScriptManager.cs
+++ b/code/client/clrcore-v2/ScriptManager.cs
@@ -64,7 +64,11 @@ namespace CitizenFX.Core
 				// See https://stackoverflow.com/a/11915414
 
 				Func<Type, bool> typesPredicate = t =>
-					t != null && !t.IsAbstract && t.IsSubclassOf(typeof(BaseScript)) && t.GetConstructor(Type.EmptyTypes) != null;
+					t != null
+					&& !t.IsAbstract
+					&& t.IsSubclassOf(typeof(BaseScript))
+					&& t.GetConstructor(Type.EmptyTypes) != null
+					&& !(t.GetCustomAttribute<EnableOnLoadAttribute>()?.Enable == false);
 
 				/*foreach (var type in assembly.GetTypes())
 				{


### PR DESCRIPTION
* Events can now be registered through `Events.RegisterEventHandler(...)` from anywhere,
* BaseScripts can be attributed with `[EnableOnLoad(<true|false>)]` making it explicit if it should be automatically loaded or not,
* More documentation.