### PR TITLE
feat(extra-natives/five) `GET_VEHICLE_HAS_FLAG`

### DIFF
--- a/ext/native-decls/GetVehicleHasFlag.md
+++ b/ext/native-decls/GetVehicleHasFlag.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_HAS_FLAG
+
+```c
+bool GET_VEHICLE_HAS_FLAG(Vehicle vehicle, int flagIndex);
+```
+
+Get vehicle.meta flag by index. Useful examples include FLAG_LAW_ENFORCEMENT (31), FLAG_RICH_CAR (36), FLAG_IS_ELECTRIC (43), FLAG_IS_OFFROAD_VEHICLE (48).
+
+Complete list of flags: https://gtamods.com/wiki/Vehicles.meta#flags
+Compilation of all vehicles' metadata files (including their flags): https://forum.cfx.re/t/vehicle-meta-files-last-dlc/5142301
+
+## Parameters
+* **vehicle**: The vehicle to obtain data for.
+* **flagIndex**: Flag index (0-203)
+
+## Return value
+A boolean for whether the flag is set.


### PR DESCRIPTION
Adds an extra native to query vehicle.meta flags
The complete list of flags can be found at https://gtamods.com/wiki/Vehicles.meta#flags
Tested on b2802
EDIT: Tested on b1604 and b3095 on every vehicle class. Also tested on empty vehicles and vehicles driven by npcs.

