### PR TITLE
fix(server/impl): initConnect addition overflow

### DIFF
--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -215,7 +215,7 @@ static std::optional<TicketData> VerifyTicketEx(const std::string& ticket)
 		return {};
 	}
 
-	uint32_t length = *(uint32_t*)&ticketData[20 + 4 + 128];
+	size_t length = static_cast<size_t>(*(uint32_t*)&ticketData[20 + 4 + 128]);
 
 	// validate full length
 	if (ticketData.size() < 20 + 4 + 128 + 4 + length)


### PR DESCRIPTION
Invalid ticket lengths could lead to an out-of-bounds read, crashing the server. This is relatively easy to exploit as well (just change the field in an existing valid cfxTicket to `FF FF FF FF`, and send it on to a server you want to crash) and therefore a bit risky - I've been trying to report this privately for ages (see the Sep 6, 2023 commit date!), but it seems to have slipped through the cracks and not been acted on at all for the past _four months_.

### Goal of this PR
Make the server not crash when sending an invalid ticket.


### How is this PR achieving the goal
Using larger types.


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows. Should work on Linux as well.


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

