### PR TITLE
fix(sdk): don't instantiate resmon when there's no resource manager

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -510,6 +510,11 @@ static InitFunction initFunction([]()
 					std::vector<std::tuple<std::string, double, double, int64_t, int64_t>> resourceDatasClean;
 					for (const auto& data : resourceDatas)
 					{
+						if (std::get<0>(data) == "_cfx_internal")
+						{
+							continue;
+						}
+
 						resourceDatasClean.push_back(tuple_slice<0, std::tuple_size_v<decltype(resourceDatasClean)::value_type>>(data));
 					}
 

--- a/code/components/citizen-server-fxdk/src/SdkIpc.cpp
+++ b/code/components/citizen-server-fxdk/src/SdkIpc.cpp
@@ -754,6 +754,11 @@ namespace fxdk
 
 		m_timer->on<uvw::TimerEvent>([this, ipc](const uvw::TimerEvent& evt, uvw::TimerHandle&)
 		{
+			if (!fx::ResourceManager::GetCurrent())
+			{
+				return;
+			}
+
 			if (!m_resourceMonitor)
 			{
 				m_resourceMonitor = std::make_unique<fx::ResourceMonitor>();
@@ -764,6 +769,11 @@ namespace fxdk
 			std::vector<std::tuple<std::string, double, double, int64_t, int64_t>> resourceDatasClean;
 			for (const auto& data : resourceDatas)
 			{
+				if (std::get<0>(data) == "_cfx_internal")
+				{
+					continue;
+				}
+
 				resourceDatasClean.push_back(tuple_slice<0, std::tuple_size_v<decltype(resourceDatasClean)::value_type>>(data));
 			}
 


### PR DESCRIPTION
And ignore the `_cfx_internal` resource for sdk resmon