### PR TITLE
fix(clrcore-v2): MemoryAccess, StateBag.Global, & Exports/RefFunc fixes

### DIFF
--- a/code/client/clrcore-v2/Coroutine/Coroutine.cs
+++ b/code/client/clrcore-v2/Coroutine/Coroutine.cs
@@ -202,6 +202,8 @@ namespace CitizenFX.Core
 			return GetResultInternal();
 		}
 
+		internal object GetResultNonThrowing() => GetResultInternal();
+
 		protected virtual object GetResultInternal() => null;
 
 		internal void Complete() => CompleteInternal(State.Completed);

--- a/code/client/clrcore-v2/Interop/LocalFunction.cs
+++ b/code/client/clrcore-v2/Interop/LocalFunction.cs
@@ -53,12 +53,15 @@ namespace CitizenFX.Core
 					&& requestAsyncCallback is Callback callbackRequested)
 				{
 					var c = new Coroutine<object>();
-					callbackRequested(new Action<object, object>((a, e) =>
+					callbackRequested(new Action<object, object>((results, exception) =>
 					{
-						if (e != null)
-							c.SetException(new Exception(e.ToString()));
+						if (exception != null)
+							c.Fail(null, new Exception(exception.ToString()));
+						else if(results is object[] array && array.Length > 0)
+							c.Complete(array[0]);
 						else
-							c.Complete(a);
+							c.Complete(null);
+
 					}));
 
 					return c;

--- a/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
+++ b/code/client/clrcore-v2/Interop/MsgPackSerializer.cs
@@ -35,8 +35,8 @@ namespace CitizenFX.Core
 				using (var packer = Packer.Create(stream, PackerCompatibilityOptions.None))
 				{
 					Serialize(obj, packer);
-					//return stream.ToArray();
-					return stream.GetBuffer();
+					return stream.ToArray(); // other runtimes read the full length we give them, so shrink the buffer (copy)
+					//return stream.GetBuffer();
 				}
 			}
 

--- a/code/client/clrcore-v2/Native/Native.cs
+++ b/code/client/clrcore-v2/Native/Native.cs
@@ -93,7 +93,7 @@ namespace CitizenFX.Core.Native
 				ulong* __data = stackalloc ulong[] { (ulong)p_referenceIdentity, (ulong)p_argsSerialized, unchecked((ulong)argsSerialized.value?.LongLength), (ulong)&retLength };
 				ScriptContext.InvokeNative(ref s_0xe3551879, 0xe3551879, __data, 4); // INVOKE_FUNCTION_REFERENCE
 
-				return MsgPackDeserializer.DeserializeArray((byte*)__data, (long)retLength);
+				return MsgPackDeserializer.DeserializeArray(*(byte**)__data, (long)retLength);
 			}
 		}
 

--- a/code/client/clrcore-v2/StateBag.cs
+++ b/code/client/clrcore-v2/StateBag.cs
@@ -6,9 +6,9 @@ namespace CitizenFX.Core
 	[SecuritySafeCritical]
 	public class StateBag
 	{
-		private CString m_bagName;
+		private readonly CString m_bagName;
 
-		static StateBag Global => new StateBag("global");
+		public static StateBag Global { get; } = new StateBag("global");
 
 		internal StateBag(string bagName)
 		{

--- a/code/client/clrcore/External/Camera.cs
+++ b/code/client/clrcore/External/Camera.cs
@@ -1,5 +1,6 @@
 using System;
 using CitizenFX.Core.Native;
+using System.Security;
 
 #if MONO_V2
 using CitizenFX.Core;
@@ -62,6 +63,7 @@ namespace CitizenFX.Core
 
 		private IntPtr MatrixAddress
 		{
+			[SecuritySafeCritical]
 			get
 			{
 				IntPtr address = MemoryAddress;
@@ -69,7 +71,11 @@ namespace CitizenFX.Core
 				{
 					return IntPtr.Zero;
 				}
+#if MONO_V2
+				return MemoryAccess.Offset(address, MemoryAccess.IsBitSet(address, 0x220, 0) ? 0x110 : 0x30);
+#else
 				return (MemoryAccess.ReadByte(address + 0x220) & 1) == 0 ? address + 0x30 : address + 0x110;
+#endif
 			}
 		}
 
@@ -526,21 +532,33 @@ namespace CitizenFX.Core
 		/// </summary>
 		public static Vector3 UpVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x210, Vector3.Up);
+#else
 			get { return MemoryAccess.ReadVector3(MemoryAddress + 0x210); }
+#endif
 		}
 		/// <summary>
 		/// Gets the forward vector of the <see cref="GameplayCamera"/>, see also <seealso cref="Direction"/>.
 		/// </summary>
 		public static Vector3 ForwardVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x200, Vector3.ForwardLH);
