### PR TITLE
feat(gamestate/server): CREATE_TRAIN(_CARRIAGE) natives

### DIFF
--- a/code/components/citizen-server-impl/component.json
+++ b/code/components/citizen-server-impl/component.json
@@ -27,7 +27,8 @@
 		"vendor:folly",
 		"vendor:concurrentqueue",
 		"vendor:xenium",
-		"vendor:rocksdb"
+		"vendor:rocksdb",
+		"vendor:tinyxml2-dll"
 	],
 	"provides": []
 }

--- a/code/components/citizen-server-impl/include/parser/Parser.h
+++ b/code/components/citizen-server-impl/include/parser/Parser.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "StdInc.h"
+#include <tinyxml2.h>
+
+#include <ScriptWarnings.h>
+#include <ClientRegistry.h>
+#include <ResourceManager.h>
+#include <VFSManager.h>
+
+namespace fx::data {
+	template<typename T>
+	class Parser
+	{
+	protected:
+		T m_data;
+	public:
+		inline bool LoadFile(fwRefContainer<fx::Resource> resource, std::string_view file)
+		{
+			const std::string& rootPath = resource->GetPath();
+
+			if (rootPath.empty())
+			{
+				return false;
+			}
+
+			fwRefContainer<vfs::Stream> stream = vfs::OpenRead(rootPath + "/" + std::string{ file });
+
+			if (!stream.GetRef())
+			{
+				fx::scripting::Warningf("", "Unable to locate file at @%s/%s", resource->GetName(), file);
+				return false;
+			}
+
+			auto data = stream->ReadToEnd();
+			tinyxml2::XMLDocument document;
+			tinyxml2::XMLError error = document.Parse(reinterpret_cast<const char*>(data.data()), data.size());
+
+			if (error == tinyxml2::XML_SUCCESS)
+			{
+				return ParseFile(document);
+			}
+		};
+
+	   virtual bool ParseFile(tinyxml2::XMLDocument&) = 0;
+
+		T GetData()
+		{
+			return m_data;
+		};
+	};
+}

