### PR TITLE
feat(gamestate/fivem): add a ConVar to disable REQUEST_RAGDOLL_EVENT

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -99,6 +99,9 @@ static std::shared_ptr<ConVar<int>> g_requestControlSettleVar;
 static RequestControlFilterMode g_requestControlFilterState;
 static int g_requestControlSettleDelay;
 
+static std::shared_ptr<ConVar<bool>> g_enableRagdollRequestsVar;
+static bool g_enableRagdollRequests;
+
 static uint32_t MakeHandleUniqifierPair(uint16_t objectId, uint16_t uniqifier)
 {
 	return ((uint32_t)objectId << 16) | (uint32_t)uniqifier;
@@ -6773,7 +6776,15 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 		return GetRequestControlEventHandler(client, std::move(buffer));
 	}
 
-	if(eventType == NETWORK_PLAY_SOUND_EVENT)
+	if (eventType == RAGDOLL_REQUEST_EVENT)
+	{
+		return []
+		{
+			return g_enableRagdollRequests;
+		};
+	}
+
+	if (eventType == NETWORK_PLAY_SOUND_EVENT)
 	{
 		return []()
 		{
@@ -6869,6 +6880,7 @@ static InitFunction initFunction([]()
 		}
 
 		g_networkedSoundsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedSounds", ConVar_None, true, &g_networkedSoundsEnabled);
+		g_enableRagdollRequestsVar = instance->AddVariable<bool>("sv_enableRagdollRequests", ConVar_None, true, &g_enableRagdollRequests);
 
 		g_networkedPhoneExplosionsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedPhoneExplosions", ConVar_None, false, &g_networkedPhoneExplosionsEnabled);
 


### PR DESCRIPTION
This is a follow up to some of the discussion from #2237

This adds a ConVar for server owners to disable ragdoll requests `set sv_enableRagdollRequests false`.