+#else
 			get { return MemoryAccess.ReadVector3(MemoryAddress + 0x200); }
+#endif
 		}
 		/// <summary>
 		/// Gets the right vector of the <see cref="GameplayCamera"/>.
 		/// </summary>
 		public static Vector3 RightVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x1F0, Vector3.Right);
+#else
 			get { return MemoryAccess.ReadVector3(MemoryAddress + 0x1F0); }
+#endif
 		}
 
 		/// <summary>
@@ -548,7 +566,11 @@ namespace CitizenFX.Core
 		/// </summary>
 		public static Matrix Matrix
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x1F0, default(Matrix));
+#else
 			get { return MemoryAccess.ReadMatrix(MemoryAddress + 0x1F0); }
+#endif
 		}
 
 		/// <summary>

--- a/code/client/clrcore/External/Checkpoint.cs
+++ b/code/client/clrcore/External/Checkpoint.cs
@@ -1,5 +1,6 @@
 using System;
 using CitizenFX.Core.Native;
+using System.Security;
 
 #if MONO_V2
 using CitizenFX.Core;
@@ -231,6 +232,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public Vector3 Position
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0, Vector3.Zero);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 0, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -249,12 +254,17 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteVector3(memoryAddress, value);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets the position where this <see cref="Checkpoint"/> points to.
 		/// </summary>
 		public Vector3 TargetPosition
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 16, Vector3.Zero);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 16, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -273,6 +283,7 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteVector3(memoryAddress + 16, value);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -280,6 +291,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public CheckpointIcon Icon
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => (CheckpointIcon)MemoryAccess.ReadIfNotNull(MemoryAddress, 56, 0);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 56, (int)value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -298,10 +313,24 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteInt(memoryAddress + 56, (int)value);
 			}
+#endif
 		}
 
 		public CheckpointCustomIcon CustomIcon
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => (CheckpointCustomIcon)MemoryAccess.ReadIfNotNull(MemoryAddress, 52, (byte)0);
+			[SecuritySafeCritical]
+			set
+			{
+				IntPtr address = MemoryAddress;
+				if (address != IntPtr.Zero)
+				{
+					MemoryAccess.Write(MemoryAddress, 52, (byte)value);
+					MemoryAccess.Write(MemoryAddress, 56, (int)42); //sets the icon to a custom icon
+				}
+			}
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -321,6 +350,7 @@ namespace CitizenFX.Core
 				MemoryAccess.WriteByte(memoryAddress + 52, value);
 				MemoryAccess.WriteInt(memoryAddress + 56, 42);//sets the icon to a custom icon
 			}
+#endif
 		}
 
 		/// <summary>
@@ -328,6 +358,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public float Radius
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 60, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 60, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -346,6 +380,7 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteFloat(memoryAddress + 60, value);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -353,6 +388,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public Color Color
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 80, Color.Transparent);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 80, (uint)value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -371,12 +410,17 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteInt(memoryAddress + 80, Color.ToArgb());
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets the color of the icon in this <see cref="Checkpoint"/>.
 		/// </summary>
 		public Color IconColor
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 84, Color.Transparent);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 84, (uint)value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -395,6 +439,7 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteInt(memoryAddress + 84, Color.ToArgb());
 			}
+#endif
 		}
 
 		/// <summary>
