### PR TITLE
added playerDeathEvent

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -473,6 +473,7 @@ struct CPedHealthNodeData
 	int armour;
 	uint32_t causeOfDeath;
 	int sourceOfDamage;
+	bool isDead;
 };
 
 struct CPedOrientationNodeData
@@ -726,6 +727,8 @@ public:
 	virtual bool GetScriptHash(uint32_t* scriptHash) = 0;
 
 	virtual bool IsEntityVisible(bool* visible) = 0;
+
+	virtual void SetPedDead(bool isDead) = 0;
 };
 
 enum class NetObjEntityType

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -3617,6 +3617,18 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, false>
 
 		return false;
 	}
+
+	virtual void SetPedDead(bool isDead) override
+	{
+		auto [hasNode, node] = this->template GetData<CPedHealthDataNode>();
+
+		if (hasNode)
+		{
+			auto data = &node->data;
+
+			node->data.isDead = isDead;
+		}
+	}
 };
 
 using CAutomobileSyncTree = SyncTree<

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -961,6 +961,24 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 				}
 			}
 
+			if (entity->type == sync::NetObjEntityType::Player)
+			{
+				auto entityHealth = entity->syncTree->GetPedHealth();
+
+				if (entityHealth->health <= 0 && !entityHealth->isDead)
+				{
+					auto ownerRef = entity->GetClient();
+
+					entity->syncTree->SetPedDead(true);
+
+					evMan->TriggerEvent2("playerDeathEvent", {}, fmt::sprintf("%d", ownerRef->GetNetId()), entityHealth->causeOfDeath, entityHealth->sourceOfDamage);
+				}
+				else if (entityHealth->isDead && entityHealth->health >= 1)
+				{
+					entity->syncTree->SetPedDead(false);
+				}
+			}
+
 			float position[3];
 			entity->syncTree->GetPosition(position);
 


### PR DESCRIPTION
Has many different use cases such as fully server side player death handling.

Example:
```
AddEventHandler('playerDeathEvent', function(source, causeOfDeath, sourceOfDamage)
    print('playerDeathEvent', source, causeOfDeath, sourceOfDamage)
end)
```