### PR TITLE
increase FragmentStore pool

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -278,7 +278,7 @@
 						</Item>
 						<Item>
 							<PoolName>FragmentStore</PoolName>
-							<PoolSize value="58000"/>
+							<PoolSize value="74000"/>
 						</Item>
 						<Item>
 							<PoolName>GamePlayerBroadcastDataHandler_Remote</PoolName>


### PR DESCRIPTION
by increasing the FragmoreStore pool it will allow servers to be able to increase the limit on cars with mods, we have recently run into an issue after updating to the latest DLC build from GTA Online that having so many custom cars is now cause the client to crash while on loading screen & that there FragmentStore pool is full.