### PR TITLE
feat(scripting/v8): allow to set the max listeners count

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -83,10 +83,12 @@ type CitizenImmediate = Omit<CitizenTimer, 'refresh'>;
 declare var Citizen: CitizenInterface;
 
 declare function addRawEventListener(eventName: string, callback: Function): void
+declare function setMaxRawEventListeners(max: number): void
 
 declare function addEventListener(eventName: string, callback: Function, netSafe?: boolean): void
 declare function on(eventName: string, callback: Function): void
 declare function AddEventHandler(eventName: string, callback: Function): void
+declare function setMaxEventListeners(max: number): void
 
 declare function addNetEventListener(eventName: string, callback: Function): void
 declare function onNet(eventName: string, callback: Function): void

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -207,6 +207,9 @@ const EXT_LOCALFUNCREF = 11;
 	global.addRawEventListener = rawEmitter.on.bind(rawEmitter);
 	global.addRawEventHandler = global.addRawEventListener;
 
+	// Raw events configuration
+	global.setMaxRawEventListeners = rawEmitter.setMaxListeners.bind(rawEmitter);
+
 	// Client events
 	global.addEventListener = (name, callback, netSafe = false) => {
 		if (netSafe) {
@@ -218,6 +221,9 @@ const EXT_LOCALFUNCREF = 11;
 		emitter.on(name, callback);
 	};
 	global.on = global.addEventListener;
+
+	// Event Emitter configuration
+	global.setMaxEventListeners = emitter.setMaxListeners.bind(emitter);
 
 	// Net events
 	global.addNetEventListener = (name, callback) => global.addEventListener(name, callback, true);


### PR DESCRIPTION


### Goal of this PR
By default any event that is listened more than 10 times will trigger a log error saying that there may be a memory leak. 

In some cases users may want to listen more than 10 times to a specific event this patch allow to not display a log message in those cases by setting the correct value to the setMaxEventListeners.

It's not a real problem, but often users will print this error saying it's the cause of a bug (but it's not) and it's misleading.

### How is this PR achieving the goal

This PR allow to configure the max listeners count so a developer can set it according to his code behavior.


### This PR applies to the following area(s)

FiveM, RedM, Server, ScRT: JS

### Successfully tested on

**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

N/A
