### PR TITLE
Day one patch for b2944 support

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1898,6 +1898,11 @@ struct CObjectCreationDataNode
 		state.buffer.WriteBit(false);
 		state.buffer.WriteBit(false);
 
+		if (Is2944())
+		{
+			state.buffer.WriteBit(false);
+		}
+
 		return true;
 	}
 
@@ -1995,7 +2000,18 @@ struct CObjectCreationDataNode
 
 		bool unk24 = state.buffer.ReadBit();
 
-		// ...more data in b2944
+		if (Is2944())
+		{
+			bool unk25 = state.buffer.ReadBit();
+
+			if (unk25)
+			{
+				auto unk26 = state.buffer.Read<int>(32);
+				auto unk27 = state.buffer.Read<int>(32);
+				auto unk28 = state.buffer.Read<int>(32);
+				auto unk29 = state.buffer.ReadBit();
+			}
+		}
 
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4539,6 +4539,12 @@ void CExplosionEvent::Parse(rl::MessageBuffer& buffer)
 	f189 = buffer.Read<uint8_t>(1);
 	isInvisible = buffer.Read<uint8_t>(1);
 	f126 = buffer.Read<uint8_t>(1);
+
+	if (Is2944())
+	{
+		auto unk2944 = buffer.Read<uint8_t>(1);
+	}
+
 	f241 = buffer.Read<uint8_t>(1);
 	f243 = buffer.Read<uint8_t>(1); // 1604+
 
@@ -4785,7 +4791,7 @@ void CWeaponDamageEvent::Parse(rl::MessageBuffer& buffer)
 
 		if (_f92)
 		{
-			buffer.Read<uint8_t>(4);
+			buffer.Read<uint8_t>(Is2802() ? 5 : 4);
 		}
 	}
 

--- a/code/components/gta-streaming-five/src/PatchPedRandomVariation.cpp
+++ b/code/components/gta-streaming-five/src/PatchPedRandomVariation.cpp
@@ -1,0 +1,37 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include "CrossBuildRuntime.h"
+
+//
+// This code patches an edge case when running `SET_PED_RANDOM_COMPONENT_VARIATION` native may crash the game.
+// Crash happens because there's no checks that validates component variation unlike in other natives.
+// In game build 2944.0 R* has added gen9 exclusive content into a shared dlc (i.e. not *-g9ec).
+// We're adding validation check to the function that set ped component variation.
+//
+
+static hook::cdecl_stub<bool(void*, int, int)> _doesPedComponentDrawableExist([]()
+{
+	return xbr::IsGameBuildOrGreater<2699>() ? hook::get_call(hook::get_pattern("E8 ? ? ? ? 84 C0 0F 84 ? ? ? ? 48 8B 57 48")) : nullptr;
+});
+
+static char (*g_origSetStreamedPedComponentVariation)(void*, void*, void*, int, int, int, int, int, int, char);
+
+static char SetStreamedPedComponentVariation(void* ped, void* unk1, void* unk2, int compId, int drawableId, int unk3, int textureId, int paletteId, int unk4, char unk5)
+{
+	if (!_doesPedComponentDrawableExist(ped, compId, drawableId))
+	{
+		return false;
+	}
+
+	return g_origSetStreamedPedComponentVariation(ped, unk1, unk2, compId, drawableId, unk3, textureId, paletteId, unk4, unk5);
+}
+
+static HookFunction hookFunctionMetadataDep([]
+{
+	if (xbr::IsGameBuildOrGreater<2944>())
+	{
+		auto location =  hook::get_pattern("E8 ? ? ? ? EB 24 89 44 24 38");
+		hook::set_call(&g_origSetStreamedPedComponentVariation, location);
+		hook::call(location, SetStreamedPedComponentVariation);	
+	}
+});

--- a/code/components/scripthookv/src/VishCompat.cpp
+++ b/code/components/scripthookv/src/VishCompat.cpp
@@ -272,11 +272,13 @@ enum eGameVersion : int
 	VER_1_0_2612_1_NOSTEAM = 74,
 	VER_1_0_2699_0_NOSTEAM = 78,
 	VER_1_0_2802_0_NOSTEAM = 80,
