### PR TITLE
Fix crashes during streaming objects removal on FiveM b2802+

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.cpp
@@ -1247,8 +1247,8 @@ static HookFunction hookFunction{[] ()
 		}
 	}
 
-	// fix crash caused by lack of nullptr check for CWeaponInfo, introduced as a R* bug in 2545
-	if (xbr::IsGameBuildOrGreater<2545>())
+	// fix crash caused by lack of nullptr check for CWeaponInfo, introduced as a R* bug in 2545.0, fixed in 2628.2
+	if (xbr::IsGameBuildOrGreater<2545>() && !xbr::IsGameBuildOrGreater<2628>())
 	{
 		auto location = hook::get_pattern("41 81 7F 10 F3 9C CD 45");
 


### PR DESCRIPTION
Fixes R* bug (null pointer dereference) introduced in 2802.0 (and not fixed in 2944.0) related to the new RTTI system. One of the most popular crashes on these builds.
Also disable another null pointer dereference crash fix (on newest builds) since it was fixed by R* 🎉