### PR TITLE
AddVehiclePhoneExplosiveDevice & DetonateVehiclePhoneExplosiveDevice fix

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -90,6 +90,9 @@ std::shared_ptr<ConVar<bool>> g_oneSyncARQ;
 static std::shared_ptr<ConVar<bool>> g_networkedSoundsEnabledVar;
 static bool g_networkedSoundsEnabled;
 
+static std::shared_ptr<ConVar<bool>> g_networkedPhoneExplosionsEnabledVar;
+static bool g_networkedPhoneExplosionsEnabled;
+
 static std::shared_ptr<ConVar<int>> g_requestControlVar;
 static std::shared_ptr<ConVar<int>> g_requestControlSettleVar;
 
@@ -6778,6 +6781,14 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 		};
 	}
 
+	if (eventType == REQUEST_PHONE_EXPLOSION_EVENT)
+	{
+		return []()
+		{
+			return g_networkedPhoneExplosionsEnabled;
+		};
+	}
+
 	if (isReply)
 	{
 		switch(eventType)
@@ -6858,6 +6869,8 @@ static InitFunction initFunction([]()
 		}
 
 		g_networkedSoundsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedSounds", ConVar_None, true, &g_networkedSoundsEnabled);
+
+		g_networkedPhoneExplosionsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedPhoneExplosions", ConVar_None, false, &g_networkedPhoneExplosionsEnabled);
 
 		g_requestControlVar = instance->AddVariable<int>("sv_filterRequestControl", ConVar_None, (int)RequestControlFilterMode::NoFilter, (int*)&g_requestControlFilterState);
 		g_requestControlSettleVar = instance->AddVariable<int>("sv_filterRequestControlSettleTimer", ConVar_None, 30000, &g_requestControlSettleDelay);


### PR DESCRIPTION
Fix for abusing AddVehiclePhoneExplosiveDevice & DetonateVehiclePhoneExplosiveDevice by hackers

Exploit allow hackers to send explosion as other player ( The one who is network owner of car )

Cheaters have been employing two primary methods to carry out this exploit:

AddVehiclePhoneExplosiveDevice: This native function allows cheats to attach explosive devices to in-game vehicles. These devices can then be triggered remotely, causing an explosion at a location determined by the cheater.

DetonateVehiclePhoneExplosiveDevice: This native function is used by cheaters to remotely detonate the explosive devices attached to vehicles. This is how they send explosions as if they were other players.