### PR TITLE
feat(resources/chat): Enable command toggleChat for RedM

### DIFF
--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -225,27 +225,21 @@ local kvpEntry = GetResourceKvpString('hideState')
 local chatHideState = kvpEntry and tonumber(kvpEntry) or CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
 local isFirstHide = true
 
-if not isRDR then
-  -- Allow only for Fivem until RedM supports it
-  if RegisterKeyMapping then
+if RegisterKeyMapping then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
-  end
 end
 
-  RegisterCommand('toggleChat', function(source,args,rawCommand)
-   
-        if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
-          chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-        elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
-          chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-        elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
-          chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-        end
-       SetResourceKvp('hideState', tostring(chatHideState))
-
-    isFirstHide = false
-  
-  end, false)
+RegisterCommand('toggleChat', function(source, args, rawCommand)
+	if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
+		chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+	elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
+		chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+	elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
+		chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+	end
+	SetResourceKvp('hideState', tostring(chatHideState))
+	isFirstHide = false
+end, false)
 
 
 Citizen.CreateThread(function()

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -230,21 +230,24 @@ if not isRDR then
   if RegisterKeyMapping then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end
+end
 
-  RegisterCommand('toggleChat', function()
-    if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
-      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-    end
+  TriggerEvent("chat:addSuggestion", "/toggleChat" , "set Chat state from whenactive hidden or always visible",{})
+  RegisterCommand('toggleChat', function(source,args,rawCommand)
+   
+        if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
+          chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+        elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
+          chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+        elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
+          chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+        end
+       SetResourceKvp('hideState', tostring(chatHideState))
 
     isFirstHide = false
-
-    SetResourceKvp('hideState', tostring(chatHideState))
+  
   end, false)
-end
+
 
 Citizen.CreateThread(function()
   SetTextChatEnabled(false)

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -232,7 +232,11 @@ if not isRDR then
   end
 end
 
-  TriggerEvent("chat:addSuggestion", "/toggleChat" , "set Chat state from whenactive hidden or always visible",{})
+
+CreateThread(function()
+  Wait(1000)
+  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {})
+end)
   RegisterCommand('toggleChat', function(source,args,rawCommand)
    
         if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -212,7 +212,6 @@ RegisterNUICallback('loaded', function(data, cb)
   refreshThemes()
 
   chatLoaded = true
-  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {})
   cb('ok')
 end)
 
@@ -227,6 +226,7 @@ local chatHideState = kvpEntry and tonumber(kvpEntry) or CHAT_HIDE_STATES.SHOW_W
 local isFirstHide = true
 
 if not isRDR then
+  -- Allow only for Fivem until RedM supports it
   if RegisterKeyMapping then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -212,7 +212,7 @@ RegisterNUICallback('loaded', function(data, cb)
   refreshThemes()
 
   chatLoaded = true
-
+  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {})
   cb('ok')
 end)
 
@@ -232,11 +232,6 @@ if not isRDR then
   end
 end
 
-
-CreateThread(function()
-  Wait(1000)
-  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {})
-end)
   RegisterCommand('toggleChat', function(source,args,rawCommand)
    
         if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then


### PR DESCRIPTION
allow command toggleChat for RedM users to be able to controll the chat window

an addSuggestion was also added for users to know what states does it have as well.

cfx forum thread of the request 
https://forum.cfx.re/t/allow-togglechat-for-redm-users/5158193