### PR TITLE
tweak(data/five): increase audio occlusion related pool sizes

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -362,15 +362,15 @@
 						</Item>
 						<Item>
 							<PoolName>OcclusionPathNode</PoolName>
-							<PoolSize value="5250"/>
+							<PoolSize value="20000"/>
 						</Item>
 						<Item>
 							<PoolName>OcclusionPortalEntity</PoolName>
-							<PoolSize value="280"/>
+							<PoolSize value="3000"/>
 						</Item>
 						<Item>
 							<PoolName>OcclusionPortalInfo</PoolName>
-							<PoolSize value="550"/>
+							<PoolSize value="3000"/>
 						</Item>
 						<Item>
 							<PoolName>Peds</PoolName>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
When linking multiple large interiors together, the amount of path nodes, portal infos and portal entities grows exponentially per interior linked. To allow for this, we need to increase the pool size.


### How is this PR achieving the goal
By increasing the following pools; 
OcclusionPathNode currently allocates 82 KB, new size would be 312 KB
OcclusionPortalInfo currently allocates 42 KB, new size would be 960 KB
OcclusionPortalEntity currently allocates 8 KB, new size would be 93 KB

So this would increase usage by 1366 KB, which is a reasonable increase for gained possibilities.



### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM



### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 2372, 2802

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

