### PR TITLE
tweak(clrcore-v2): KeyMapAttribute, shared library tweaks, and several bug fixes

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace CitizenFX.Core
 {
@@ -50,6 +51,45 @@ namespace CitizenFX.Core
 		{
 			Command = command;
 			Restricted = restricted;
+		}
+	}
+
+#if !IS_FXSERVER
+	/// <summary>
+	/// Register this method to listen for the given key <see cref="Command"/> when this <see cref="BaseScript"/> is loaded
+	/// </summary>
+	/// <remarks>This will bind the given input details to the command, triggering all commands registered as such.<br />Only works on <see cref="BaseScript"/> inherited class methods</remarks>
+#else
+	/// <summary>Does nothing on server side</summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public class KeyMapAttribute : Attribute
+	{
+		public string Command { get; }
+		public string Description { get; }
+		public string InputMapper { get; }
+		public string InputParameter { get; }
+
+		/// <inheritdoc cref="KeyMapAttribute"/>
+		/// <param name="command">The command to execute, and the identifier of the binding</param>
+		/// <param name="description">A description for in the settings menu</param>
+		/// <param name="inputMapper">The mapper ID to use for the default binding, e.g. keyboard</param>
+		/// <param name="inputParameter">The IO parameter ID to use for the default binding, e.g. f3</param>
+		public KeyMapAttribute(string command, string description, string inputMapper, string inputParameter)
+		{
+			Command = command;
+			Description = description;
+			InputMapper = inputMapper;
+			InputParameter = inputParameter;
+		}
+
+		/// <inheritdoc cref="KeyMapAttribute"/>
+		/// <remarks>Does not register the key mapping, so it works the same as <see cref="Command"/></remarks>
+		/// <param name="commandOnly">The command to execute, and the identifier of the binding</param>
+		public KeyMapAttribute(string commandOnly)
+		{
+			Command = commandOnly;
 		}
 	}
 

--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -228,11 +228,15 @@ namespace CitizenFX.Core
 		{
 			lock (m_tickList)
 			{
-				int index = m_tickList.FindIndex(th => th.Equals(tick));
-				if (index >= 0)
+				for (int i = 0; i < m_tickList.Count; ++i)
 				{
-					m_tickList[index].Stop();
-					m_tickList.RemoveAt(index);
+					var stored = m_tickList[i];
+					if (stored.m_coroutine.Method == tick.Method && stored.m_coroutine.Target == tick.Target)
+					{
+						stored.Stop();
+						m_tickList.RemoveAt(i);
+						break;
+					}
 				}
 			}
 		}