--- a/code/components/citizen-server-impl/include/parser/TrainParser.h
+++ b/code/components/citizen-server-impl/include/parser/TrainParser.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "Parser.h"
+
+namespace fx::data
+{
+	struct CTrainCarriageInfo
+	{
+		const char* m_modelName;
+
+		uint32_t m_maxPedsPerCarriage;
+		bool m_flipModelDir;
+		bool m_doInteriorLights;
+		bool m_carriageVertOffset;
+		uint32_t m_repeatCount;
+	};
+
+	struct CTrainConfig
+	{
+		const char* m_name;
+		float m_populateTrainDist;
+		bool m_announceStations;
+		bool m_doorsBeep;
+		bool m_carriagesHang;
+		bool m_carriagesSwing;
+		bool m_carriagesUseEvenTrackSpacing;
+		bool m_linkTracksWithAdjacentStations;
+		bool m_noRandomSpawns;
+		float m_carriageGap;
+
+		std::vector<CTrainCarriageInfo> m_carriages;
+	};
+
+	struct CTrainTrack
+	{
+		const char* m_trainConfigName;
+		bool m_isPingPongTrack;
+		bool m_stopsAtStations;
+		bool m_MPStopsAtStations;
+		int32_t m_speed;
+		int32_t m_breakingDist;
+	};
+}
+
+namespace fx
+{
+	class CTrainConfigParser : public fwRefCountable, public data::Parser<std::vector<data::CTrainConfig>>
+	{
+		bool ParseFile(tinyxml2::XMLDocument& document) override
+		{
+			tinyxml2::XMLElement* configs = document.FirstChildElement("train_configs");
+
+			if (!configs)
+			{
+				return false;
+			}
+
+			std::vector<data::CTrainConfig> trainConfigs;
+			tinyxml2::XMLElement* config = configs->FirstChildElement("train_config");
+
+			if (config == nullptr)
+			{
+				return false;
+			}
+
+			while (config)
+			{
+				data::CTrainConfig trainConfig{};
+				trainConfig.m_name = config->Attribute("name");
+				trainConfig.m_populateTrainDist = config->IntAttribute("populate_train_dist", 0);
+				trainConfig.m_announceStations = config->BoolAttribute("announce_stations", false);
+				trainConfig.m_doorsBeep = config->BoolAttribute("doors_beep", false);
+				trainConfig.m_carriagesHang = config->BoolAttribute("carriages_hang", false);
+				trainConfig.m_carriagesSwing = config->BoolAttribute("carriages_swing", false);
+				trainConfig.m_linkTracksWithAdjacentStations = config->BoolAttribute("link_tracks_with_adjacent_stations", true);
+				trainConfig.m_noRandomSpawns = config->BoolAttribute("no_random_spawn", true);
+				trainConfig.m_carriageGap = config->FloatAttribute("carriage_gap", 0.1);
+
+				tinyxml2::XMLElement* carriage = config->FirstChildElement("carriage");
+				while (carriage)
+				{
+					data::CTrainCarriageInfo carriageInfo{};
+					carriageInfo.m_modelName = config->Attribute("model_name");
+					carriageInfo.m_maxPedsPerCarriage = config->IntAttribute("max_peds_per_carriage", 0);
+					carriageInfo.m_flipModelDir = config->BoolAttribute("flip_model_dir", false);
+					carriageInfo.m_doInteriorLights = config->BoolAttribute("do_interior_lights", false);
+					carriageInfo.m_carriageVertOffset = config->FloatAttribute("carriage_vert_offset", 1.0);
+					carriageInfo.m_repeatCount = config->IntAttribute("repeat_count", 1);
+
+					trainConfig.m_carriages.push_back(carriageInfo);
+
+					carriage = carriage->NextSiblingElement("carriage");
+				}
+
+				trainConfigs.push_back(trainConfig);
+				config = config->NextSiblingElement("train_config");
+			}
+
+			m_data = trainConfigs;
+			return true;
+		}
+	};
+
+	class CTrainTrackParser : public fwRefCountable, public data::Parser<std::vector<data::CTrainTrack>>
+	{
+		bool ParseFile(tinyxml2::XMLDocument& document)
+		{
+			tinyxml2::XMLElement* tracks = document.FirstChildElement("train_tracks");
+
+			if (!tracks)
+			{
+				return false;
+			}
+
+			std::vector<data::CTrainTrack> trainTracks;
+			tinyxml2::XMLElement* track = tracks->FirstChildElement("train_track");
+
+			if (track == nullptr)
+			{
+				return false;
+			}
+
+			while (track)
+			{
+				data::CTrainTrack trainTrack{};
+				trainTrack.m_trainConfigName = track->Attribute("trainConfigName");
+				trainTrack.m_isPingPongTrack = track->BoolAttribute("isPingPongTrack", false);
+				trainTrack.m_stopsAtStations = track->BoolAttribute("stopsAtStations", false);
+				trainTrack.m_MPStopsAtStations = track->BoolAttribute("MPstopsAtStations", false);
+				trainTrack.m_speed = track->IntAttribute("speed", 8);
+				trainTrack.m_breakingDist = track->IntAttribute("brakingDist", 10);
+
+				trainTracks.push_back(trainTrack);
+				track = track->NextSiblingElement("train_track");
+			}
+
+			m_data = trainTracks;
+			return true;
+		}
+	};
+}
+
+DECLARE_INSTANCE_TYPE(fx::CTrainConfigParser);
+DECLARE_INSTANCE_TYPE(fx::CTrainTrackParser);

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -547,18 +547,18 @@ struct CTrainGameStateDataNodeData
 	bool isEngine;
 	bool isCaboose;
 
-	bool unk12;
+	bool isMissionTrain;
 
 	bool direction;
 
-	bool unk14;
+	bool hasPassengerCarriages;
 
 	bool renderDerailed;
 
 	// 2372 {
-	bool unk198; //unk198
-	bool highPrecisionBlending; //unk224
-	bool hasNoThreadId; //unk199
+	bool allowRemovalByPopulation;
+	bool highPrecisionBlending;
+	bool shouldStopAtStations;
 	// }
 
 	bool forceDoorsOpen;
@@ -646,17 +646,6 @@ enum ePopType
 	POPTYPE_REPLAY,
 	POPTYPE_CACHE,
 	POPTYPE_TOOL
