### PR TITLE
Add DOES_PLAYER_EXIST native

### DIFF
--- a/code/components/citizen-server-impl/src/ClientRegistry.cpp
+++ b/code/components/citizen-server-impl/src/ClientRegistry.cpp
@@ -223,6 +223,7 @@ namespace fx
 			events->TriggerClientEvent("onPlayerJoining", target, client->GetNetId(), client->GetName(), bigModeSlot);
 		}
 
+		m_clientsByNetId[oldNetID].reset();
 		// trigger connection handlers
 		OnConnectedClient(client.get());
 	}

--- a/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
@@ -30,6 +30,11 @@ static void CreatePlayerCommands()
 		return client->GetName().c_str();
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("DOES_PLAYER_EXIST", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
+	{
+		return true;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_GUID", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
 	{
 		return client->GetGuid().c_str();

--- a/ext/native-decls/DoesPlayerExist.md
+++ b/ext/native-decls/DoesPlayerExist.md
@@ -1,0 +1,39 @@
+---
+ns: CFX
+apiset: server
+---
+## DOES_PLAYER_EXIST
+
+```c
+BOOL DOES_PLAYER_EXIST(char* playerSrc);
+```
+
+Returns whether or not the player exists
+
+## Return value
+True of the player exists, false otherwise
+
+## Examples
+
+```lua
+local deferralMessages = { "Isn't this just magical!", "We can defer all day!", "You'll get in eventually", "You're totally not going to sit here forever", "The Fruit Tree is a lie" }
+AddEventHandler("playerConnecting", function(name, setKickReason, deferrals)
+    local source = source
+    deferrals.defer()
+
+    Wait(0)
+
+
+    local messageIndex = 0
+
+    repeat
+        Wait(2000)
+        if messageIndex >= #deferralMessages then
+            deferrals.done()
+        else
+            messageIndex = messageIndex + 1
+        end
+        deferrals.update(deferralMessages[messageIndex])
+    until not DoesPlayerExist(source)
+end)
+```


### PR DESCRIPTION
This was something I [asked about a while ago](https://forum.cfx.re/t/is-player-active-native/5041300) and have finally gotten around to implementing.

In testing `DOES_PLAYER_EXIST` I found that `m_clientsByNetId` doesn't release the oldNetId which broke some of the use cases for this native, so we reset it.

I'm not sure if this breaks anything anywhere, but please correct me if I'm wrong