### PR TITLE
feat(extra-natives/five): read current & next gear from correct offsets

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -498,8 +498,8 @@ static HookFunction initFunction([]()
 	{
 		auto location = hook::get_pattern<char>("A8 02 0F 84 ? ? ? ? 0F B7 86");
 
-		CurrentGearOffset = *(uint32_t*)(location + 11);
-		NextGearOffset = *(uint32_t*)(location + 18);
+		CurrentGearOffset = *(uint32_t*)(location + 18);
+		NextGearOffset = *(uint32_t*)(location + 11);
 	}
 
 	{


### PR DESCRIPTION
Fix for issue reported on forums, memory offsets used by CurrentGear and NextGear natives turned out to be incorrect / were reporting unexpected results: https://forum.cfx.re/t/native-getvehiclecurrentgear-is-reading-from-the-wrong-address-in-memory/5159163

The variables these offsets get assigned to were swapped by mistake, this was discovered by comparing offsets calculated at runtime with a known good Manual Transmission mod which reports expected numbers (linked in forum thread)

Tested the variable swap under all currently supported builds, the resulting offsets now line up nicely with the mod
