### PR TITLE
fix(scripting/lua): correct LuaNativeContext constructor

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptNatives.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptNatives.cpp
@@ -1226,7 +1226,7 @@ struct LuaNativeContext : public fxNativeContext
 {
 	LUA_INLINE LuaNativeContext(void*, int numArguments)
 	{
-		numArguments = numArguments;
+		this->numArguments = numArguments;
 		numResults = 0;
 	}
 


### PR DESCRIPTION
Fixes #2183 and the forums post referenced (SetPlayerRoutingBucket, SetEntityRoutingBucket natives)

Repro
```lua
RegisterCommand("setBucket", function(source, args)
    SetPlayerRoutingBucket(tostring(source), (tonumber(args[1] or "100") or 100))
end, false)

RegisterCommand("getBucket", function(source)
    print(("You are in bucket %s"):format(GetPlayerRoutingBucket(tostring(source))))
end, false)
```