### PR TITLE
tweak(input/five): release cursor capture for the game's cursor

### DIFF
--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -793,6 +793,17 @@ static HookFunction hookFunction([]()
 
 	// cancel out ioLogitechLedDevice
 	hook::jump(hook::get_pattern("85 C0 0F 85 ? ? 00 00 48 8B CB FF 15", -0x77), Return0);
+
+	// hook up cursor lock to CMousePointer::_bIsVisible
+	static auto isPointerVisible = hook::get_address<bool*>(hook::get_pattern("80 3D ? ? ? ? 00 0F 45 C6 88 05 ? ? ? ? 48 8B 5C", 10), 2, 6) + 2;
+
+	InputHook::QueryMayLockCursor.Connect([](int& may)
+	{
+		if (*isPointerVisible)
+		{
+			may = FALSE;
+		}
+	});
 });
 
 fwEvent<HWND, UINT, WPARAM, LPARAM, bool&, LRESULT&> InputHook::DeprecatedOnWndProc;


### PR DESCRIPTION
Custom bits of UI (NUI focus, as well as the F8 console/dear ImGui) do this already, which makes the game's mouse cursor (such as in the pause menu) behave differently.

This commit solves this by hooking up the QueryMayLockCursor event to a flag specifying if the cursor is visible.

Feature was requested in DMs by @summeryukata at some point:

> is there a way to make fivem not confine the cursor
> like, when i have f8 open i can drag it out no problem, but if I pause it keeps it locked to the window

### Goal of this PR
Add a little feature for consistency.


### How is this PR achieving the goal
Implements the feature.


### This PR applies to the following area(s)
FiveM, rage:input:five


### Successfully tested on
**Game builds:** 1604-3095

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

(force-pushed as commit signing did not work first try - used the wrong key for the committer identity, then forgot `-S` the second time)