### PR TITLE
Clamp attribute index in `SET_PED_COMBAT_ATTRIBUTES` for FiveM and RedM

### DIFF
--- a/code/components/gta-core-five/include/RageParser.h
+++ b/code/components/gta-core-five/include/RageParser.h
@@ -126,6 +126,7 @@ namespace rage
 			parEnumDefinition* enumData;
 			uint32_t arrayElemCount;
 		};
+		uint16_t enumElemCount; // +48 for enum defs
 	};
 
 	class parMember

--- a/code/components/gta-core-five/include/RageParser.h
+++ b/code/components/gta-core-five/include/RageParser.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "ComponentExport.h"
 #include <atArray.h>
 
-#ifdef COMPILING_GTA_CORE_FIVE
-#define GTA_CORE_EXPORT DLL_EXPORT
-#else
-#define GTA_CORE_EXPORT DLL_IMPORT
+#ifdef GTA_FIVE
+#define GTA_CORE_TARGET GTA_CORE_FIVE
+#elif IS_RDR3
+#define GTA_CORE_TARGET GTA_CORE_RDR3
 #endif
 
 namespace rage
@@ -45,7 +46,12 @@ namespace rage
 		Half = 30,
 		Int64 = 31,
 		UInt64 = 32,
-		Double = 33
+		Double = 33,
+#ifdef IS_RDR3
+		Guid = 34,
+		Vec2f = 35,
+		QuatV = 36,
+#endif
 	};
 
 	struct parEnumField
@@ -143,13 +149,21 @@ namespace rage
 	public:
 		virtual ~parStructure() = default;
 
+#if IS_RDR3
+		uint8_t m_critSection[0x28];
+#endif
+
 		uint32_t m_nameHash; // +8
 
 		char m_pad[4]; // +12
 
 		parStructure* m_baseClass; // +16
 
+#if IS_RDR3
+		char m_pad2[32]; // +24
+#else
 		char m_pad2[24]; // +24
+#endif
 
 		atArray<rage::parMember*> m_members; // +48
 
@@ -168,7 +182,9 @@ namespace rage
 		void(*m_delete)(void*);
 	};
 
-	GTA_CORE_EXPORT rage::parStructure* GetStructureDefinition(const char* structType);
+	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(const char* structType);
 
-	GTA_CORE_EXPORT rage::parStructure* GetStructureDefinition(uint32_t structHash);
+	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(uint32_t structHash);
 }
+
+#undef GTA_CORE_TARGET

--- a/code/components/gta-core-rdr3/component.lua
+++ b/code/components/gta-core-rdr3/component.lua
@@ -8,5 +8,6 @@ return function()
 	files {
 		'components/gta-core-five/src/GameAudioState.cpp',
 		'components/gta-core-rdr3/include/GameAudioState.h',
+		'components/gta-core-five/include/RageParser.h',
 	}
 end

--- a/code/components/gta-core-rdr3/src/RageParser.cpp
+++ b/code/components/gta-core-rdr3/src/RageParser.cpp
@@ -1,0 +1,28 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <RageParser.h>
+
+static void** g_parser;
+
+static hook::cdecl_stub<rage::parStructure* (void* parser, uint32_t)> _parser_getStructure([]()
+{
+	return hook::get_call(hook::get_pattern("8B 10 E8 ? ? ? ? 8A 48 50", 2));
+});
+
+namespace rage
+{
+	DLL_EXPORT rage::parStructure* GetStructureDefinition(const char* structType)
+	{
+		return _parser_getStructure(*g_parser, HashRageString(structType));
+	}
+
+	DLL_EXPORT rage::parStructure* GetStructureDefinition(uint32_t structHash)
+	{
+		return _parser_getStructure(*g_parser, structHash);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	g_parser = hook::get_address<void**>(hook::get_pattern("8B 10 E8 ? ? ? ? 8A 48 50", -4));
+});

--- a/code/components/rage-scripting-rdr3/src/scrEngine.cpp
+++ b/code/components/rage-scripting-rdr3/src/scrEngine.cpp
@@ -249,12 +249,12 @@ static uint64_t MapNative(uint64_t hash)
 
 bool RegisterNativeOverride(uint64_t hash, scrEngine::NativeHandler handler)
 {
-	NativeRegistration*& registration = registrationTable[(hash & 0xFF)];
-
 	uint64_t origHash = hash;
 
 	// remove cached fastpath native
 	g_fastPathMap.erase(NativeHash{ origHash });
+
+	hash = MapNative(hash);
 
 	NativeRegistration* table = registrationTable[hash & 0xFF];
 
@@ -281,16 +281,16 @@ bool RegisterNativeOverride(uint64_t hash, scrEngine::NativeHandler handler)
 
 void RegisterNative(uint64_t hash, scrEngine::NativeHandler handler)
 {
-	hash = MapNative(hash);
-
-	// re-implemented here as the game's own function is obfuscated
-	NativeRegistration*& registration = registrationTable[(hash & 0xFF)];
-
 	// see if there's somehow an entry by this name already
 	if (RegisterNativeOverride(hash, handler))
 	{
 		return;
 	}
+
+	hash = MapNative(hash);
+
+	// re-implemented here as the game's own function is obfuscated
+	NativeRegistration*& registration = registrationTable[(hash & 0xFF)];
 
 	if (registration->getNumEntries() == 7)
 	{


### PR DESCRIPTION
See https://github.com/citizenfx/natives/pull/892

Additional changes related to FiveM:
- Reworked rage parser code to use the modern component exporting approach.
- Added `enumElemCount` to `parMemberDefinition` to avoid manual iterations.

In order to make it also work in RedM, these additional changes was made:
- Implemented side-by-side rage parser support for RDR3.
- Fixed a bug that was breaking native handlers overriding.