### PR TITLE
Reset "can stand on top" flag and map after disconnection in FiveM

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -1375,10 +1375,15 @@ static HookFunction initFunction([]()
 
 	OnKillNetworkDone.Connect([]()
 	{
-		g_skipRepairVehicles.clear();
 		ResetFlyThroughWindscreenParams();
+
 		*g_trainsForceDoorsOpen = true;
+
+		g_skipRepairVehicles.clear();
+		g_canPedStandOnVehicles.clear();
+
 		g_overrideUseDefaultDriveByClipset = false;
+		g_overrideCanPedStandOnVehicle = false;
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_AUTO_REPAIR_DISABLED", [](fx::ScriptContext& context)

--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -1388,27 +1388,24 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_AUTO_REPAIR_DISABLED", [](fx::ScriptContext& context)
 	{
-		auto vehHandle = context.GetArgument<int>(0);
-		auto shouldDisable = context.GetArgument<bool>(1);
-
-		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(vehHandle);
-
-		if (shouldDisable)
+		if (fwEntity* entity = getAndCheckVehicle(context, "SET_VEHICLE_AUTO_REPAIR_DISABLED"))
 		{
-			g_skipRepairVehicles.insert(entity);
-		}
-		else
-		{
-			g_skipRepairVehicles.erase(entity);
+			auto shouldDisable = context.GetArgument<bool>(1);
+
+			if (shouldDisable)
+			{
+				g_skipRepairVehicles.insert(entity);
+			}
+			else
+			{
+				g_skipRepairVehicles.erase(entity);
+			}	
 		}
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("ADD_VEHICLE_DELETION_TRACE", [](fx::ScriptContext& context)
 	{
-		auto vehHandle = context.GetArgument<int>(0);
-		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(vehHandle);
-
-		if (entity->IsOfType<CVehicle>())
+		if (fwEntity* entity = getAndCheckVehicle(context, "ADD_VEHICLE_DELETION_TRACE"))
 		{
 			g_deletionTraces.insert(entity);
 			g_deletionTraces2.insert(entity);
@@ -1417,10 +1414,7 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("OVERRIDE_VEHICLE_PEDS_CAN_STAND_ON_TOP_FLAG", [](fx::ScriptContext& context)
 	{
-		auto vehHandle = context.GetArgument<int>(0);
-		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(vehHandle);
-
-		if (entity->IsOfType<CVehicle>())
+		if (fwEntity* entity = getAndCheckVehicle(context, "OVERRIDE_VEHICLE_PEDS_CAN_STAND_ON_TOP_FLAG"))
 		{
 			bool can = context.GetArgument<bool>(1);
 			SetCanPedStandOnVehicle(entity, can ? 1 : -1);
@@ -1429,10 +1423,7 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("RESET_VEHICLE_PEDS_CAN_STAND_ON_TOP_FLAG", [](fx::ScriptContext& context)
 	{
-		auto vehHandle = context.GetArgument<int>(0);
-		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(vehHandle);
-
-		if (entity->IsOfType<CVehicle>())
+		if (fwEntity* entity = getAndCheckVehicle(context, "RESET_VEHICLE_PEDS_CAN_STAND_ON_TOP_FLAG"))
 		{
 			SetCanPedStandOnVehicle(entity, 0);
 		}


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The goal of this PR is to fix an oversight where the "can stand on top" flag (`g_overrideCanPedStandOnVehicle`) and the vehicle map (`g_canPedStandOnVehicles`) weren't reset after disconnection from a server. Also, tweak some natives to use `getAndCheckVehicle` to avoid code duplication.

### How is this PR achieving the goal

This PR achieves the goal by resetting the flag and map during `OnKillNetworkDone`. Also, it tweaks the relevant code to use the `getAndCheckVehicle` helper.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604, 2060, 2189, 2372, 2545, 2612, 2699, 2802, 2944, 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


