### PR TITLE
feat(clrcore-v2): full BaseScript enable-/disablement + DynFunc caching and fixes

### DIFF
--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -96,6 +96,25 @@ namespace CitizenFX.Core
 		}
 
 		public void Add(string key, DynFunc value) => this[key].Add(value);
+
+		/// <summary>
+		/// Should only be called by <see cref="BaseScript.Enable"/> or any other code that guarantees that it is only called once
+		/// </summary>
+		internal void Enable()
+		{
+			foreach (var ev in this)
+			{
+				ev.Value.Enable();
+			}
+		}
+
+		internal void Disable()
+		{
+			foreach (var ev in this)
+			{
+				ev.Value.Disable();
+			}
+		}
 	}
 
 	public class EventHandlerSet
@@ -110,10 +129,7 @@ namespace CitizenFX.Core
 
 		~EventHandlerSet()
 		{
-			for(int i = 0; i < m_handlers.Count; ++i)
-			{
-				EventsManager.RemoveEventHandler(m_eventName, m_handlers[i]);
-			}
+			Disable();
 		}
 
 		/// <summary>
@@ -176,5 +192,25 @@ namespace CitizenFX.Core
 		/// <param name="deleg">delegate to register</param>
 		/// <returns>itself</returns>
 		public static EventHandlerSet operator -(EventHandlerSet entry, Delegate deleg) => entry.Remove(deleg);
+
+
+		/// <summary>
+		/// Should only be called by <see cref="EventHandler.Enable"/> or any other code that guarantees that it is only called once
+		/// </summary>
+		internal void Enable()
+		{
+			for (int i = 0; i < m_handlers.Count; ++i)
+			{
+				EventsManager.AddEventHandler(m_eventName, m_handlers[i]);
+			}
+		}
+
+		internal void Disable()
+		{
+			for (int i = 0; i < m_handlers.Count; ++i)
+			{
+				EventsManager.RemoveEventHandler(m_eventName, m_handlers[i]);
+			}
+		}
 	}
 }

--- a/code/client/clrcore-v2/Interop/Exports.cs
+++ b/code/client/clrcore-v2/Interop/Exports.cs
@@ -31,7 +31,21 @@ namespace CitizenFX.Core
 
 		~Exports()
 		{
-			foreach(var export in m_exports.Keys)
+			Disable();
+		}
+
+		/// <summary>
+		/// Should only be called by <see cref="BaseScript.Enable"/> or any other code that guarantees that it is only called once
+		/// </summary>
+		internal void Enable()
+		{
+			foreach (var entry in m_exports)
+				ExportsManager.AddExportHandler(entry.Key, entry.Value);
+		}
+
+		internal void Disable()
+		{
+			foreach (var export in m_exports.Keys)
 				ExportsManager.RemoveExportHandler(export);
 		}
 

