### PR TITLE
fix(github): give permissions to label PRs

### DIFF
--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -14,6 +14,7 @@ on:
       - '!*.sh'
 
 permissions:
+  issues: write
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
### Goal of this PR

Enable GitHub PR evaluating workflow to label PRs and continue compile checks


### How is this PR achieving the goal

Giving this workflow the `issue` write permission.

Note: I was unable to test this on my own repos, but research shows it's related to missing the `issues` write permission (can come from our organization). One would expect this to be fine with `pull-requests` write permissions.


### This PR applies to the following area(s)

GitHub


### Successfully tested on

GitHub Runners

**Game builds:** N/A

**Platforms:** GitHub Runners


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues



