### PR TITLE
Draw origin index typo in RedM

### DIFF
--- a/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
@@ -42,7 +42,7 @@ static void RenderScriptIm()
 	// The game never uses this buffer itself, but it *may* be changed in the future updates.
 	// This code isn't ready for such a scenario, so might potentially require tweaks.
 	// Like if something allocate script im buffer before us, we would need to resize it
-	// and not just rewrite everything with out custom stuff.
+	// and not just rewrite everything without custom stuff.
 
 	if (g_scriptImRequests.empty())
 	{
@@ -162,7 +162,7 @@ static HookFunction hookFunction([]()
 		store.m_items[index] = data;
 		store.m_count += 1;
 
-		*g_scriptDrawOriginIndex = store.m_count;
+		*g_scriptDrawOriginIndex = index;
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("CLEAR_DRAW_ORIGIN", [](fx::ScriptContext& context)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fixing a regression introduced in #2268, basically because of this typo we're skipping draw origin index "0".


### How is this PR achieving the goal
By fixing a typo.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1311, 1355, 1436, 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixing an issue reported by Kono in DMs.

