### PR TITLE
Improve player talking hook for FiveM

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -437,10 +437,16 @@ static hook::cdecl_stub<void* (CNetGamePlayer*)> getPlayerPedForNetPlayer([]()
 });
 
 #ifdef GTA_FIVE
-static const uint32_t g_entityNetObjOffset = 208;
+static constexpr uint32_t g_entityNetObjOffset = 208;
 #elif IS_RDR3
-static const uint32_t g_entityNetObjOffset = 224;
+static constexpr uint32_t g_entityNetObjOffset = 224;
 #endif
+
+rage::netObject* GetNetObjectFromEntity(void* entity)
+{
+	// technically must be at least CDynamicEntity
+	return *(rage::netObject**)((char*)entity + g_entityNetObjOffset);
+}
 
 rage::netObject* GetLocalPlayerPedNetObject()
 {
@@ -448,9 +454,7 @@ rage::netObject* GetLocalPlayerPedNetObject()
 
 	if (ped)
 	{
-		auto netObj = *(rage::netObject**)((char*)ped + g_entityNetObjOffset);
-
-		return netObj;
+		return GetNetObjectFromEntity(ped);
 	}
 
 	return nullptr;
@@ -489,7 +493,7 @@ void HandleClientDrop(const NetLibraryClientInfo& info)
 
 		if (ped)
 		{
-			auto netObj = *(rage::netObject**)((char*)ped + g_entityNetObjOffset);
+			auto netObj = GetNetObjectFromEntity(ped);
 
 			if (netObj)
 			{
@@ -4702,7 +4706,7 @@ static InitFunction initFunction([]()
 			return;
 		}
 
-		auto netObj = *(rage::netObject**)(entity + g_entityNetObjOffset);
+		auto netObj = GetNetObjectFromEntity(entity);
 
 		static char blah[90000];
 
@@ -4743,7 +4747,7 @@ static InitFunction initFunction([]()
 			return;
 		}
 
-		auto netObj = *(rage::netObject**)(entity + g_entityNetObjOffset);
+		auto netObj = GetNetObjectFromEntity(entity);
 
 		static char blah[90000];
 
@@ -4931,7 +4935,7 @@ static InitFunction initFunction([]()
 			return;
 		}
 
-		auto obj = *(rage::netObject**)(entity + g_entityNetObjOffset);
+		auto obj = GetNetObjectFromEntity(entity);
 
 		auto data = context.GetArgument<const char*>(1);
 
@@ -5003,7 +5007,7 @@ static InitFunction initFunction([]()
 			return;
 		}
 
-		auto obj = *(rage::netObject**)(entity + g_entityNetObjOffset);
+		auto obj = GetNetObjectFromEntity(entity);
 		//obj->GetBlender()->m_30();
 		obj->GetBlender()->m_58();
 	});
@@ -5011,7 +5015,7 @@ static InitFunction initFunction([]()
 	static ConsoleCommand saveCloneCmd("save_clone", [](const std::string& address)
 	{
 		uintptr_t addressPtr = _strtoui64(address.c_str(), nullptr, 16);
-		auto netObj = *(rage::netObject**)(addressPtr + g_entityNetObjOffset);
+		auto netObj = GetNetObjectFromEntity((void*)addressPtr);
 
 		static char blah[90000];
 

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -46,6 +46,11 @@ using json = nlohmann::json;
 static NetLibrary* g_netLibrary;
 
 #ifdef GTA_FIVE
+static uint32_t g_gamerInfoGamerIdOffset;
+static uint32_t g_playerInfoPedOffset;
+#endif
+
+#ifdef GTA_FIVE
 static hook::cdecl_stub<void()> _initVoiceChatConfig([]()
 {
 	return hook::get_pattern("89 44 24 58 0F 29 44 24 40 E8", -0x12E);
@@ -711,11 +716,9 @@ static bool _isPlayerTalking(void* mgr, char* playerData)
 	}
 
 #ifdef GTA_FIVE
-	// 1290
-	// #TODO1365
-	// #TODO1493
-	// #TODO1604
-	auto playerInfo = playerData - 32 - 48 - 16 - (xbr::IsGameBuildOrGreater<2060>() ? 8 : 0);
+	// rlGamerInfo = rlGamerId - (1604: 64, 2060: 72, 2372: 104, 2944: 192, ...)
+	// CPlayerInfo = rlGamerInfo - 32 (fwExtensibleBase offset, unlikely to change)
+	auto playerInfo = playerData - g_gamerInfoGamerIdOffset - 32;
 
 	// preemptive check for invalid players (FIVEM-CLIENT-1604-TQKV) with uncertain server changes
 	if ((uintptr_t)playerInfo < 0xFFFF)
@@ -724,9 +727,10 @@ static bool _isPlayerTalking(void* mgr, char* playerData)
 	}
 
 	// get the ped
-	auto ped = *(char**)(playerInfo + 456);
+	auto ped = *(char**)(playerInfo + g_playerInfoPedOffset);
 #elif IS_RDR3
-	// rlGamerInfo = playerData - 200, rlGamerInfo + 896 = CPed
+	// rlGamerInfo = playerData - 200
+	// CPed = rlGamerInfo + 896
 	auto ped = *(char**)(playerData + 696);
 #endif
 
@@ -835,6 +839,13 @@ static HookFunction hookFunction([]()
 	g_preferenceArray = hook::get_address<uint32_t*>(hook::get_pattern("48 8D 15 ? ? ? ? 8D 43 01 83 F8 02 77 2D", 3));
 	g_viewportGame = hook::get_address<CViewportGame**>(hook::get_pattern("33 C0 48 39 05 ? ? ? ? 74 2E 48 8B 0D ? ? ? ? 48 85 C9 74 22", 5));
 	g_actorPos = hook::get_address<float*>(hook::get_pattern("BB 00 00 40 00 48 89 7D F8 89 1D", -4)) + 12;
+
+	{
+		auto location = hook::get_pattern<char>("BA 11 00 00 00 0F 10");
+		g_gamerInfoGamerIdOffset = xbr::IsGameBuildOrGreater<2944>() ? *(uint32_t*)(location + 8) : *(uint8_t*)(location - 1);
+	}
+
+	g_playerInfoPedOffset = *hook::get_pattern<uint32_t>("4C 8B 81 ? ? ? ? 41 8B 80", 3);
 #elif IS_RDR3
 	g_viewportGame = hook::get_address<CViewportGame**>(hook::get_pattern("0F 2F F0 76 ? 4C 8B 35", 8));
 

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -701,6 +701,8 @@ static bool(*g_origIsPlayerTalking)(void*, void*);
 
 extern CNetGamePlayer* netObject__GetPlayerOwner(rage::netObject* object);
 
+extern rage::netObject* GetNetObjectFromEntity(void* entity);
+
 static bool _isPlayerTalking(void* mgr, char* playerData)
 {
 	if (g_origIsPlayerTalking(mgr, playerData))
@@ -730,11 +732,7 @@ static bool _isPlayerTalking(void* mgr, char* playerData)
 
 	if (ped)
 	{
-#ifdef GTA_FIVE
-		auto netObj = *(rage::netObject**)(ped + 208);
-#elif IS_RDR3
-		auto netObj = *(rage::netObject**)(ped + 224);
-#endif
+		auto netObj = GetNetObjectFromEntity(ped);
 
 		if (netObj)
 		{


### PR DESCRIPTION
Patterns should future-proof this code from getting broken again, hopefully. Plus added a bit of explanation in the comments. Reworking this code to use `rage::netInterface::GetPlayerFromGamerId` might be considered in the future, however this function was heavily obfuscated in latest game builds, plus using it will add performance overhead. Simple memory layout hacks may work for some time.

Plus added a shared function to get net object from entity, it should decrease hard-to-read code duplication and ensure consistency.