### PR TITLE
feat(extra-natives/five): LOAD_ROPE_DATA_FROM_PATH

### DIFF
--- a/code/components/extra-natives-five/include/ropeManager.h
+++ b/code/components/extra-natives-five/include/ropeManager.h
@@ -46,6 +46,10 @@ public:
 	atArray<ropeData*> typeData; // 0x8
 
 	static ropeDataManager* GetInstance();
+
+	static void Init();
+
+	static void Shutdown();
 };
 static_assert(sizeof(ropeDataManager) == 0x18);
 
@@ -134,6 +138,8 @@ public:
 	LinkedList<phVerletCloth*> cloths; // 0x58
 
 	ropeInstance* FindRope(int handle);
+
+	void RemoveAllRopes();
 
 	static ropeManager* GetInstance();
 };

--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -686,6 +686,10 @@
 							<PoolName>scrGlobals</PoolName>
 							<PoolSize value="15080000"/>
 						</Item>
+						<Item>
+							<PoolName>ropeData</PoolName>
+							<PoolSize value="32"/>
+						</Item>
 					</Entries>
 				</PoolSizes>
 

--- a/ext/native-decls/LoadRopeDataFromPath.md
+++ b/ext/native-decls/LoadRopeDataFromPath.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+---
+## LOAD_ROPE_DATA_FROM_PATH
+
+```c
+BOOL LOAD_ROPE_DATA_FROM_PATH(char* resourceName, char* fileName);
+```
+
+## Parameters
+* **resourceName**: The name of the resource containing the file
+* **fileName**: The name of the rope data file
+
+Loads a rope data file from the specified resource, removing any previous rope data in the process.
+Calling this native will remove all existing ropes in the world and unload rope textures.
+For compatibility it is recommended to use common:/data/ropedata.xml as a template for the file and add additional entries on the end of it.
+
+## Return value
+True if the file was loaded otherwise false if the file does not exist.


### PR DESCRIPTION
Adds a way to load a custom rope data file, useful for modifying/creating new ropes with additional textures, radii and colours as seen in https://i.imgur.com/1EpFIyP.png
Additionally fixes the game crashing if calling `ADD_ROPE` with an invalid index (8 onwards with default rope data loaded)