![FiveM_2024-01-14_02-22-34](https://github.com/citizenfx/fivem/assets/155013276/85f9a798-3dfd-450d-9311-08803eda693c)
![FiveM_2024-01-14_02-21-12](https://github.com/citizenfx/fivem/assets/155013276/0ecddbb8-68f0-45a9-8584-4c38f1b37d1f)
![FiveM_2024-01-14_02-38-49](https://github.com/citizenfx/fivem/assets/155013276/bd6be0c9-502c-4fab-8ea3-903d1d678d94)

<details>
  <summary>Sample Resource in Typescript</summary>

  ```ts
  RegisterCommand("print-flags", () => console.log(getAllVehicleFlags()), false);

  function getAllVehicleFlags(mVehicle = GetVehiclePedIsIn(PlayerPedId(), false)) {
    const flags = [];
    for (let i = 0; i < 204; i++) {
      if (GetVehicleHasFlag(mVehicle, i)) flags.push(VEHICLE_FLAGS[i]);
    }
    return flags;
  }

  export enum VEHICLE_FLAGS {
    FLAG_SMALL_WORKER,
    FLAG_BIG,
    FLAG_NO_BOOT,
    FLAG_ONLY_DURING_OFFICE_HOURS,
    FLAG_BOOT_IN_FRONT,
    FLAG_IS_VAN,
    FLAG_AVOID_TURNS,
    FLAG_HAS_LIVERY,
    FLAG_LIVERY_MATCH_EXTRA,
    FLAG_SPORTS,
    FLAG_DELIVERY,
    FLAG_NOAMBIENTOCCLUSION,
    FLAG_ONLY_ON_HIGHWAYS,
    FLAG_TALL_SHIP,
    FLAG_SPAWN_ON_TRAILER,
    FLAG_SPAWN_BOAT_ON_TRAILER,
    FLAG_EXTRAS_GANG,
    FLAG_EXTRAS_CONVERTIBLE,
    FLAG_EXTRAS_TAXI,
    FLAG_EXTRAS_RARE,
    FLAG_EXTRAS_REQUIR,
    FLAG_EXTRAS_STRONG,
    FLAG_EXTRAS_ONLY_BREAK_WHEN_DESTROYED,
    FLAG_EXTRAS_SCRIPT,
    FLAG_EXTRAS_ALL,
    FLAG_EXTRAS_MATCH_LIVERY,
    FLAG_DONT_ROTATE_TAIL_ROTOR,
    FLAG_PARKING_SENSORS,
    FLAG_PEDS_CAN_STAND_ON_TOP,
    FLAG_TAILGATE_TYPE_BOOT,
    FLAG_GEN_NAVMESH,
    FLAG_LAW_ENFORCEMENT,
    FLAG_EMERGENCY_SERVICE,
    FLAG_DRIVER_NO_DRIVE_BY,
    FLAG_NO_RESPRAY,
    FLAG_IGNORE_ON_SIDE_CHECK,
    FLAG_RICH_CAR,
    FLAG_AVERAGE_CAR,
    FLAG_POOR_CAR,
    FLAG_ALLOWS_RAPPEL,
    FLAG_DONT_CLOSE_DOOR_UPON_EXIT,
    FLAG_USE_HIGHER_DOOR_TORQUE,
    FLAG_DISABLE_THROUGH_WINDSCREEN,
    FLAG_IS_ELECTRIC,
    FLAG_NO_BROKEN_DOWN_SCENARIO,
    FLAG_IS_JETSKI,
    FLAG_DAMPEN_STICKBOMB_DAMAGE,
    FLAG_DONT_SPAWN_IN_CARGEN,
    FLAG_IS_OFFROAD_VEHICLE,
    FLAG_INCREASE_PED_COMMENTS,
    FLAG_EXPLODE_ON_CONTACT,
    FLAG_USE_FAT_INTERIOR_LIGHT,
    FLAG_HEADLIGHTS_USE_ACTUAL_BONE_POS,
    FLAG_FAKE_EXTRALIGHTS,
    FLAG_CANNOT_BE_MODDED,
    FLAG_DONT_SPAWN_AS_AMBIENT,
    FLAG_IS_BULKY,
    FLAG_BLOCK_FROM_ATTRACTOR_SCENARIO,
    FLAG_IS_BUS,
    FLAG_USE_STEERING_PARAM_FOR_LEAN,
    FLAG_CANNOT_BE_DRIVEN_BY_PLAYER,
    FLAG_SPRAY_PETROL_BEFORE_EXPLOSION,
    FLAG_ATTACH_TRAILER_ON_HIGHWAY,
    FLAG_ATTACH_TRAILER_IN_CITY,
    FLAG_HAS_NO_ROOF,
    FLAG_ALLOW_TARGETING_OF_OCCUPANTS,
    FLAG_RECESSED_HEADLIGHT_CORONAS,
    FLAG_RECESSED_TAILLIGHT_CORONAS,
    FLAG_IS_TRACKED_FOR_TRAILS,
    FLAG_HEADLIGHTS_ON_LANDINGGEAR,
    FLAG_CONSIDERED_FOR_VEHICLE_ENTRY_WHEN_STOOD_ON,
    FLAG_GIVE_SCUBA_GEAR_ON_EXIT,
    FLAG_IS_DIGGER,
    FLAG_IS_TANK,
    FLAG_USE_COVERBOUND_INFO_FOR_COVERGEN,
    FLAG_CAN_BE_DRIVEN_ON,
    FLAG_HAS_BULLETPROOF_GLASS,
    FLAG_CANNOT_TAKE_COVER_WHEN_STOOD_ON,
    FLAG_INTERIOR_BLOCKED_BY_BOOT,
    FLAG_DONT_TIMESLICE_WHEELS,
    FLAG_FLEE_FROM_COMBAT,
    FLAG_DRIVER_SHOULD_BE_FEMALE,
    FLAG_DRIVER_SHOULD_BE_MALE,
    FLAG_COUNT_AS_FACEBOOK_DRIVEN,
    FLAG_BIKE_CLAMP_PICKUP_LEAN_RATE,
    FLAG_PLANE_WEAR_ALTERNATIVE_HELMET,
    FLAG_USE_STRICTER_EXIT_COLLISION_TESTS,
    FLAG_TWO_DOORS_ONE_SEAT,
    FLAG_USE_LIGHTING_INTERIOR_OVERRIDE,
    FLAG_USE_RESTRICTED_DRIVEBY_HEIGHT,
    FLAG_CAN_HONK_WHEN_FLEEING,
    FLAG_PEDS_INSIDE_CAN_BE_SET_ON_FIRE_MP,
    FLAG_REPORT_CRIME_IF_STANDING_ON,
    FLAG_HELI_USES_FIXUPS_ON_OPEN_DOOR,
    FLAG_FORCE_ENABLE_CHASSIS_COLLISION,
    FLAG_CANNOT_BE_PICKUP_BY_CARGOBOB,
    FLAG_CAN_HAVE_NEONS,
    FLAG_HAS_INTERIOR_EXTRAS,
    FLAG_HAS_TURRET_SEAT_ON_VEHICLE,
    FLAG_ALLOW_OBJECT_LOW_LOD_COLLISION,
    FLAG_DISABLE_AUTO_VAULT_ON_VEHICLE,
    FLAG_USE_TURRET_RELATIVE_AIM_CALCULATION,
    FLAG_USE_FULL_ANIMS_FOR_MP_WARP_ENTRY_POINTS,
    FLAG_HAS_DIRECTIONAL_SHUFFLES,
    FLAG_DISABLE_WEAPON_WHEEL_IN_FIRST_PERSON,
    FLAG_USE_PILOT_HELMET,
    FLAG_USE_WEAPON_WHEEL_WITHOUT_HELMET,
    FLAG_PREFER_ENTER_TURRET_AFTER_DRIVER,
    FLAG_USE_SMALLER_OPEN_DOOR_RATIO_TOLERANCE,
    FLAG_USE_HEADING_ONLY_IN_TURRET_MATRIX,
    FLAG_DONT_STOP_WHEN_GOING_TO_CLIMB_UP_POINT,
    FLAG_HAS_REAR_MOUNTED_TURRET,
    FLAG_DISABLE_BUSTING,
    FLAG_IGNORE_RWINDOW_COLLISION,
    FLAG_HAS_GULL_WING_DOORS,
    FLAG_CARGOBOB_HOOK_UP_CHASSIS,
    FLAG_USE_FIVE_ANIM_THROW_FP,
    FLAG_ALLOW_HATS_NO_ROOF,
    FLAG_HAS_REAR_SEAT_ACTIVITIES,
    FLAG_HAS_LOWRIDER_HYDRAULICS,
    FLAG_HAS_BULLET_RESISTANT_GLASS,
    FLAG_HAS_INCREASED_RAMMING_FORCE,
    FLAG_HAS_CAPPED_EXPLOSION_DAMAGE,
    FLAG_HAS_LOWRIDER_DONK_HYDRAULICS,
    FLAG_HELICOPTER_WITH_LANDING_GEAR,
    FLAG_JUMPING_CAR,
    FLAG_HAS_ROCKET_BOOST,
    FLAG_RAMMING_SCOOP,
    FLAG_HAS_PARACHUTE,
    FLAG_RAMP,
    FLAG_HAS_EXTRA_SHUFFLE_SEAT_ON_VEHICLE,
    FLAG_FRONT_BOOT,
    FLAG_HALF_TRACK,
    FLAG_RESET_TURRET_SEAT_HEADING,
    FLAG_TURRET_MODS_ON_ROOF,
    FLAG_UPDATE_WEAPON_BATTERY_BONES,
    FLAG_DONT_HOLD_LOW_GEARS_WHEN_ENGINE_UNDER_LOAD,
    FLAG_HAS_GLIDER,
    FLAG_INCREASE_LOW_SPEED_TORQUE,
    FLAG_USE_AIRCRAFT_STYLE_WEAPON_TARGETING,
    FLAG_KEEP_ALL_TURRETS_SYNCHRONISED,
    FLAG_SET_WANTED_FOR_ATTACHED_VEH,
    FLAG_TURRET_ENTRY_ATTACH_TO_DRIVER_SEAT,
    FLAG_USE_STANDARD_FLIGHT_HELMET,
    FLAG_SECOND_TURRET_MOD,
    FLAG_THIRD_TURRET_MOD,
    FLAG_HAS_EJECTOR_SEATS,
    FLAG_TURRET_MODS_ON_CHASSIS,
    FLAG_HAS_JATO_BOOST_MOD,
    FLAG_IGNORE_TRAPPED_HULL_CHECK,
    FLAG_HOLD_TO_SHUFFLE,
    FLAG_TURRET_MOD_WITH_NO_STOCK_TURRET,
    FLAG_EQUIP_UNARMED_ON_ENTER,
    FLAG_DISABLE_CAMERA_PUSH_BEYOND,
    FLAG_HAS_VERTICAL_FLIGHT_MODE,
    FLAG_HAS_OUTRIGGER_LEGS,
    FLAG_CAN_NAVIGATE_TO_ON_VEHICLE_ENTRY,
    FLAG_DROP_SUSPENSION_WHEN_STOPPED,
    FLAG_DONT_CRASH_ABANDONED_NEAR_GROUND,
    FLAG_USE_INTERIOR_RED_LIGHT,
    FLAG_HAS_HELI_STRAFE_MODE,
    FLAG_HAS_VERTICAL_ROCKET_BOOST,
    FLAG_CREATE_WEAPON_MANAGER_ON_SPAWN,
    FLAG_USE_ROOT_AS_BASE_LOCKON_POS,
    FLAG_HEADLIGHTS_ON_TAP_ONLY,
    FLAG_CHECK_WARP_TASK_FLAG_DURING_ENTER,
    FLAG_USE_RESTRICTED_DRIVEBY_HEIGHT_HIGH,
    FLAG_INCREASE_CAMBER_WITH_SUSPENSION_MOD,
    FLAG_NO_HEAVY_BRAKE_ANIMATION,
    FLAG_HAS_TWO_BONNET_BONES,
    FLAG_DONT_LINK_BOOT2,
    FLAG_HAS_INCREASED_RAMMING_FORCE_WITH_CHASSIS_MOD,
    FLAG_HAS_INCREASED_RAMMING_FORCE_VS_ALL_VEHICLES,
    FLAG_HAS_EXTENDED_COLLISION_MODS,
    FLAG_HAS_NITROUS_MOD,
    FLAG_HAS_JUMP_MOD,
    FLAG_HAS_RAMMING_SCOOP_MOD,
    FLAG_HAS_SUPER_BRAKES_MOD,
    FLAG_CRUSHES_OTHER_VEHICLES,
    FLAG_HAS_WEAPON_BLADE_MODS,
    FLAG_HAS_WEAPON_SPIKE_MODS,
    FLAG_FORCE_BONNET_CAMERA_INSTEAD_OF_POV,
    FLAG_RAMP_MOD,
    FLAG_HAS_TOMBSTONE,
    FLAG_HAS_SIDE_SHUNT,
    FLAG_HAS_FRONT_SPIKE_MOD,
    FLAG_HAS_RAMMING_BAR_MOD,
    FLAG_TURRET_MODS_ON_CHASSIS5,
    FLAG_HAS_SUPERCHARGER,
    FLAG_IS_TANK_WITH_FLAME_DAMAGE,
    FLAG_DISABLE_DEFORMATION,
    FLAG_ALLOW_RAPPEL_AI_ONLY,
    FLAG_USE_RESTRICTED_DRIVEBY_HEIGHT_MID_ONLY,
    FLAG_FORCE_AUTO_VAULT_ON_VEHICLE_WHEN_STUCK,
    FLAG_SPOILER_MOD_DOESNT_INCREASE_GRIP,
    FLAG_NO_REVERSING_ANIMATION,
    FLAG_IS_QUADBIKE_USING_BIKE_ANIMATIONS,
    FLAG_IS_FORMULA_VEHICLE,
    FLAG_LATCH_ALL_JOINTS,
    FLAG_REJECT_ENTRY_TO_VEHICLE_WHEN_STOOD_ON,
    FLAG_CHECK_IF_DRIVER_SEAT_IS_CLOSER_THAN_TURRETS_WITH_ON_BOARD_ENTER,
    FLAG_RENDER_WHEELS_WITH_ZERO_COMPRESSION,
    FLAG_USE_LENGTH_OF_VEHICLE_BOUNDS_FOR_PLAYER_LOCKON_POS,
    FLAG_PREFER_FRONT_SEAT,
  }
  ```
</details>