### PR TITLE
Add typedefs for RedM and update native-doc-tooling

### DIFF
--- a/ext/natives/codegen_types.lua
+++ b/ext/natives/codegen_types.lua
@@ -114,3 +114,25 @@ type 'func'
 
 type 'object'
 	nativeType 'object'
+
+-- rdr3 specific
+type 'ItemSet'
+	nativeType 'int'
+
+type 'AnimScene'
+	nativeType 'int'
+
+type 'PersChar'
+	nativeType 'int'
+
+type 'PopZone'
+	nativeType 'int'
+
+type 'Prompt'
+	nativeType 'int'
+
+type 'PropSet'
+	nativeType 'int'
+
+type 'Volume'
+	nativeType 'int'


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The goal of this PR is to add typedefs necessary for updating and building natives for RedM and update  the `native-doc-tooling` submodule. See [citizenfx/native-doc-tooling](https://github.com/citizenfx/native-doc-tooling/commit/a8f791baa8505579acde770a8ec558baad5d936c) changes.


### How is this PR achieving the goal

This PR achieves the goal by adding the missed typedefs.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** -

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