-};
-
-//TODO: Probably should be moved out of fx::sync namespace
-struct scrVector
-{
-	float x;
-	int pad;
-	float y;
-	int pad2;
-	float z;
-	int pad3;
 };
 
 struct SyncTreeBase
@@ -1123,6 +1112,9 @@ struct ScriptGuid
 		g_scriptHandlePool->Delete((fx::ScriptGuid*)ptr);
 	}
 };
+
+auto GetTrain(fx::ServerGameState* sgs, uint32_t objectId) -> fx::sync::SyncEntityPtr;
+auto GetNextTrain(fx::ServerGameState* sgs, const fx::sync::SyncEntityPtr& entity) -> fx::sync::SyncEntityPtr;
 
 struct EntityCreationState
 {

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -556,9 +556,9 @@ struct CTrainGameStateDataNodeData
 	bool renderDerailed;
 
 	// 2372 {
-	bool unk198;
-	bool unk224;
-	bool unk199;
+	bool unk198; //unk198
+	bool highPrecisionBlending; //unk224
+	bool hasNoThreadId; //unk199
 	// }
 
 	bool forceDoorsOpen;
@@ -646,6 +646,17 @@ enum ePopType
 	POPTYPE_REPLAY,
 	POPTYPE_CACHE,
 	POPTYPE_TOOL
+};
+
+//TODO: Probably should be moved out of fx::sync namespace
+struct scrVector
+{
+	float x;
+	int pad;
+	float y;
+	int pad2;
+	float z;
+	int pad3;
 };
 
 struct SyncTreeBase

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2628,21 +2628,22 @@ struct CTrainGameStateDataNode : GenericSerializeDataNode<CTrainGameStateDataNod
 		//2372 inserted a bool between isEngine and isCaboose
 		if (Is2372())
 		{
-			s.Serialize(data.unk198);
+			//Modified by 0x2310A8F9421EBF43
+			s.Serialize(data.allowRemovalByPopulation);
 		}
 
 		s.Serialize(data.isCaboose);
-		s.Serialize(data.unk12);
+		s.Serialize(data.isMissionTrain);
 		s.Serialize(data.direction);
-		s.Serialize(data.unk14);
+		s.Serialize(data.hasPassengerCarriages);
 		s.Serialize(data.renderDerailed);
 
 		s.Serialize(data.forceDoorsOpen);
 
 		if (Is2372())
 		{
-			//Always true on randomly spawned trains
-			s.Serialize(data.hasNoThreadId);
+			// true on randomly spawned metro trains
+			s.Serialize(data.shouldStopAtStations);
 
 			//Modified by 0xEC0C1D4922AF9754
 			s.Serialize(data.highPrecisionBlending);

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2624,20 +2624,29 @@ struct CTrainGameStateDataNode : GenericSerializeDataNode<CTrainGameStateDataNod
 		s.Serialize(3, data.trainState);
 
 		s.Serialize(data.isEngine);
+		
+		//2372 inserted a bool between isEngine and isCaboose
+		if (Is2372())
+		{
+			s.Serialize(data.unk198);
+		}
+
 		s.Serialize(data.isCaboose);
 		s.Serialize(data.unk12);
 		s.Serialize(data.direction);
 		s.Serialize(data.unk14);
 		s.Serialize(data.renderDerailed);
 
-		if (Is2372()) // Sequence of bits need to be verified for 2732
-		{
-			s.Serialize(data.unk198);
-			s.Serialize(data.unk224);
-			s.Serialize(data.unk199);
-		}
-
 		s.Serialize(data.forceDoorsOpen);
+
+		if (Is2372())
+		{
+			//Always true on randomly spawned trains
+			s.Serialize(data.hasNoThreadId);
+
+			//Modified by 0xEC0C1D4922AF9754
+			s.Serialize(data.highPrecisionBlending);
+		}
 
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -19,6 +19,7 @@
 #include <EASTL/fixed_vector.h>
 
 #include <state/Pool.h>
+#include <parser/TrainParser.h>
 
 #include <IteratorView.h>
 
@@ -839,7 +840,8 @@ void sync::SyncCommandList::Execute(const fx::ClientSharedPtr& client)
 }
 
 #ifdef STATE_FIVE
