### PR TITLE
feat(state-bag): initial implementation of state bag filters

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -72,7 +72,7 @@ public:
 	//
 	// Sets data for a key.
 	//
-	virtual void SetKey(int source, std::string_view key, std::string_view data, bool replicated = true) = 0;
+	virtual void SetKey(int slotId, std::string_view key, std::string_view data, bool replicated = true) = 0;
 
 	//
 	// Sets the owning peer ID.
@@ -112,7 +112,7 @@ public:
 	// Should be called when receiving a state bag control packet.
 	// arg: outBagNameName; if given (!= nullptr) and if the state bag wasn't found then this string will contain the bag name, otherwise outBagNameName is unchanged.
 	//
-	virtual void HandlePacket(int source, std::string_view data, std::string* outBagNameName = nullptr) = 0;
+	virtual void HandlePacket(int slotId, std::string_view data, std::string* outBagNameName = nullptr) = 0;
 
 	//
 	// Gets a state bag by an identifier. Returns an empty shared_ptr if not found.
@@ -145,6 +145,10 @@ public:
 	//
 	virtual void AddSafePreCreatePrefix(std::string_view idPrefix, bool useParentTargets) = 0;
 
+	//
+	// A rejection handler for state bags, this is ran before OnStateBagChange
+	//
+	fwEvent<std::string_view, std::string_view, const msgpack::object&> ShouldAllowStateBagChange;
 	//
 	// An event handling a state bag value change.
 	//

