### PR TITLE
fix(scripting/v8): raw event listeners

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -463,10 +463,21 @@ const EXT_LOCALFUNCREF = 11;
 				global.source = parseInt(source.substr(13));
 			}
 
-			const payload = unpack(payloadSerialized) || [];
-			const listeners = emitter.listeners(name);
+			// Running raw event listeners
+			try {
+				rawEmitter.emit(name, payloadSerialized, source);
+			} catch (e) {
+				console.error('Unhandled error during running raw event listeners', e);
+			}
 
-			if (listeners.length === 0 || !Array.isArray(payload)) {
+			const listeners = emitter.listeners(name);
+			if (listeners.length == 0) {
+				global.source = null;
+				return;
+			}
+
+			const payload = unpack(payloadSerialized) || [];
+			if(!Array.isArray(payload)) {
 				global.source = null;
 				return;
 			}
@@ -488,13 +499,6 @@ const EXT_LOCALFUNCREF = 11;
 				} catch (e) {
 					global.printError('event `' + name + '\'', e);
 				}
-			}
-
-			// Running raw event listeners
-			try {
-				rawEmitter.emit(name, payloadSerialized, source);
-			} catch (e) {
-				console.error('Unhandled error during running raw event listeners', e);
 			}
 
 			global.source = null;


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fixes issue where raw event listeners weren't triggered without standard subscribers.
Skips payload deserialization when no standard event subscribers are present.

### How is this PR achieving the goal

Fixing these issues in js scripting event function

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: JS


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->