### PR TITLE
feat(extra-natives/five): current amount and maximum pool size

### DIFF
--- a/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
+++ b/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
@@ -19,8 +19,9 @@ class RefPool
 {
 private:
 	TEntry** m_baseAddress;
-	uint32_t m_count;
-	char m_pad[36];
+	size_t m_count;
+	size_t m_freeSpace;
+	char m_pad2[24];
 	uint32_t* m_validBits;
 	// ...
 
@@ -44,6 +45,12 @@ public:
 	size_t GetSize()
 	{
 		return m_count;
+	}
+
+	// copying the behaviour of atPoolBase by returning the used space
+	size_t GetCountDirect()
+	{
+		return (m_count - m_freeSpace);
 	}
 };
 #endif
@@ -161,6 +168,15 @@ static void SerializePool(fx::ScriptContext& context)
 	}
 
 	context.SetResult(fx::SerializeObject(guids));
+}
+
+template<typename TTraits>
+static void GetPoolSize(fx::ScriptContext& context)
+{
+	TTraits::PoolType* pool = TTraits::GetPool();
+
+	context.SetResult<int>(pool->GetCountDirect());
+	*context.GetArgument<int*>(1) = pool->GetSize();
 }
 
 struct FindHandle
@@ -286,6 +302,23 @@ static InitFunction initFunction([]()
 			SerializePool<PickupPoolTraits>(context);
 		else if (pool.compare("CVehicle") == 0)
 			SerializePool<VehiclePoolTraits>(context);
+		else
+		{
+			throw std::runtime_error(va("Invalid pool: %s", pool));
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_GAME_POOL_SIZE", [](fx::ScriptContext& context)
+	{
+		std::string pool = context.CheckArgument<const char*>(0);
+		if (pool.compare("CPed") == 0)
+			GetPoolSize<PedPoolTraits>(context);
+		else if (pool.compare("CObject") == 0)
+			GetPoolSize<ObjectPoolTraits>(context);
+		else if (pool.compare("CPickup") == 0)
+			GetPoolSize<PickupPoolTraits>(context);
+		else if (pool.compare("CVehicle") == 0)
+			GetPoolSize<VehiclePoolTraits>(context);
 		else
 		{
 			throw std::runtime_error(va("Invalid pool: %s", pool));

--- a/ext/native-decls/GetGamePoolSize.md
+++ b/ext/native-decls/GetGamePoolSize.md
@@ -1,0 +1,28 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_GAME_POOL_SIZE
+
+```c
+int GET_GAME_POOL_SIZE(char* poolName, int* maxPoolSize);
+```
+
+### Supported pools
+* `CPed`: Peds (including animals) and players.
+* `CObject`: Objects (props), doors, and projectiles.
+* `CVehicle`: Vehicles.
+* `CPickup`: Pickups.
+
+## Examples
+```lua
+local currentAmount, maxPoolSize = GetGamePoolSize('CObject') -- Get the current amount and max pool size of objects
+print("CObject " .. currentAmount .. "/" .. maxPoolSize)
+```
+
+## Parameters
+* **poolName**: The pool name to get the current amount and max size from.
+
+## Return value
+Returns the current amount of entries in the specified pool and the pools maximum size.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

To allow you to see the current pool size and it's maximum size.
...


### How is this PR achieving the goal
By exposing the current amount and the maximum pool size.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Natives
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 2372

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