--- a/ext/native-decls/AddStateBagChangeHandler.md
+++ b/ext/native-decls/AddStateBagChangeHandler.md
@@ -23,7 +23,7 @@ function StateBagChangeHandler(bagName: string, key: string, value: any, reserve
 * **reserved**: Currently unused.
 * **replicated**: Whether the set is meant to be replicated.
 
-At this time, the change handler can't opt to reject changes.
+If you want to filter certain state changes use [ADD_STATE_BAG_FILTER](?_0x305DFB)
 
 If bagName refers to an entity, use [GET_ENTITY_FROM_STATE_BAG_NAME](?_0x4BDF1868) to get the entity handle
 If bagName refers to a player, use [GET_PLAYER_FROM_STATE_BAG_NAME](?_0xA56135E0) to get the player handle
@@ -42,7 +42,7 @@ AddStateBagChangeHandler("blockTasks", null, async (bagName, key, value /* boole
     let entity = GetEntityFromStateBagName(bagName);
     // Whoops, we were don't have a valid entity!
     if (entity === 0) return;
-    // We don't want to freeze the entity position if the entity collision hasn't loaded yet
+    // We don't want to freeze the entity position if the map collisions hasn't loaded yet
     while (!HasCollisionLoadedAroundEntity(entity)) {
         // The entity went out of our scope before the collision loaded
         if (!DoesEntityExist(entity)) return;
@@ -55,11 +55,11 @@ AddStateBagChangeHandler("blockTasks", null, async (bagName, key, value /* boole
 ```
 
 ```lua
-AddStateBagChangeHandler("blockTasks", nil, function(bagName, key, value) 
+AddStateBagChangeHandler("blockTasks", nil, function(bagName, key, value)
     local entity = GetEntityFromStateBagName(bagName)
     -- Whoops, we don't have a valid entity!
-    if entity === 0 then return end
-    -- We don't want to freeze the entity position if the entity collision hasn't loaded yet
+    if entity == 0 then return end
+    -- We don't want to freeze the entity position if the map collisions hasn't loaded yet
     while not HasCollisionLoadedAroundEntity(entity) do
         -- The entity went out of our scope before the collision loaded
         if not DoesEntityExist(entity) then return end

--- a/ext/native-decls/AddStateBagFilter.md
+++ b/ext/native-decls/AddStateBagFilter.md
@@ -1,0 +1,73 @@
+---
+ns: CFX
+apiset: server
+---
+## ADD_STATE_BAG_FILTER
+
+```c
+int ADD_STATE_BAG_FILTER(char* keyFilter, char* bagFilter, func handler);
+```
+**Experimental**: This native may be altered or removed in future versions of CitizenFX without warning.
+
+Registers a state bag filter to handle rejection.
+
+The state bag filter can reject replicated state bag changes by returning false in the handler, this will sync back the original value to the client and trigger the clients change handler.
+
+**Note**: Every filter is not guaranteed to run, they run on the order which they where registered, until one of the filter rejects the value.
+
+The function called expects to match the following signature:
+```ts
+function StateBagFilter(bagName: string, key: string, value: any): boolean;
+```
+
+* **bagName**: The internal bag ID for the state bag which changed. This is usually `player:Source`, `entity:NetID`
+  or `localEntity:Handle`.
+* **key**: The requested changed key.
+* **value**: The value requested to be changed
+
+If you want to get the caller of the filter, use [NETWORK_GET_ENTITY_OWNER](#_0x526FEE31)
+
+If bagName refers to an entity, use [GET_ENTITY_FROM_STATE_BAG_NAME](?_0x4BDF1868) to get the entity handle
+If bagName refers to a player, use [GET_PLAYER_FROM_STATE_BAG_NAME](?_0xA56135E0) to get the player handle
+
+## Parameters
+* **keyFilter**: The key to check for, or null for no filter.
+* **bagFilter**: The bag ID to check for such as `entity:65535`, or null for no filter.
+* **handler**: The handler function.
+
+## Return value
+A cookie to remove the filter.
+
+## Examples
+```js
+const rejectStateChangeForNetIds = new Set([65535, 65538, 65577]);
+AddStateBagFilter("blockTasks", null, async (bagName, key, value /* boolean */, source) => {
+    let ent = GetEntityFromStateBagName(bagName);
+    // Whoops, we were don't have a valid entity!
+    if (ent === 0) return;
+    const netId = NetworkGetNetworkIdFromEntity(entity);
+    if (rejectStateChangeForNetIds.has(netId) || typeof (value) !== "boolean") {
+        // Reject the change
+        return false;
+    }
+    // Accept the change
+    return true;
+})
+```
+
+```lua
+local rejectStateChangeForNetIds = { [65535] = true, [65538] = true, [65577] = true }
+AddStateBagFilter("blockTasks", nil, function(bagName, key, value)
+    local ent = GetEntityFromStateBagName(bagName)
+    -- Whoops, we don't have a valid entity!
+    if ent == 0 then return end
+    local netId = NetworkGetNetworkIdFromEntity(entity);
+    if rejectStateChangeForNetIds[netId] or type(value) ~= "number" then
+        -- Reject the change
+        return false
+    end
+    -- Accept the change
+    return true
+end)
+```
+

--- a/ext/native-decls/RemoveStateBagFilter.md
+++ b/ext/native-decls/RemoveStateBagFilter.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## REMOVE_STATE_BAG_REJECT_HANDLER
+
+```c
+void REMOVE_STATE_BAG_REJECT_HANDLER(int cookie);
+```
+
+**Experimental**: This native may be altered or removed in future versions of CitizenFX without warning.
+
+Removes a handler for rejects to a state bag.
+
+## Parameters
+* **cookie**: The cookie.
+


### PR DESCRIPTION
This is an initial implementation of state bag rejections

This was tested and works, this will reject the state bag change and properly sync the original value back to the calling client. 

```js
AddStateBagFilter("key", "", (bagName, key, value) => {
    console.log("requested change", key, value);
    setTimeout(() => {
        console.log("actual value", Player(1).state.key)
    }, 0)
	// false is used to reject changes
	return false;
})
```

There are a few things that I still need to do

## Todos
- [x] Figure out why returning nothing in AddStateBagChangeHandler causes the server to crash (maybe its just on debug)
- [x] Reset value properly if `originalValue` is none
- [x] Document state bag rejection 
