### PR TITLE
feat(clrcore-v2): more coroutine features and moving server types to Server namespace

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -33,6 +33,7 @@ namespace CitizenFX.Core
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class TickAttribute : Attribute
 	{
+		public bool StopOnException { get; set; } = false;
 		public TickAttribute() { }
 	}
 

--- a/code/client/clrcore-v2/Coroutine/Canceler.cs
+++ b/code/client/clrcore-v2/Coroutine/Canceler.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+
+namespace CitizenFX.Core
+{
+	public class Canceler
+	{
+		public bool IsCanceled { get; private set; } = false;
+		public bool ThrowOnCancelation { get; set; } = false;
+
+		public event Action OnCancel;
+
+		public CancelerToken Token => new CancelerToken(this);
+
+		public Canceler() { }
+
+		public void Cancel()
+		{
+			IsCanceled = true;
+			OnCancel?.Invoke();
+			OnCancel = null;
+		}
+
+		public static implicit operator CancelerToken(Canceler canceler) => canceler.Token;
+	}
+
+	public readonly struct CancelerToken
+	{
+		private readonly Canceler m_canceler;
+
+		public bool IsCanceled => m_canceler?.IsCanceled == true;
+		public bool ThrowOnCancelation => m_canceler?.ThrowOnCancelation == true;
+
+		public event Action OnCancel
+		{
+			add { if (m_canceler != null) m_canceler.OnCancel += value; }
+			remove { if (m_canceler != null) m_canceler.OnCancel -= value; }
+		}
+
+		public CancelerToken(Canceler canceler) => m_canceler = canceler;
+
+		/// <summary>
+		/// Combination of <see cref="IsCanceled"/> and <see cref="ThrowOnCancelation"/> for throwing support
+		/// </summary>
+		/// <returns><see langword="true"/> if we need to stop execution of the coroutine otherwise <see langword="false"/></returns>
+		/// <exception cref="CoroutineCanceledException"></exception>
+		internal bool CancelOrThrowIfRequested()
+		{
+			if (m_canceler?.IsCanceled == true)
+			{
+				if (m_canceler.ThrowOnCancelation)
+				{
+					throw new CoroutineCanceledException($"Coroutine execution was canceled by a {nameof(Canceler)}");
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public void AddOnCancelAction(Action action) => m_canceler.OnCancel += action;
+	}
+
+	public class CoroutineCanceledException : Exception
+	{
+		public CoroutineCanceledException() { }
+		public CoroutineCanceledException(string message) : base(message) { }
+	}
+}

--- a/code/client/clrcore-v2/Coroutine/CoroutineMethods.cs
+++ b/code/client/clrcore-v2/Coroutine/CoroutineMethods.cs
@@ -1,0 +1,441 @@
+using System.Collections.Generic;
+using System;
+using System.Runtime.InteropServices;
+
+namespace CitizenFX.Core
+{
+	public partial class Coroutine
+	{
+		public static Coroutine Completed()
+		{
+			var coroutine = new Coroutine();
+			coroutine.Complete();
+			return coroutine;
+		}
+
+		public static Coroutine<T> Completed<T>(T result)
+		{
+			var coroutine = new Coroutine<T>();
+			coroutine.Complete(result);
+			return coroutine;
+		}
+
+		#region Delaying
+
+		/// <summary>
+		/// Await to stall execution and continue next frame.
+		/// </summary>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Yield()
+		{
+			var coroutine = new Coroutine();
+			Scheduler.Schedule(coroutine.Complete);
+			return coroutine;
+		}
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given time.
+		/// </summary>
+		/// <param name="time">Time in milliseconds after we want to continue execution</param>
+		/// <remarks>Current time can be retrieved by using <see cref="Scheduler.CurrentTime"/></remarks>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine WaitUntil(TimePoint time)
+		{
+			var coroutine = new Coroutine();
+			Scheduler.Schedule(coroutine.Complete, time);
+			return coroutine;
+		}
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given time.
+		/// </summary>
+		/// <param name="time">Time in milliseconds after we want to continue execution</param>
+		/// <param name="cancelerToken">Canceling token, can be used to stop early</param>
+		/// <remarks>Current time can be retrieved by using <see cref="Scheduler.CurrentTime"/></remarks>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine WaitUntil(TimePoint time, CancelerToken cancelerToken)
+		{
+			if (!cancelerToken.CancelOrThrowIfRequested())
+			{
+				var coroutine = new Coroutine();
+
+				void OnCancel()
+				{
+					Scheduler.Unschedule(OnWaited, time);
+					coroutine.Complete();
+				}
+
+				void OnWaited()
+				{
+					coroutine.Complete();
+					cancelerToken.OnCancel -= OnCancel;
+				}
+
+				Scheduler.Schedule(OnWaited, time);
+				cancelerToken.OnCancel += OnCancel;
+
+				return coroutine;
+			}
+
+			return Completed();
+		}
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given delay.
+		/// </summary>
+		/// <param name="delay">Delay in milliseconds after we want to continue execution</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Wait(ulong delay) => WaitUntil(Scheduler.CurrentTime + delay);
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given delay.
+		/// </summary>
+		/// <param name="delay">Delay in milliseconds after we want to continue execution</param>
+		/// <param name="cancelerToken">Canceling token, can be used to stop early</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Wait(ulong delay, CancelerToken cancelerToken) => WaitUntil(Scheduler.CurrentTime + delay, cancelerToken);
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given delay.
+		/// </summary>
+		/// <param name="delay">Delay in milliseconds after we want to continue execution</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Delay(ulong delay) => WaitUntil(Scheduler.CurrentTime + delay);
+
+		/// <summary>
+		/// Await to stall execution of the current async method and continue after the given delay.
+		/// </summary>
+		/// <param name="delay">Delay in milliseconds after we want to continue execution</param>
+		/// <param name="cancelerToken">Canceling token, can be used to stop early</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Delay(ulong delay, CancelerToken cancelerToken) => WaitUntil(Scheduler.CurrentTime + delay, cancelerToken);
+
+		#endregion
+
+		#region Scheduling
+
+		/// <summary>
+		/// Schedules a delegate to be run at a later time
+		/// </summary>
+		/// <param name="function">Delegate to run</param>
+		/// <param name="delay">Delay until the <paramref name="function"/> is executed</param>
+		/// <param name="iterations">Amount of times we want to run the <paramref name="function"/>. <see cref="Repeat.Infinite"/> or <see cref="ulong.MaxValue"/> to infinitely loop.</param>
+		/// <param name="cancelerToken">Allows the cancellation of the given <paramref name="function"/> before it got executed</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static async Coroutine Schedule(Func<Coroutine> function, ulong delay, ulong iterations = Repeat.Infinite, CancelerToken cancelerToken = default)
+		{
+			if (iterations > 0)
+			{
+				while ((iterations == Repeat.Infinite || iterations-- > 0) && !cancelerToken.CancelOrThrowIfRequested())
+				{
+					await Delay(delay, cancelerToken);
+
+					if (cancelerToken.CancelOrThrowIfRequested())
+						return;
+
+					await function();
+				}
+			}
+		}
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static async Coroutine<T> Schedule<T>(Func<Coroutine<T>> function, ulong delay, ulong iterations = Repeat.Infinite, CancelerToken cancelerToken = default)
+		{
+			T result = default;
+
+			if (iterations > 0)
+			{
+				while ((iterations == Repeat.Infinite || iterations-- > 0) && !cancelerToken.CancelOrThrowIfRequested())
+				{
+					await Delay(delay, cancelerToken);
+
+					if (cancelerToken.CancelOrThrowIfRequested())
+						return result;
+
+					result = await function();
+				}
+			}
+
+			return result;
+		}
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static async Coroutine Schedule(Func<Coroutine> function, TimePoint time, CancelerToken cancelerToken = default)
+		{
+			await WaitUntil(time, cancelerToken);
+
+			if (!cancelerToken.CancelOrThrowIfRequested())
+			{
+				await function();
+			}
+		}
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static async Coroutine<T> Schedule<T>(Func<Coroutine<T>> function, TimePoint time, CancelerToken cancelerToken = default)
+		{
+			await WaitUntil(time, cancelerToken);
+			return !cancelerToken.CancelOrThrowIfRequested() ? await function() : default;
+		}
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine Schedule(Func<Coroutine> function)
+			=> Schedule(function, Scheduler.CurrentTime, default);
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine Schedule(Func<Coroutine> function, ulong delay, CancelerToken cancelerToken)
+			=> Schedule(function, Scheduler.CurrentTime + delay, cancelerToken);
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine<T> Schedule<T>(Func<Coroutine<T>> function, ulong delay, CancelerToken cancelerToken)
+			=> Schedule(function, Scheduler.CurrentTime + delay, cancelerToken);
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine Schedule(Action function)
+			=> Schedule(async () => function(), Scheduler.CurrentTime, default);
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine Schedule(Action function, ulong delay, CancelerToken cancelerToken = default)
+			=> Schedule(async () => function(), Scheduler.CurrentTime + delay, cancelerToken);
+
+		/// <inheritdoc cref="Schedule(Func{Coroutine}, ulong, ulong, CancelerToken)"/>
+		public static Coroutine Schedule(Action function, ulong delay, ulong iterations, CancelerToken cancelerToken = default)
+			=> Schedule(async () => function(), delay, iterations, cancelerToken);
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+		#endregion
+
+		#region Run
+
+		/// <summary>
+		/// Runs given function directly and allows the caller to await it.
+		/// </summary>
+		/// <param name="function">Function to run</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Run(Func<Coroutine> function) => function();
+
+		/// <inheritdoc cref="Run(Func{Coroutine})"/>
+		public static Coroutine Run(Action function)
+		{
+			function();
+			return Completed();
+		}
+
+		/// <summary>
+		/// Runs given function directly and allows the caller to await it.
+		/// </summary>
+		/// <param name="function">Function to run</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine Run<TResult>(Func<Coroutine<TResult>> function) => function();
+
+		/// <summary>
+		/// Runs given function next frame and allows the caller to await it.
+		/// </summary>
+		/// <param name="function">Function to run</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine RunNextFrame(Func<Coroutine> function)
+		{
+			var coroutine = new Coroutine();
+			Scheduler.Schedule(async () =>
+			{
+				await function();
+				coroutine.Complete();
+			});
+			return coroutine;
+		}
+
+		/// <inheritdoc cref="RunNextFrame(Func{Coroutine})"/>
+		public static Coroutine RunNextFrame(Action function)
+		{
+			var coroutine = new Coroutine();
+			Scheduler.Schedule(() =>
+			{
+				function();
+				coroutine.Complete();
+			});
+			return coroutine;
+		}
+
+		/// <summary>
+		/// Runs given function directly and allows the caller to await it.
+		/// </summary>
+		/// <param name="function">Function to run</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine<T> RunNextFrame<T>(Func<Coroutine<T>> function)
+		{
+			var coroutine = new Coroutine<T>();
+			Scheduler.Schedule(async () =>
+			{
+				var result = await function();
+				coroutine.Complete(result);
+			});
+			return coroutine;
+		}
+
+		#endregion
+
+		#region Multiple awaitment
+
+		/// <summary>
+		/// Run all functions and await the first one to complete
+		/// </summary>
+		/// <remarks>Will run the coroutines directly</remarks>
+		/// <param name="coroutines">Coroutines to await</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine WhenAny(params Coroutine[] coroutines)
+		{
+			var coroutine = new Coroutine();
+			var awaitees = new List<Coroutine>();
+
+			void Complete()
+			{
+				// disable continuation calls for all awaited coroutines
+				for (int i = 0; i < awaitees.Count; ++i)
+				{
+					awaitees[i].ClearContinueWith();
+				}
+
+				coroutine.Complete();
+			}
+
+			for (int i = 0; i < coroutines.Length; ++i)
+			{
+				Coroutine active = coroutines[i];
+				if (!active.IsCompleted)
+				{
+					awaitees.Add(active);
+					active.ContinueWith(Complete);
+				}
+				else
+				{
+					return active;
+				}
+			}
+
+			return coroutine;
+		}
+
+		/// <summary>
+		/// Run all functions and await the first one to complete
+		/// </summary>
+		/// <remarks>Will run the coroutines directly</remarks>
+		/// <param name="coroutines">Coroutines to await</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine<T> WhenAny<T>(params Coroutine<T>[] coroutines)
+		{
+			var coroutine = new Coroutine<T>();
+			var awaitees = new List<Coroutine<T>>();
+
+			void Complete(Coroutine awaitee)
+			{
+				// disable continuation calls for all awaited coroutines
+				for (int i = 0; i < awaitees.Count; ++i)
+				{
+					awaitees[i].m_continuation = null;
+				}
+
+				coroutine.Complete((awaitee as Coroutine<T>).Result);
+			}
+
+			for (int i = 0; i < coroutines.Length; ++i)
+			{
+				Coroutine<T> active = coroutines[i];
+				if (!active.IsCompleted)
+				{
+					awaitees.Add(active);
+					active.ContinueWith(Complete);
+				}
+				else
+				{
+					return active;
+				}
+			}
+
+			return coroutine;
+		}
+
+		/// <summary>
+		/// Run all functions and await all to complete
+		/// </summary>
+		/// <param name="coroutines">Coroutines to await</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine WhenAll(params Coroutine[] coroutines)
+		{
+			var coroutine = new Coroutine();
+			var awaitees = new List<Coroutine>();
+			var exceptions = new List<Exception>();
+
+			void OnAwaiteeComplete(Coroutine awaitee)
+			{
+				if (awaitee.Exception != null)
+				{
+					exceptions.Add(awaitee.Exception);
+				}
+
+				awaitees.Remove(awaitee);
+				if (awaitees.Count == 0)
+				{
+					if (exceptions.Count == 0)
+						coroutine.Complete();
+					else
+						coroutine.Fail(null, new AggregateException(exceptions.ToArray()));
+				}
+			}
+
+			for (int i = 0; i < coroutines.Length; ++i)
+			{
+				Coroutine active = coroutines[i];
+				if (!active.IsCompleted)
+				{
+					awaitees.Add(active);
+					active.ContinueWith(OnAwaiteeComplete);
+				}
+			}
+
+			return awaitees.Count > 0 ? coroutine : Completed();
+		}
+
+		/// <summary>
+		/// Run all functions and await all to complete
+		/// </summary>
+		/// <param name="coroutines">Coroutines to await</param>
+		/// <returns>Awaitable <see cref="Coroutine"/></returns>
+		public static Coroutine WhenAll<T>(params Coroutine<T>[] coroutines)
+		{
+			var coroutine = new Coroutine();
+			var awaitees = new List<Coroutine>();
+			var exceptions = new List<Exception>();
+
+			void OnAwaiteeComplete(Coroutine awaitee)
+			{
+				if (awaitee.Exception != null)
+				{
+					exceptions.Add(awaitee.Exception);
+				}
+
+				awaitees.Remove(awaitee);
+				if (awaitees.Count == 0)
+				{
+					if (exceptions.Count == 0)
+						coroutine.Complete((awaitee as Coroutine<T>).Result);
+					else
+						coroutine.Fail(null, new AggregateException(exceptions.ToArray()));
+				}
+			}
+
+			for (int i = 0; i < coroutines.Length; ++i)
+			{
+				Coroutine active = coroutines[i];
+				if (!active.IsCompleted)
+				{
+					awaitees.Add(active);
+					active.ContinueWith(OnAwaiteeComplete);
+				}
+			}
+
+			return awaitees.Count > 0 ? coroutine : Completed();
+		}
+
+		#endregion
+	}
+}

--- a/code/client/clrcore-v2/Coroutine/TimePoint.cs
+++ b/code/client/clrcore-v2/Coroutine/TimePoint.cs
@@ -1,0 +1,28 @@
+
+namespace CitizenFX.Core
+{
+	/// <summary>
+	/// Absolute time for scheduling on fixed points in time
+	/// </summary>
+	public readonly struct TimePoint
+	{
+		private readonly ulong m_time;
+		
+		public TimePoint(ulong timeInMilliseconds) => m_time = timeInMilliseconds;
+		
+		public static TimePoint operator+ (TimePoint timePoint, ulong timeInMilliseconds) => new TimePoint(timePoint.m_time + timeInMilliseconds);
+		public static TimePoint operator -(TimePoint timePoint, ulong timeInMilliseconds) => new TimePoint(timePoint.m_time - timeInMilliseconds);
+		public static TimePoint operator *(TimePoint timePoint, ulong timeInMilliseconds) => new TimePoint(timePoint.m_time * timeInMilliseconds);
+		public static TimePoint operator /(TimePoint timePoint, ulong timeInMilliseconds) => new TimePoint(timePoint.m_time / timeInMilliseconds);
+
+		public static implicit operator ulong(TimePoint timePoint) => timePoint.m_time;
+		public static explicit operator TimePoint(ulong timeInMilliseconds) => new TimePoint(timeInMilliseconds);
+
+		public override string ToString() => m_time.ToString();
+	}
+
+	public struct Repeat
+	{
+		public const ulong Infinite = ulong.MaxValue;
+	}
+}

--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -95,7 +95,7 @@ namespace CitizenFX.Core
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static ulong Tick(ulong hostTime, bool profiling)
 		{
-			Scheduler.CurrentTime = hostTime;
+			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 
 			try
@@ -114,7 +114,7 @@ namespace CitizenFX.Core
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static unsafe ulong TriggerEvent(string eventName, byte* argsSerialized, int serializedSize, string sourceString, ulong hostTime, bool profiling)
 		{
-			Scheduler.CurrentTime = hostTime;
+			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 			
 			Binding origin = !sourceString.StartsWith("net") ? Binding.Local : Binding.Remote;
@@ -143,7 +143,7 @@ namespace CitizenFX.Core
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static unsafe ulong LoadAssembly(string name, ulong hostTime, bool profiling)
 		{
-			Scheduler.CurrentTime = hostTime;
+			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 
 			ScriptManager.LoadAssembly(name, true);
@@ -154,7 +154,7 @@ namespace CitizenFX.Core
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
 		internal static unsafe ulong CallRef(int refIndex, byte* argsSerialized, uint argsSize, out IntPtr retvalSerialized, out uint retvalSize, ulong hostTime, bool profiling)
 		{
-			Scheduler.CurrentTime = hostTime;
+			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 
 			ReferenceFunctionManager.IncomingCall(refIndex, argsSerialized, argsSize, out retvalSerialized, out retvalSize);

--- a/code/client/clrcore/Server/Entity.cs
+++ b/code/client/clrcore/Server/Entity.cs
@@ -1,21 +1,25 @@
 using System;
-using CitizenFX.Core.Native;
 
 #if MONO_V2
+using CitizenFX.Core;
 using API = CitizenFX.Server.Native.Natives;
-using Prop = CitizenFX.Core.Object;
+using Prop = CitizenFX.Server.Object;
 using compat_int_uint = System.UInt32;
 using compat_int_entity_type = CitizenFX.Shared.EntityType;
 #else
+using CitizenFX.Core.Native;
 using compat_int_uint = System.Int32;
 using compat_int_entity_type = System.Int32;
 #endif
 
+#if MONO_V2
+namespace CitizenFX.Server
+{
+	public abstract class Entity : PoolObject, IEquatable<Entity>, ISpatial, Shared.IEntity
+#else
 namespace CitizenFX.Core
 {
 	public abstract class Entity : PoolObject, IEquatable<Entity>, ISpatial
-#if MONO_V2
-		, Shared.IEntity
 #endif
 	{
 		public Entity(int handle) : base(handle)

--- a/code/client/clrcore/Server/Interfaces.cs
+++ b/code/client/clrcore/Server/Interfaces.cs
@@ -1,10 +1,13 @@
+#if MONO_V2
+using CitizenFX.Core;
+using INativeValue = CitizenFX.Core.Native.Input.Primitive;
+
+namespace CitizenFX.Server
+#else
 using CitizenFX.Core.Native;
 
-#if MONO_V2
-using INativeValue = CitizenFX.Core.Native.Input.Primitive;
-#endif
-
 namespace CitizenFX.Core
+#endif
 {
 	public interface ISpatial
 	{

--- a/code/client/clrcore/Server/Ped.cs
+++ b/code/client/clrcore/Server/Ped.cs
@@ -1,16 +1,15 @@
-using System;
-using CitizenFX.Core.Native;
-using System.Security;
-
 #if MONO_V2
 using API = CitizenFX.Server.Native.Natives;
-#endif
+
+namespace CitizenFX.Server
+{
+	public sealed class Ped : Entity, Shared.IPed
+#else
+using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
 {
 	public sealed class Ped : Entity
-#if MONO_V2
-		, Shared.IPed
 #endif
 	{
 		public Ped(int handle) : base(handle)

--- a/code/client/clrcore/Server/Prop.cs
+++ b/code/client/clrcore/Server/Prop.cs
@@ -1,10 +1,6 @@
-using System;
-using CitizenFX.Core.Native;
-using System.Security;
-
-namespace CitizenFX.Core
-{
 #if MONO_V2
+namespace CitizenFX.Server
+{
 	public sealed class Object : Entity, Shared.IObject
 	{
 		public Object(int handle) : base(handle)
@@ -12,6 +8,8 @@ namespace CitizenFX.Core
 		}
 	}
 #else
+namespace CitizenFX.Core
+{
 	public sealed class Prop : Entity
 	{
 		public Prop(int handle) : base(handle)

--- a/code/client/clrcore/Server/ServerWrappers.cs
+++ b/code/client/clrcore/Server/ServerWrappers.cs
@@ -6,14 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 
 #if MONO_V2
+using CitizenFX.Core;
 using static CitizenFX.Server.Native.Natives;
-#else
-using static CitizenFX.Core.Native.API;
-#endif
 
-namespace CitizenFX.Core
+namespace CitizenFX.Server
 {
-#if MONO_V2
 	public class Player	: Shared.Player
 	{
 		internal Player(Remote remote)
@@ -22,6 +19,10 @@ namespace CitizenFX.Core
 		}
 
 #else
+using static CitizenFX.Core.Native.API;
+
+namespace CitizenFX.Core
+{
 	public class Player
 	{
 		private string m_handle;

--- a/code/client/clrcore/Server/Vehicle.cs
+++ b/code/client/clrcore/Server/Vehicle.cs
@@ -1,12 +1,11 @@
-using System;
-using CitizenFX.Core.Native;
-using System.Security;
-
+#if MONO_V2
+namespace CitizenFX.Server
+{
+	public sealed class Vehicle : Entity, Shared.IVehicle
+#else
 namespace CitizenFX.Core
 {
 	public sealed class Vehicle : Entity
-#if MONO_V2
-		, Shared.IVehicle
 #endif
 	{
 		public Vehicle(int handle) : base(handle)


### PR DESCRIPTION
feat(clrcore-v2): more coroutine features
* await `Coroutine.Run(func)`, runs the function directly and allows awaiting it
* await `Coroutine.RunNextFrame(func)`, runs the function on the next frame and allows awaiting it
* await `Coroutine.WhenAny(...)`, awaits until the first awaitee finishes
* await `Coroutine.WhenAll(...)`, awaits until all awaitees finish
* `Coroutine.Schedule(func, delay)` to run func after delay
* `Coroutine.Schedule(func, delay, iterations)` to run func after delay for an x amount of iterations
* `Canceler` support for `Schedule`, `Delay`, and `WaitUntil`
* `Scheduler` and `Coroutine` use `TimePoint` for all absolute timing needs distinguishing it from `ulong` delay scheduling
* `Coroutine` internal rework
  - Fixed exeption propagation
  - Adding more completion states and enables it for more future options
  - Using `MultiCastDelegate` as continuation

tweak(clrcore-v2): move server types to Server namespace
Server types weren't moved into the `CitizenFX.Server` namespace with the last shared-library update.

resolves thorium-cfx/mono_v2_get_started#8 and resolves thorium-cfx/mono_v2_get_started#7