### PR TITLE
Fix gamer tags crew component in FiveM b3095

### DIFF
--- a/code/components/citizen-playernames-five/src/HookGamerInfo.cpp
+++ b/code/components/citizen-playernames-five/src/HookGamerInfo.cpp
@@ -186,6 +186,12 @@ struct PatternPair
 	int offset;
 };
 
+template<typename T, T Value>
+static T Return()
+{
+	return Value;
+}
+
 static HookFunction hookFunction([]()
 {
 	const size_t gamerInfoSize = (xbr::IsGameBuildOrGreater<2060>()) ? sizeof(CGamerInfo<2060>) : sizeof(CGamerInfo<1604>);
@@ -402,6 +408,9 @@ static HookFunction hookFunction([]()
 	{
 		LimitPatch(hook::pattern("83 FB ? 77 ? 48 69 DB").count(1).get(0).get<void>(0));
 		LimitPatch(hook::pattern("83 FB 33 77 74 48 8B FB").count(1).get(0).get<void>(0));
+
+		// There's a new unknown "privilege" check that needs to be patched.
+		hook::jump(hook::get_pattern("84 C0 74 04 32 C0 EB 11 48 8B D6", -0x21), Return<bool, true>);
 	}
 	else
 	{


### PR DESCRIPTION
### Goal of this PR
To make the gamer tags crew component to work on game build 3095.


### How is this PR achieving the goal
This is achieved by patching a function that was preventing this functionality from working (some additional unknown "privilege" checks or so).


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3095

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Addresses the problem reported in this forum topic:
https://forum.cfx.re/t/gamer-tag-crew-component-does-not-work-on-newest-3095-game-build/5201652