+	VER_1_0_2944_0_NOSTEAM = 83,
 };
 
 // ScriptHookV uses incremental numbers instead of build
 DLL_EXPORT eGameVersion getGameVersion()
 {
+	if (xbr::IsGameBuildOrGreater<2944>()) return VER_1_0_2944_0_NOSTEAM;
 	if (xbr::IsGameBuildOrGreater<2802>()) return VER_1_0_2802_0_NOSTEAM;
 	if (xbr::IsGameBuildOrGreater<2699>()) return VER_1_0_2699_0_NOSTEAM;
 	if (xbr::IsGameBuildOrGreater<2612>()) return VER_1_0_2612_1_NOSTEAM;

--- a/data/client/citizen/common/data/ui/pausemenu.xml
+++ b/data/client/citizen/common/data/ui/pausemenu.xml
@@ -189,6 +189,14 @@
 			</MenuDisplayOptions>
 		</Item>
     
+		<Item>
+			<MenuOption>MENU_OPTION_CONTROLS_HOLD_SPRINT</MenuOption>
+			<MenuDisplayOptions>
+				<Item> <cTextId>MO_TAP_SPRINT</cTextId> </Item>
+				<Item> <cTextId>MO_HOLD_SPRINT</cTextId> </Item>
+			</MenuDisplayOptions>
+		</Item>
+
     <Item>
 			<MenuOption>MENU_OPTION_DISPLAY_MEASUREMENT</MenuOption>
 			
@@ -2296,6 +2304,7 @@
 				<Item> <cTextId>MO_CTRL_CONTEXT</cTextId>	<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_CONTROLS_CONTEXT</MenuPref> 		<MenuOption>MENU_OPTION_CONTROLS_CONTEXT</MenuOption>	 <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> </Item>
 				<Item> <cTextId>MO_TAR</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_TARGET_CONFIG</MenuPref> 		<MenuOption>MENU_OPTION_DISPLAY_TARGET_CONFIG</MenuOption>	 <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> <Flags>InitiallyDisabled</Flags> <Contexts>*ALL*,InMP</Contexts></Item>
 				<Item> <cTextId>MO_TAR</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_TARGET_CONFIG</MenuPref> 		<MenuOption>MENU_OPTION_DISPLAY_TARGET_CONFIG</MenuOption>	 <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> <Contexts>*NONE*,InMP</Contexts></Item>
+				<Item> <cTextId>MO_SPRINT</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_HOLD_SPRINT</MenuPref> 		<MenuOption>MENU_OPTION_CONTROLS_HOLD_SPRINT</MenuOption>	 <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> <Contexts>*NONE*,InSP,*ALL*,b2944</Contexts></Item>
 				<Item> <cTextId>MO_VIB</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_VIBRATION</MenuPref> 			<MenuOption>MENU_OPTION_DISPLAY_ON_OFF</MenuOption>	  <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> </Item>
 				<Item> <cTextId>MO_INV</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_INVERT_LOOK</MenuPref> 			<MenuOption>MENU_OPTION_DISPLAY_INVERT_LOOK</MenuOption>   <MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> </Item>
 				<Item> <cTextId>MO_CTY</cTextId>		<MenuAction>MENU_OPTION_ACTION_PREF_CHANGE</MenuAction>		<MenuPref>PREF_CONTROL_CONFIG</MenuPref>		<MenuOption>MENU_OPTION_DISPLAY_CONTROL_CONFIG</MenuOption>	<MenuUniqueId>MENU_UNIQUE_ID_SETTINGS_LIST</MenuUniqueId> <Contexts>*NONE*,RemotePlay</Contexts></Item>

--- a/ext/native-decls/IsPedComponentVariationGen9Exclusive.md
+++ b/ext/native-decls/IsPedComponentVariationGen9Exclusive.md
@@ -1,0 +1,33 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE
+
+```c
+bool IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE(Ped ped, int componentId, int drawableId);
+```
+
+## Examples
+```lua
+local ped = PlayerPedId()
+
+for component = 0, 12 do
+  local count = GetNumberOfPedDrawableVariations(ped, component)
+
+  for drawable = 0, count - 1 do
+    if IsPedComponentVariationGen9Exclusive(ped, component, drawable) then
+      print("Component " .. component .. " drawable " .. drawable .. " is a gen9 exclusive, skip!")
+    end
+  end
+end
+```
+
+## Parameters
+* **ped**: The target ped.
+* **componentId**: The component id.
+* **drawableId**: The drawable id.
+
+## Return value
+Whether or not the ped component variation is a gen9 exclusive (stub assets).


### PR DESCRIPTION
- Tweaked server game state data nodes and net events.
- Added new gamepad sprint option in `pausemenu.xml`.
- Scripthook game version enum entry.
- Fixed random crash when using `SET_PED_RANDOM_COMPONENT_VARIATION`.
- Added `IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE` native allowing to "filter" stub gen9ec assets that R* added into a main dlcpack.
