### PR TITLE
feat(cfx-ui/sorting): add a new server list sorting for relevant ^server name search

### DIFF
--- a/ext/cfx-ui/src/cfx/base/serverUtils.ts
+++ b/ext/cfx-ui/src/cfx/base/serverUtils.ts
@@ -6,7 +6,7 @@ import emojiRegex from 'emoji-regex';
 import { IServerListConfig, ServersListType } from "cfx/common/services/servers/lists/types";
 import { IPinnedServersConfig, IServerView } from 'cfx/common/services/servers/types';
 import { IAutocompleteIndex } from 'cfx/common/services/servers/source/types';
-import { isAddressSearchTerm } from './searchTermsParser';
+import { ISearchTerm, isAddressSearchTerm } from './searchTermsParser';
 
 export const EOL_LINK = 'aka.cfx.re/eol';
 export const EOS_LINK = 'aka.cfx.re/eos';
@@ -150,6 +150,19 @@ export function shouldPrioritizePinnedServers(config: IServerListConfig): boolea
   }
 
   return config.type === ServersListType.Supporters;
+}
+
+export function getPrioritizedServerName(config: IServerListConfig): ISearchTerm | undefined {
+  const name = config.searchTextParsed.find((item) => item.type === 'name');
+  if (!name) {
+    return;
+  }
+
+  if (name.value.length < 3) {
+    return;
+  }
+
+  return name;
 }
 
 /**

--- a/ext/cfx-ui/src/cfx/common/services/servers/lists/FavoriteServersList.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/lists/FavoriteServersList.ts
@@ -2,7 +2,7 @@ import { makeAutoObservable } from "mobx";
 import { IServersService } from "../servers.service";
 import { IServersStorageService } from "../serversStorage.service";
 import { filterList } from "../source/listFilter";
-import { sortList } from "../source/listSorter";
+import { sortList, sortFilteredList } from "../source/listSorter";
 import { IListableServerView } from "../source/types";
 import { serverView2ListableServerView } from "../transformers";
 import { IPinnedServersConfig, IServerView } from "../types";
@@ -35,11 +35,13 @@ export class FavoriteServersList implements IServersList {
       this._config.get(),
     );
 
-    return filterList(
+    const filteredList = filterList(
       listableFavoriteServers,
       sortedList,
       this._config.get(),
     );
+
+    return sortFilteredList(listableFavoriteServers, filteredList, this._config.get());
   }
 
   constructor(

--- a/ext/cfx-ui/src/cfx/common/services/servers/source/WorkerSource.worker.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/source/WorkerSource.worker.ts
@@ -3,7 +3,7 @@ import { filterList } from "./listFilter";
 import { getAllMasterListServers } from "./utils/fetchers";
 import { IAutocompleteIndex, IListableServerView } from "./types";
 import { IServerListConfig } from "../lists/types";
-import { sortList } from "./listSorter";
+import { sortFilteredList, sortList } from "./listSorter";
 import { serverView2ListableServerView } from "../transformers";
 import { AutocompleteIndexer } from "./autocomplete";
 import { shouldPrioritizePinnedServers } from "cfx/base/serverUtils";
@@ -152,9 +152,15 @@ export class ServersWorker {
       return;
     }
 
-    this.sendList(list.config, list.id, filterList(
+    const filteredList = filterList(
       this.listableServersMap,
       this.getSortedList(list.config),
+      list.config,
+    );
+
+    this.sendList(list.config, list.id, sortFilteredList(
+      this.listableServersMap,
+      filteredList,
       list.config,
     ));
   }


### PR DESCRIPTION
### Goal of this commit

When you are searching for a specific server in the server list, sometimes the name of your community might be used in other project descriptions, making a user struggle to find the server he is looking for.

For example, if you type in the search bar names like Echo, RSM, GLife, Impulse, or many others, you will end up with non-relevant servers putting random names into their project description and showing up at the top of the list because they've more boost power (Except if the server is pinned).

The goal of this change is to sort in a better way when the user inputs a server name (or project name). If the project's name starts with was the user is inputting, it will be sorted above the top boosted servers.

### Result

I have added this gif to show you how it will impact your search.

![](https://cdn.discordapp.com/attachments/576723881797222401/1131706295049797682/gif_preview.gif)

### Potential issues

One issue with my edit is that we do not rely on the cached result of the server list if we have a relevant name to sort. We also don't uniquely cache every new sorting, so it is fine, I guess.

Feel free to share any ideas/comments you may have