### PR TITLE
fix(scripting/lua): error when awaiting a rejected promise

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -115,7 +115,7 @@ function Citizen.Await(promise)
 		coroutine_yield()
 	end
 
-	if promise.state == 2 then
+	if promise.state == 2 or promise.state == 4 then
 		error(promise.value, 2)
 	end
 


### PR DESCRIPTION
When awaiting a promise that has already been rejected it will return the promise value rather than throwing an error.

```lua
local function fn(cb) cb('err') end

CreateThread(function()
    local p = promise.new()

    fn(function(err)
        p:reject(err)
    end)

    print(Citizen.Await(p))
    print('hello world')
end)
```