### PR TITLE
feat(net/client): Add state bag methods

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -96,6 +96,16 @@ public:
 	// Gets data for a key.
 	//
 	virtual std::optional<std::string> GetKey(std::string_view key) = 0;
+
+	//
+	// Returns whether the state bag has data for this key
+	//
+	virtual bool HasKey(std::string_view key) = 0;
+
+	//
+	// Returns all the keys that the state bag has data for
+	//
+	virtual std::vector<std::string> GetKeys() = 0;
 };
 
 class CRC_EXPORT StateBagComponent : public fwRefCountable, public IAttached<ResourceManager>

--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -101,6 +101,8 @@ public:
 	virtual ~StateBagImpl() override;
 
 	virtual std::optional<std::string> GetKey(std::string_view key) override;
+	virtual bool HasKey(std::string_view key) override;
+	virtual std::vector<std::string> GetKeys() override;
 	virtual void SetKey(int source, std::string_view key, std::string_view data, bool replicated = true) override;
 	virtual void SetRoutingTargets(const std::set<int>& peers) override;
 
@@ -165,6 +167,26 @@ std::optional<std::string> StateBagImpl::GetKey(std::string_view key)
 	}
 
 	return {};
+}
+
+std::vector<std::string> StateBagImpl::GetKeys()
+{
+	std::vector<std::string> keys;
+	std::shared_lock _(m_dataMutex);
+
+	for (auto data : m_data)
+	{
+		keys.push_back(data.first);
+	}
+	
+	return keys;
+}
+
+
+bool StateBagImpl::HasKey(std::string_view key)
+{
+	std::shared_lock _(m_dataMutex);
+	return m_data.count(key) != 0;
 }
 
 void StateBagImpl::SetKey(int source, std::string_view key, std::string_view data, bool replicated /* = true */)

--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -396,4 +396,40 @@ static InitFunction initFunction([] ()
 
 		sbac->OnStateBagChange.Disconnect(size_t(cookie));
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("STATE_BAG_HAS_VALUE", [](fx::ScriptContext& context)
+	{
+		auto bagName = context.CheckArgument<const char*>(0);
+		auto keyName = context.CheckArgument<const char*>(1);
+
+		auto rm = fx::ResourceManager::GetCurrent();
+		auto sbac = rm->GetComponent<fx::StateBagComponent>();
+
+		auto bag = sbac->GetStateBag(bagName);
+
+		if (!bag)
+		{
+			context.SetResult(false);
+			return;
+		}
+
+		context.SetResult(bag->HasKey(keyName));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_STATE_BAG_KEYS", [](fx::ScriptContext& context)
+	{
+		auto bagName = context.CheckArgument<const char*>(0);
+
+		auto rm = fx::ResourceManager::GetCurrent();
+		auto sbac = rm->GetComponent<fx::StateBagComponent>();
+
+		std::vector<std::string> keys;
+
+		if (auto bag = sbac->GetStateBag(bagName))
+		{
+			keys = bag->GetKeys();
+		}
+
+		context.SetResult(fx::SerializeObject(keys));
+	});
 });

--- a/ext/native-decls/GetStateBagKeys.md
+++ b/ext/native-decls/GetStateBagKeys.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: shared
+---
+## GET_STATE_BAG_KEYS
+
+```c
+object GET_STATE_BAG_KEYS(char* bagName);
+```
+
+## Parameters
+* **bagName**: The name of the bag.
+
+## Return value
+Returns an array containing all keys for which the state bag has associated values.

--- a/ext/native-decls/StateBagHasValue.md
+++ b/ext/native-decls/StateBagHasValue.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: shared
+---
+## STATE_BAG_HAS_VALUE
+
+```c
+bool STATE_BAG_HAS_VALUE(char* bagName, char* key);
+```
+
+## Parameters
+* **bagName**: The name of the bag.
+* **key**: The key used to check data existence.
+
+## Return value
+Returns true if the data associated with the specified key exists; otherwise, returns false.


### PR DESCRIPTION
The modifications in this pull request introduce two new natives along with supporting methods for state bags.


### Goal of this PR
`STATE_BAG_HAS_VALUE`: This native is designed to eliminate unnecessary deserialization of state bag values. It serves the purpose of determining whether a value exists for a specific key within the state bag without the need for full deserialization.

`GET_STATE_BAG_KEYS`: This native expands the utility of state bags by enabling the construction of custom models around the state bag without the necessity to manually check each key for existence. This enhancement streamlines the process of working with state bags and facilitates the creation of more efficient and organized models.

### This PR applies to the following area(s)
FiveM, RedM, Server,


### Successfully tested on
**Game builds:**  2944

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


