### PR TITLE
feat(nui/resources): SEND_DUI_KEY_DOWN & SEND_DUI_KEY_UP

### DIFF
--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -371,7 +371,7 @@ namespace nui
 	bool OVERLAY_DECL HasMainUI();
 	void OVERLAY_DECL SetMainUI(bool enable);
 	void OVERLAY_DECL SetHideCursor(bool hide);
-
+	int  OVERLAY_DECL GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam);
 	void ProcessInput();
 
 	void OVERLAY_DECL ExecuteRootScript(const std::string& scriptBit);

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -191,89 +191,89 @@ namespace nui
 	void ProcessInput()
 	{
 	}
-}
 
-int GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam)
-{
-	int modifiers = 0;
-	if (isKeyDown(VK_SHIFT))
-		modifiers |= EVENTFLAG_SHIFT_DOWN;
-	if (isKeyDown(VK_CONTROL))
-		modifiers |= EVENTFLAG_CONTROL_DOWN;
-	if (isKeyDown(VK_MENU))
-		modifiers |= EVENTFLAG_ALT_DOWN;
-
-	// Low bit set from GetKeyState indicates "toggled".
-	if (::GetKeyState(VK_NUMLOCK) & 1)
-		modifiers |= EVENTFLAG_NUM_LOCK_ON;
-	if (::GetKeyState(VK_CAPITAL) & 1)
-		modifiers |= EVENTFLAG_CAPS_LOCK_ON;
-
-	switch (wparam)
+	int GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam)
 	{
-		case VK_RETURN:
-			if ((lparam >> 16) & KF_EXTENDED)
+		int modifiers = 0;
+		if (isKeyDown(VK_SHIFT))
+			modifiers |= EVENTFLAG_SHIFT_DOWN;
+		if (isKeyDown(VK_CONTROL))
+			modifiers |= EVENTFLAG_CONTROL_DOWN;
+		if (isKeyDown(VK_MENU))
+			modifiers |= EVENTFLAG_ALT_DOWN;
+
+		// Low bit set from GetKeyState indicates "toggled".
+		if (::GetKeyState(VK_NUMLOCK) & 1)
+			modifiers |= EVENTFLAG_NUM_LOCK_ON;
+		if (::GetKeyState(VK_CAPITAL) & 1)
+			modifiers |= EVENTFLAG_CAPS_LOCK_ON;
+
+		switch (wparam)
+		{
+			case VK_RETURN:
+				if ((lparam >> 16) & KF_EXTENDED)
+					modifiers |= EVENTFLAG_IS_KEY_PAD;
+				break;
+			case VK_INSERT:
+			case VK_DELETE:
+			case VK_HOME:
+			case VK_END:
+			case VK_PRIOR:
+			case VK_NEXT:
+			case VK_UP:
+			case VK_DOWN:
+			case VK_LEFT:
+			case VK_RIGHT:
+				if (!((lparam >> 16) & KF_EXTENDED))
+					modifiers |= EVENTFLAG_IS_KEY_PAD;
+				break;
+			case VK_NUMLOCK:
+			case VK_NUMPAD0:
+			case VK_NUMPAD1:
+			case VK_NUMPAD2:
+			case VK_NUMPAD3:
+			case VK_NUMPAD4:
+			case VK_NUMPAD5:
+			case VK_NUMPAD6:
+			case VK_NUMPAD7:
+			case VK_NUMPAD8:
+			case VK_NUMPAD9:
+			case VK_DIVIDE:
+			case VK_MULTIPLY:
+			case VK_SUBTRACT:
+			case VK_ADD:
+			case VK_DECIMAL:
+			case VK_CLEAR:
 				modifiers |= EVENTFLAG_IS_KEY_PAD;
-			break;
-		case VK_INSERT:
-		case VK_DELETE:
-		case VK_HOME:
-		case VK_END:
-		case VK_PRIOR:
-		case VK_NEXT:
-		case VK_UP:
-		case VK_DOWN:
-		case VK_LEFT:
-		case VK_RIGHT:
-			if (!((lparam >> 16) & KF_EXTENDED))
-				modifiers |= EVENTFLAG_IS_KEY_PAD;
-			break;
-		case VK_NUMLOCK:
-		case VK_NUMPAD0:
-		case VK_NUMPAD1:
-		case VK_NUMPAD2:
-		case VK_NUMPAD3:
-		case VK_NUMPAD4:
-		case VK_NUMPAD5:
-		case VK_NUMPAD6:
-		case VK_NUMPAD7:
-		case VK_NUMPAD8:
-		case VK_NUMPAD9:
-		case VK_DIVIDE:
-		case VK_MULTIPLY:
-		case VK_SUBTRACT:
-		case VK_ADD:
-		case VK_DECIMAL:
-		case VK_CLEAR:
-			modifiers |= EVENTFLAG_IS_KEY_PAD;
-			break;
-		case VK_SHIFT:
-			if (isKeyDown(VK_LSHIFT))
+				break;
+			case VK_SHIFT:
+				if (isKeyDown(VK_LSHIFT))
+					modifiers |= EVENTFLAG_IS_LEFT;
+				else if (isKeyDown(VK_RSHIFT))
+					modifiers |= EVENTFLAG_IS_RIGHT;
+				break;
+			case VK_CONTROL:
+				if (isKeyDown(VK_LCONTROL))
+					modifiers |= EVENTFLAG_IS_LEFT;
+				else if (isKeyDown(VK_RCONTROL))
+					modifiers |= EVENTFLAG_IS_RIGHT;
+				break;
+			case VK_MENU:
+				if (isKeyDown(VK_LMENU))
+					modifiers |= EVENTFLAG_IS_LEFT;
+				else if (isKeyDown(VK_RMENU))
+					modifiers |= EVENTFLAG_IS_RIGHT;
+				break;
+			case VK_LWIN:
 				modifiers |= EVENTFLAG_IS_LEFT;
-			else if (isKeyDown(VK_RSHIFT))
+				break;
+			case VK_RWIN:
 				modifiers |= EVENTFLAG_IS_RIGHT;
-			break;
-		case VK_CONTROL:
-			if (isKeyDown(VK_LCONTROL))
-				modifiers |= EVENTFLAG_IS_LEFT;
-			else if (isKeyDown(VK_RCONTROL))
-				modifiers |= EVENTFLAG_IS_RIGHT;
-			break;
-		case VK_MENU:
-			if (isKeyDown(VK_LMENU))
-				modifiers |= EVENTFLAG_IS_LEFT;
-			else if (isKeyDown(VK_RMENU))
-				modifiers |= EVENTFLAG_IS_RIGHT;
-			break;
-		case VK_LWIN:
-			modifiers |= EVENTFLAG_IS_LEFT;
-			break;
-		case VK_RWIN:
-			modifiers |= EVENTFLAG_IS_RIGHT;
-			break;
+				break;
+		}
+		return modifiers;
 	}
