### PR TITLE
fix(clrclore): ignore captured traces if null

### DIFF
--- a/code/client/clrcore/InternalManager.cs
+++ b/code/client/clrcore/InternalManager.cs
@@ -585,6 +585,7 @@ namespace CitizenFX.Core
 			IEnumerable<StackFrame> stackFrames;
 
 			// HACK: workaround to iterate inner traces ourselves.
+			// TODO: remove this once we've updated libraries
 			var fieldCapturedTraces = typeof(StackTrace).GetField("captured_traces", BindingFlags.NonPublic | BindingFlags.Instance);
 			if (fieldCapturedTraces != null)
 			{
@@ -592,7 +593,7 @@ namespace CitizenFX.Core
 
 				// client's mscorlib is missing this piece of code, copied from https://github.com/mono/mono/blob/ef848cfa83ea16b8afbd5b933968b1838df19505/mcs/class/corlib/System.Diagnostics/StackTrace.cs#L181
 				var accum = new List<StackFrame>();
-				foreach (var t in captured_traces)
+				foreach (var t in captured_traces ?? Array.Empty<StackTrace>())
 				{
 					for (int i = 0; i < t.FrameCount; i++)
 						accum.Add(t.GetFrame(i));


### PR DESCRIPTION
This should've be null checked and ignored. We'll fix it like this as it's not performance critical and we'll need to remove it anyway when we'll update the libraries.

fixes: #2265