### PR TITLE
increase txd store pool size

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -458,7 +458,7 @@
 						</Item>
 						<Item>
 							<PoolName>TxdStore</PoolName>
-							<PoolSize value="105500"/>
+							<PoolSize value="205500"/>
 						</Item>
 						<Item>
 							<PoolName>CNetObjVehicle</PoolName>


### PR DESCRIPTION
### Goal of this PR

with this update, it will be possible to use clothes made by the most famous creators with many variables and not limit yourself to using old gamebuilds...

for exampe: i have a pack of clothes that works with gamebuild 2802, with the latest gamebuild 3095 I get the error, like many other people, of txd store limit to 105500)

### How is this PR achieving the goal

the pr archive the goal increasing the value...

### This PR applies to the following area(s)

fivem


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


