### PR TITLE
fix(clrcore-v2): CAS transparency fixes and better Dynfunc exception logging

### DIFF
--- a/code/client/clrcore-v2/AssemblyInfo.cs
+++ b/code/client/clrcore-v2/AssemblyInfo.cs
@@ -1,9 +1,18 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
+using System.Security;
 
 [assembly: TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName = ".NET Framework 4.5")]
+
 [assembly: AssemblyTitle("CitizenFX.Core V2")]
+[assembly: AssemblyCompany("The CitizenFX Collective")]
+[assembly: AssemblyCopyright("Copyright CitizenFX and contributors, licensed under the FiveM Platform Agreement")]
+
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: AllowPartiallyTrustedCallers] // allows us to use SecAnnotate properly
 
 #if IS_FXSERVER
 [assembly: AssemblyDescription("CitizenFX.Core for FXServer")]
@@ -21,9 +30,3 @@ using System.Runtime.Versioning;
 [assembly: InternalsVisibleTo("CitizenFX.LibertyM")]
 [assembly: InternalsVisibleTo("CitizenFX.LibertyM.NativeImpl")]
 #endif
-
-[assembly: AssemblyCompany("The CitizenFX Collective")]
-[assembly: AssemblyCopyright("Copyright CitizenFX and contributors, licensed under the FiveM Platform Agreement")]
-
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/code/client/clrcore-v2/Debug.cs
+++ b/code/client/clrcore-v2/Debug.cs
@@ -1,12 +1,48 @@
 using System;
+using System.ComponentModel;
+using System.Reflection;
 using System.Security;
 
 namespace CitizenFX.Core
 {
+	[Flags]
+	public enum DynFuncExceptions : uint
+	{
+		/// <summary>
+		/// Ignore any exception thrown
+		/// /// </summary>
+		None = 0x0,
+
+		/// <summary>
+		/// If you like to keep the option to ignore calls with incorrect arguments but d
+		/// </summary>
+		/// <example>
+		/// // Disable InvalidCastException logs but still make use of them being ignored
+		/// Debug.LogExceptionsOnDynFunc &amp;= ~DynFuncExceptions.InvalidCastException;
+		/// </example>
+		InvalidCastException = 0x1,
+
+		/// <summary>
+		/// Will output parameters vs argument conversion/castability report, helpful for development
+		/// </summary>
+		/// <remarks>Can have a performance if it's hit often.</remarks>
+		ReportTypeMatching = 1u << 31,
+
+		//ReportVerbose = 1u << 30,
+
+		AllExceptions = ~0u >> 2,
+		AllReports = ~AllExceptions, // the remaining bits are ours
+		
+		/// <summary>
+		/// Panic mode, give all details
+		/// </summary>
+		Everything = ~0u
+	}
+
 	public static class Debug
 	{
 		private static string s_debugName = "script:mono";
-		public static bool LogInvalidCastExceptionsOnDynFunc { get; set; } = true;
+		public static DynFuncExceptions LogExceptionsOnDynFunc { get; set; } = DynFuncExceptions.Everything;
 
 		internal static void Initialize(string resourceName)
 		{
@@ -39,17 +75,97 @@ namespace CitizenFX.Core
 			}
 		}*/
 
-		/// <summary>
-		/// Simple logic to determine if the InvalidCastException came from the DynFunc and if so if we should print it or ignore it
-		/// </summary>
-		/// <param name="exc">the thrown exception in question</param>
-		/// <param name="func">the DynFunc that was being executed</param>
-		/// <returns>true if we should still print/log it</returns>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		[SecuritySafeCritical]
-		internal static bool ShouldWeLogDynFuncError(Exception exc, DynFunc func)
+		public static void WriteException(Exception exception, DynFunc dynFunc, object[] arguments, string methodAnnotation = "dynamic method")
 		{
-			return exc.TargetSite != func.Method
-				|| (!(exc is InvalidCastException) || LogInvalidCastExceptionsOnDynFunc);
+			if (LogExceptionsOnDynFunc == 0)
+				return;
+
+			string errorMessage = "";
+
+			if (exception is InvalidCastException && (LogExceptionsOnDynFunc & DynFuncExceptions.InvalidCastException) != 0)
+			{
+				if ((LogExceptionsOnDynFunc & DynFuncExceptions.ReportTypeMatching) != 0)
+				{
+					string GetTypeName(Type type)
+					{
+						return type.Assembly == typeof(Int32).Assembly
+							? type.ToString().Substring(type.Namespace.Length + 1)
+							: type.ToString();
+					}
+
+					MethodInfo methodInfo = dynFunc.GetWrappedMethod();
+					ParameterInfo[] parameters = methodInfo.GetParameters();
+
+					string comma = "";
+					string argumentsString = "";
+					string parametersString = "";
+
+					const string sourceString = " ^2// [Source] parameters are hidden^7";
+					string hasSource = "";
+
+					// Test arguments against the parameters
+					int a = 0, p = 0;
+					for (; p < parameters.Length && a < arguments.Length; ++p)
+					{
+						ParameterInfo pInfo = parameters[p];
+						Type pType = pInfo.ParameterType;
+						string pName = GetTypeName(pType);
+
+						if (pInfo.GetCustomAttribute<SourceAttribute>() != null)
+						{
+							hasSource = sourceString;
+						}
+						else
+						{
+							Type aType = arguments[a]?.GetType();
+							string aName = aType is null ? "null" : GetTypeName(aType);
+
+							bool assignable = pType.IsAssignableFrom(aType)
+								|| (typeof(IConvertible).IsAssignableFrom(pType) && typeof(IConvertible).IsAssignableFrom(aType));
+
+							int maxNameSize = Math.Max(aName.Length, pName.Length);
+							argumentsString += comma + (assignable ? aName.PadRight(maxNameSize) : $"^1{aName}^7".PadRight(maxNameSize + 4));
+							parametersString += comma + (assignable ? pName.PadRight(maxNameSize) : $"^1{pName}^7".PadRight(maxNameSize + 4));
+
+							++a;
+						}
+
+						comma = ", ";
+					}
+
+					// add missing parameters
+					for (; p < parameters.Length; ++p)
+					{
+						ParameterInfo pInfo = parameters[p];
+						if (pInfo.GetCustomAttribute<SourceAttribute>() != null)
+						{
+							hasSource = sourceString;
+						}
+
+						parametersString += comma + $"^1{GetTypeName(pInfo.ParameterType)}^7";
+						comma = ", ";
+					}
+
+					// add excess arguments
+					for (; a < arguments.Length; ++a)
+					{
+						Type aType = arguments[a]?.GetType();
+						string aName = aType is null ? "null" : GetTypeName(aType);
+						argumentsString += comma + aName;
+						comma = ", ";
+					}
+
+					errorMessage += $"\n  expected: ({parametersString}){hasSource}\n  received: ({argumentsString})" +
+						$"\n  * Any type in ^1red^7 is not convertible, castable, or simply missing and requires attention.";
+				}
+			}
+
+			// Write the actual error/exception
+			WriteLine($"^1SCRIPT ERROR: Could not invoke {methodAnnotation} {dynFunc.Method.Name}^7" +
+				errorMessage +
+				$"\n^3Failed with exception:\n{exception}^7");
 		}
 	}
 }