@@ -402,6 +447,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public float CylinderNearHeight
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 68, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 68, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -420,12 +469,17 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteFloat(memoryAddress + 68, value);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets the far height of the cylinder of this <see cref="Checkpoint"/>.
 		/// </summary>
 		public float CylinderFarHeight
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 72, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 72, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -444,12 +498,17 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteFloat(memoryAddress + 72, value);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets the radius of the cylinder in this <see cref="Checkpoint"/>.
 		/// </summary>
 		public float CylinderRadius
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 76, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 76, value);
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -468,6 +527,7 @@ namespace CitizenFX.Core
 				}
 				MemoryAccess.WriteFloat(memoryAddress + 76, value);
 			}
+#endif
 		}
 
 

--- a/code/client/clrcore/External/Entity.cs
+++ b/code/client/clrcore/External/Entity.cs
@@ -79,8 +79,13 @@ namespace CitizenFX.Core
 		/// <value>
 		/// The health in float.
 		/// </value>
+		
 		public float HealthFloat
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 640, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 640, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -99,7 +104,9 @@ namespace CitizenFX.Core
 
 				MemoryAccess.WriteFloat(MemoryAddress + 640, value);
 			}
+#endif
 		}
+
 		/// <summary>
 		/// Gets or sets the maximum health of this <see cref="Entity"/> as an <see cref="int"/>.
 		/// </summary>
@@ -126,6 +133,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public float MaxHealthFloat
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 644, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, 644, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -144,7 +155,9 @@ namespace CitizenFX.Core
 
 				MemoryAccess.WriteFloat(MemoryAddress + 644, value);
 			}
+#endif
 		}
+
 		/// <summary>
 		/// Gets a value indicating whether this <see cref="Entity"/> is dead.
 		/// </summary>
@@ -293,6 +306,9 @@ namespace CitizenFX.Core
 
 		public Vector3 UpVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x80, Vector3.Zero);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -301,12 +317,17 @@ namespace CitizenFX.Core
 				}
 				return MemoryAccess.ReadVector3(MemoryAddress + 0x80);
 			}
+#endif
 		}
+
 		/// <summary>
 		/// Gets the vector that points to the right of this <see cref="Entity"/>
 		/// </summary>
 		public Vector3 RightVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x60, Vector3.Zero);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -315,12 +336,16 @@ namespace CitizenFX.Core
 				}
 				return MemoryAccess.ReadVector3(MemoryAddress + 0x60);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets the vector that points in front of this <see cref="Entity"/>
 		/// </summary>
 		public Vector3 ForwardVector
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x70, Vector3.ForwardLH);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -329,6 +354,7 @@ namespace CitizenFX.Core
 				}
 				return MemoryAccess.ReadVector3(MemoryAddress + 0x70);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -336,6 +362,9 @@ namespace CitizenFX.Core
 		/// </summary>
 		public Matrix Matrix
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 0x60, default(Matrix));
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -345,6 +374,7 @@ namespace CitizenFX.Core
 				}
 				return MemoryAccess.ReadMatrix(memoryAddress + 96);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -355,6 +385,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsPositionFrozen
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 0x2E, 1, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -364,6 +397,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.IsBitSet(MemoryAddress + 0x2E, 1);
 			}
+#endif
 			set
 			{
 				API.FreezeEntityPosition(Handle, value);
@@ -413,6 +447,20 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool HasGravity
 		{
+#if MONO_V2
+			[SecuritySafeCritical]
+			get
+			{
+				IntPtr address = MemoryAddress;
+				if (address != IntPtr.Zero)
+				{
+					address = MemoryAccess.Read<IntPtr>(address, 48);
+					return address == IntPtr.Zero || MemoryAccess.IsBitSet(address, 26, 4);
+				}
+
+				return true;
+			}
+#else
 			get
 			{
 				IntPtr memoryAddress = MemoryAddress;
@@ -428,6 +476,7 @@ namespace CitizenFX.Core
 				return !MemoryAccess.IsBitSet(memoryAddress + 26, 4);
 
 			}
+#endif
 			set
 			{
 				API.SetEntityHasGravity(Handle, value);
@@ -520,6 +569,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsRendered
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 176, 4, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -529,6 +581,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.IsBitSet(MemoryAddress + 176, 4);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets a value indicating whether this <see cref="Entity"/> is upright.
@@ -631,6 +684,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsFireProof
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 5, false);
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 392, 5, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -658,6 +715,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 5);
 				}
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Entity"/> is melee proof.
@@ -667,6 +725,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsMeleeProof
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 7, false);
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 392, 7, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -694,6 +756,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 7);
 				}
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Entity"/> is bullet proof.
@@ -703,6 +766,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsBulletProof
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 4, false);
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 392, 4, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -730,6 +797,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 4);
 				}
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Entity"/> is explosion proof.
@@ -739,6 +807,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsExplosionProof
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 11, false);
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 392, 11, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -766,6 +838,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 11);
 				}
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Entity"/> is collision proof.
@@ -775,6 +848,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsCollisionProof
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 6, false);
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 392, 6, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -802,6 +879,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 6);
 				}
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Entity"/> is invincible.
@@ -811,6 +889,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsInvincible
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 8, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -820,6 +901,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.IsBitSet(MemoryAddress + 392, 8);
 			}
