### PR TITLE
Bump mono v2 flag date

### DIFF
--- a/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
@@ -263,11 +263,12 @@ int MonoScriptRuntime::HandlesFile(char* filename, IScriptHostWithResourceData* 
 	}
 
 	// last supported date for this pilot of mono_rt2, in UTC
-	constexpr int maxYear = 2024, maxMonth = 3, maxDay = 31;
+	constexpr int maxYear = 2024, maxMonth = 6, maxDay = 4;
 
 	// Allowed values for mono_rt2
 	constexpr std::string_view allowedValues[] = {
 		// put latest on top, right here ↓
+		"Prerelease expiring 2024-06-04. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2024-03-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2023-12-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2023-08-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,


### PR DESCRIPTION
### Goal of this PR
Expand the length of the mono v2 runtime earlier in order to not disturb people who are actively using this runtime in their resources


### How is this PR achieving the goal

Bumping the date a few months


### This PR applies to the following area(s)

FiveM, RedM, Client, Server, C#


### Successfully tested on

**Game builds:** All

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


