### PR TITLE
tweak(client): remove non-ASLR game executables

### DIFF
--- a/code/components/sticky/src/LaunchIntercept.cpp
+++ b/code/components/sticky/src/LaunchIntercept.cpp
@@ -34,7 +34,7 @@ void Component_RunPreInit()
 
 	if (hostData->IsMasterProcess() && !debugMode)
 	{
-		auto processName = MakeCfxSubProcess(L"GameProcess.exe", fmt::sprintf(L"game_%d%s", xbr::GetGameBuild(), (IsWindows8Point1OrGreater()) ? L"_aslr" : L""));
+		auto processName = MakeCfxSubProcess(L"GameProcess.exe", fmt::sprintf(L"game_%d_aslr", xbr::GetGameBuild()));
 
 		STARTUPINFOW si = { 0 };
 		si.cb = sizeof(si);


### PR DESCRIPTION
Since b6cc153df04ec066b01f7647ca150a684501844a blocks the client from running on Windows 7 or 8, these builds aren't needed anymore, as they served as a workaround for Windows before 8.1 not supporting high-entropy virtual addresses, leading to the logic in [`hook::get_unadjusted`](https://github.com/citizenfx/fivem/blob/66d052957b28a5102eba86fad5947e40b22597dc/code/client/shared/Hooking.h#L82) not working.

When merging this PR, keep in mind:
1. The change in `sticky` should be mirrored in `adhesive` in `fivem-private` as well.
2. If incremental builds do not remove old binary artifacts, the non-ASLR binaries should be removed manually.

### Goal of this PR
Clean up the build output and remove unneeded executables.


### How is this PR achieving the goal
Dropping the unneeded non-ASLR builds.


### This PR applies to the following area(s)
FiveM, RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
N/A
