### PR TITLE
Add `GET_WORLD_COORD_FROM_SCREEN_COORD` for RedM

### DIFF
--- a/code/components/extra-natives-five/include/GamePrimitives.h
+++ b/code/components/extra-natives-five/include/GamePrimitives.h
@@ -114,11 +114,11 @@ struct fwSearchVolume
 
 struct grcViewport
 {
-	float m_mat1[16];
-	float m_mat2[16];
-	float m_viewProjection[16];
+	float m_world[16];
+	float m_worldView[16];
+	float m_worldViewProj[16];
 	float m_inverseView[16];
-	char m_pad[64];
+	float m_view[16];
 	float m_projection[16];
 };
 
@@ -146,7 +146,7 @@ inline rage::Vec3V Unproject(const rage::grcViewport& viewport, const rage::Vec3
 {
 	using namespace DirectX;
 
-	auto invVP = XMMatrixInverse(NULL, XMLoadFloat4x4((const XMFLOAT4X4*)viewport.m_viewProjection));
+	auto invVP = XMMatrixInverse(NULL, XMLoadFloat4x4((const XMFLOAT4X4*)viewport.m_worldViewProj));
 	auto inVec = XMVectorSet((viewPos.x * 2.0f) - 1.0f, ((1.0 - viewPos.y) * 2.0f) - 1.0f, viewPos.z, 1.0f);
 	auto outCoord = XMVector3TransformCoord(inVec, invVP);
 

--- a/code/components/extra-natives-five/src/GamePrimitives_Im3D.cpp
+++ b/code/components/extra-natives-five/src/GamePrimitives_Im3D.cpp
@@ -232,7 +232,7 @@ void gz::Draw(const RemoteDrawLists* lists)
 		SetBlendState(GetStockStateIdentifier(BlendStateDefault));
 
 		shader->SetParameter(uViewport, viewportSize, 8, 1);
-		shader->SetParameter(uViewProjMatrix, viewport.m_viewProjection, 16, 4);
+		shader->SetParameter(uViewProjMatrix, viewport.m_worldViewProj, 16, 4);
 
 		rage::grcDrawMode mode;
 

--- a/code/components/extra-natives-rdr3/include/GamePrimitives.h
+++ b/code/components/extra-natives-rdr3/include/GamePrimitives.h
@@ -54,12 +54,12 @@ struct spdRay
 
 struct grcViewport
 {
-	float m_mat1[16];
-	float m_mat2[16];
-	float m_viewProjection[16];
-	float m_inverseView[16];
-	char m_pad[64];
+	float m_world[16];
+	float m_worldView[16];
 	float m_projection[16];
+	float m_inverseView[16];
+	float m_unknown[16];
+	float m_view[16];
 };
 }
 
@@ -81,7 +81,7 @@ inline rage::Vec3V Unproject(const rage::grcViewport& viewport, const rage::Vec3
 {
 	using namespace DirectX;
 
-	auto composite = XMMatrixMultiply(XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_projection), XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_viewProjection));
+	auto composite = XMMatrixMultiply(XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_view), XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_projection));
 	auto invVP = XMMatrixInverse(NULL, composite);
 	auto inVec = XMVectorSet((viewPos.x * 2.0f) - 1.0f, ((1.0 - viewPos.y) * 2.0f) - 1.0f, viewPos.z, 1.0f);
 	auto outCoord = XMVector3TransformCoord(inVec, invVP);

--- a/code/components/extra-natives-rdr3/include/GamePrimitives.h
+++ b/code/components/extra-natives-rdr3/include/GamePrimitives.h
@@ -51,4 +51,44 @@ struct spdRay
 	Vec3V start;
 	Vec3V end;
 };
+
+struct grcViewport
+{
+	float m_mat1[16];
+	float m_mat2[16];
+	float m_viewProjection[16];
+	float m_inverseView[16];
+	char m_pad[64];
+	float m_projection[16];
+};
+}
+
+struct CViewportGame
+{
+public:
+	virtual ~CViewportGame() = 0;
+
+private:
+	char m_pad[8];
+
+public:
+	rage::grcViewport viewport;
+};
+
+extern CViewportGame** g_viewportGame;
+
+inline rage::Vec3V Unproject(const rage::grcViewport& viewport, const rage::Vec3V& viewPos)
+{
+	using namespace DirectX;
+
+	auto composite = XMMatrixMultiply(XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_projection), XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_viewProjection));
+	auto invVP = XMMatrixInverse(NULL, composite);
+	auto inVec = XMVectorSet((viewPos.x * 2.0f) - 1.0f, ((1.0 - viewPos.y) * 2.0f) - 1.0f, viewPos.z, 1.0f);
+	auto outCoord = XMVector3TransformCoord(inVec, invVP);
+
+	return {
+		XMVectorGetX(outCoord),
+		XMVectorGetY(outCoord),
+		XMVectorGetZ(outCoord)
+	};
 }

--- a/code/components/extra-natives-rdr3/include/GamePrimitives.h
+++ b/code/components/extra-natives-rdr3/include/GamePrimitives.h
@@ -81,7 +81,7 @@ inline rage::Vec3V Unproject(const rage::grcViewport& viewport, const rage::Vec3
 {
 	using namespace DirectX;
 
-	auto composite = XMMatrixMultiply(XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_view), XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_projection));
+	auto composite = XMMatrixMultiply(XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_worldView), XMLoadFloat4x4((const XMFLOAT4X4*)&viewport.m_projection));
 	auto invVP = XMMatrixInverse(NULL, composite);
 	auto inVec = XMVectorSet((viewPos.x * 2.0f) - 1.0f, ((1.0 - viewPos.y) * 2.0f) - 1.0f, viewPos.z, 1.0f);
 	auto outCoord = XMVector3TransformCoord(inVec, invVP);


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Add `GET_WORLD_COORD_FROM_SCREEN_COORD` native for RedM.


### How is this PR achieving the goal

By adapting related FiveM code for Red Dead Redemption 2 and RedM.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1311, 1355, 1436, 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Fixes #1977 

Demonstration:
[Video](https://github.com/citizenfx/fivem/assets/10367215/0c3e3e1c-2ec0-44c7-88c1-5e5dae1195fd)



