### PR TITLE
fix(convar): add ConVar_Internal and mark sv_icon and version as internal

### DIFF
--- a/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
@@ -158,8 +158,8 @@ void InfoHttpHandlerComponentLocals::AttachToObject(fx::ServerInstanceBase* inst
 	m_instance = instance;
 	ivVar = instance->AddVariable<int>("sv_infoVersion", ConVar_ServerInfo, 0);
 	maxClientsVar = instance->AddVariable<int>("sv_maxClients", ConVar_ServerInfo, 30);
-	iconVar = instance->AddVariable<std::string>("sv_icon", ConVar_None, "");
-	versionVar = instance->AddVariable<std::string>("version", ConVar_None, "FXServer-" GIT_DESCRIPTION);
+	iconVar = instance->AddVariable<std::string>("sv_icon", ConVar_Internal, "");
+	versionVar = instance->AddVariable<std::string>("version", ConVar_Internal, "FXServer-" GIT_DESCRIPTION);
 	crashCmd = instance->AddCommand("_crash", []()
 	{
 		*(volatile int*)0 = 0;


### PR DESCRIPTION
Someone accidentally `sv_icon` instead of `load_server_icon`, not knowing that `sv_icon` was internal and doesn't have any validation logic.

This adds `ConVar_Internal` to deal with this and block modification to ConVars that shouldn't be writable.

It should be noted this makes any value that wants to set its value have to use `SetRawValue` but for this use case should be fine.

[Here is the thread in the FiveM discord](https://discord.com/channels/192358910387159041/1122205927794298920/1122206106937208882) or 1122205927794298920 in case the link doesn't work.