### PR TITLE
fix(tool/formats): five -> rdr3 embedded textures crash on unload

### DIFF
--- a/code/components/rage-formats-x/include/convert/phBound_five_rdr3.h
+++ b/code/components/rage-formats-x/include/convert/phBound_five_rdr3.h
@@ -163,9 +163,9 @@ static inline void fillPolyhedronBound(rdr3::phBoundPolyhedron* out, five::phBou
 	{
 		if (inPolys[i].type == 0)
 		{
-			outPolys[i].poly.v1 = inPolys[i].poly.v1;
-			outPolys[i].poly.v2 = inPolys[i].poly.v2;
-			outPolys[i].poly.v3 = inPolys[i].poly.v3;
+			outPolys[i].poly.v1 = (inPolys[i].poly.v1 & 0x7FFF);
+			outPolys[i].poly.v2 = (inPolys[i].poly.v2 & 0x7FFF);
+			outPolys[i].poly.v3 = (inPolys[i].poly.v3 & 0x7FFF);
 			outPolys[i].poly.e1 = inPolys[i].poly.e1;
 			outPolys[i].poly.e2 = inPolys[i].poly.e2;
 			outPolys[i].poly.e3 = inPolys[i].poly.e3;
@@ -474,6 +474,36 @@ static inline void fillGeometryBound(rdr3::phBoundGeometry* out, five::phBoundGe
 	out->SetMaterials(materials.size(), &materials[0]);
 }
 
+static inline void fillBoundPolyMaterial(rdr3::phBound* out, five::phBound* in)
+{
+	five::phBoundMaterial inMaterial = in->GetMaterial();
+	rdr3::phBoundMaterial outMaterial = { 0 };
+
+	outMaterial.mat1.materialIdx = ConvertMaterialIndexrdr3(inMaterial.mat1.materialIdx);
+	outMaterial.mat1.roomId = inMaterial.mat1.roomId;
+
+	outMaterial.mat2.stairs = inMaterial.mat1.stairs;
+	outMaterial.mat2.blockClimb = inMaterial.mat1.blockClimb;
+	outMaterial.mat2.seeThrough = inMaterial.mat1.seeThrough;
+	outMaterial.mat2.shootThrough = inMaterial.mat1.shootThrough;
+	outMaterial.mat2.notCover = inMaterial.mat1.notCover;
+	outMaterial.mat2.walkablePath = inMaterial.mat1.walkablePath;
+	outMaterial.mat2.noCamCollision = inMaterial.mat1.noCamCollision;
+	outMaterial.mat2.shootThroughFx = inMaterial.mat1.shootThroughFx;
+
+	outMaterial.mat2.noDecal = inMaterial.mat2.noDecal;
+	outMaterial.mat2.noNavmesh = inMaterial.mat2.noNavmesh;
+	outMaterial.mat2.noRagdoll = inMaterial.mat2.noRagdoll;
+	outMaterial.mat2.vehicleWheel = inMaterial.mat2.vehicleWheel;
+	outMaterial.mat2.noPtfx = inMaterial.mat2.noPtfx;
+	outMaterial.mat2.tooSteepForPlayer = inMaterial.mat2.tooSteepForPlayer;
+	outMaterial.mat2.noNetworkSpawn = inMaterial.mat2.noNetworkSpawn;
+	outMaterial.mat2.noCamCollisionAllowClipping = inMaterial.mat2.noCamCollisionAllowClipping;
+	outMaterial.mat2.unknown = inMaterial.mat2.unknown;
+
+	out->SetMaterial(outMaterial);
+}
+
 template<>
 rdr3::phBoundGeometry* convert(five::phBoundGeometry* bound)
 {
@@ -523,6 +553,7 @@ rdr3::phBoundSphere* convert(five::phBoundSphere* bound)
 	auto out = new (false) rdr3::phBoundSphere;
 
 	fillBaseBound(out, bound);
+	fillBoundPolyMaterial(out, bound);
 
 	return out;
 }
@@ -533,10 +564,7 @@ rdr3::phBoundBox* convert(five::phBoundBox* bound)
 	auto out = new (false) rdr3::phBoundBox;
 
 	fillBaseBound(out, bound);
-
-	//rage::rdr3::phBoundMaterial material = { 0 };
-	//material.mat1.materialIdx = ConvertMaterialIndex(bound->GetMaterial().mat1.materialIdx);
-	//out->SetMaterial(material);
+	fillBoundPolyMaterial(out, bound);
 
 	return out;
 }
@@ -547,6 +575,7 @@ rdr3::phBoundCapsule* convert(five::phBoundCapsule* bound)
 	auto out = new (false) rdr3::phBoundCapsule;
 
 	fillBaseBound(out, bound);
+	fillBoundPolyMaterial(out, bound);
 
 	return out;
 }

--- a/code/components/rage-formats-x/include/rmcDrawable.h
+++ b/code/components/rage-formats-x/include/rmcDrawable.h
@@ -167,7 +167,7 @@ namespace sga
 	private:
 		void* m_texturePtr; // filled at runtime
 
-		uint8_t m_pad[56];
+		uint8_t m_pad[64];
 
 	public:
 		ShaderResourceView()
@@ -176,7 +176,7 @@ namespace sga
 				0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 			};
 
 			memcpy(m_pad, f, sizeof(m_pad));
@@ -218,8 +218,7 @@ protected:
 #elif defined(RAGE_FORMATS_GAME_RDR3)
 	// sga::Texture
 	uint32_t m_blockSize;
-	uint16_t m_blockCount;
-	uint16_t m_blockPad;
+	uint32_t m_blockCount;
 	union
 	{
 		uint32_t m_flags;
@@ -234,7 +233,7 @@ protected:
 	uint8_t m_tileMode; // 0x0D?
 	uint8_t m_antiAliasType; // 0
 	uint8_t m_levels;
-	bool m_unkFlag; // format-related
+	uint8_t m_unk11; // format-related
 	uint8_t m_unk12;
 	uint8_t m_unk13;
 	// sga::imageParams end
@@ -242,6 +241,9 @@ protected:
 	pgPtr<char> m_name;
 	pgPtr<sga::ShaderResourceView> m_srv;
 	pgPtr<void> m_pixelData;
+	uint32_t m_unk18;
+	uint32_t m_unk19;
+	uint64_t m_unk20;
 #endif
 
 public:
@@ -282,11 +284,13 @@ public:
 
 		m_tileMode = 0xD;
 		m_antiAliasType = 0;
-		m_unkFlag = false;
+		m_unk11 = 0;
 		m_unk12 = 0;
 		m_unk13 = 0;
 		m_usageCount = 1;
-		m_blockPad = 0;
+		m_unk18 = 0;
+		m_unk19 = 0;
+		m_unk20 = 0;
 #endif
 	}
 
@@ -1096,8 +1100,8 @@ public:
 		memset(m_pad, 0, sizeof(m_pad));
 		memset(m_pad2, 0, sizeof(m_pad2));
 
-		m_const1 = 1;
-		m_const2 = 2;
+		m_const1 = 0;
+		m_const2 = 0;
 	}
 
 	inline char* GetName()


### PR DESCRIPTION
### Goal of this PR
Fix crash when models with embedded textures crash on unload

### This PR applies to the following area(s)
RedM converter

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
