### PR TITLE
fix(server/gui): 'FXServer/unknown' in console title

### DIFF
--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -180,10 +180,19 @@ private:
 				auto conCtx = m_instance->GetComponent<console::Context>();
 				auto hostNameVar = conCtx->GetVariableManager()->FindEntryRaw("sv_hostname");
 				auto iconVar = conCtx->GetVariableManager()->FindEntryRaw("sv_icon");
-				auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
 
 				if (hostNameVar && consoleWindowState.lastHostname != hostNameVar->GetValue())
 				{
+					auto gameNameVar = conCtx->GetVariableManager()->FindEntryRaw("gamename");
+
+					if (!gameNameVar)
+					{
+						if (auto fallbackContext = conCtx->GetFallbackContext())
+						{
+							gameNameVar = fallbackContext->GetVariableManager()->FindEntryRaw("gamename");
+						}
+					}
+
 					consoleWindowState.lastHostname = hostNameVar->GetValue();
 
 					SetConsoleTitle(fmt::sprintf(L"Cfx.re Server (FXServer/%s) - %s", ToWide((gameNameVar) ? gameNameVar->GetValue() : "unknown"), ToWide(consoleWindowState.lastHostname)).c_str());

--- a/code/components/citizen-server-gui/src/ServerGui.cpp
+++ b/code/components/citizen-server-gui/src/ServerGui.cpp
@@ -193,9 +193,12 @@ private:
 						}
 					}
 
+					// suffix 'txAdmin' if we're the txAdmin child process
+					auto txSuffix = console::GetDefaultContext()->GetVariableManager()->FindEntryRaw("txAdminServerMode") ? "/txAdmin" : "";
+
 					consoleWindowState.lastHostname = hostNameVar->GetValue();
 
-					SetConsoleTitle(fmt::sprintf(L"Cfx.re Server (FXServer/%s) - %s", ToWide((gameNameVar) ? gameNameVar->GetValue() : "unknown"), ToWide(consoleWindowState.lastHostname)).c_str());
+					SetConsoleTitle(fmt::sprintf(L"Cfx.re Server (FXServer/%s%s) - %s", ToWide((gameNameVar) ? gameNameVar->GetValue() : "unknown"), ToWide(txSuffix), ToWide(consoleWindowState.lastHostname)).c_str());
 				}
 
 				if (iconVar && consoleWindowState.lastIcon != iconVar->GetValue())


### PR DESCRIPTION
At one point, the `gamename` variable moved to the fallback console context, which made the code here only ever show 'unknown' instead of an actual game name (like 'FXServer/gta5').

As a fix, we will look this up in the fallback console context as well.

![image](https://github.com/citizenfx/fivem/assets/24576130/146dda2c-4ea7-4f04-8f8c-366f2970f342)