+#endif
 			set
 			{
 				API.SetEntityInvincible(Handle, value);
@@ -833,6 +915,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool IsOnlyDamagedByPlayer
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 392, 9, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -842,6 +927,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.IsBitSet(MemoryAddress + 392, 9);
 			}
+#endif
 			set
 			{
 				API.SetEntityOnlyDamagedByPlayer(Handle, value);

--- a/code/client/clrcore/External/ParticleEffects.cs
+++ b/code/client/clrcore/External/ParticleEffects.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using CitizenFX.Core.Native;
+using System.Security;
 
 #if MONO_V2
 using CitizenFX.Core;
@@ -299,11 +300,16 @@ namespace CitizenFX.Core
 		protected readonly string _effectName;
 		protected Vector3 _offset;
 		protected Vector3 _rotation;
+#if MONO_V2
+		protected Vector4 _color;
+#else
 		protected Color _color;
+#endif
 		protected float _scale;
 		protected float _range;
 		protected InvertAxis _InvertAxis;
 		#endregion
+
 		internal ParticleEffect(ParticleEffectsAsset asset, string effectName)
 		{
 			Handle = -1;
@@ -361,6 +367,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public Vector3 Offset
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 144, ref _offset);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 144, _offset = value);
+#else
 			get
 			{
 				IntPtr address = MemoryAddress;
@@ -387,6 +397,7 @@ namespace CitizenFX.Core
 					}
 				}
 			}
+#endif
 		}
 
 		/// <summary>
@@ -413,6 +424,13 @@ namespace CitizenFX.Core
 		/// <summary>
 		/// Gets or sets the <see cref="Color"/> of this <see cref="ParticleEffect"/>.
 		/// </summary>
+#if MONO_V2
+		public Vector4 Color
+		{
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 320, ref _color);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 320, _color = value);
+		}
+#else
 		public Color Color
 		{
 			get
@@ -443,6 +461,7 @@ namespace CitizenFX.Core
 				}
 			}
 		}
+#endif
 
 		/// <summary>
 		/// Gets or sets the size scaling factor of this <see cref="ParticleEffect"/>
@@ -454,6 +473,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public float Scale
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 336, ref _scale);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 336, _scale = value);
+#else
 			get
 			{
 				IntPtr address = MemoryAddress;
@@ -472,10 +495,15 @@ namespace CitizenFX.Core
 					MemoryAccess.WriteFloat(MemoryAccess.ReadPtr(address + 32) + 336, value);
 				}
 			}
