### PR TITLE
Earlier connect to server when using "fivem://connect"

### DIFF
--- a/code/components/glue/src/ConnectToNative.cpp
+++ b/code/components/glue/src/ConnectToNative.cpp
@@ -1477,14 +1477,11 @@ void Component_RunPreInit()
 		{
 // #TODOLIBERTY: ?
 #ifndef GTA_NY
-			rage::OnInitFunctionStart.Connect([](rage::InitFunctionType type)
+			NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary*)
 			{
-				if (type == rage::InitFunctionType::INIT_CORE)
-				{
-					ConnectTo(connectHost, false, connectParams);
-					connectHost = "";
-					connectParams = "";
-				}
+				ConnectTo(connectHost, false, connectParams);
+				connectHost = "";
+				connectParams = "";
 			}, 999999);
 #endif
 		}


### PR DESCRIPTION
### Goal of this PR

When using ""fivem://connect"", the time between launching the game and getting any "connecting" feedback can about a minute on slower machines, so this PR aims to make use of a very cheap speed up to try and improve user feedback as it seems that the game can run initfunctions while connecting to a server instead of having to wait before connecting.

### How is this PR achieving the goal

The game launcher now attempts a ConnectTo when netLibrary is created instead of waiting on INIT_CORE

### This PR applies to the following area(s)

FiveM, RedM


### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues


