### PR TITLE
Fix typo in `CVehicle::GetHandlingData` (b2802 and b2944)

### DIFF
--- a/code/components/gta-streaming-five/include/EntitySystem.h
+++ b/code/components/gta-streaming-five/include/EntitySystem.h
@@ -787,7 +787,7 @@ public:
 
 	inline CHandlingData* GetHandlingData()
 	{
-		if (xbr::IsGameBuildOrGreater<2802>())
+		if (xbr::IsGameBuildOrGreater<3095>())
 		{
 			return impl.m3095.m_handlingData;
 		}


### PR DESCRIPTION
Fixes #2307

### Goal of this PR
Fix the reported regression.
...


### How is this PR achieving the goal
Fixing the reported regression.


### This PR applies to the following area(s)
`gta-streaming-five`
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:**  2802, 2944, 3095

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes #2307

