### PR TITLE
feat(clrcore-v2): command parameter remapping

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -47,6 +47,10 @@ namespace CitizenFX.Core
 	{
 		public string Command { get; }
 		public bool Restricted { get; set; }
+
+		/// <returns></returns>
+		/// <inheritdoc cref="Func.ConstructCommandRemapped(object, System.Reflection.MethodInfo)"/>
+		public bool RemapParameters { get; set; } = false;
 		public CommandAttribute(string command, bool restricted = false)
 		{
 			Command = command;
@@ -70,6 +74,10 @@ namespace CitizenFX.Core
 		public string Description { get; }
 		public string InputMapper { get; }
 		public string InputParameter { get; }
+
+		/// <returns></returns>
+		/// <inheritdoc cref="Func.ConstructCommandRemapped(object, System.Reflection.MethodInfo)"/>
+		public bool RemapParameters { get; set; } = false;
 
 		/// <inheritdoc cref="KeyMapAttribute"/>
 		/// <param name="command">The command to execute, and the identifier of the binding</param>

--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -25,8 +25,7 @@ namespace CitizenFX.Core
 		private readonly List<CoroutineRepeat> m_tickList = new List<CoroutineRepeat>();
 
 		/// <summary>
-		/// An event containing callbacks to attempt to schedule on every game tick.
-		/// A callback will only be rescheduled once the associated task completes.
+		/// A method to be scheduled on every game tick, do note that they'll only be rescheduled for the next frame once the method returns.
 		/// </summary>
 		protected event Func<Coroutine> Tick
 		{
@@ -95,11 +94,11 @@ namespace CitizenFX.Core
 								break;
 
 							case CommandAttribute command:
-								RegisterCommand(command.Command, Func.Create(this, method), command.Restricted);
+								RegisterCommand(command.Command, Func.CreateCommand(this, method, command.RemapParameters), command.Restricted);
 								break;
 #if !IS_FXSERVER
 							case KeyMapAttribute keyMap:
-								RegisterKeyMap(keyMap.Command, keyMap.Description, keyMap.InputMapper, keyMap.InputParameter, Func.Create(this, method));
+								RegisterKeyMap(keyMap.Command, keyMap.Description, keyMap.InputMapper, keyMap.InputParameter, Func.CreateCommand(this, method, keyMap.RemapParameters));
 								break;
 #endif
 							case ExportAttribute export:
@@ -265,7 +264,7 @@ namespace CitizenFX.Core
 
 		#endregion
 
-		#region Events Handlers
+		#region Events & Command registration
 		internal void RegisterEventHandler(string eventName, DynFunc deleg, Binding binding = Binding.Local) => EventHandlers[eventName].Add(deleg, binding);
 		internal void UnregisterEventHandler(string eventName, DynFunc deleg) => EventHandlers[eventName].Remove(deleg);
 

--- a/code/client/clrcore-v2/Remote.cs
+++ b/code/client/clrcore-v2/Remote.cs
@@ -25,9 +25,8 @@ namespace CitizenFX.Core
 				m_playerId = null;
 		}
 
-		internal Remote(Binding binding, string playerId) : this(playerId)
-		{
-		}
+		internal Remote(Binding binding, string playerId) : this(playerId) { }
+		internal static Remote Create(ushort remote) => new Remote(remote.ToString());
 
 		internal static bool IsRemoteInternal(Remote remote) => remote.m_playerId != null;
 
@@ -38,8 +37,10 @@ namespace CitizenFX.Core
 		internal bool m_isServer;
 
 		internal Remote(Binding binding, string playerId) => m_isServer = binding == Binding.Remote;
-
 		internal Remote(bool isServer) => m_isServer = isServer;
+		internal Remote(ushort remote) => m_isServer = remote != ushort.MaxValue; // TODO: what's server id?
+
+		internal static Remote Create(ushort remote) => new Remote(remote);
 
 		internal static bool IsRemoteInternal(Remote remote) => remote.m_isServer;
 


### PR DESCRIPTION
Allows commands and keymappers to create a different DynFunc that remaps and converts the arguments into different parameters. Can be requested by using: `[Command("...", RemapParameters = true)]`

Note that this isn't yet tested thoroughly.

resolves thorium-cfx/mono_v2_get_started#19