### PR TITLE
fix(rdr3/audio): add pattern offset for asynchronousAudio

### DIFF
--- a/code/components/gta-core-five/src/GameAudioState.cpp
+++ b/code/components/gta-core-five/src/GameAudioState.cpp
@@ -419,7 +419,7 @@ static HookFunction hookFunction([]()
 		static auto asynchronousAudio = hook::get_address<bool*>(hook::get_pattern("E8 ? ? ? ? 40 38 35 ? ? ? ? 75 05", 8));
 		static auto audioTimeout = hook::get_address<int*>(hook::get_pattern("8B 15 ? ? ? ? 41 03 D6 3B", 2));
 #elif IS_RDR3
-		static auto asynchronousAudio = hook::get_address<bool*>(hook::get_pattern("80 3D ? ? ? ? ? 74 38 33 DB 40 84 FF 74 19"));
+		static auto asynchronousAudio = hook::get_address<bool*>(hook::get_pattern("80 3D ? ? ? ? ? 74 38 33 DB 40 84 FF 74 19", 2));
 		static auto audioTimeout = hook::get_address<int*>(hook::get_pattern("8B 15 ? ? ? ? 41 03 D6 3B", 2));
 #endif
 		// See https://github.com/citizenfx/fivem/issues/1446 comments for a more viable solution:


### PR DESCRIPTION


### Goal of this PR
<!-- Consice explanation of what this PR meant to achieve -->

...


### How is this PR achieving the goal
By adding the proper offset.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RedM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes https://forum.cfx.re/t/crash-gta-core-rdr3-10f9c
