### PR TITLE
fix(extra-natives/five): relaxed entity fire id cleanup

### DIFF
--- a/code/components/extra-natives-five/src/NativeFixes.cpp
+++ b/code/components/extra-natives-five/src/NativeFixes.cpp
@@ -239,7 +239,7 @@ void FreeOrphanFireEntries()
 {
 	for (auto& i : *g_fireInstances)
 	{
-		if (!i.entity() && i.flags() & 0x4)
+		if (!i.entity() && i.flags() == 0x4)
 		{
 			i.flags() &= ~0x4;
 		}


### PR DESCRIPTION
changes the cleanup condition to one that doesn't interfere with StartScriptFire initiated fires but still effectively prevents orphaned fire IDs

tested on b1604 w/ scripts provided by the original fix dev (PR https://github.com/citizenfx/fivem/pull/2041), their tests still pass & script fires now function as expected again