--- a/code/client/clrcore-v2/Interop/ExportsManager.cs
+++ b/code/client/clrcore-v2/Interop/ExportsManager.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security;
 using System.Runtime.CompilerServices;
 using CitizenFX.Core.Native;
 
 namespace CitizenFX.Core
 {
-	public delegate Coroutine<object> ExportFunc(params object[] args);
+	public delegate Coroutine<dynamic> ExportFunc(params object[] args);
 
 	internal static class ExportsManager
 	{

--- a/code/client/clrcore-v2/Interop/Types/CString.cs
+++ b/code/client/clrcore-v2/Interop/Types/CString.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Linq;
 using System.Security;
 using System.Runtime.InteropServices;
@@ -12,6 +11,7 @@ namespace CitizenFX.Core
 	/// </summary>
 	/// <remarks>In general don't use this type where you would normally use <see cref="string"/> in your .NET code, it needs to do conversion between UTF16 and UTF8 and is therefore slower.
 	/// This type and its conversions are more performant in regards to interop with native code (C++), and other runtimes, for these cases you may want to use this.</remarks>
+	[SecuritySafeCritical]
 	public sealed class CString : IComparable, IComparable<CString>, ICloneable, IEquatable<CString>/*, IConvertible, IEnumerable, IEnumerable<byte>*/
 	{
 		// Notes while working on this type:
@@ -21,6 +21,11 @@ namespace CitizenFX.Core
 		// Performance notes:
 		// 1. This type showed a speed increase of ~43% to ~47% when using strings while interfacing with C++ code,
 		// 2. Moving most methods to C++ and using InternalCall proved to be 1/3 slower, unless we build it into the runtime directly like `string`, which we highly unlikely do.
+
+		/// <summary>
+		/// An empty <see cref="CString"/> equivalent to <see cref="string.Empty"/>, null terminated for interop.
+		/// </summary>				
+		public static CString Empty { get; } = new CString(new byte[] { 0x0 });
 
 		[NonSerialized] internal readonly byte[] value;
 

--- a/code/client/clrcore-v2/Native/Native.cs
+++ b/code/client/clrcore-v2/Native/Native.cs
@@ -8,6 +8,7 @@ namespace CitizenFX.Core.Native
 	{
 		private static UIntPtr s_0xd233a168;
 		private static UIntPtr s_0x5fa79b0f;
+		private static UIntPtr s_0xd7664fd1;
 		private static UIntPtr s_0xe3551879;
 		private static UIntPtr s_0x1e86f206;
 		private static UIntPtr s_0xf4e2079d;
@@ -39,6 +40,19 @@ namespace CitizenFX.Core.Native
 			{
 				ulong* __data = stackalloc ulong[] { (ulong)p_commandName, (ulong)p_handler, N64.Val(restricted) };
 				ScriptContext.InvokeNative(ref s_0x5fa79b0f, 0x5fa79b0f, __data, 3); // REGISTER_COMMAND
+			}
+		}
+
+		[SecuritySafeCritical]
+		public static unsafe void RegisterKeyMapping(CString commandString, CString description, CString defaultMapper, CString defaultParameter)
+		{
+			fixed (void* p_commandString = commandString?.value
+				, p_description = description?.value
+				, p_defaultMapper = defaultMapper?.value
+				, p_defaultParameter = defaultParameter?.value)
+			{
+				ulong* __data = stackalloc ulong[] { (ulong)p_commandString, (ulong)p_description, (ulong)p_defaultMapper, (ulong)p_defaultParameter };
+				ScriptContext.InvokeNative(ref s_0xd7664fd1, 0xd7664fd1, __data, 4);
 			}
 		}
 

--- a/code/client/clrcore-v2/Native/Native.cs
+++ b/code/client/clrcore-v2/Native/Native.cs
@@ -94,7 +94,7 @@ namespace CitizenFX.Core.Native
 			{
 				ulong* __data = stackalloc ulong[] { (ulong)p_referenceIdentity };
 				ScriptContext.InvokeNative(ref s_0xf4e2079d, 0xf4e2079d, __data, 1); // DUPLICATE_FUNCTION_REFERENCE
-				return *(OutString*)__data;
+				return (byte[])*(OutString*)__data;
 			}
 		}
 

--- a/code/client/clrcore-v2/Native/Types/NativeTypes.cs
+++ b/code/client/clrcore-v2/Native/Types/NativeTypes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 
 namespace CitizenFX.Core.Native
 {
@@ -90,49 +91,5 @@ namespace CitizenFX.Core.Native
 
 		public unsafe object Deserialize() => MsgPackDeserializer.Deserialize(data, (long)size);
 		internal unsafe object[] DeserializeArray() => MsgPackDeserializer.DeserializeArray(data, (long)size);
-	}
-
-	[SecuritySafeCritical]
-	public readonly ref struct OutString
-	{
-#pragma warning disable 0649 // this type is reinterpreted i.e.: (OutString*)ptr
-		private unsafe readonly byte* data;
-#pragma warning restore 0649
-
-		/// <summary>
-		/// A managed string that holds a conerted copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
-		/// </summary>
-		/// <param name="str"></param>
-		[SecuritySafeCritical]
-		public static unsafe implicit operator string(in OutString str) => Marshal.PtrToStringAnsi((IntPtr)str.data);
-
-		/// <summary>
-		/// A managed string that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
-		/// </summary>
-		/// <param name="str"></param>
-		[SecuritySafeCritical]
-		public static unsafe implicit operator CString(in OutString str) => CString.Create(str.data);
-
-		/// <summary>
-		/// A managed byte[] that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
-		/// </summary>
-		/// <param name="str"></param>
-		[SecuritySafeCritical]
-		public static unsafe implicit operator byte[](in OutString str)
-		{
-			// TODO: PERF: check if moving this to an internal C++ backed function will be faster
-			byte* end = str.data;
-			if (end != null)
-			{
-				for (; *end != 0x0; ++end); // find the end, excluding the '\0'
-				long length = end - str.data;
-
-				byte[] array = new byte[length];
-				Marshal.Copy((IntPtr)str.data, array, 0, (int)length);
-				return array;
-			}
-
-			return null;
-		}
 	}
 }

--- a/code/client/clrcore-v2/Native/Types/OutString.cs
+++ b/code/client/clrcore-v2/Native/Types/OutString.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Security;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace CitizenFX.Core
+{
+	[SecuritySafeCritical]
+	public readonly ref struct OutString
+	{
+#pragma warning disable 0649 // this type is reinterpreted i.e.: (OutString*)ptr
+		private unsafe readonly byte* data;
+#pragma warning restore 0649
+
+		/// <summary>
+		/// A managed string that holds a conerted copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
+		/// </summary>
+		/// <param name="str"></param>
+		[SecuritySafeCritical]
+		public static unsafe implicit operator string(in OutString str) => Marshal.PtrToStringAnsi((IntPtr)str.data);
+
+		/// <summary>
+		/// A managed string that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
+		/// </summary>
+		/// <param name="str"></param>
+		[SecuritySafeCritical]
+		public static unsafe explicit operator CString(in OutString str) => CString.Create(str.data);
+
+		/// <summary>
+		/// A managed byte[] that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
+		/// </summary>
+		/// <param name="str"></param>
+		[SecuritySafeCritical]
+		public static unsafe explicit operator byte[](in OutString str)
+		{
+			// TODO: PERF: check if moving this to an internal C++ backed function will be faster
+			byte* end = str.data;
+			if (end != null)
+			{
+				for (; *end != 0x0; ++end) ; // find the end, excluding the '\0'
+				long length = end - str.data;
+
+				byte[] array = new byte[length];
+				Marshal.Copy((IntPtr)str.data, array, 0, (int)length);
+				return array;
+			}
+
+			return null;
+		}
+
+		public override string ToString() => (string)this;
+
+		public CString ToCString() => (CString)this;
+
+		/// <summary>
+		/// Retrieves a substring from this string. Starting at the specified <paramref name="startIndex"/> in strides of <see cref="byte"/>
+		/// </summary>
+		/// <param name="startIndex">Character index to start the new string with</param>
+		/// <param name="length">Amount of characters requested, after <paramref name="startIndex"/></param>
+		/// <returns><see cref="string"/> starting from <paramref name="startIndex"/>, <see cref="string.Empty"/> if we passed the end, or <see langword="null"/></returns>
+		[SecuritySafeCritical]
+		public unsafe string SubString(uint startIndex, uint length = uint.MaxValue)
+		{
+			byte* end = data;
+			if (end == null)
+			{
+				return null;
+			}
+
+			for (; *end != 0x0; ++end); // find the end, i.e.: '\0'
+			long maxLength = end - data;
+
+			if (startIndex == maxLength)
+			{
+				return string.Empty;
+			}
+			else if (startIndex > maxLength)
+			{
+				throw new ArgumentOutOfRangeException(nameof(startIndex));
+			}
+
+			long copyLength = Math.Min(maxLength - startIndex, length);
+			return Encoding.UTF8.GetString(data + startIndex, (int)copyLength);
+		}
+
+		/// <summary>
+		/// Retrieves a substring from this string. Starting at the specified <paramref name="startIndex"/> in strides of <see cref="byte"/>
+		/// </summary>
+		/// <param name="startIndex">Character index to start the new string with</param>
+		/// <param name="length">Amount of characters requested, after <paramref name="startIndex"/></param>
+		/// <returns><see cref="CString"/> starting from <paramref name="startIndex"/>, <see cref="CString.Empty"/> if we passed the end, or <see langword="null"/></returns>
+		[SecuritySafeCritical]
+		public unsafe CString SubCString(uint startIndex, uint length = uint.MaxValue)
+		{
+			byte* end = data;
+			if (end == null)
+			{
+				return null;
+			}
+
+			for (; *end != 0x0; ++end) ; // find the end, i.e.: '\0'
+			long maxLength = end - data;
+
+			if (startIndex == maxLength)
+			{
+				return CString.Empty;
+			}
+			else if (startIndex > maxLength)
+			{
+				throw new ArgumentOutOfRangeException(nameof(startIndex));
+			}
+
+			long copyLength = Math.Min(maxLength - startIndex, length);
+			return CString.Create(data + startIndex, (uint)copyLength);
+		}
+	}
+}

--- a/code/premake5.lua
+++ b/code/premake5.lua
@@ -551,12 +551,12 @@ if _OPTIONS['game'] ~= 'launcher' then
 		clr 'Unsafe'
 		files {
 			'client/clrcore-v2/*.cs',
-			'client/clrcore-v2/Coroutine/*.cs',
-			'client/clrcore-v2/Interop/*.cs',
-			'client/clrcore-v2/Math/v2/*.cs',
-			'client/clrcore-v2/Native/*.cs',
-			'client/clrcore-v2/Shared/*.cs',
-			'client/clrcore-v2/System/*.cs',
+			'client/clrcore-v2/Coroutine/**.cs',
+			'client/clrcore-v2/Interop/**.cs',
+			'client/clrcore-v2/Math/v2/**.cs',
+			'client/clrcore-v2/Native/**.cs',
+			'client/clrcore-v2/Shared/**.cs',
+			'client/clrcore-v2/System/**.cs',
 			
 			-- Math, cherry pick from v1 files for now
 			'client/clrcore-v2/Math/GameMath.cs',


### PR DESCRIPTION
feat(clrcore-v2): KeyMapAttribute
Support for:
* `[KeyMap("Command", description, inputMapper, inputParameter)]`
* `[KeyMap("+Command", description, inputMapper, inputParameter)]`
* `[KeyMap("-Command")]` non-key-binding

tweak(clrcore-v2): shared library update
`ServerScript` & `ClientScript` are now present in both client and server environments, but will only load in their respective environment.

fix(clrcore-v2): several bug fixes
* `Tick -=` will now properly remove previous registered tick methods.
* Small file/folder reorganization and allows recursive files in v2 folders to be included.
* Exports return `dynamic` enabling compiler code generation for dynamic types.
* `OutString` reduced to 1 implicit conversion operator, allowing the compiler to use that one for `(object)` casts and enabling use-cases like: `Debug.WriteLine($"Game name: {Natives.GetGameName()}");`.

resolves thorium-cfx/mono_v2_get_started#10, resolves thorium-cfx/mono_v2_get_started#11, resolves thorium-cfx/mono_v2_get_started#12