+#endif
 		}
 
 		public float Range
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 384, ref _range);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAccess.DerefIfNotNull(MemoryAddress, 32), 384, _range = value);
+#else
 			get
 			{
 				IntPtr address = MemoryAddress;
@@ -490,6 +518,7 @@ namespace CitizenFX.Core
 				_range = value;
 				API.SetParticleFxLoopedRange(Handle, value);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -642,6 +671,7 @@ namespace CitizenFX.Core
 			var result = new EntityParticleEffect(_asset, _effectName, entity)
 			{
 				Bone = entity.Bones[_entityBone.Index],
+
 				Offset = _offset,
 				Rotation = _rotation,
 				Color = _color,
@@ -716,6 +746,7 @@ namespace CitizenFX.Core
 		{
 			var result = new CoordinateParticleEffect(_asset, _effectName, position)
 			{
+
 				Rotation = _rotation,
 				Color = _color,
 				Scale = _scale,

--- a/code/client/clrcore/External/Ped.cs
+++ b/code/client/clrcore/External/Ped.cs
@@ -251,6 +251,10 @@ namespace CitizenFX.Core
 		/// </summary>
 		public float ArmorFloat
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1474 : 0x1464, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1474 : 0x1464, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -273,6 +277,7 @@ namespace CitizenFX.Core
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
+#endif
 		}
 		/// <summary>
 		/// Gets or sets how accurate this <see cref="Ped"/>s shooting ability is.
@@ -439,6 +444,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public float Sweat
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, 4464, 0.0f);
+#else
 			[SecuritySafeCritical]
 			get
 			{
@@ -448,6 +456,7 @@ namespace CitizenFX.Core
 				}
 				return MemoryAccess.ReadInt(MemoryAddress + 4464);
 			}
+#endif
 			set
 			{
 				if (value < 0)
@@ -606,6 +615,10 @@ namespace CitizenFX.Core
 		/// </value>
 		public float InjuryHealthThreshold
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1480 : 0x1470, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1480 : 0x1470, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -628,6 +641,7 @@ namespace CitizenFX.Core
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -642,6 +656,10 @@ namespace CitizenFX.Core
 		/// </remarks>
 		public float FatalInjuryHealthThreshold
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1484 : 0x1474, 0.0f);
+			[SecuritySafeCritical] set => MemoryAccess.WriteIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1484 : 0x1474, value);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -664,6 +682,7 @@ namespace CitizenFX.Core
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
+#endif
 		}
 
 		/// <summary>
@@ -1183,6 +1202,9 @@ namespace CitizenFX.Core
 
 		public bool DropsWeaponsOnDeath
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, Game.Version >= GameVersion.v1_0_877_1_Steam ? 0x13E5 : 0x13BD, 6, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -1194,6 +1216,7 @@ namespace CitizenFX.Core
 
 				return (MemoryAccess.ReadByte(MemoryAddress + offset) & (1 << 6)) == 0;
 			}
+#endif
 			set
 			{
 				API.SetPedDropsWeaponsWhenDead(Handle, value);
@@ -1295,6 +1318,14 @@ namespace CitizenFX.Core
 		}
 		public bool CanSufferCriticalHits
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get
+			{
+				int offset = Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x13BC : 0x13AC;
+				offset = Game.Version >= GameVersion.v1_0_877_1_Steam ? 0x13E4 : offset;
+				return MemoryAccess.ReadIfNotNull(MemoryAddress, offset, false);
+			}
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -1307,6 +1338,7 @@ namespace CitizenFX.Core
 
 				return (MemoryAccess.ReadByte(MemoryAddress + offset) & (1 << 2)) == 0;
 			}
+#endif
 			set
 			{
 				API.SetPedSuffersCriticalHits(Handle, value);

--- a/code/client/clrcore/External/Vehicle.cs
+++ b/code/client/clrcore/External/Vehicle.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CitizenFX.Core.Native;
+using System.Security;
 
 #if MONO_V2
 using CitizenFX.Core;
@@ -749,6 +750,9 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool ProvidesCover
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.IsBitSetIfNotNull(MemoryAddress, 0x8D4, 2, false);
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -761,6 +765,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 2);
 			}
+#endif
 			set
 			{
 				API.SetVehicleProvidesCover(Handle, value);
@@ -775,6 +780,19 @@ namespace CitizenFX.Core
 		/// </value>
 		public bool DropsMoneyOnExplosion
 		{
+#if MONO_V2
+			[SecuritySafeCritical]
+			get
+			{
+				IntPtr address = MemoryAddress;
+				if (address != IntPtr.Zero && MemoryAccess.Read<int>(address, 0xB58) <= 8)
+				{
+					return MemoryAccess.IsBitSet(address, 0x1409, 1);
+				}
+
+				return false;
+			}
+#else
 			get
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -789,6 +807,7 @@ namespace CitizenFX.Core
 				}
 				return false;
 			}
