### PR TITLE
fix(extra/patches): fix values not being reset on server disconnect

### DIFF
--- a/code/client/citicore/console/Console.Variables.cpp
+++ b/code/client/citicore/console/Console.Variables.cpp
@@ -230,6 +230,20 @@ int ConsoleVariableManager::GetEntryFlags(const std::string& name)
 	return 0;
 }
 
+int ConsoleVariableManager::GetEntryDefaultFlags(const std::string& name)
+{
+	std::unique_lock<std::shared_mutex> lock(m_mutex);
+
+	auto it = m_entries.find(name);
+
+	if (it != m_entries.end())
+	{
+		return it->second.defaultFlags;
+	}
+
+	return 0;
+}
+
 void ConsoleVariableManager::ForAllVariables(const TVariableCB& callback, int flagMask)
 {
 	// store first so we don't have to deal with recursive locks

--- a/code/client/citicore/console/Console.Variables.h
+++ b/code/client/citicore/console/Console.Variables.h
@@ -121,6 +121,8 @@ public:
 
 	virtual int GetEntryFlags(const std::string& name);
 
+	virtual int GetEntryDefaultFlags(const std::string& name);
+
 	virtual void ForAllVariables(const TVariableCB& callback, int flagMask = 0xFFFFFFFF);
 
 	virtual void RemoveVariablesWithFlag(int flags);
@@ -147,6 +149,8 @@ private:
 	{
 		std::string name;
 
+		int defaultFlags;
+
 		int flags;
 
 		THandlerPtr variable;
@@ -154,7 +158,7 @@ private:
 		int token;
 
 		inline Entry(const std::string& name, int flags, const THandlerPtr& variable, int token)
-		    : name(name), flags(flags), variable(variable), token(token)
+			: name(name), flags(flags), variable(variable), token(token), defaultFlags(flags)
 		{
 		}
 	};

--- a/code/components/extra-natives-five/src/PatchNetworkChecks.cpp
+++ b/code/components/extra-natives-five/src/PatchNetworkChecks.cpp
@@ -62,6 +62,7 @@ static HookFunction hookFunction([]()
 
 	OnKillNetworkDone.Connect([]()
 	{
+		se::ScopedPrincipal principalScopeInternal(se::Principal{ "system.internal" });
 		enableFlyThroughWindscreen.GetHelper()->SetValue("false");
 		enablePlayerRagdollOnCollision.GetHelper()->SetValue("false");
 		enablePlayerJumpRagdollControl.GetHelper()->SetValue("false");

--- a/code/components/glue/src/BindNetLibrary.cpp
+++ b/code/components/glue/src/BindNetLibrary.cpp
@@ -106,13 +106,15 @@ static InitFunction initFunction([] ()
 				console::GetDefaultContext()->GetVariableManager()->Unregister(convarName);
 			}
 
+			auto varManager = console::GetDefaultContext()->GetVariableManager();
 			// Revert values modified by server back to their old values
 			for (const std::string& convarName : convarsModifiedByServer)
 			{
-				auto convar = console::GetDefaultContext()->GetVariableManager()->FindEntryRaw(convarName);
-				if (convar)
+				auto convar = varManager->FindEntryRaw(convarName);
+				// We don't want to reset convars that are defaulted to ConVar_Replicated (i.e. game_enableFlyThroughWindscreen)
+				if (convar && !(varManager->GetEntryDefaultFlags(convarName) & ConVar_Replicated))
 				{
-					console::GetDefaultContext()->GetVariableManager()->RemoveEntryFlags(convarName, ConVar_Replicated);
+					varManager->RemoveEntryFlags(convarName, ConVar_Replicated);
 					convar->SetValue(convar->GetOfflineValue());
 				}
 			}


### PR DESCRIPTION
This fixes not properly resetting `game_*` ConVars on disconnect.

This also fixes another bug found when trying to fix this that improperly resets all `ConVar_Replicated` flags even if the ConVar had it as its default, which allowed the client to change `game_*` natives on servers that don't have it set by default.