### PR TITLE
fix(build): update mojo files for python 3.12

### DIFF
--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom/parse/lexer.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom/parse/lexer.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 
@@ -17,7 +17,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("ply")
+  importlib.util.find_spec("ply")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("mojo"), "third_party"))
 from ply.lex import TOKEN

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/fileutil_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/fileutil_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import shutil
 import sys
@@ -20,7 +20,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom import fileutil

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/data_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/data_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom.generate import data

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/generator_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/generator_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom.generate import generator

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/module_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/module_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom.generate import module as mojom

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/pack_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/generate/pack_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -20,7 +20,7 @@ def _GetDirAbove(dirname):
 
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom.generate import pack

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/ast_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/ast_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 import mojom.parse.ast as ast

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/conditional_features_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/conditional_features_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os
 import sys
 import unittest
@@ -20,7 +20,7 @@ def _GetDirAbove(dirname):
 
 
 try:
-  imp.find_module('mojom')
+  importlib.util.find_spec('mojom')
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove('pylib'), 'pylib'))
 import mojom.parse.ast as ast

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/lexer_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/lexer_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -21,7 +21,7 @@ sys.path.insert(1, os.path.join(_GetDirAbove("mojo"), "third_party"))
 from ply import lex
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 import mojom.parse.lexer

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/parser_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/parser_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 import mojom.parse.ast as ast

--- a/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/translate_unittest.py
+++ b/vendor/chromium/mojo/public/tools/bindings/pylib/mojom_tests/parse/translate_unittest.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import imp
+import importlib
 import os.path
 import sys
 import unittest
@@ -18,7 +18,7 @@ def _GetDirAbove(dirname):
       return path
 
 try:
-  imp.find_module("mojom")
+  importlib.util.find_spec("mojom")
 except ImportError:
   sys.path.append(os.path.join(_GetDirAbove("pylib"), "pylib"))
 from mojom.parse import ast


### PR DESCRIPTION
This allows compilation of the mojo project with python 3.12.
* Replace `imp` module with the newer `importlib.util` module that was added in 3.4.
* This allowed for successful builds on my test machines (windows and linux),
* Some reports say that `setuptools` or `distutils` was still missing and is needed to build the natives, I wasn't able to replicate this.

Note: setuptools can can installed as follows: `pip install setuptools` or `py -3 -m pip install setuptools`