### PR TITLE
Population ped creation event for RedM

### DIFF
--- a/code/components/citizen-resources-gta/src/PopulationCreationFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/PopulationCreationFunctions.cpp
@@ -1,6 +1,6 @@
 #include <StdInc.h>
 
-#if defined(GTA_FIVE)
+#if defined(GTA_FIVE) || defined(IS_RDR3)
 #include <EntitySystem.h>
 
 #include <ResourceManager.h>

--- a/code/components/devtools-five/src/WorldEditor.cpp
+++ b/code/components/devtools-five/src/WorldEditor.cpp
@@ -22,15 +22,10 @@
 
 #include <nutsnbolts.h>
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, uint64_t* archetypeUnk)> getArchetype([]()
-{
-	return hook::get_call(hook::pattern("89 44 24 40 8B 4F 08 80 E3 01 E8").count(1).get(0).get<void>(10));
-});
-
 /*static ConsoleCommand consoleCmd("make_entity", [](const std::string& name)
 {
-	uint64_t index;
-	fwArchetype* archetype = getArchetype(HashString(name.c_str()), &index);
+	rage::fwModelId index;
+	fwArchetype* archetype = rage::fwArchetypeManager::GetArchetypeFromHashKey(HashString(name.c_str()), index);
 
 	fwEntityDef entityDef;
 	entityDef.archetypeName = HashString(name.c_str());
@@ -228,8 +223,8 @@ void RecreateModel()
 	entityDef.flags = 0;
 	entityDef.lodLevel = 1;
 
-	uint64_t index;
-	getArchetype(archetypeDef->name, &index);
+	rage::fwModelId index;
+	rage::fwArchetypeManager::GetArchetypeFromHashKey(archetypeDef->name, index);
 
 	fwEntity* entity = mi->CreateEntity();
 	entity->SetModelIndex((uint32_t*)&index);

--- a/code/components/extra-natives-five/src/PedExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/PedExtraNatives.cpp
@@ -12,11 +12,6 @@
 
 #include <GameInit.h>
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, uint64_t* archetypeUnk)> getArchetype([]()
-{
-	return hook::get_call(hook::pattern("89 44 24 40 8B 4F 08 80 E3 01 E8").count(1).get(0).get<void>(10));
-});
-
 class CPedHeadBlendData
 {
 public:
@@ -254,8 +249,8 @@ static HookFunction initFunction([]()
 	{
 		for (auto& [pedModel, personality] : undoPersonalities)
 		{
-			uint64_t index;
-			auto archetype = getArchetype(pedModel, &index);
+			rage::fwModelId index;
+			auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKey(pedModel, index);
 
 			// if is ped
 			if (archetype && archetype->miType == 6)
@@ -272,8 +267,8 @@ static HookFunction initFunction([]()
 		auto pedModel = context.GetArgument<uint32_t>(0);
 		auto personality = context.GetArgument<uint32_t>(1);
 
-		uint64_t index;
-		auto archetype = getArchetype(pedModel, &index);
+		rage::fwModelId index;
+		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKey(pedModel, index);
 
 		// if is ped
 		if (archetype && archetype->miType == 6)
@@ -299,8 +294,8 @@ static HookFunction initFunction([]()
 	{
 		auto pedModel = context.GetArgument<uint32_t>(0);
 
-		uint64_t index;
-		auto archetype = getArchetype(pedModel, &index);
+		rage::fwModelId index;
+		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKey(pedModel, index);
 
 		// if is ped
 		if (archetype && archetype->miType == 6)
@@ -316,8 +311,8 @@ static HookFunction initFunction([]()
 	{
 		auto pedModel = context.GetArgument<uint32_t>(0);
 
-		uint64_t index;
-		auto archetype = getArchetype(pedModel, &index);
+		rage::fwModelId index;
+		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKey(pedModel, index);
 
 		uint32_t result = 0;
 

--- a/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
+++ b/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
@@ -1072,23 +1072,6 @@ static hook::cdecl_stub<void*(fwEntityDef*, int fileIdx, fwArchetype* archetype,
 	return hook::get_call(hook::pattern("4C 8D 4C 24 40 4D 8B C6 41 8B D7 48 8B CF").count(1).get(0).get<void>(14));
 });
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, uint64_t* archetypeUnk)> getArchetype([]()
-{
-	return hook::get_call(hook::pattern("89 44 24 40 8B 4F 08 80 E3 01 E8").count(1).get(0).get<void>(10));
-});
-
-fwArchetype* GetArchetypeSafe(uint32_t archetypeHash, uint64_t* archetypeUnk)
-{
-	__try
-	{
-		return getArchetype(archetypeHash, archetypeUnk);
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER)
-	{
-		return nullptr;
-	}
-}
-
 static InitFunction initFunction([]()
 {
 	OnMainGameFrame.Connect([]
@@ -1231,8 +1214,8 @@ static InitFunction initFunction([]()
 					fwEntityDef* entityDef = (fwEntityDef*)MakeStructFromMsgPack("CEntityDef", entityData);
 					mapData->entities.Set(i, entityDef);
 
-					uint64_t archetypeUnk = 0xFFFFFFF;
-					fwArchetype* archetype = GetArchetypeSafe(entityDef->archetypeName, &archetypeUnk);
+					rage::fwModelId modelId{ 0xFFFFFFF };
+					fwArchetype* archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(entityDef->archetypeName, modelId);
 
 					if (archetype)
 					{

--- a/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
+++ b/code/components/extra-natives-five/src/RuntimeAssetNatives.cpp
@@ -1214,7 +1214,7 @@ static InitFunction initFunction([]()
 					fwEntityDef* entityDef = (fwEntityDef*)MakeStructFromMsgPack("CEntityDef", entityData);
 					mapData->entities.Set(i, entityDef);
 
-					rage::fwModelId modelId{ 0xFFFFFFF };
+					rage::fwModelId modelId;
 					fwArchetype* archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(entityDef->archetypeName, modelId);
 
 					if (archetype)

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -212,8 +212,31 @@ using fwArchetype = ::fwArchetype;
 
 struct fwModelId
 {
-	uint64_t id;
+	union
+	{
+		uint32_t value;
+
+		struct
+		{
+			uint16_t modelIndex;
+			uint16_t mapTypesIndex : 12;
+			uint16_t flags : 4;
+		};
+	};
+
+	fwModelId()
+		: modelIndex(0xFFFF), mapTypesIndex(0xFFF), flags(0)
+	{
+	}
+
+	fwModelId(uint32_t idx)
+		: value(idx)
+	{
+	}
 };
+
+static_assert(sizeof(fwModelId) == 4);
+
 
 class STREAMING_EXPORT fwArchetypeManager
 {

--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -219,6 +219,8 @@ class STREAMING_EXPORT fwArchetypeManager
 {
 public:
 	static fwArchetype* GetArchetypeFromHashKey(uint32_t hash, fwModelId& id);
+
+	static fwArchetype* GetArchetypeFromHashKeySafe(uint32_t hash, fwModelId& id);
 };
 }
 

--- a/code/components/gta-streaming-five/src/EntitySystem.cpp
+++ b/code/components/gta-streaming-five/src/EntitySystem.cpp
@@ -64,3 +64,15 @@ fwArchetype* rage::fwArchetypeManager::GetArchetypeFromHashKey(uint32_t hash, fw
 {
 	return getArchetype(hash, id);
 }
+
+fwArchetype* rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(uint32_t hash, fwModelId& id)
+{
+	__try
+	{
+		return getArchetype(hash, id);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		return nullptr;
+	}
+}

--- a/code/components/gta-streaming-five/src/EntitySystem.cpp
+++ b/code/components/gta-streaming-five/src/EntitySystem.cpp
@@ -55,7 +55,7 @@ static HookFunction hookFunction([]
 	fwSceneUpdateExtension_classId = hook::get_address<uint32_t*>(hook::get_pattern("48 8B D3 48 89 73 08 E8", -64));
 });
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& archetypeUnk)> getArchetype([]()
+static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& id)> getArchetype([]()
 {
 	return hook::get_call(hook::pattern("89 44 24 40 8B 4F 08 80 E3 01 E8").count(1).get(0).get<void>(10));
 });

--- a/code/components/gta-streaming-five/src/PatchStreamingPreparation.cpp
+++ b/code/components/gta-streaming-five/src/PatchStreamingPreparation.cpp
@@ -528,8 +528,7 @@ static void fwEntity_DtorWrap(rage::fwEntity* entity)
 		// to do this, we use a little hack to not have to manually read the archetype list:
 		// the base rage::fwEntity::SetModelId doesn't do anything other than setting (rcx + 32)
 		// to the resolved archetype, or nullptr if none
-		rage::fwModelId modelId;
-		modelId.id = midx;
+		rage::fwModelId modelId(midx);
 
 		void* fakeEntity[40 / 8] = { 0 };
 		_fwEntity_SetModelId(fakeEntity, modelId);

--- a/code/components/gta-streaming-five/src/PlacementHacks.cpp
+++ b/code/components/gta-streaming-five/src/PlacementHacks.cpp
@@ -400,7 +400,7 @@ void ParseArchetypeFile(char* text, size_t length)
 						archetypeHash = _atoi64(&(archetypeName.c_str())[5]);
 					}
 
-					rage::fwModelId modelId{ 0xFFFFFFF };
+					rage::fwModelId modelId;
 					fwArchetype* archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(archetypeHash, modelId);
 
 					if (archetype)

--- a/code/components/gta-streaming-five/src/PlacementHacks.cpp
+++ b/code/components/gta-streaming-five/src/PlacementHacks.cpp
@@ -66,14 +66,9 @@ CMapData::CMapData()
 	_mapData_ctor(this);
 }
 
-static hook::cdecl_stub<void*(fwEntityDef*, int fileIdx, fwArchetype* archetype, uint64_t* archetypeUnk)> fwEntityDef__instantiate([] ()
+static hook::cdecl_stub<void*(fwEntityDef*, int fileIdx, fwArchetype* archetype, rage::fwModelId* archetypeUnk)> fwEntityDef__instantiate([] ()
 {
 	return hook::get_call(hook::pattern("4C 8D 4C 24 40 4D 8B C6 41 8B D7 48 8B CF").count(1).get(0).get<void>(14));
-});
-
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, uint64_t* archetypeUnk)> getArchetype([] ()
-{
-	return hook::get_call(hook::pattern("89 44 24 40 8B 4F 08 80 E3 01 E8").count(1).get(0).get<void>(10));
 });
 
 atArray<fwFactoryBase<fwArchetype>*>* g_archetypeFactories;
@@ -123,18 +118,6 @@ static hook::cdecl_stub<void(fwArchetype*)> registerArchetype([]()
 {
 	return hook::get_pattern("48 8B D9 8A 49 60 80 F9", -11);
 });
-
-fwArchetype* GetArchetypeSafe(uint32_t archetypeHash, uint64_t* archetypeUnk)
-{
-	__try
-	{
-		return getArchetype(archetypeHash, archetypeUnk);
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER)
-	{
-		return nullptr;
-	}
-}
 
 static std::vector<CMapDataContents*> g_sceneContentsList;
 static uintptr_t sceneNodeThing;
@@ -417,8 +400,8 @@ void ParseArchetypeFile(char* text, size_t length)
 						archetypeHash = _atoi64(&(archetypeName.c_str())[5]);
 					}
 
-					uint64_t archetypeUnk = 0xFFFFFFF;
-					fwArchetype* archetype = GetArchetypeSafe(archetypeHash, &archetypeUnk);
+					rage::fwModelId modelId{ 0xFFFFFFF };
+					fwArchetype* archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(archetypeHash, modelId);
 
 					if (archetype)
 					{
@@ -440,7 +423,7 @@ void ParseArchetypeFile(char* text, size_t length)
 
 						getUInt("flags", &entityDef->flags);
 
-						void* entity = fwEntityDef__instantiate(entityDef, 0, archetype, &archetypeUnk);
+						void* entity = fwEntityDef__instantiate(entityDef, 0, archetype, &modelId);
 
 						contents->entities[i] = entity;
 

--- a/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
+++ b/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
@@ -53,16 +53,16 @@ static void* CreatePopulationPedWrap(uint16_t a1, int a2, const char* sourceName
 	// apply changed data
 	if (creationState.model != modelHash)
 	{
-		rage::fwModelId archetypeUnk{ mi };
-		rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(creationState.model, archetypeUnk);
+		rage::fwModelId idx{ mi };
+		rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(creationState.model, idx);
 
-		uint32_t at = archetypeUnk.id;
+		uint32_t at = idx.value;
 		if (!hasModelLoaded(&at))
 		{
 			return nullptr;
 		}
 
-		mi = archetypeUnk.id & 0xFFFF;
+		mi = idx.modelIndex;
 	}
 
 	position[0] = creationState.position[0];

--- a/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
+++ b/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
@@ -3,24 +3,35 @@
 
 #include <EntitySystem.h>
 
-
-static hook::cdecl_stub<fwArchetype*(uint32_t* archetypeUnk)> getArchetypeFromUnk([]()
+static hook::cdecl_stub<fwArchetype*(uint32_t* modelIndex)> getArchetypeFromModelIndex([]()
 {
+#ifdef GTA_FIVE
 	return hook::get_call(hook::get_pattern("89 44 24 30 E8 ? ? ? ? 48 8B CB 48 8B F0 E8", 4));
+#elif IS_RDR3
+	return hook::get_call(hook::get_pattern("44 89 44 24 48 E8 ? ? ? ? 48 8B F8 48 85 C0 0F 84", 5));
+#endif
 });
 
 static hook::cdecl_stub<bool(uint32_t* mi)> hasModelLoaded([]()
 {
+#ifdef GTA_FIVE
 	return hook::get_call(hook::get_pattern("25 FF FF FF 3F 89 45 6F E8 ? ? ? ? 84 C0", 8));
+#elif IS_RDR3
+	return hook::get_call(hook::get_pattern("48 8D 4D 60 E8 ? ? ? ? 84 C0 74 ? F3", 4));
+#endif
 });
 
 DLL_EXPORT fwEvent<PopulationCreationState*> OnCreatePopulationPed;
 
+#ifdef GTA_FIVE
 static void*(*g_createPopulationPed)(int32_t mi, float* position, float, void*, char a5, unsigned int a6, __int64 a7, char a8, char a9, char a10, char a11, __int64 a12, char a13, char a14, unsigned int a15, int a16, __int64 a17, __int64 a18, char a19, int a20, char a21);
-
 static void* CreatePopulationPedWrap(uint32_t mi, float* position, float a3, void* a4, char a5, unsigned int a6, __int64 a7, char a8, char a9, char a10, char a11, __int64 a12, char a13, char a14, unsigned int a15, int a16, __int64 a17, __int64 a18, char a19, int a20, char a21)
+#elif IS_RDR3
+static void* (*g_createPopulationPed)(uint16_t a1, int a2, const char* sourceName, int32_t mi, float* position, float, void*, char a8, void* a9, void* a10, char a11, char a12, void* a13, void* a14, char a15, void* a16, void* a17, int a18, void* a19, int* a20, void* a21);
+static void* CreatePopulationPedWrap(uint16_t a1, int a2, const char* sourceName, uint32_t mi, float* position, float a6, void* a7, char a8, void* a9, void* a10, char a11, char a12, void* a13, void* a14, char a15, void* a16, void* a17, int a18, void* a19, int* a20, void* a21)
+#endif
 {
-	auto archetype = getArchetypeFromUnk(&mi);
+	auto archetype = getArchetypeFromModelIndex(&mi);
 	uint32_t modelHash = 0;
 
 	if (archetype)
@@ -61,7 +72,11 @@ static void* CreatePopulationPedWrap(uint32_t mi, float* position, float a3, voi
 	// if allowed, create the ped
 	if (creationState.allowed)
 	{
+#ifdef GTA_FIVE
 		return g_createPopulationPed(mi, position, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21);
+#elif IS_RDR3
+		return g_createPopulationPed(a1, a2, sourceName, mi, position, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21);
+#endif
 	}
 
 	return nullptr;
@@ -71,7 +86,12 @@ static void* CreatePopulationPedWrap(uint32_t mi, float* position, float a3, voi
 
 static HookFunction hookFunction([]()
 {
+#ifdef GTA_FIVE
 	auto location = hook::get_call(hook::get_pattern("44 89 7C 24 28 88 44 24 20 44 88 2D ? ? ? ? E8", 16));
+#elif IS_RDR3
+	auto location = hook::get_call(hook::get_pattern("83 4C 24 40 FF 88 44 24 38 48 8D", 30));
+#endif
+
 	MH_Initialize();
 	MH_CreateHook(location, CreatePopulationPedWrap, (void**)&g_createPopulationPed);
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
+++ b/code/components/gta-streaming-five/src/PopulationCreationHooks.cpp
@@ -3,7 +3,6 @@
 
 #include <EntitySystem.h>
 
-fwArchetype* GetArchetypeSafe(uint32_t archetypeHash, uint64_t* archetypeUnk);
 
 static hook::cdecl_stub<fwArchetype*(uint32_t* archetypeUnk)> getArchetypeFromUnk([]()
 {
@@ -43,16 +42,16 @@ static void* CreatePopulationPedWrap(uint32_t mi, float* position, float a3, voi
 	// apply changed data
 	if (creationState.model != modelHash)
 	{
-		uint64_t archetypeUnk = mi;
-		GetArchetypeSafe(creationState.model, &archetypeUnk);
+		rage::fwModelId archetypeUnk{ mi };
+		rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(creationState.model, archetypeUnk);
 
-		uint32_t at = archetypeUnk;
+		uint32_t at = archetypeUnk.id;
 		if (!hasModelLoaded(&at))
 		{
 			return nullptr;
 		}
 
-		mi = archetypeUnk & 0xFFFF;
+		mi = archetypeUnk.id & 0xFFFF;
 	}
 
 	position[0] = creationState.position[0];

--- a/code/components/gta-streaming-five/src/TextureStreamingLimits.cpp
+++ b/code/components/gta-streaming-five/src/TextureStreamingLimits.cpp
@@ -24,8 +24,8 @@ static int CalculateMipLevelHook(uint8_t type, uint16_t width, uint16_t height, 
 		auto baseName = strName.substr(0, strName.find('.'));
 
 		// try getting the relevant archetype, and see if it's a vehicle
-		rage::fwModelId archetypeUnk{ 0xFFFFFFF };
-		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(HashString(baseName.c_str()), archetypeUnk);
+		rage::fwModelId idx;
+		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(HashString(baseName.c_str()), idx);
 
 		if (archetype)
 		{

--- a/code/components/gta-streaming-five/src/TextureStreamingLimits.cpp
+++ b/code/components/gta-streaming-five/src/TextureStreamingLimits.cpp
@@ -9,8 +9,6 @@ extern std::string GetCurrentStreamingName();
 
 static int(*g_origCalculateMipLevel)(uint8_t type, uint16_t width, uint16_t height, uint8_t levels, uint32_t format);
 
-fwArchetype* GetArchetypeSafe(uint32_t archetypeHash, uint64_t* archetypeUnk);
-
 static ConVar<int>* g_maxVehicleTextureRes;
 static ConVar<int>* g_maxVehicleTextureResRgba;
 static uintptr_t g_vtbl_CVehicleModelInfo;
@@ -26,8 +24,8 @@ static int CalculateMipLevelHook(uint8_t type, uint16_t width, uint16_t height, 
 		auto baseName = strName.substr(0, strName.find('.'));
 
 		// try getting the relevant archetype, and see if it's a vehicle
-		uint64_t archetypeUnk = 0xFFFFFFF;
-		auto archetype = GetArchetypeSafe(HashString(baseName.c_str()), &archetypeUnk);
+		rage::fwModelId archetypeUnk{ 0xFFFFFFF };
+		auto archetype = rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(HashString(baseName.c_str()), archetypeUnk);
 
 		if (archetype)
 		{

--- a/code/components/gta-streaming-rdr3/component.lua
+++ b/code/components/gta-streaming-rdr3/component.lua
@@ -9,5 +9,6 @@ return function()
 		'components/gta-streaming-five/include/Streaming.h',
 		'components/gta-streaming-five/src/LoadStreamingFile.cpp',
 		'components/gta-streaming-five/src/StreamingFreeTests.cpp',
+		'components/gta-streaming-five/src/PopulationCreationHooks.cpp',
 	}
 end

--- a/code/components/gta-streaming-rdr3/include/EntitySystem.h
+++ b/code/components/gta-streaming-rdr3/include/EntitySystem.h
@@ -34,8 +34,30 @@ namespace rage
 {
 struct fwModelId
 {
-	uint64_t id;
+	union
+	{
+		uint32_t value;
+
+		struct
+		{
+			uint16_t modelIndex;
+			uint16_t mapTypesIndex : 12;
+			uint16_t flags : 4;
+		};
+	};
+
+	fwModelId()
+		: modelIndex(0xFFFF), mapTypesIndex(0xFFF), flags(0)
+	{
+	}
+
+	fwModelId(uint32_t idx)
+		: value(idx)
+	{
+	}
 };
+
+static_assert(sizeof(fwModelId) == 4);
 
 class STREAMING_EXPORT fwArchetypeManager
 {

--- a/code/components/gta-streaming-rdr3/include/EntitySystem.h
+++ b/code/components/gta-streaming-rdr3/include/EntitySystem.h
@@ -17,6 +17,17 @@ class STREAMING_EXPORT fwArchetype
 {
 public:
 	virtual ~fwArchetype() = default;
+
+public:
+	void* dynamicArchetypeComponent;
+	char pad[16];
+	float bsCenter[3];
+	float radius;
+	float aabbMin[4];
+	float aabbMax[4];
+	char pad2[16];
+	uint32_t hash;
+	char pad3[12];
 };
 
 namespace rage
@@ -30,6 +41,8 @@ class STREAMING_EXPORT fwArchetypeManager
 {
 public:
 	static fwArchetype* GetArchetypeFromHashKey(uint32_t hash, fwModelId& id);
+
+	static fwArchetype* GetArchetypeFromHashKeySafe(uint32_t hash, fwModelId& id);
 };
 
 class STREAMING_EXPORT fwRefAwareBase
@@ -205,3 +218,12 @@ class CVehicle : public fwEntity
 class CPed : public fwEntity
 {
 };
+
+struct PopulationCreationState
+{
+	float position[3];
+	uint32_t model;
+	bool allowed;
+};
+
+STREAMING_EXPORT extern fwEvent<PopulationCreationState*> OnCreatePopulationPed;

--- a/code/components/gta-streaming-rdr3/src/EntitySystem.cpp
+++ b/code/components/gta-streaming-rdr3/src/EntitySystem.cpp
@@ -13,7 +13,7 @@ fwEntity* rage::fwScriptGuid::GetBaseFromGuid(int handle)
 	return getScriptEntity(handle);
 }
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& modelId)> getArchetype([]()
+static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& id)> getArchetype([]()
 {
 	return hook::get_call(hook::pattern("8B 4E 08 C1 EB 05 80 E3 01 E8").count(1).get(0).get<void>(9));
 });

--- a/code/components/gta-streaming-rdr3/src/EntitySystem.cpp
+++ b/code/components/gta-streaming-rdr3/src/EntitySystem.cpp
@@ -13,7 +13,7 @@ fwEntity* rage::fwScriptGuid::GetBaseFromGuid(int handle)
 	return getScriptEntity(handle);
 }
 
-static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& archetypeUnk)> getArchetype([]()
+static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& modelId)> getArchetype([]()
 {
 	return hook::get_call(hook::pattern("8B 4E 08 C1 EB 05 80 E3 01 E8").count(1).get(0).get<void>(9));
 });
@@ -21,4 +21,16 @@ static hook::cdecl_stub<fwArchetype*(uint32_t nameHash, rage::fwModelId& archety
 fwArchetype* rage::fwArchetypeManager::GetArchetypeFromHashKey(uint32_t hash, fwModelId& id)
 {
 	return getArchetype(hash, id);
+}
+
+fwArchetype* rage::fwArchetypeManager::GetArchetypeFromHashKeySafe(uint32_t hash, fwModelId& id)
+{
+	__try
+	{
+		return getArchetype(hash, id);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		return nullptr;
+	}
 }


### PR DESCRIPTION
Plus some code cleanup.
The event work in the same way as in FiveM (`populationPedCreating`), see [docs](https://docs.fivem.net/docs/scripting-reference/events/list/populationPedCreating/).

Example from docs with `CS_dutch` model:
![image](https://github.com/citizenfx/fivem/assets/10367215/f308f0af-dcb2-44a2-9291-a215ed7242fe)