-static auto GetTrain(fx::ServerGameState* sgs, uint32_t objectId) -> fx::sync::SyncEntityPtr
+
+auto GetTrain(fx::ServerGameState* sgs, uint32_t objectId) -> fx::sync::SyncEntityPtr
 {
 	if (objectId != 0)
 	{
@@ -854,7 +856,7 @@ static auto GetTrain(fx::ServerGameState* sgs, uint32_t objectId) -> fx::sync::S
 	return {};
 };
 
-static auto GetNextTrain(fx::ServerGameState* sgs, const fx::sync::SyncEntityPtr& entity) -> fx::sync::SyncEntityPtr
+auto GetNextTrain(fx::ServerGameState* sgs, const fx::sync::SyncEntityPtr& entity) -> fx::sync::SyncEntityPtr
 {
 	if (auto trainState = entity->syncTree->GetTrainState())
 	{
@@ -6940,8 +6942,15 @@ static InitFunction initFunction([]()
 		g_oneSyncWorkaround763185 = instance->AddVariable<bool>("onesync_workaround763185", ConVar_None, false);
 
 		fwRefContainer<fx::ServerGameState> sgs = new fx::ServerGameState();
+		
+		fwRefContainer<fx::CTrainConfigParser> trainConfigParser = new fx::CTrainConfigParser();
+		fwRefContainer<fx::CTrainTrackParser> trainTrackParser = new fx::CTrainTrackParser();
+
 		instance->SetComponent(sgs);
 		instance->SetComponent<fx::ServerGameStatePublic>(sgs);
+
+		instance->SetComponent<fx::CTrainConfigParser>(trainConfigParser);
+		instance->SetComponent<fx::CTrainTrackParser>(trainTrackParser);
 
 		instance->GetComponent<fx::GameServer>()->OnSyncTick.Connect([=]()
 		{

--- a/ext/native-decls/server/CreateTrain.md
+++ b/ext/native-decls/server/CreateTrain.md
@@ -1,0 +1,33 @@
+---
+ns: CFX
+apiset: server
+---
+## CREATE_TRAIN
+
+```c
+Vehicle CREATE_TRAIN(Hash modelHash, float x, float y, float z, bool direction, bool stopsAtStations, float cruiseSpeed, int trackId, int trainConfigIndex);
+```
+
+Creates a functioning train using 'server setter' logic (like CREATE_VEHICLE_SERVER_SETTER and CREATE_AUTOMOBILE).
+
+## Parameters
+* **modelHash**: The model of train to spawn.
+* **x**: Spawn coordinate X component.
+* **y**: Spawn coordinate Y component.
+* **z**: Spawn coordinate Z component.
+* **direction**: The direction in which the train will go (true = forward, false = backward)
+* **stopsAtStations**: Should the train stop at stations on the track (>b2372)
+* **cruiseSpeed**: The desired speed for the train to achieve (maximum 30.0f)
+* **trackId**: The track the train should follow (0 = Main Track, 3 = Metro track)
+* **trainConfigIndex**: The train variation id, found in trains.xml
+
+## Return value
+A script handle for the train.
+
+## Examples
+```lua
+-- Coordinates of the first node (0) in track 3
+local coordinates = vec3(193.196, -603.836, 16.7565)
+local metro = CreateTrain(`metrotrain`, coordinates, true, true, 12.0, 3, 25)
+print(GetTrainCarriageIndex(metro)) -- should return 0
+```

--- a/ext/native-decls/server/CreateTrainCarriage.md
+++ b/ext/native-decls/server/CreateTrainCarriage.md
@@ -1,0 +1,43 @@
+---
+ns: CFX
+apiset: server
+---
+## CREATE_TRAIN_CARRIAGE
+
+```c
+Vehicle CREATE_TRAIN_CARRIAGE(Vehicle train, Hash modelHash, float distanceFromEngine);
+```
+
+Creates and attaches train carriage to the target train.
+
+## Parameters
+* **train**: The target train.
+* **modelHash**: The model of train to spawn.
+* **distanceFromEngine**: how far the carriage should be from the engine carriage, maximum 1000.0f
+
+## Return value
+A script handle for the train carriage.
+
+## Examples
+```lua
+--[[
+    To work out distanceFromEngine:
+    First Carriage:
+    lengthOfCarriage = (modelBoundBoxMaxY - modelBoundBoxMinY)
+    distanceFromEngine = lengthOfCarriage + carriageGap (found in trains.xml)
+
+    Each Additional Carriage: add distance to previous carriage distanceFromEngine
+
+    Example with metrotrain, trainconfigIndex 26 (b2802)
+    lengthOfCarriage = (5.611063 - -5.667999) 
+    distanceFromEngine = lengthOfCarriage + -0.5 = 10.7791
+]]
+
+-- Coordinates of the first node (0) in track 3
+local coordinates = vec3(193.196, -603.836, 16.7565)
+local metro = CreateTrain(`metrotrain`, coordinates, true, true, 12.0, 3, 25)
+
+-- This carriage would be flipped as in trains.xml 'flip_model_dir' is true for the second carriage 
+local metroCarriage = CreateTrainCarriage(metro, `metrotrain`, 10.7791)
+print(GetTrainCarriageIndex(metroCarriage)) -- Will return 1. 
+```

--- a/ext/native-decls/server/LoadTrackConfigFromPath.md
+++ b/ext/native-decls/server/LoadTrackConfigFromPath.md
@@ -1,0 +1,23 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## LOAD_TRACK_CONFIG_FROM_PATH
+
+```c
+BOOL LOAD_TRACK_CONFIG_FROM_PATH(char* resourceName, char* fileName);
+```
+
+Loads custom train track config information for the server to use alongside [`CREATE_TRAIN`](#_0x7AC8C6B9)
+
+## Examples
+
+```lua
+LoadTrackConfigFromPath('trains', 'traintracks.xml')
+```
+
+## Parameters
+* **rseourceName**: The name of the resource containing the track config
+* **fileName**: The name of the file
+

--- a/ext/native-decls/server/LoadTrainConfigFromPath.md
+++ b/ext/native-decls/server/LoadTrainConfigFromPath.md
@@ -1,0 +1,23 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## LOAD_TRAIN_CONFIG_FROM_PATH
+
+```c
+BOOL LOAD_TRAIN_CONFIG_FROM_PATH(char* resourceName, char* fileName);
+```
+
+Loads custom train config information for the server to use alongside [`CREATE_TRAIN`](#_0x7AC8C6B9)
+
+## Examples
+
+```lua
+LoadTrainConfigFromPath('trains', 'trains.xml')
+```
+
+## Parameters
+* **rseourceName**: The name of the resource containing the train config
+* **fileName**: The name of the file
+


### PR DESCRIPTION
### Goal of this PR

Allows for server-side creation of functioning trains, to be used in strict and relaxed entity lockdown modes.

### How is this PR achieving the goal

By adding the ``CREATE_TRAIN`` and ``CREATE_TRAIN_CARRIAGE`` to allow for the creation of trains and its carriages through server-setters. The following ``LOAD_TRAIN_CONFIG_FROM_PATH`` and ``LOAD_TRAIN_TRACKS_FROM_PATH`` are also added to address the issue of the server lacking knowledge of train configurations and train index's. Currently the information is only used to prevent invalid track ID's and train config indexes which cause unintended client behaviour. 

Modifications were required for the client, to have server-setter trains behave as intended when re-entering a the scope of a client or changing ownership. By updating the trains current track node to its relative position and then force blending on ownership change (if the server was the last owner). This has no effect on client created trains or trains actively owned by other players.

While creating this PR I also completed the ``CTrainGameStateDataNode`` based on the research provided by [gottfriedleibniz](https://forum.cfx.re/t/train-carriages-becoming-detached/3430416/8?u=ehbw), and some of my own.

Examples of Invalid and Valid uses of these natives can be found here: https://gist.github.com/Ehbw/c40e88f0686275f4a6fe417573babb64

A functioning script snippet can be found here: https://gist.github.com/Ehbw/ef9d2302c4833bab5b23160588ff3a6f

### This PR applies to the following area(s)

FiveM, Server, Natives

### Successfully tested on

Builds prior to the tuners update (2372) results in all trains being deleted by the owning client when leaving the owner's scope. This behaviour is identical to client created trains on these same builds. This would be resolved with blocking deletion of any server-owned entity as suggested here https://github.com/citizenfx/fivem/issues/962

**Game builds:** 1604-3095

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
resolves #2197 