-	return modifiers;
-}
+	}
 
 OsrImeHandlerWin* g_imeHandler;
 
@@ -375,7 +375,7 @@ static HookFunction initFunction([] ()
 
 			keyEvent.windows_key_code = vKey;
 			keyEvent.native_key_code = scanCode;
-			keyEvent.modifiers = GetCefKeyboardModifiers(vKey, scanCode);
+			keyEvent.modifiers = nui::GetCefKeyboardModifiers(vKey, scanCode);
 
 			if (down)
 			{
@@ -784,7 +784,7 @@ static HookFunction initFunction([] ()
 
 				keyEvent.windows_key_code = wParam;
 				keyEvent.native_key_code = lParam;
-				keyEvent.modifiers = GetCefKeyboardModifiers(wParam, lParam);
+				keyEvent.modifiers = nui::GetCefKeyboardModifiers(wParam, lParam);
 
 				if (msg != WM_CHAR)
 				{

--- a/ext/native-decls/SendDuiKeyDown.md
+++ b/ext/native-decls/SendDuiKeyDown.md
@@ -1,0 +1,37 @@
+---
+ns: CFX
+apiset: client
+---
+## SEND_DUI_KEY_DOWN
+
+```c
+void SEND_DUI_KEY_DOWN(long duiObject, char* keyPressed);
+```
+
+Injects a "Key Up" event into the DUI browser
+
+## Parameters
+* **duiObject**: The DUI browser handle.
+* **keyPressed**: the key to inject into the browser
+
+> Currently Supports Ascii characters
+
+## Example
+
+```lua
+CreateThread(function()
+    local dui = CreateDui("https://forum.cfx.re", 1920, 1080) -- Create A Dui Object
+    while true do
+        Wait(0) -- Wait Every Tick.
+        --[[
+            Drawing Dui Logic
+        ]]
+        if IsControlJustPressed(0, 38) then -- E key Pressed
+            SendDuiKeyDown(dui, "e") -- Tell the Dui object the key was pressed
+        end
+         if IsControlJustReleased(0, 38) then -- E key Released
+            SendDuiKeyUp(dui, "e") -- Tell the Dui object the key was released
+        end
+    end
+end)
+```

--- a/ext/native-decls/SendDuiKeyDown.md
+++ b/ext/native-decls/SendDuiKeyDown.md
@@ -8,7 +8,7 @@ apiset: client
 void SEND_DUI_KEY_DOWN(long duiObject, char* keyPressed);
 ```
 
-Injects a "Key Up" event into the DUI browser
+Injects a "Key Down" event into the DUI browser
 
 ## Parameters
 * **duiObject**: The DUI browser handle.

--- a/ext/native-decls/SendDuiKeyUp.md
+++ b/ext/native-decls/SendDuiKeyUp.md
@@ -1,0 +1,37 @@
+---
+ns: CFX
+apiset: client
+---
+## SEND_DUI_KEY_UP
+
+```c
+void SEND_DUI_KEY_UP(long duiObject, char* keyPressed);
+```
+
+Injects a "Key Up" event into the DUI browser
+
+## Parameters
+* **duiObject**: The DUI browser handle.
+* **keyPressed**: the key to inject into the browser
+
+> Currently Supports Ascii characters
+
+## Example
+
+```lua
+CreateThread(function()
+    local dui = CreateDui("https://forum.cfx.re", 1920, 1080) -- Create A Dui Object
+    while true do
+        Wait(0) -- Wait Every Tick.
+        --[[
+            Drawing Dui Logic
+        ]]
+        if IsControlJustPressed(0, 38) then -- E key Pressed
+            SendDuiKeyDown(dui, "e") -- Tell the Dui object the key was pressed
+        end
+         if IsControlJustReleased(0, 38) then -- E key Released
+            SendDuiKeyUp(dui, "e") -- Tell the Dui object the key was released
+        end
+    end
+end)
+```


### PR DESCRIPTION
This PR adds 2 natives:
SEND_DUI_KEY_DOWN
SEND_DUI_KEY_UP

These new natives allow you to inject keyboard events directly into the browser. which was previously:
A. impossible on any external sites
B. very janky and too specific (having to apply the code to each individual input) on internal UI

The need for this was also explained [on the forums](https://forum.cfx.re/t/dui-nui-request-for-send-dui-key-down-send-dui-key-up/5166146) and I have made a [preview video](https://youtu.be/oDJYPvRLcWM) to showcase the type of amazing things these natives can enable.