### PR TITLE
feat(resources/chat): Add `toggleChat` for RedM and extra parameter to set chat state

### DIFF
--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -232,25 +232,25 @@ if RegisterKeyMapping then
 end
 
 RegisterCommand('toggleChat', function(source, args, rawCommand)
-	if not args[1] then
-		if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
-			chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-		elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
-			chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-		elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
-			chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-		end
-	else
-		if args[1] == "visible" then
-			chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-		elseif args[1] == "hidden" then
-			chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-		elseif args[1] == "whenactive" then
-			chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-		end
-	end
-	SetResourceKvp('hideState', tostring(chatHideState))
-	isFirstHide = false
+  if not args[1] then
+    if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
+      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+    end
+  else
+    if args[1] == "visible" then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+    elseif args[1] == "hidden" then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+    elseif args[1] == "whenactive" then
+      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+    end
+  end
+  isFirstHide = false
+  SetResourceKvp('hideState', tostring(chatHideState))
 end, false)
 
 Citizen.CreateThread(function()

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -212,7 +212,9 @@ RegisterNUICallback('loaded', function(data, cb)
   refreshThemes()
 
   chatLoaded = true
-
+  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
+    { name = "state", help = "whenactive hidden visible" },
+  })
   cb('ok')
 end)
 
@@ -231,13 +233,6 @@ if not isRDR then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end
 end
-
-CreateThread(function()
-  Wait(1000)
-  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
-    { name = "state", help = "whenactive hidden visible" },
-  })
-end)
 
 RegisterCommand('toggleChat', function(source, args, rawCommand)
   if not args[1] then

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -235,9 +235,7 @@ end
 CreateThread(function()
   Wait(1000)
   addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
-    { name = "state", help = "whenactive" },
-    { name = "state", help = "hidden" },
-    { name = "state", help = "visible" }
+    { name = "state", help = "whenactive hidden visible" },
   })
 end)
 

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -212,7 +212,7 @@ RegisterNUICallback('loaded', function(data, cb)
   refreshThemes()
 
   chatLoaded = true
-  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
+  addSuggestion('/toggleChat', 'set Chat state', {
     { name = "state", help = "whenactive hidden visible" },
   })
   cb('ok')
@@ -227,34 +227,30 @@ local CHAT_HIDE_STATES = {
 local kvpEntry = GetResourceKvpString('hideState')
 local chatHideState = kvpEntry and tonumber(kvpEntry) or CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
 local isFirstHide = true
-
-if not isRDR then
-  if RegisterKeyMapping then
-    RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
-  end
+if RegisterKeyMapping then
+	RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
 end
 
 RegisterCommand('toggleChat', function(source, args, rawCommand)
-  if not args[1] then
-    if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
-      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-    end
-    SetResourceKvp('hideState', tostring(chatHideState))
-  else
-    if args[1] == "visible" then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-    elseif args[1] == "hidden" then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-    elseif args[1] == "whenactive" then
-      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-    end
-  end
-
-  isFirstHide = false
+	if not args[1] then
+		if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
+			chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+		elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
+			chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+		elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
+			chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+		end
+	else
+		if args[1] == "visible" then
+			chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+		elseif args[1] == "hidden" then
+			chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+		elseif args[1] == "whenactive" then
+			chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+		end
+	end
+	SetResourceKvp('hideState', tostring(chatHideState))
+	isFirstHide = false
 end, false)
 
 Citizen.CreateThread(function()
@@ -263,12 +259,13 @@ Citizen.CreateThread(function()
 
   local lastChatHideState = -1
   local origChatHideState = -1
+  local input = isRDR and `INPUT_MP_TEXT_CHAT_ALL` or 245
 
   while true do
     Wait(0)
 
     if not chatInputActive then
-      if IsControlPressed(0, isRDR and `INPUT_MP_TEXT_CHAT_ALL` or 245) --[[ INPUT_MP_TEXT_CHAT_ALL ]] then
+      if IsControlPressed(0, input) then
         chatInputActive = true
         chatInputActivating = true
 
@@ -279,7 +276,7 @@ Citizen.CreateThread(function()
     end
 
     if chatInputActivating then
-      if not IsControlPressed(0, isRDR and `INPUT_MP_TEXT_CHAT_ALL` or 245) then
+      if not IsControlPressed(0, input) then
         SetNuiFocus(true)
 
         chatInputActivating = false

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -231,12 +231,15 @@ if not isRDR then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end
 end
- 
-addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
-  { name = "state", help = "whenactive" },
-  { name = "state", help = "hidden" },
-  { name = "state", help = "visible" }
-})
+
+CreateThread(function()
+  Wait(1000)
+  addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
+    { name = "state", help = "whenactive" },
+    { name = "state", help = "hidden" },
+    { name = "state", help = "visible" }
+  })
+end)
 
 RegisterCommand('toggleChat', function(source, args, rawCommand)
   if not args[1] then

--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -230,8 +230,16 @@ if not isRDR then
   if RegisterKeyMapping then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end
+end
+ 
+addSuggestion('/toggleChat', 'set Chat state from whenactive hidden or always visible', {
+  { name = "state", help = "whenactive" },
+  { name = "state", help = "hidden" },
+  { name = "state", help = "visible" }
+})
 
-  RegisterCommand('toggleChat', function()
+RegisterCommand('toggleChat', function(source, args, rawCommand)
+  if not args[1] then
     if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
       chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
     elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
@@ -239,12 +247,19 @@ if not isRDR then
     elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
       chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
     end
-
-    isFirstHide = false
-
     SetResourceKvp('hideState', tostring(chatHideState))
-  end, false)
-end
+  else
+    if args[1] == "visible" then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+    elseif args[1] == "hidden" then
+      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+    elseif args[1] == "whenactive" then
+      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+    end
+  end
+
+  isFirstHide = false
+end, false)
 
 Citizen.CreateThread(function()
   SetTextChatEnabled(false)


### PR DESCRIPTION
This pr aims to allow the use of toggleChat command for RedM users.
It also allows an extra argument to use for chat states, for example when players have left session with state as `visible` since it uses ResourceKvp when they re enter it shows visble, this extra parameter allows to manipulate chat state in other resources
example:
`ExecuteCommand("toggleChat hidden")`

In summary:
- use of toggleChat command for RedM users
- extra parameter to allow resources to manipulate chat states
- adds a chat suggestion so players are aware of what states are supported
- smal optimisation on the look up for input for rdr gtav that was done inside the while loop
- removed isRDR check in the future if RegisterKeymapping is implemented in RedM  the check for `if RegisterKeymapping` should  and is enough, and a future pr wont be needed here.