--- a/code/client/clrcore-v2/DynFunc.cs
+++ b/code/client/clrcore-v2/DynFunc.cs
@@ -9,12 +9,14 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 using System.Security;
 
 namespace CitizenFX.Core
 {
 	public delegate object DynFunc(Remote remote, params object[] arguments);
 
+	[SecuritySafeCritical]
 	public static class Func
 	{
 		private static readonly Dictionary<MethodInfo, MethodInfo> s_wrappedMethods = new Dictionary<MethodInfo, MethodInfo>();

--- a/code/client/clrcore-v2/Interop/CString.cs
+++ b/code/client/clrcore-v2/Interop/CString.cs
@@ -90,7 +90,8 @@ namespace CitizenFX.Core
 			return null;
 		}
 
-		public object Clone() => new CString(value.ToArray());
+		[SecuritySafeCritical]
+		public object Clone() => new CString((byte[])value.Clone());
 
 		#endregion
 
@@ -162,6 +163,8 @@ namespace CitizenFX.Core
 		/// <param name="startIndex">start character index</param>
 		/// <returns>CString with the requested part of characters of this string</returns>
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="startIndex"/> &lt; 0 or &gt;= Length</exception>
+
+		[SecuritySafeCritical]
 		public CString SubString(uint startIndex)
 		{
 			uint maxLength = (uint)Length;
@@ -195,6 +198,8 @@ namespace CitizenFX.Core
 		/// <param name="length">amount of characters we want in total, can be less.</param>
 		/// <returns>CString with the requested part of characters of this string</returns>
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="startIndex"/> &lt; 0 or &gt;= Length</exception>
+
+		[SecuritySafeCritical]
 		public CString Substring(uint startIndex, uint length)
 		{
 			uint maxLength = (uint)Length;
@@ -211,6 +216,7 @@ namespace CitizenFX.Core
 			throw new ArgumentOutOfRangeException();
 		}
 
+		[SecuritySafeCritical]
 		public static CString operator +(CString left, CString right)
 		{
 			if (left.value != null)
@@ -236,6 +242,7 @@ namespace CitizenFX.Core
 
 		#region Comparison
 
+		[SecuritySafeCritical]
 		public static unsafe bool operator ==(CString left, CString right)
 		{
 			if (left == right)
@@ -244,6 +251,7 @@ namespace CitizenFX.Core
 				return left.value.SequenceEqual(right.value);
 		}
 
+		[SecuritySafeCritical]
 		public static unsafe bool operator !=(CString left, CString right)
 		{
 			if (left != right)
@@ -254,6 +262,8 @@ namespace CitizenFX.Core
 
 		public static bool IsNullOrEmpty(CString str) => !(str?.value.Length != 1);
 		public override bool Equals(object obj) => obj is CString str && value.Equals(str.value);
+
+		[SecuritySafeCritical]
 		public bool Equals(CString other) => this == other || value.Equals(other.value);
 
 		public int CompareTo(object obj) => obj is CString str ? CompareTo(str) : 0;
@@ -310,7 +320,7 @@ namespace CitizenFX.Core
 		/// </summary>
 		/// <param name="str">string to compare</param>
 		/// <returns>true if both sides have equivalent characters in the ASCII character space</returns>
-		public unsafe bool CompareASCII(string str)
+		public bool CompareASCII(string str)
 		{
 			return CompareASCII(this, str);
 		}
@@ -322,6 +332,7 @@ namespace CitizenFX.Core
 		/// <param name="left">CString to compare</param>
 		/// <param name="right">string to compare</param>
 		/// <returns>true if both sides have equivalent characters in the ASCII character space</returns>
+		[SecuritySafeCritical]
 		public static unsafe bool CompareASCII(CString left, string right)
 		{
 			if (left == null && right == null)
@@ -352,6 +363,7 @@ namespace CitizenFX.Core
 		/// <param name="str">string to convert</param>
 		/// <param name="invalid">character to insert in case of a non-7 bit character</param>
 		/// <returns>CString with only ASCII (7 bit) characters, or null if <paramref name="str"/> == null</returns>
+		[SecuritySafeCritical]
 		public static unsafe CString ToASCII(string str, byte invalid = (byte)'?')
 		{
 			fixed (char* src = str)
@@ -375,6 +387,7 @@ namespace CitizenFX.Core
 
 		#region Encoding algorithms
 
+		[SecuritySafeCritical]
 		public override unsafe int GetHashCode()
 		{
 			fixed (byte* pin = value)

--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -39,12 +39,7 @@ namespace CitizenFX.Core
 						}
 						catch (Exception ex)
 						{
-							if (Debug.ShouldWeLogDynFuncError(ex, ev.Item1))
-							{
-								string argsString = string.Join<string>(", ", args.Select(a => a != null ? a.GetType().ToString() : "null"));
-								Debug.WriteLine($"^1Error while handling event: {eventName}\n\twith arguments: ({argsString})^7");
-								Debug.PrintError(ex);
-							}
+							Debug.WriteException(ex, ev.Item1, args, "event handler");
 						}
 					}
 				}

--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security;
 
 using CitizenFX.Core.Native;
 
@@ -10,6 +11,8 @@ namespace CitizenFX.Core
 	{
 		private static Dictionary<string, List<Tuple<DynFunc, Binding>>> s_eventHandlers = new Dictionary<string, List<Tuple<DynFunc, Binding>>>();
 
+
+		[SecuritySafeCritical]
 		internal static unsafe void IncomingEvent(string eventName, string sourceString, Binding origin, byte* argsSerialized, int serializedSize, object[] args)
 		{
 			if (s_eventHandlers.TryGetValue(eventName, out var delegateList))

--- a/code/client/clrcore-v2/Interop/ExportsManager.cs
+++ b/code/client/clrcore-v2/Interop/ExportsManager.cs
@@ -20,6 +20,7 @@ namespace CitizenFX.Core
 			ExportPrefix = CreateExportPrefix(resourceName);
 		}
 
+		[SecuritySafeCritical]
 		internal static unsafe bool IncomingRequest(string eventName, string sourceString, Binding origin, byte* argsSerialized, int serializedSize, ref object[] args)
 		{
 			if (s_exports.TryGetValue(eventName, out var export) && (export.Item2 & origin) != 0)

--- a/code/client/clrcore-v2/Interop/ExportsManager.cs
+++ b/code/client/clrcore-v2/Interop/ExportsManager.cs
@@ -51,12 +51,7 @@ namespace CitizenFX.Core
 						}
 						catch (Exception ex)
 						{
-							if (Debug.ShouldWeLogDynFuncError(ex, export.Item1))
-							{
-								string argsString = string.Join<string>(", ", args.Select(a => a.GetType().ToString()));
-								Debug.WriteLine($"^1Error while handling export: {eventName.Remove(0, eventName.LastIndexOf('_') + 1)}\n\twith arguments: ({argsString})^7");
-								Debug.PrintError(ex);
-							}
+							Debug.WriteException(ex, export.Item1, arguments, "export function");
 						}
 #if IS_FXSERVER
 						// last spot holds the player

--- a/code/client/clrcore-v2/Interop/LocalFunction.cs
+++ b/code/client/clrcore-v2/Interop/LocalFunction.cs
@@ -14,7 +14,6 @@ namespace CitizenFX.Core
 			CoreNatives.DuplicateFunctionReference(reference); // increment the refcount
 		}
 
-		[SecuritySafeCritical]
 		public static Callback Create(string reference)
 		{
 			var localFunctionReference = new _LocalFunction(reference);

--- a/code/client/clrcore-v2/Interop/MsgPackDeserializer.cs
+++ b/code/client/clrcore-v2/Interop/MsgPackDeserializer.cs
@@ -10,6 +10,7 @@ namespace CitizenFX.Core
 	public delegate Coroutine<object> Callback(params object[] args);
 
 	// Can be a struct as it's merely used for for temporary storage
+	[SecuritySafeCritical]
 	internal struct MsgPackDeserializer
 	{
 		private unsafe byte* m_ptr;
@@ -175,6 +176,7 @@ namespace CitizenFX.Core
 
 			return retobject;
 		}
+
 		private unsafe byte[] ReadBytes(uint length)
 		{
 			var ptr = (IntPtr)AdvancePointer(length);
@@ -325,7 +327,10 @@ namespace CitizenFX.Core
 			byte* curPtr = m_ptr;
 			m_ptr += amount;
 			if (m_ptr > m_end)
-				throw new ArgumentException($"msgpack deserializer tried to retrieve 8 bytes, {m_end - m_ptr} bytes remained");
+			{
+				m_ptr -= amount; // reverse damage
+				throw new ArgumentException($"MsgPackDeserializer tried to retrieve {amount} bytes while only {m_end - m_ptr} bytes remain");
+			}
 
 			return curPtr;
 		}

--- a/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
+++ b/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using MsgPack;
 using MsgPack.Serialization;
 using System.Security;
@@ -10,6 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace CitizenFX.Core
 {
+	[SecuritySafeCritical]
 	internal static class MsgPackSerializer
 	{
 		internal readonly static ByteArray nullResult;
@@ -305,6 +305,7 @@ namespace CitizenFX.Core
 	/// <summary>
 	/// Experimental memory stream
 	/// </summary>
+	[SecuritySafeCritical]
 	internal class CoTaskMemoryStream : Stream
 	{
 		private unsafe IntPtr buffer;
@@ -409,6 +410,7 @@ namespace CitizenFX.Core
 			throw new NotImplementedException();
 		}
 
+		[SecuritySafeCritical]
 		public override int Read(byte[] buffer, int offset, int count)
 		{
 			int length = Math.Min(count, this.length - position);

--- a/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
+++ b/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
@@ -176,8 +175,7 @@ namespace CitizenFX.Core
 				}
 				catch (Exception ex)
 				{
-					string argsString = string.Join<string>(", ", args.Select(a => a is null ? "null" : a.GetType().ToString()));
-					Debug.PrintError(ex, $"handling function reference: {funcRef.m_method.Method.Name}\n\twith arguments: ({argsString})");
+					Debug.WriteException(ex, funcRef.m_method, args, "reference function");
 				}
 
 				if (result is Coroutine coroutine)

--- a/code/client/clrcore-v2/Native/CustomNativeInvoker.cs
+++ b/code/client/clrcore-v2/Native/CustomNativeInvoker.cs
@@ -11,6 +11,7 @@ using ContextType = CitizenFX.Core.RageScriptContext;
 
 namespace CitizenFX.Core.Native
 {
+	[SecuritySafeCritical]
 	public static class CustomNativeInvoker
 	{
 
@@ -54,7 +55,6 @@ namespace CitizenFX.Core.Native
 			}
 		}
 
-		[SecuritySafeCritical]
 		public static unsafe T Call<T>(ulong hash, params Argument[] arguments)
 		{
 			ulong* __data = stackalloc ulong[32];
@@ -62,14 +62,12 @@ namespace CitizenFX.Core.Native
 			return (T)ScriptContext.GetResult(typeof(T), __data, hash);
 		}
 
-		[SecuritySafeCritical]
 		public static unsafe void Call(ulong hash, params Argument[] arguments)
 		{
 			ulong* __data = stackalloc ulong[32];
 			InvokeInternal(__data, hash, arguments);
 		}
 
-		[SecurityCritical]
 		private static unsafe void InvokeInternal(ulong* data, ulong nativeHash, Argument[] args)
 		{
 			CustomInvocation invoker = default;

--- a/code/client/clrcore-v2/Native/MemoryAccess.cs
+++ b/code/client/clrcore-v2/Native/MemoryAccess.cs
@@ -4,6 +4,7 @@ using System.Security;
 
 namespace CitizenFX.Core.Native
 {
+	[SecuritySafeCritical]
 	internal static class MemoryAccess
 	{
 		public static int[] GetPickupObjectHandles() => new int[0];

--- a/code/client/clrcore-v2/Native/NativeTypes.cs
+++ b/code/client/clrcore-v2/Native/NativeTypes.cs
@@ -60,7 +60,7 @@ namespace CitizenFX.Core.Native
 		public static implicit operator Vector3(NativeVector3 self) => new Vector3(self.x, self.y, self.z);
 	}
 
-	public ref struct InFunc
+	public readonly ref struct InFunc
 	{
 		internal readonly byte[] value;
 		
@@ -72,7 +72,7 @@ namespace CitizenFX.Core.Native
 		public static implicit operator InFunc(DynFunc func) => new InFunc(func);
 	}
 
-	public ref struct InPacket
+	public readonly ref struct InPacket
 	{
 		internal readonly byte[] value;
 		public InPacket(object obj) => value = MsgPackSerializer.Serialize(obj);
@@ -80,7 +80,8 @@ namespace CitizenFX.Core.Native
 		public static implicit operator InPacket(object[] obj) => Serialize(obj);
 	}
 
-	public ref struct OutPacket
+	[SecuritySafeCritical]
+	public readonly ref struct OutPacket
 	{
 #pragma warning disable 0649 // this type is reinterpreted i.e.: (OutPacket*)ptr
 		private unsafe readonly byte* data;
@@ -91,7 +92,8 @@ namespace CitizenFX.Core.Native
 		internal unsafe object[] DeserializeArray() => MsgPackDeserializer.DeserializeArray(data, (long)size);
 	}
 
-	public ref struct OutString
+	[SecuritySafeCritical]
+	public readonly ref struct OutString
 	{
 #pragma warning disable 0649 // this type is reinterpreted i.e.: (OutString*)ptr
 		private unsafe readonly byte* data;

--- a/code/client/clrcore-v2/Native/ScriptContext.cs
+++ b/code/client/clrcore-v2/Native/ScriptContext.cs
@@ -19,16 +19,16 @@ using ContextType = CitizenFX.Core.RageScriptContext;
 
 namespace CitizenFX.Core
 {
-	public static class ScriptContext
+	internal static class ScriptContext
 	{
 		internal static readonly ConcurrentQueue<GCHandle> s_gcHandles = new ConcurrentQueue<GCHandle>();
 
-		private static byte[] s_stringHeap = new byte[1024 * 256];
+		private static readonly byte[] s_stringHeap = new byte[1024 * 256];
 		private static int s_stringHeapPosition = 0;
 		private static GCHandle s_stringHeapHandle;
-		private static IntPtr s_stringHeapHandlePtr;
+		private static readonly IntPtr s_stringHeapHandlePtr;
 
-		private static List<IntPtr> s_cleanUp = new List<IntPtr>();
+		private static readonly List<IntPtr> s_cleanUp = new List<IntPtr>();
 
 		[SecuritySafeCritical]
 		static ScriptContext()
@@ -37,6 +37,8 @@ namespace CitizenFX.Core
 			s_stringHeapHandlePtr = s_stringHeapHandle.AddrOfPinnedObject();
 		}
 
+
+		[SecuritySafeCritical]
 		internal static void CleanUp()
 		{
 			s_stringHeapPosition = 0;
@@ -47,6 +49,8 @@ namespace CitizenFX.Core
 			}
 		}
 
+
+		[SecurityCritical]
 		internal static unsafe ByteArray SerializeObject(object v)
 		{
 			var argsSerialized = MsgPackSerializer.Serialize(v);
@@ -150,6 +154,7 @@ namespace CitizenFX.Core
 			}
 		}
 
+		[SecurityCritical]
 		internal unsafe static T GetResultPrimitive<T>(Type type, ulong* ptr, ulong hash) where T : unmanaged
 		{
 #if NATIVE_PTR_CHECKS_INCLUDE
@@ -192,6 +197,8 @@ namespace CitizenFX.Core
 
 		#endregion
 	}
+
+	[SecurityCritical]
 	internal struct ByteArray
 	{
 		public unsafe byte* ptr;

--- a/code/client/clrcore-v2/Native/ScriptContextData.cs
+++ b/code/client/clrcore-v2/Native/ScriptContextData.cs
@@ -6,7 +6,7 @@ using System.Security;
 namespace CitizenFX.Core
 {
 	[StructLayout(LayoutKind.Sequential)]
-	[Serializable]
+	[Serializable, SecurityCritical]
 	internal struct fxScriptContext
 	{
 		public unsafe ulong* functionDataPtr;
@@ -14,7 +14,7 @@ namespace CitizenFX.Core
 		public int numArguments;
 		public int numResults;
 
-		[SecuritySafeCritical, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal unsafe void Initialize(ulong* data, int argCount)
 		{
 			functionDataPtr =  data;
@@ -24,7 +24,7 @@ namespace CitizenFX.Core
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
-	[Serializable]
+	[Serializable, SecurityCritical]
 	internal unsafe struct RageScriptContext
 	{
 		public ulong* functionDataPtr;
@@ -40,7 +40,7 @@ namespace CitizenFX.Core
 
 		public fixed byte padding[96];
 
-		[SecuritySafeCritical, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal unsafe void Initialize(ulong* data, int argCount)
 		{
 			functionDataPtr = retDataPtr = data;
@@ -48,7 +48,7 @@ namespace CitizenFX.Core
 			numResults = 0;
 		}
 
-		[SecuritySafeCritical, MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal unsafe static void CopyVectorData(RageScriptContext* ctx)
 		{
 			Vector3** dst = (Vector3**)ctx->copyToVectors;

--- a/code/client/clrcore-v2/ScriptManager.cs
+++ b/code/client/clrcore-v2/ScriptManager.cs
@@ -10,12 +10,14 @@ using System.Threading;
 
 namespace CitizenFX.Core
 {
+	[SecuritySafeCritical]
 	internal static class ScriptManager
 	{
 		private static readonly List<BaseScript> s_activeScripts = new List<BaseScript>();
 
-		private static Dictionary<string, Assembly> s_loadedAssemblies = new Dictionary<string, Assembly>();
-		private static HashSet<string> s_assemblySearchPaths = new HashSet<string>();
+		private static readonly Dictionary<string, Assembly> s_loadedAssemblies = new Dictionary<string, Assembly>();
+
+		private static readonly HashSet<string> s_assemblySearchPaths = new HashSet<string>();
 
 		#region Initialization
 

--- a/code/client/clrcore-v2/StateBag.cs
+++ b/code/client/clrcore-v2/StateBag.cs
@@ -3,6 +3,7 @@ using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
 {
+	[SecuritySafeCritical]
 	public class StateBag
 	{
 		private CString m_bagName;
@@ -14,8 +15,7 @@ namespace CitizenFX.Core
 			m_bagName = (CString)bagName;
 		}
 
-		[SecuritySafeCritical]
-		public unsafe void Set(string key, object data, bool replicate)
+		public void Set(string key, object data, bool replicate)
 			=> CoreNatives.SetStateBagValue(m_bagName, key, InPacket.Serialize(data), replicate);
 
 		public dynamic Get(string key)


### PR DESCRIPTION
fix(clrcore-v2): CAS transparency fixes

* Fixes all CAS errors reported by SecAnnotate on the the client assembly.
* Plus an exception message fix for MsgPackDeserializer

tweak(clrcore-v2): more guidance on DynFunc exceptions

DynFunc exceptions run through exports, events, and reference functions can now give more details on the issue by rechecking types and their ability to be used.
Should reduce support requests and/or make them easy to solve