### PR TITLE
feat(discord): user toggle for rich presence

### DIFF
--- a/code/components/citizen-resources-client/src/ConsoleScriptFunctions.cpp
+++ b/code/components/citizen-resources-client/src/ConsoleScriptFunctions.cpp
@@ -12,8 +12,10 @@ static InitFunction initFunction([]()
 
 		// this should not be exposed to script
 		// #TODO: 'not exposed to script' convar flags
-		if (HashString(varName.c_str()) == HashString("cl_ownershipTicket") || // ownership ticket is *very* bad to expose as users can pretend to be other users using this
-			HashString(varName.c_str()) == HashString("ui_updateChannel"))     // update channel is often misused as a marker for other things
+		uint32_t hashedVarName = HashString(varName.c_str());
+		if (hashedVarName == HashString("cl_ownershipTicket") ||   // ownership ticket is *very* bad to expose as users can pretend to be other users using this
+			hashedVarName == HashString("ui_updateChannel") ||     // update channel is often misused as a marker for other things
+			hashedVarName == HashString("cl_discordRichPresence")) // users probably set this for privacy reasons, no need for peeking eyes
 		{
 			context.SetResult(context.CheckArgument<const char*>(1));
 			return;

--- a/code/components/discord/src/DiscordPresence.cpp
+++ b/code/components/discord/src/DiscordPresence.cpp
@@ -9,6 +9,8 @@
 
 #include <ScriptEngine.h>
 
+#include <CoreConsole.h>
+
 #ifdef GTA_FIVE
 #define DEFAULT_APP_ID "382624125287399424"
 #define DEFAULT_APP_ASSET "fivem_large"
@@ -53,6 +55,12 @@ static std::string g_discordAppAssetText;
 static std::string g_discordAppAssetSmallText;
 
 static std::optional<std::tuple<std::pair<std::string, std::string>, std::pair<std::string, std::string>>> g_buttons;
+
+static std::shared_ptr<ConVar<std::string>> g_richPresenceState;
+
+static std::string g_lastRichPresenceState = "disabled";
+
+static size_t g_onGameFrameCookie = -1;
 
 static void UpdatePresence()
 {
@@ -153,17 +161,81 @@ static void UpdatePresence()
 	}
 }
 
+static void OnRichPresenceStateChange(internal::ConsoleVariableEntry<std::string>* richPresenceState)
+{
+	std::string state = richPresenceState->GetValue();
+
+	if (state != "disabled" && state != "restricted" && state != "enabled")
+	{
+		richPresenceState->SetValue("enabled");
+		return;
+	}
+
+	if (state == g_lastRichPresenceState)
+	{
+		return;
+	}
+
+	if (g_lastRichPresenceState == "enabled")
+	{
+		OnGameFrame.Disconnect(g_onGameFrameCookie);
+		g_onGameFrameCookie = -1;
+	}
+
+	if (g_lastRichPresenceState == "disabled" || (state == "restricted" && g_lastDiscordAppId != DEFAULT_APP_ID))
+	{
+		if (state == "restricted" && g_lastDiscordAppId != DEFAULT_APP_ID)
+		{
+			g_lastDiscordAppId = DEFAULT_APP_ID;
+			Discord_Shutdown();
+		}
+		DiscordEventHandlers handlers;
+		memset(&handlers, 0, sizeof(handlers));
+		Discord_Initialize(g_lastDiscordAppId.c_str(), &handlers, 1, nullptr);
+	}
+
+	if (state == "enabled" && g_onGameFrameCookie == -1)
+	{
+		g_richPresenceChanged = true;
+		g_onGameFrameCookie = OnGameFrame.Connect([]()
+		{
+			Discord_RunCallbacks();
+
+			UpdatePresence();
+		});
+	}
+	else if (state == "restricted")
+	{
+		DiscordRichPresence discordPresence;
+		memset(&discordPresence, 0, sizeof(discordPresence));
+		discordPresence.largeImageKey = g_discordAppAsset.c_str();
+		discordPresence.smallImageKey = g_discordAppAssetSmall.c_str();
+		discordPresence.largeImageText = g_discordAppAssetText.c_str();
+		discordPresence.smallImageText = g_discordAppAssetSmallText.c_str();
+
+		Discord_UpdatePresence(&discordPresence);
+	}
+	else if (state == "disabled")
+	{
+		Discord_Shutdown();
+	}
+
+	g_lastRichPresenceState = state;
+};
+
 static InitFunction initFunction([]()
 {
-	DiscordEventHandlers handlers;
-	memset(&handlers, 0, sizeof(handlers));
 	g_discordAppId = DEFAULT_APP_ID;
 	g_discordAppAsset = DEFAULT_APP_ASSET;
 	g_discordAppAssetSmall = DEFAULT_APP_ASSET_SMALL;
 	g_discordAppAssetText = DEFAULT_APP_ASSET_TEXT;
 	g_discordAppAssetSmallText = DEFAULT_APP_ASSET_SMALL_TEXT;
-	
-	Discord_Initialize(g_discordAppId.c_str(), &handlers, 1, nullptr);
+	g_richPresenceState = std::make_shared<ConVar<std::string>>("cl_discordRichPresence", ConVar_Archive | ConVar_UserPref, "", OnRichPresenceStateChange);
+
+	if (g_richPresenceState->GetValue() == "")
+	{
+		g_richPresenceState->GetHelper()->SetValue("enabled");
+	}
 
 	OnRichPresenceSetTemplate.Connect([](const std::string& text)
 	{
@@ -190,13 +262,6 @@ static InitFunction initFunction([]()
 	});
 
 	OnRichPresenceSetTemplate("In the menus\n");
-
-	OnGameFrame.Connect([]()
-	{
-		Discord_RunCallbacks();
-
-		UpdatePresence();
-	});
 
 	OnKillNetworkDone.Connect([]()
 	{

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -131,6 +131,8 @@
     "#Settings_FixedSizeNUIDesc": "Force in-server UI to 1920x1080 resolution, scaled/letterboxed to fit (for servers with UI assuming 1920x1080)",
     "#Settings_NoiseSuppression": "Voice chat noise suppression",
     "#Settings_NoiseSuppressionDesc": "Enable background noise suppression (using RNNoise) for the built-in voice chat",
+    "#Settings_DiscordRichPresence": "Discord activity status",
+    "#Settings_DiscordRichPresenceDesc": "Displays the server you're currently connected to and allows servers to display a custom activity status on your Discord profile.",
     "#Settings_ConnectedProfiles": "Linked identities",
     "#Settings_UpdateChannel": "Update channel",
     "#Settings_UpdateChannelDesc": "Try out new features and changes before they launch. Has a chance of breaking.",

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
@@ -310,6 +310,23 @@ const GAME_GAME_SETTINGS = new Map<string, ISetting.AnySetting>([
       ...convarAccessorsBoolean('voice_enableNoiseSuppression'),
     },
   ],
+  [
+    'discordRichPresence',
+    {
+      type: 'switch',
+
+      label: $L('#Settings_DiscordRichPresence'),
+      description: $L('#Settings_DiscordRichPresenceDesc'),
+
+      ...convarAccessorsString('cl_discordRichPresence'),
+
+      options: {
+        ['enabled']: 'Enabled',
+        ['restricted']: 'Hide status',
+        ['disabled']: 'Disabled',
+      },
+    }
+  ],
 
   [
     'customEmoji',


### PR DESCRIPTION
Requested in https://forum.cfx.re/t/5018677

Allow users to either completely disable Discords Rich Presence status or only show the current game version without displaying any game status.