+#endif
 			set
 			{
 				API.SetVehicleCreatesMoneyPickupsWhenExploded(Handle, value);
@@ -1047,6 +1066,9 @@ namespace CitizenFX.Core
 			{
 				return API.GetIsLeftVehicleHeadlightDamaged(Handle);
 			}
+#if MONO_V2
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 1916, 0, value);
+#else
 			set
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -1065,6 +1087,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 0);
 				}
 			}
+#endif
 		}
 		public bool IsRightHeadLightBroken
 		{
@@ -1072,6 +1095,9 @@ namespace CitizenFX.Core
 			{
 				return API.GetIsRightVehicleHeadlightDamaged(Handle);
 			}
+#if MONO_V2
+			[SecuritySafeCritical] set => MemoryAccess.WriteBitIfNotNull(MemoryAddress, 1916, 1, value);
+#else
 			set
 			{
 				if (MemoryAddress == IntPtr.Zero)
@@ -1090,6 +1116,7 @@ namespace CitizenFX.Core
 					MemoryAccess.ClearBit(address, 1);
 				}
 			}
+#endif
 		}
 		public bool IsRearBumperBrokenOff
 		{
@@ -1666,17 +1693,25 @@ namespace CitizenFX.Core
 
 		public static VehicleHash[] GetAllModelsOfClass(VehicleClass vehicleClass)
 		{
+#if MONO_V2
+			throw new NotImplementedException();
+#else
 			return Array.ConvertAll<int, VehicleHash>(MemoryAccess.VehicleModels[(int)vehicleClass].ToArray(), item => (VehicleHash)item);
+#endif
 		}
 
 		public static VehicleHash[] GetAllModels()
 		{
+#if MONO_V2
+			throw new NotImplementedException();
+#else
 			List<VehicleHash> allModels = new List<VehicleHash>();
 			for (int i = 0; i < 0x20; i++)
 			{
 				allModels.AddRange(Array.ConvertAll<int, VehicleHash>(MemoryAccess.VehicleModels[i].ToArray(), item => (VehicleHash)item));
 			}
 			return allModels.ToArray();
+#endif
 		}
 
 		/// <summary>

--- a/code/client/clrcore/External/VehicleWheelCollection.cs
+++ b/code/client/clrcore/External/VehicleWheelCollection.cs
@@ -1,6 +1,7 @@
 using CitizenFX.Core.Native;
 using System;
 using System.Collections.Generic;
+using System.Security;
 
 #if MONO_V2
 namespace CitizenFX.FiveM
@@ -38,6 +39,9 @@ namespace CitizenFX.Core
 
 		public int Count
 		{
+#if MONO_V2
+			[SecuritySafeCritical] get => MemoryAccess.ReadIfNotNull(_owner.MemoryAddress, Game.Version >= GameVersion.v1_0_372_2_Steam ? 0xAA8 : 0xA88, 0);
+#else
 			get
 			{
 				if (_owner.MemoryAddress == IntPtr.Zero)
@@ -49,6 +53,7 @@ namespace CitizenFX.Core
 
 				return MemoryAccess.ReadInt(_owner.MemoryAddress + offset);
 			}
+#endif
 		}
 	}
 }

--- a/code/client/clrcore/Math/v2/Color.cs
+++ b/code/client/clrcore/Math/v2/Color.cs
@@ -115,7 +115,7 @@ namespace CitizenFX.Core
 		internal unsafe int ToArgb() { fixed(uint* p = argb) return (int)p[0]; }
 #endif
 
-		public override string ToString() => $"Color({R}, {G}, {B}, {A})";
+		public override string ToString() => $"Color({A}, {R}, {G}, {B})";
 
 		public unsafe bool Equals(Color other) => (uint)this == (uint)other;
 	}


### PR DESCRIPTION
fix(clrcore-v2): allow use of Entity's MemoryAccess methods
* Clean up, rectify CAS, and add other helper functions in previously copied v1 `MemoryAccess.cs`.
* Move CAS transparency guarantee to MemoryAccess users.
* Use new MemoryAccess helper functions in Entity methods.

fix(clrcore-v2): make StateBag.Global public
resolves thorium-cfx/mono_v2_get_started#9

fix(clrcore-v2): exports/reffunc fixes
* Fix (a)sync exports calls
* Properly handle latest exception fixes for Exports and RefFuncs
* Shrink serialized data to interface properly with other runtimes