### PR TITLE
feat(natives/server): implement 'GET_PLAYER_PROOFS'

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -572,6 +572,14 @@ struct CPlayerGameStateNodeData
 	int maxHealth;
 	int maxArmour;
 
+	int bulletProof;
+	int fireProof;
+	int explosionProof;
+	int collisionProof;
+	int meleeProof;
+	int drownProof;
+	int steamProof;
+	
 	bool neverTarget;
 	int spectatorId;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2704,12 +2704,19 @@ struct CPlayerGameStateDataNode
 		auto unk12 = state.buffer.ReadBit();
 		auto unk13 = state.buffer.ReadBit();
 		auto bulletProof = state.buffer.ReadBit();
+		data.bulletProof = bulletProof;
 		auto fireProof = state.buffer.ReadBit();
+		data.fireProof = fireProof;
 		auto explosionProof = state.buffer.ReadBit();
+		data.explosionProof = explosionProof;
 		auto collisionProof = state.buffer.ReadBit();
+		data.collisionProof = collisionProof;
 		auto meleeProof = state.buffer.ReadBit();
+		data.meleeProof = meleeProof;
 		auto drownProof = state.buffer.ReadBit();
+		data.drownProof = drownProof;
 		auto steamProof = state.buffer.ReadBit();
+		data.steamProof = steamProof;
 		auto unk21 = state.buffer.ReadBit();
 		auto unk22 = state.buffer.ReadBit();
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1161,6 +1161,24 @@ static void Init()
 		return pn ? pn->playerTeam : 0;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_PROOFS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (context.GetArgumentCount() > 7)
+		{
+			auto pn = entity->syncTree->GetPlayerGameState();
+
+			*context.GetArgument<int*>(1) = pn ? pn->bulletProof : 0;
+			*context.GetArgument<int*>(2) = pn ? pn->fireProof : 0;
+			*context.GetArgument<int*>(3) = pn ? pn->explosionProof : 0;
+			*context.GetArgument<int*>(4) = pn ? pn->collisionProof : 0;
+			*context.GetArgument<int*>(5) = pn ? pn->meleeProof : 0;
+			*context.GetArgument<int*>(6) = pn ? pn->drownProof : 0;
+			*context.GetArgument<int*>(7) = pn ? pn->steamProof : 0;
+		}
+
+		return 1;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_AIR_DRAG_MULTIPLIER_FOR_PLAYERS_VEHICLE", MakePlayerEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto pn = entity->syncTree->GetPlayerGameState();

--- a/ext/native-decls/GetPlayerProofs.md
+++ b/ext/native-decls/GetPlayerProofs.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: server
+---
+
+## GET_PLAYER_PROOFS
+
+```c
+void GET_PLAYER_PROOFS(Player player, int* bulletProof, int* fireProof, int* explosionProof, int* collisionProof, int* meleeProof, int* drownProof, int* steamProof);
+```
+
+Gets the player proofs for certain types of damage.
+
+## Return value
+
+Returns 1 if true, otherwise 0 if false.
+
+## Parameters
+
+-   **entity**: The player entity to get the proofs of.
+-   **bulletProof**:
+-   **fireProof**:
+-   **explosionProof**:
+-   **collisionProof**:
+-   **meleeProof**:
+-   **drownProof**:
+-   **steamProof**:


### PR DESCRIPTION
### Goal of this PR
<!-- Consice explanation of what this PR meant to achieve -->
This PR implements the `GET_PLAYER_PROOFS` native, which enables getting a player's damage type proofs on the server, similar to how the native `_GET_ENTITY_PROOFS` works on the client.


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 2944 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


