### PR TITLE
Bump mono v2 flag date

### DIFF
--- a/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
@@ -263,7 +263,7 @@ int MonoScriptRuntime::HandlesFile(char* filename, IScriptHostWithResourceData* 
 	}
 
 	// last supported date for this pilot of mono_rt2, in UTC
-	constexpr int maxYear = 2023, maxMonth = 12, maxDay = 31;
+	constexpr int maxYear = 2024, maxMonth = 4, maxDay = 30;
 
 	// Allowed values for mono_rt2
 	constexpr std::string_view allowedValues[] = {

--- a/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
@@ -268,6 +268,7 @@ int MonoScriptRuntime::HandlesFile(char* filename, IScriptHostWithResourceData* 
 	// Allowed values for mono_rt2
 	constexpr std::string_view allowedValues[] = {
 		// put latest on top, right here ↓
+		"Prerelease expiring 2024-04-30. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2023-12-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2023-08-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2023-06-30. See https://aka.cfx.re/mono-rt2-preview for info."sv,


### PR DESCRIPTION
The mono v2 flag will expire in 4 days, it would be useful to increase it for another 4 months as was done last time.

### Goal of this PR
<!-- Consice explanation of what this PR meant to achieve -->

Make mono v2 continue to be used after the last supported date (2023/12/31)


### How is this PR achieving the goal

Adding 4 months as was done last time to the flag date(2024/04/30)


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM, Client, Server, C#


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** All 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.