### PR TITLE
tweak(native-decls): add docs for undocumented natives

### DIFF
--- a/ext/native-decls/SetVehicleCurrentGear.md
+++ b/ext/native-decls/SetVehicleCurrentGear.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_VEHICLE_CURRENT_GEAR
+
+```c
+void SET_VEHICLE_CURRENT_GEAR(Vehicle vehicle, int gear);
+```
+
+Changes a vehicle's current gear.
+
+## Parameters
+* **vehicle**: Target vehicle.
+* **gear**: The gear to set.


### PR DESCRIPTION
## Current changes in this PR

- Added SetVehicleCurrentGear.md for extra native `SET_VEHICLE_CURRENT_GEAR`


## RegisterNativeHandler lookup

Here's a list of extra natives that are registered but not documented:

<img width="451" alt="Code_2024-01-30_17-22-17" src="https://github.com/citizenfx/fivem/assets/155013276/4ed07c89-41c7-45fb-b6ac-e02484243150">

<details>
  <summary><i>Click here to reveal github blame links for each native</i></summary>
  
* Missing docs: `GET_RESOURCE_KVP`
  * ↳ registered at [citizen-resources-client/src/KVScriptFunctions.cpp#L568](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-resources-client/src/KVScriptFunctions.cpp#L568)
  * ↳ registered at [citizen-server-impl/src/ServerKVScriptFunctions.cpp#L341](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-server-impl/src/ServerKVScriptFunctions.cpp#L341)
* Missing docs: `FORMAT_STACK_TRACE`
  * ↳ registered at [citizen-scripting-core/src/ScriptHost.cpp#L671](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-scripting-core/src/ScriptHost.cpp#L671)
* Missing docs: `GET_RESOURCE_RAW_KVP`
* Missing docs: `SET_RESOURCE_RAW_KVP`
* Missing docs: `SET_RESOURCE_RAW_KVP_NO_SYNC`
* Missing docs: `GET_RESOURCE_KVP_PROPERTY`
  * ↳ registered at [citizen-server-impl/src/ServerKVScriptFunctions.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-server-impl/src/ServerKVScriptFunctions.cpp)
* Missing docs: `SET_SYNC_ENTITY_LOCKDOWN_MODE`
  * ↳ registered at [citizen-server-impl/src/state/ServerGameState_Scripting.cpp#L438](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp#L438)
* Missing docs: `CREATE_AUTOMOBILE`
  * ↳ registered at [citizen-server-impl/src/state/ServerSetters.cpp#L306](https://github.com/citizenfx/fivem/blame/master/code/components/citizen-server-impl/src/state/ServerSetters.cpp#L306)
* Missing docs: `DRAW_IM_VERTICES`
* Missing docs: `DRAW_TEXTURED_IM_VERTICES`
* Missing docs: `DRAW_TEXTURED_IM_VERTICES_CLIPPED`
  * ↳ registered at [extra-natives-five/src/DrawImNatives.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/extra-natives-five/src/DrawImNatives.cpp)
* Missing docs: `GET_ENTITY_ADDRESS`
  * ↳ registered at [extra-natives-five/src/NuiAudioSink.cpp#L2484](https://github.com/citizenfx/fivem/blame/master/code/components/extra-natives-five/src/NuiAudioSink.cpp#L2484)
  * ↳ registered at [handling-loader-five/src/HandlingLoader.cpp#L597](https://github.com/citizenfx/fivem/blame/master/code/components/handling-loader-five/src/HandlingLoader.cpp#L597)
* Missing docs: `SET_ENTITY_ROTATION_VELOCITY`
* Missing docs: `SET_VEHICLE_CURRENT_GEAR`
* Missing docs: `SET_VEHICLE_NEXT_GEAR`
* Missing docs: `ADD_VEHICLE_DELETION_TRACE`
  * ↳ registered at [extra-natives-five/src/VehicleExtraNatives.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/extra-natives-five/src/VehicleExtraNatives.cpp)
* Missing docs: `SEND_SDK_MESSAGE`
* Missing docs: `SEND_SDK_MESSAGE_TO_BACKEND`
  * ↳ registered at [glue/src/ConnectToNative.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/glue/src/ConnectToNative.cpp)
* Missing docs: `EXPERIMENTAL_BLEND`
  * ↳ registered at [gta-net-five/src/CloneExperiments.cpp#L5054](https://github.com/citizenfx/fivem/blame/master/code/components/gta-net-five/src/CloneExperiments.cpp#L5054)
* Missing docs: `GET_AUDIOCONTEXT_FOR_CLIENT`
* Missing docs: `GET_AUDIOCONTEXT_FOR_SERVERID`
  * ↳ registered at [gta-net-five/src/MumbleVoice.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/gta-net-five/src/MumbleVoice.cpp)      
* Missing docs: `CREATE_DRAWABLE`
* Missing docs: `GET_DRAWABLE_LODGROUP`
* Missing docs: `SET_LODGROUP_BOUNDS_MIN`
* Missing docs: `SET_LODGROUP_BOUNDS_MAX`
* Missing docs: `SET_LODGROUP_CENTER`
* Missing docs: `SET_LODGROUP_RADIUS`
* Missing docs: `CREATE_LODGROUP_MODEL`
  * ↳ registered at [scrbind-formats/src/Drawable.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/scrbind-formats/src/Drawable.cpp)      
* Missing docs: `AUDIOCONTEXT_CONNECT`
* Missing docs: `AUDIOCONTEXT_DISCONNECT`
* Missing docs: `AUDIOCONTEXT_GET_CURRENT_TIME`
* Missing docs: `AUDIOCONTEXT_GET_SOURCE`
* Missing docs: `AUDIOCONTEXT_GET_DESTINATION`
* Missing docs: `AUDIOCONTEXT_CREATE_BIQUADFILTERNODE`
* Missing docs: `AUDIOCONTEXT_CREATE_WAVESHAPERNODE`
* Missing docs: `BIQUADFILTERNODE_SET_TYPE`
* Missing docs: `BIQUADFILTERNODE_Q`
* Missing docs: `BIQUADFILTERNODE_GAIN`
* Missing docs: `BIQUADFILTERNODE_FREQUENCY`
* Missing docs: `BIQUADFILTERNODE_DETUNE`
* Missing docs: `BIQUADFILTERNODE_DESTROY`
* Missing docs: `WAVESHAPERNODE_SET_CURVE`
* Missing docs: `WAVESHAPERNODE_DESTROY`
* Missing docs: `AUDIOPARAM_SET_VALUE`
* Missing docs: `AUDIOPARAM_SET_VALUE_AT_TIME`
* Missing docs: `AUDIOPARAM_SET_VALUE_CURVE_AT_TIME`
* Missing docs: `AUDIOPARAM_DESTROY`
  * ↳ registered at [voip-mumble/src/MumbleAudioOutput.cpp](https://github.com/citizenfx/fivem/blame/master/code/components/voip-mumble/src/MumbleAudioOutput.cpp)
  
</details>

##### SET_ENTITY_ROTATION_VELOCITY
  - A gta native doing the same thing was introduced in b2372 under the name SET_ENTITY_**ANGULAR**_VELOCITY
  - This is essentially an undocumented shim for <b2372 named "rotation" instead of "angular"
  - using the term "rotation" instead of "angular" is also done in server-side GET_ENTITY_ROTATION_VELOCITY
  - SET_ENTITY_ROTATION_VELOCITY is listed in rpc_spec_natives.lua, but doesn't generate a file to /native_md/
  - I guess it's fine undocumented?
##### SET_VEHICLE_NEXT_GEAR
  - This name is wrong as it actually sets the PREV gear (at least in >=b2802)
  - The getter GET_VEHICLE_NEXT_GEAR (which is documented) retrieves the PREV gear as well
  - This variable doesn't appear to have any effect in the game whatsoever anyway
  - Renaming the getter and/or documenting the setter would probably cause more trouble than it's worth
#### What else?
Let me know if I should generate an md file for any of the other ones