### PR TITLE
feat(extra-natives/five): Add `SET_INTERIOR_PROBE_LENGTH` for FiveM

### DIFF
--- a/ext/native-decls/SetEmitterProbeLength.md
+++ b/ext/native-decls/SetEmitterProbeLength.md
@@ -1,0 +1,34 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_EMITTER_PROBE_LENGTH
+
+```c
+void SET_EMITTER_PROBE_LENGTH(float probeLength);
+```
+
+Allows StaticEmitter's without a linked entity to make use of environment features like occlusion and reverb even if they are located higher than 20.0 units above any static collision inside interiors.
+
+This native allows you to extend the probe range up to 150.0 units.
+
+## Examples
+
+```lua
+RegisterCommand("setEmitterProbeLength", function(src, args, raw)
+    local probeLength = (tonumber(args[1]) + 0.0)
+
+    print("Extending emitter probes to: ", probeLength)
+    SetEmitterProbeLength(probeLength)
+end)
+
+RegisterCommand("resetEmitterProbeLength", function()
+    print("Resetting emitter probes to default settings")
+    SetEmitterProbeLength(20.0)
+end)
+```
+
+
+## Parameters
+* **probeLength**: The desired probe length (20.0 - 150.0)

--- a/ext/native-decls/SetInteriorProbeLength.md
+++ b/ext/native-decls/SetInteriorProbeLength.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_INTERIOR_PROBE_LENGTH
+
+```c
+void SET_INTERIOR_PROBE_LENGTH(float probeLength);
+```
+
+Overwrite the games default CPortalTracker interior detection range.
+This fixes potentially unwanted behaviour in the base game and allows you to build custom interiors with larger ceiling heights without running into graphical glitches.
+
+By default CPortalTracker will probe 4 units downward trying to reach collisions that are part of the interior the entity is in.
+If no collision can be found 16 units are used in some circumstances.
+
+There are 30+ hard coded special cases, only some of them exposed via script (for example `ENABLE_STADIUM_PROBES_THIS_FRAME`).
+
+This native allows you to extend the probe range up to 150 units which is the same value the game uses for the `xs_arena_interior`
+
+## Examples
+
+```lua
+RegisterCommand("setInteriorProbeLength", function(src, args, raw)
+    local probeLength = (tonumber(args[1]) + 0.0)
+
+    print("Extending interior detection probes to: ", probeLength)
+    SetInteriorProbeLength(probeLength)
+end)
+
+RegisterCommand("resetInteriorProbeLength", function()
+    print("Resetting interior detection probes to default settings")
+    SetInteriorProbeLength(0.0)
+end)
+```
+
+
+## Parameters
+* **probeLength**: The desired probe length (0.0 - 150.0)


### PR DESCRIPTION
### Goal of this PR

Allow servers to customize the probe distance used in `CPortalTracker`.

All dynamic entities own an instance of `CPortalTracker`. It is used to detect traversal from and into interiors, through portals and other related actions. 
By default the probing function inside `CPortalTracker`'s tick/update function probes downwards 4.0 units, trying to extract the interior the entity is in from collision data (staticboundsstore).

In many cases this will not work, leading to ~30 hard coded special cases based on interior archetype hash. Rockstar extends the probing distance for these interiors, most notably in `xs_arena_interior` to 150.0f.

### How is this PR achieving the goal

By adding a new FiveM native `SET_INTERIOR_PROBE_LENGTH` to give servers individual control of game behaviour depending on their needs.

- The override value is applied to all probes shorter than itself. 
- User input is clamped to `0.0f - 150.0f`
- Session reset is handled, the override is reset on disconnect

Test code:
```lua
RegisterCommand("setInteriorProbeLength", function(src, args, raw)
    local probeLength = (tonumber(args[1]) + 0.0)

    print("Extending interior detection probes to: ", probeLength)
    SetInteriorProbeLength(probeLength)
end)

RegisterCommand("resetInteriorProbeLength", function()
    print("Resetting interior detection probes to default settings")
    SetInteriorProbeLength(0.0)
end)
```

Examples of use cases:
- Specific custom interiors with unusual dimensions
- Housing systems with script created floors
- Improved render behaviour when trying to locate and noclip into underground interiors

Demo:
https://streamable.com/jxm0ux

![image](https://github.com/citizenfx/fivem/assets/26795431/b18e42fc-7c34-48b0-89d0-aecad50f0149)



### This PR applies to the following area(s)
FiveM

### Successfully tested on

**Game builds:** All available FiveM builds
**Configurations:** Debug / Release
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Base game behavior 


