### PR TITLE
fix(github): PR labeling permission

### DIFF
--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,6 +1,6 @@
 name: Validate PR
 on:
-  pull_request:
+  pull_request_target:
     types: [ reopened, opened, edited, synchronize, ready_for_review ]
     paths:
       - 'code/**'
@@ -14,7 +14,6 @@ on:
       - '!*.sh'
 
 permissions:
-  issues: write
   pull-requests: write
 
 concurrency:


### PR DESCRIPTION
### Goal of this PR

Enable labelling of external fork PRs, also continuing builds of PRs targeting `RedM`, `ScRT: Lua`, etc.

### How is this PR achieving the goal

Finally found the documentation:

> GitHub only grants read access tokens for `pull_request` events, at most. If you encounter an `Error: HttpError: Resource not accessible by integration`, it's likely due to these permission constraints. To resolve this issue, you can modify the `on:` section of your workflow to use `pull_request_target` instead of `pull_request`

- https://github.com/actions/labeler?tab=readme-ov-file#permissions

Removed `issues: write` permission as shown in the example, see link.

### This PR applies to the following area(s)

GitHub

### Successfully tested on

GitHub

**Game builds:** N/A

**Platforms:** GitHub Runner


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


