### PR TITLE
Wildcard problem with REGISTER_RESOURCE_AS_EVENT_HANDLER

### DIFF
--- a/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
+++ b/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
@@ -86,7 +86,15 @@ public:
 
 	inline void AddHandledEvent(const std::string& eventName)
 	{
-		m_eventsHandled.insert(eventName);
+		if (m_eventsHandled.find("*") == m_eventsHandled.end()) //Only adds if theres no wildcard found
+		{
+			m_eventsHandled.insert(eventName);
+			return;
+		}
+
+		//if wildcard is found remove all others, so events doesn't get called multiple times...
+		m_eventsHandled.clear(); //Not sure if clear is even valid function :D
+		m_eventsHandled.insert("*");
 	}
 
 	SCRIPTING_CORE_EXPORT void Tick();

--- a/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
+++ b/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
@@ -86,16 +86,13 @@ public:
 
 	inline void AddHandledEvent(const std::string& eventName)
 	{
-		if(eventName == "*")
-		{
-			//when adding wildcard remove all others, so events doesn't get called multiple times...
-			m_eventsHandled.clear(); //Not sure if clear is even valid function :D
-			m_eventsHandled.insert("*");
-			return;
-		}
-
 		if (m_eventsHandled.find("*") == m_eventsHandled.end()) //Only adds if theres no wildcard found
 		{
+			if(eventName == "*")
+			{
+				m_eventsHandled.clear(); //when adding wildcard remove all others, so events doesn't get called multiple times...
+			}
+			
 			m_eventsHandled.insert(eventName);
 		}
 	}

--- a/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
+++ b/code/components/citizen-scripting-core/include/ResourceScriptingComponent.h
@@ -86,15 +86,18 @@ public:
 
 	inline void AddHandledEvent(const std::string& eventName)
 	{
-		if (m_eventsHandled.find("*") == m_eventsHandled.end()) //Only adds if theres no wildcard found
+		if(eventName == "*")
 		{
-			m_eventsHandled.insert(eventName);
+			//when adding wildcard remove all others, so events doesn't get called multiple times...
+			m_eventsHandled.clear(); //Not sure if clear is even valid function :D
+			m_eventsHandled.insert("*");
 			return;
 		}
 
-		//if wildcard is found remove all others, so events doesn't get called multiple times...
-		m_eventsHandled.clear(); //Not sure if clear is even valid function :D
-		m_eventsHandled.insert("*");
+		if (m_eventsHandled.find("*") == m_eventsHandled.end()) //Only adds if theres no wildcard found
+		{
+			m_eventsHandled.insert(eventName);
+		}
 	}
 
 	SCRIPTING_CORE_EXPORT void Tick();


### PR DESCRIPTION
### Goal of this PR
Is to fix wildcard problem with native REGISTER_RESOURCE_AS_EVENT_HANDLER that is used in scheduler.lua and main.js when adding event handlers and if you use the native in your own code and disable filter with wildcard, events will be called multiple times....


### How is this PR achieving the goal
Changes will make sure that if wildcard is presence it will not add event names to that filter list and if theres some when adding wildcard it will remove those....


### This PR applies to the following area(s)
Atleast FiveM Client and Server


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.