### PR TITLE
feat(client/clr): ability to send byte[] as InputArgument

### DIFF
--- a/code/client/clrcore/Native.cs
+++ b/code/client/clrcore/Native.cs
@@ -385,6 +385,11 @@ namespace CitizenFX.Core.Native
 			return new InputArgument(value);
 		}
 
+		public static implicit operator InputArgument(byte[] value)
+		{
+			return new InputArgument(value);
+		}
+
 		public static implicit operator InputArgument(Delegate value)
 		{
 			return new InputArgument(InternalManager.CanonicalizeRef(FunctionReference.Create(value).Identifier));

--- a/code/client/clrcore/ScriptContext.cs
+++ b/code/client/clrcore/ScriptContext.cs
@@ -95,6 +95,11 @@ namespace CitizenFX.Core
 
 				return;
 			}
+			else if (arg is byte[] array)
+			{
+				PushByteArray(context, array);
+				return;
+			}
 			else if (arg is InputArgument ia)
 			{
 				Push(context, ia.Value);
@@ -107,6 +112,21 @@ namespace CitizenFX.Core
 			}
 
 			context->numArguments++;
+		}
+
+		[SecurityCritical]
+		internal static unsafe void PushByteArray(ContextType* cxt, byte[] array)
+		{
+			var ptr = Marshal.AllocHGlobal(array.Length);
+			Marshal.Copy(array, 0, ptr, array.Length);
+			ms_finalizers.Enqueue(() => Free(ptr));
+
+			unsafe
+			{
+				*(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
+			}
+
+			cxt->numArguments += 1;
 		}
 
 		[SecurityCritical]


### PR DESCRIPTION
There is no way to pass byte[] to native now using C#. This PR makes it possible - I tested it [RedM] with native `0x26E87218390E6729` (notification toast showing on the left side), which needs two byte arrays passed as arguments.