--- a/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
+++ b/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
@@ -278,7 +278,7 @@ namespace CitizenFX.Core
 			if (!ts_remote)
 			{
 				var refType = ReferenceFunctionManager.Create(dynFunc);
-				packer.PackExtendedTypeValue(11, refType);
+				packer.PackExtendedTypeValue(11, refType.Value);
 			}
 			else
 			{

--- a/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
+++ b/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
@@ -7,11 +7,11 @@ using System.Threading;
 
 namespace CitizenFX.Core
 {
-	static class ReferenceFunctionManager
+	internal static class ReferenceFunctionManager
 	{
-		internal struct Function
+		internal class Function
 		{
-			public readonly DynFunc m_method;
+			public DynFunc m_method;
 			public readonly byte[] m_refId;
 			public int m_refCount;
 
@@ -28,10 +28,17 @@ namespace CitizenFX.Core
 		private static IntPtr m_retvalBuffer;
 		private static int m_retvalBufferSize;
 
-		// don't alter the returned value
+		/// <summary>
+		/// Register a delegate to other runtimes and/or our host (reference function)
+		/// </summary>
+		/// <param name="method">Delagate to register to the external world</param>
+		/// <returns>( internalReferenceId, externalReferenceId )</returns>
+		/// <remarks>Don't alter the returned value</remarks>
 		[SecuritySafeCritical]
-		public static byte[] Create(DynFunc method)
+		internal static KeyValuePair<int, byte[]> Create(DynFunc method)
 		{
+			// TODO: change return type to `ValueTuple` once clients support those
+
 			int id = method.Method.GetHashCode();
 
 			// keep incrementing until we find a free spot
@@ -41,10 +48,10 @@ namespace CitizenFX.Core
 			byte[] refId = ScriptInterface.CanonicalizeRef(id);
 			s_references[id] = new Function(method, refId);
 
-			return refId;
+			return new KeyValuePair<int, byte[]>(id, refId);
 		}
 
-		public static int Duplicate(int reference)
+		internal static int IncrementReference(int reference)
 		{
 			if (s_references.TryGetValue(reference, out var funcRef))
 			{
@@ -55,13 +62,63 @@ namespace CitizenFX.Core
 			return -1;
 		}
 
-		public static void Remove(int reference)
+		internal static void DecrementReference(int reference)
 		{
 			if (s_references.TryGetValue(reference, out var funcRef)
 				&& Interlocked.Decrement(ref funcRef.m_refCount) <= 0)
 			{
 				s_references.Remove(reference);
 			}
+		}
+
+		/// <summary>
+		/// Remove reference function by id
+		/// </summary>
+		/// <param name="referenceId">Internal reference id of the reference to remove</param>
+		internal static void Remove(int referenceId)
+		{			
+			s_references.Remove(referenceId);
+		}
+
+		/// <summary>
+		/// Remove all reference functions that are targeting a specific object
+		/// </summary>
+		/// <remarks>Slow, may need to be replaced</remarks>
+		/// <param name="target"></param>
+		internal static void RemoveAllWithTarget(object target)
+		{
+			foreach (var entry in s_references)
+			{
+				if (entry.Value.m_method.Target == target)
+				{
+					s_references.Remove(entry.Key);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Set reference function to another delegate
+		/// </summary>
+		/// <param name="referenceId">Reference id of the reference to remove</param>
+		/// <param name="newFunc">New delegate/method to set the reference function to</param>
+		/// <returns><see langword="true"/> if found and changed, <see langword="false"/> otherwise</returns>
+		internal static bool SetDelegate(int referenceId, DynFunc newFunc)
+		{
+			if (s_references.TryGetValue(referenceId, out var refFunc))
+			{
+				refFunc.m_method = newFunc;
+				return true;
+			}
+
+			return false;
+		}
+
+		internal static int CreateCommand(string command, DynFunc method, bool isRestricted)
+		{
+			var registration = Create(method);
+			Native.CoreNatives.RegisterCommand(command, new Native.InFunc(registration.Value), isRestricted);
+
+			return registration.Key;
 		}
 
 		[SecurityCritical]
@@ -104,7 +161,7 @@ namespace CitizenFX.Core
 		}
 
 		[SecurityCritical]
-		public unsafe static byte[] Invoke(int reference, byte* arguments, uint argsSize)
+		internal unsafe static byte[] Invoke(int reference, byte* arguments, uint argsSize)
 		{
 			if (s_references.TryGetValue(reference, out var funcRef))
 			{

--- a/code/client/clrcore-v2/Native/NativeTypes.cs
+++ b/code/client/clrcore-v2/Native/NativeTypes.cs
@@ -65,7 +65,7 @@ namespace CitizenFX.Core.Native
 		internal readonly byte[] value;
 		
 		internal InFunc(byte[] funcRef) => value = funcRef;
-		public InFunc(DynFunc del) => value = ReferenceFunctionManager.Create(del);
+		public InFunc(DynFunc del) => value = ReferenceFunctionManager.Create(del).Value;
 		public InFunc(Delegate del) : this(Func.Create(del)) { }
 
 		public static implicit operator InFunc(Delegate func) => new InFunc(func);

--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -165,13 +165,13 @@ namespace CitizenFX.Core
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static int DuplicateRef(int refIndex)
 		{
-			return ReferenceFunctionManager.Duplicate(refIndex);
+			return ReferenceFunctionManager.IncrementReference(refIndex);
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static void RemoveRef(int refIndex)
 		{
-			ReferenceFunctionManager.Remove(refIndex);
+			ReferenceFunctionManager.DecrementReference(refIndex);
 		}
 
 #endregion

--- a/code/client/clrcore-v2/ScriptManager.cs
+++ b/code/client/clrcore-v2/ScriptManager.cs
@@ -12,7 +12,7 @@ namespace CitizenFX.Core
 {
 	internal static class ScriptManager
 	{
-		private static readonly List<BaseScript> s_definedScripts = new List<BaseScript>();
+		private static readonly List<BaseScript> s_activeScripts = new List<BaseScript>();
 
 		private static Dictionary<string, Assembly> s_loadedAssemblies = new Dictionary<string, Assembly>();
 		private static HashSet<string> s_assemblySearchPaths = new HashSet<string>();
@@ -41,17 +41,19 @@ namespace CitizenFX.Core
 		#region Scripts
 		internal static void AddScript(BaseScript script)
 		{
-			if (!s_definedScripts.Contains(script))
+			if (!s_activeScripts.Contains(script))
 			{
-				script.Initialize();
+				s_activeScripts.Add(script);
 
-				s_definedScripts.Add(script);
+				script.Enable();
 			}
 		}
 
 		internal static void RemoveScript(BaseScript script)
 		{
-			s_definedScripts.Remove(script);
+			script.Disable();
+
+			s_activeScripts.Remove(script);
 		}
 
 		private static void LoadScripts(Assembly assembly)


### PR DESCRIPTION
feat(clrcore-v2): full BaseScript enable-/disablement
* Allows `BaseScript`s to be enabled and disabled, including all of its ticks, events, exports, and commands
* Tick methods reworked for proper stop and continue logic
* Some internal method renaming to better convey what they do

tweak(clrcore-v2): DynFunc caching and fixes
* `Func.Create` will now cache its wrappers, reusing them when requested again
* Fixes static method wrapping as reported in https://github.com/thorium-cfx/mono_v2_get_started/issues/2
* Improve `[Source]` exception text to distinctly refer to constructors and not conversion operators
* Allow users to get the wrapped method, method is hidden in intellisense as use of it is for exceptional and advanced use cases only