### PR TITLE
fix(clrcore-v2): native long/ulong types, Coroutine.Run, OutString cast, and transparency issue

### DIFF
--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -181,7 +181,7 @@ namespace CitizenFX.Core
 		/// <param name="entry">this event handler set</param>
 		/// <param name="deleg">delegate to register</param>
 		/// <returns>itself</returns>
-		public static EventHandlerSet operator +(EventHandlerSet entry, Delegate deleg) => entry.Add(Func.Create(deleg.Target, deleg.Method));
+		public static EventHandlerSet operator +(EventHandlerSet entry, Delegate deleg) => entry.Add(Func.Create(deleg));
 
 		/// <summary>
 		/// Unregister an event handler

--- a/code/client/clrcore-v2/Interop/Types/CString.cs
+++ b/code/client/clrcore-v2/Interop/Types/CString.cs
@@ -315,6 +315,13 @@ namespace CitizenFX.Core
 		/// <param name="str">null-terminated c-string</param>
 		public static explicit operator string(CString str) => str?.ToString();
 
+		/// <summary>
+		/// Copy <see cref="OutString"/> into a null-terminated c-string
+		/// </summary>
+		/// <param name="str">OutString to copy</param>
+		/// <!-- Does put a dependency on OutString -->
+		public static implicit operator CString(OutString str) => str.ToCString();
+
 		#endregion
 
 		#region ASCII operations

--- a/code/client/clrcore-v2/Native/Types/OutString.cs
+++ b/code/client/clrcore-v2/Native/Types/OutString.cs
@@ -20,13 +20,6 @@ namespace CitizenFX.Core
 		public static unsafe implicit operator string(in OutString str) => Marshal.PtrToStringAnsi((IntPtr)str.data);
 
 		/// <summary>
-		/// A managed string that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
-		/// </summary>
-		/// <param name="str"></param>
-		[SecuritySafeCritical]
-		public static unsafe explicit operator CString(in OutString str) => CString.Create(str.data);
-
-		/// <summary>
 		/// A managed byte[] that holds a copy of the unmanaged ANSI string. If ptr is null, the method returns a null string.
 		/// </summary>
 		/// <param name="str"></param>
@@ -50,7 +43,12 @@ namespace CitizenFX.Core
 
 		public override string ToString() => (string)this;
 
-		public CString ToCString() => (CString)this;
+		/// <summary>
+		/// Creates a null terminated C-string out of the returned string
+		/// </summary>
+		/// <returns>null terminated C-string</returns>
+		[SecuritySafeCritical]
+		public unsafe CString ToCString() => CString.Create(data);
 
 		/// <summary>
 		/// Retrieves a substring from this string. Starting at the specified <paramref name="startIndex"/> in strides of <see cref="byte"/>

--- a/ext/natives/codegen_out_cs_v2.lua
+++ b/ext/natives/codegen_out_cs_v2.lua
@@ -218,6 +218,8 @@ local overrideParamTypes = {
 		['Hash'] = { 'uint', false },
 		['Any'] = { 'long', false },
 		['Vector3'] = { 'Vector3', false },
+		['long'] = { 'long', false },
+		['ulong'] = { 'ulong', false },
 	},
 	[true] = -- by ref
 	{
@@ -236,6 +238,8 @@ local overrideReturnTypes = {
 	['Vector3'] = 'Vector3',
 	
 	['ulong*'] = 'ulong', -- compat file uses ulong* instead of Any*
+	['long'] = 'long',
+	['ulong'] = 'ulong',
 }
 
 -- Explanation:


### PR DESCRIPTION
fix(clrcore-v2): use (u)long types on natives when requested
* Adds overrides for (u)long types for v2 native generation to compensate for `type.nativeType` being just `int` on our 64 bit integer friends.

fix(clrcore-v2): Coroutine.Run, OutString cast, and transparency issue
* Only run Coroutine.Run(...) functions directly when we're on the main thread, otherwise we run it next frame.
* Fix return type of Coroutine.Run<T>(...);
* Move OutString -> CString conversion operator.
* Fix CAS transparency issue with EventHandlerSet's + operator for `Delegate` types (don't know why SecAnnotate didn't pick up on this).

resolves thorium-cfx/mono_v2_get_started#22