### PR TITLE
Update `CNetGamePlayer` accessors to support b3095 in FiveM

### DIFF
--- a/code/components/extra-natives-five/src/PlayerNatives.cpp
+++ b/code/components/extra-natives-five/src/PlayerNatives.cpp
@@ -1,11 +1,11 @@
 #include <StdInc.h>
-#include <ScriptEngine.h>
 
+#include <ScriptEngine.h>
 #include <ScriptSerialization.h>
 #include <NetworkPlayerMgr.h>
 #include <scrEngine.h>
-
 #include <Hooking.h>
+#include "EntitySystem.h"
 
 static int(*netInterface_GetNumPhysicalPlayers)();
 static CNetGamePlayer** (*netInterface_GetAllPhysicalPlayers)();
@@ -29,7 +29,7 @@ static void* getAndCheckPlayerInfo(fx::ScriptContext& context)
 		return nullptr;
 	}
 
-	return player->playerInfo();
+	return player->GetPlayerInfo();
 }
 
 template<typename T, int* offset>
@@ -119,15 +119,14 @@ static HookFunction hookFunction([]()
 	{
 		bool result = false;
 
-		void* playerInfo = getAndCheckPlayerInfo(context);
-
-		if (playerInfo)
+		if (void* playerInfo = getAndCheckPlayerInfo(context))
 		{
 			float newStamina = context.GetArgument<float>(1);
-			float maxStamina = *((float*)((char*)playerInfo + PlayerMaxStaminaOffset));
-			if (newStamina && newStamina <= maxStamina)
+			float maxStamina = *(float*)((char*)playerInfo + PlayerMaxStaminaOffset);
+
+			if (newStamina <= maxStamina)
 			{
-				*((float*)((char*)playerInfo + PlayerStaminaOffset)) = newStamina;
+				*(float*)((char*)playerInfo + PlayerStaminaOffset) = newStamina;
 				result = true;
 			}
 		}
@@ -139,14 +138,12 @@ static HookFunction hookFunction([]()
 	{
 		bool result = false;
 
-		void* playerInfo = getAndCheckPlayerInfo(context);
-
-		if (playerInfo)
+		if (void* playerInfo = getAndCheckPlayerInfo(context))
 		{
 			float newMaxStamina = context.GetArgument<float>(1);
-			if (newMaxStamina && newMaxStamina > 0.0)
+			if (newMaxStamina > 0.0)
 			{
-				*((float*)((char*)playerInfo + PlayerMaxStaminaOffset)) = newMaxStamina;
+				*(float*)((char*)playerInfo + PlayerMaxStaminaOffset) = newMaxStamina;
 				result = true;
 			}
 		}

--- a/code/components/gta-game-five/include/NetworkPlayerMgr.h
+++ b/code/components/gta-game-five/include/NetworkPlayerMgr.h
@@ -12,13 +12,13 @@
 #include <netPeerAddress.h>
 
 #define DECLARE_ACCESSOR(x) \
-	decltype(impl.m2372.x)& x()        \
-	{                       \
-		return (xbr::IsGameBuildOrGreater<2372>()) ? impl.m2372.x : (xbr::IsGameBuildOrGreater<2060>()) ? impl.m2060.x : impl.m1604.x;   \
+	decltype(impl.m3095.x)& x() \
+	{ \
+		return (xbr::IsGameBuildOrGreater<3095>()) ? impl.m3095.x : (xbr::IsGameBuildOrGreater<2372>()) ? impl.m2372.x : (xbr::IsGameBuildOrGreater<2060>()) ? impl.m2060.x : impl.m1604.x; \
 	} \
-	const decltype(impl.m2372.x)& x() const                         \
-	{                                                    \
-		return (xbr::IsGameBuildOrGreater<2372>()) ? impl.m2372.x : (xbr::IsGameBuildOrGreater<2060>()) ? impl.m2060.x : impl.m1604.x;  \
+	const decltype(impl.m3095.x)& x() const \
+	{ \
+		return (xbr::IsGameBuildOrGreater<3095>()) ? impl.m3095.x : (xbr::IsGameBuildOrGreater<2372>()) ? impl.m2372.x : (xbr::IsGameBuildOrGreater<2060>()) ? impl.m2060.x : impl.m1604.x; \
 	}
 
 #ifdef COMPILING_GTA_GAME_FIVE
@@ -85,6 +85,7 @@ private:
 		char end[EndPad];
 	};
 
+	// Do not forget to update `DECLARE_ACCESSOR` define when adding new impl!
 	union
 	{
 		Impl<12, 0, 28> m1604;
@@ -96,14 +97,14 @@ private:
 public:
 	void* GetPlayerInfo()
 	{
-		return (xbr::IsGameBuildOrGreater<3095>()) ? impl.m3095.playerInfo :  (xbr::IsGameBuildOrGreater<2372>()) ? impl.m2372.playerInfo : (xbr::IsGameBuildOrGreater<2060>()) ? impl.m2060.playerInfo : impl.m1604.playerInfo;
+		return playerInfo();
 	}
 
 public:
-	DECLARE_ACCESSOR(nonPhysicalPlayerData);
-	DECLARE_ACCESSOR(activePlayerIndex);
-	DECLARE_ACCESSOR(physicalPlayerIndex);
-	DECLARE_ACCESSOR(playerInfo);
+	DECLARE_ACCESSOR(nonPhysicalPlayerData)
+	DECLARE_ACCESSOR(activePlayerIndex)
+	DECLARE_ACCESSOR(physicalPlayerIndex)
+	DECLARE_ACCESSOR(playerInfo)
 };
 
 class CNetworkPlayerMgr
@@ -111,3 +112,5 @@ class CNetworkPlayerMgr
 public:
 	static GTA_GAME_EXPORT CNetGamePlayer* GetPlayer(int playerIndex);
 };
+
+#undef DECLARE_ACCESSOR


### PR DESCRIPTION
### Goal of this PR
Fixed a regression introduced in b3095 + minor code tweaks & cleanup.
...


### How is this PR achieving the goal
By adding b3095 check in `DECLARE_ACCESSOR` and replacing raw accessor with a proper method call.
...


### This PR applies to the following area(s)
FiveM, Natives

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095, 2944, 2372, 2060, 1604

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Issue `#2` from this report https://forum.cfx.re/t/a-couple-of-problems-since-the-last-updates/5200554
