### PR TITLE
Assorted Steam presence fixes

### DIFF
--- a/code/components/steam/component.lua
+++ b/code/components/steam/component.lua
@@ -1,0 +1,3 @@
+return function()
+	add_dependencies { "vendor:utfcpp" }
+end

--- a/code/components/steam/src/SteamComponent.cpp
+++ b/code/components/steam/src/SteamComponent.cpp
@@ -389,12 +389,12 @@ void SteamComponent::InitializePresence()
 
 		if (GetFileAttributes(namePath.c_str()) != INVALID_FILE_ATTRIBUTES)
 		{
-			std::wifstream nameFile(namePath);
-			std::wstringstream nameStream;
+			std::ifstream nameFile(namePath);
+			std::stringstream nameStream;
 			nameStream << nameFile.rdbuf();
 			nameFile.close();
 
-			productName = ToNarrow(nameStream.str());
+			productName = nameStream.str();
 		}
 
 		static HostSharedData<CfxPresenceState> gameData("PresenceState");

--- a/code/components/steam/src/SteamComponent.cpp
+++ b/code/components/steam/src/SteamComponent.cpp
@@ -19,6 +19,8 @@
 #include <sstream>
 #include <thread>
 
+#include <utf8.h>
+
 struct CfxPresenceState
 {
 	char gameName[512];
@@ -401,6 +403,17 @@ void SteamComponent::InitializePresence()
 		if (gameData->gameName[0])
 		{
 			productName += fmt::sprintf(": %s", gameData->gameName);
+		}
+
+		// Steam requires the name to fit in a 64-byte buffer, so we try to make sure there's no unfinished UTF-8 sequences in that case
+		if (productName.length() >= 64)
+		{
+			productName = productName.substr(0, 63);
+
+			if (auto invalidPos = utf8::find_invalid(productName); invalidPos != std::string::npos)
+			{
+				productName = productName.substr(0, invalidPos);
+			}
 		}
 
 		// set our pipe appid


### PR DESCRIPTION
This contains a fix for my test server's non-ASCII host name being broken in Steam presence, and some assorted fixes for issues caught along the way (`steamname.txt` returning mojibake, and leftover SteamChild processes lingering).

These changes may not be as meaningful if/when FiveM and RedM are assigned an actual AppID and can use the native rich presence functionality, but for the time being they solve stuff being broken randomly.

### Goal of this PR
Fix some issues that showed up regarding Steam presence.

(.. also, the 'consice' typo is still there in the template)

### How is this PR achieving the goal
See commit messages for details.


### This PR applies to the following area(s)
Client (both FiveM and RedM), `steam` component. Also updates a vendor library, this _wasn't_ tested on the Linux build as I do not have a Linux system available at this time - this should however work.


### Successfully tested on
**Game builds:** FiveM


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes. (why is this not an automated check?)


