### PR TITLE
fix(state/fivem): parse proper fields for bodyHealth, add health

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -374,6 +374,7 @@ struct CVehicleHealthNodeData
 	bool tyresFine;
 	int tyreStatus[1 << 4];
 	int bodyHealth;
+	int health;
 };
 
 struct CVehicleGameStateNodeData

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1011,6 +1011,18 @@ struct CVehicleHealthDataNode
 			}
 		}
 
+		bool isFine = state.buffer.ReadBit();
+
+		if (!isFine)
+		{
+			auto health = state.buffer.ReadSigned<int>(19);
+			data.health = health;
+		}
+		else
+		{
+			data.health = 1000;
+		}
+
 		bool bodyHealthFine = state.buffer.ReadBit();
 
 		if (!bodyHealthFine)
@@ -1021,13 +1033,6 @@ struct CVehicleHealthDataNode
 		else
 		{
 			data.bodyHealth = 1000;
-		}
-
-		bool unk16 = state.buffer.ReadBit();
-
-		if (!unk16)
-		{
-			auto unk17 = state.buffer.ReadSigned<int>(19);
 		}
 
 		bool unk18 = state.buffer.ReadBit();

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -734,6 +734,18 @@ static void Init()
 			auto pn = entity->syncTree->GetPedHealth();
 			return pn ? pn->health : 0;
 		}
+		case fx::sync::NetObjEntityType::Automobile:
+		case fx::sync::NetObjEntityType::Bike:
+		case fx::sync::NetObjEntityType::Boat:
+		case fx::sync::NetObjEntityType::Heli:
+		case fx::sync::NetObjEntityType::Plane:
+		case fx::sync::NetObjEntityType::Submarine:
+		case fx::sync::NetObjEntityType::Trailer:
+		case fx::sync::NetObjEntityType::Train:
+		{
+			auto pn = entity->syncTree->GetVehicleHealth();
+			return pn ? pn->health : 0;
+		}
 		default:
 			return 0;
 		}

--- a/ext/native-decls/GetEntityHealth.md
+++ b/ext/native-decls/GetEntityHealth.md
@@ -8,9 +8,12 @@ apiset: server
 int GET_ENTITY_HEALTH(Entity entity);
 ```
 
-Currently it only works with peds.
+Only works for vehicle and peds
 
 ## Parameters
-* **entity**: 
+* **entity**: The entity to check the health of
 
 ## Return value
+If the entity is a vehicle it will return 0-1000
+If the entity is a ped it will return 0-200
+If the entity is an object it will return 0


### PR DESCRIPTION
Fixes from what gottfriedleibniz posted on the [forums](https://forum.cfx.re/t/onesync-getvehiclebodyhealth-server-sided/4875372/7)