### PR TITLE
feat(onesyn/events): add ragdoll request event

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5163,6 +5163,22 @@ struct CRemoveAllWeaponsEvent
 	MSGPACK_DEFINE_MAP(pedId);
 };
 
+struct CRagdollRequestEvent
+{
+	void Parse(rl::MessageBuffer& buffer)
+	{
+	}
+
+	inline std::string GetName()
+	{
+		return "ragdollRequestEvent";
+	}
+
+	int placeHolder;
+
+	MSGPACK_DEFINE_MAP(placeHolder);
+};
+
 /*NETEV startProjectileEvent SERVER
 /#*
  * Triggered when a projectile is created.
@@ -6795,6 +6811,7 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 
 	switch(eventType)
 	{
+		case RAGDOLL_REQUEST_EVENT: return GetHandler<CRagdollRequestEvent>(instance, client, std::move(buffer));
 		case WEAPON_DAMAGE_EVENT: return GetHandler<CWeaponDamageEvent>(instance, client, std::move(buffer), targetPlayers);
 		case RESPAWN_PLAYER_PED_EVENT: return GetHandler<CRespawnPlayerPedEvent>(instance, client, std::move(buffer));
 		case GIVE_WEAPON_EVENT: return GetHandler<CGiveWeaponEvent>(instance, client, std::move(buffer));
@@ -6827,6 +6844,7 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 
 	switch(eventType)
 	{
+		case RAGDOLL_REQUEST_EVENT: return GetHandler<CRagdollRequestEvent>(instance, client, std::move(buffer));
 		case WEAPON_DAMAGE_EVENT: return GetHandler<CWeaponDamageEvent>(instance, client, std::move(buffer), targetPlayers);
 		case RESPAWN_PLAYER_PED_EVENT: return GetHandler<CRespawnPlayerPedEvent>(instance, client, std::move(buffer));
 		case EXPLOSION_EVENT: return GetHandler<CExplosionEvent>(instance, client, std::move(buffer));


### PR DESCRIPTION
Since some cheats have now an option to ragdoll any player server owners should be able to cancel that event.

My knowledge is limited, and I don't know how to figure out the event data. I put a placeholder so that someone with that knowledge should be able to replace that.