### PR TITLE
Add `SetWeaponsNoAimBlocking` for FiveM

### DIFF
--- a/ext/native-decls/SetWeaponsNoAimBlocking.md
+++ b/ext/native-decls/SetWeaponsNoAimBlocking.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_WEAPONS_NO_AIM_BLOCKING
+
+```c
+void SET_WEAPONS_NO_AIM_BLOCKING(BOOL state);
+```
+
+Disables weapons aim blocking due to environment for local player.
+For non-player peds [SET_PED_ENABLE_WEAPON_BLOCKING](#_0x97A790315D3831FD) can be used.
+
+## Parameters
+* **state**: On/Off


### PR DESCRIPTION
This native is meant to the way for server creators to disable builtin weapons aim blocking mechanic. For non-player peds the `SET_PED_ENABLE_WEAPON_BLOCKING` native can be used. However, it won't work for local player ped as the logic for this specific case is different. The "weapon blocking" state is synchronized between players. This native could be useful for specific some gamemodes and content creators making custom weapons (used like `weapon_digiscanner`, `weapon_fireextinguisher`, etc).