### PR TITLE
fix(nui): Fixed to be able to change the resolution setting of Fixed-size NUI

### DIFF
--- a/code/components/nui-core/include/NUIWindow.h
+++ b/code/components/nui-core/include/NUIWindow.h
@@ -212,4 +212,8 @@ public:
 	void HandlePopupShow(bool show);
 
 	bool IsFixedSizeWindow() const;
+
+private:
+	int m_fixedWidth;
+	int m_fixedHeight;
 };

--- a/code/components/nui-core/src/NUIWindow.cpp
+++ b/code/components/nui-core/src/NUIWindow.cpp
@@ -41,7 +41,7 @@ extern void AddSchemeHandlerFactories(CefRefPtr<CefRequestContext> rc);
 NUIWindow::NUIWindow(bool rawBlit, int width, int height, const std::string& windowContext)
 	: m_rawBlit(rawBlit), m_width(width), m_height(height), m_renderBuffer(nullptr), m_dirtyFlag(0), m_onClientCreated(nullptr), m_nuiTexture(nullptr), m_popupTexture(nullptr), m_swapTexture(nullptr),
 	  m_swapRtv(nullptr), m_swapSrv(nullptr), m_dereferencedNuiTexture(false), m_lastFrameTime(0), m_lastMessageTime(0), m_roundedHeight(0), m_roundedWidth(0),
-	  m_syncKey(0), m_paintType(NUIPaintTypeDummy), m_windowContext(windowContext)
+	  m_syncKey(0), m_paintType(NUIPaintTypeDummy), m_windowContext(windowContext), m_fixedWidth(1920), m_fixedHeight(1080)
 {
 	memset(&m_lastDirtyRect, 0, sizeof(m_lastDirtyRect));
 
@@ -387,6 +387,18 @@ void NUIWindow::Initialize(CefString url)
 	{
 		m_renderBuffer = new char[4 * m_roundedWidth * m_roundedHeight];
 	}
+
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	if (GetFileAttributes(fpath.c_str()) != INVALID_FILE_ATTRIBUTES)
+	{
+		m_fixedWidth = GetPrivateProfileInt(L"Game", L"FixedSizeWindowX", 1920, fpath.c_str());
+		m_fixedHeight = GetPrivateProfileInt(L"Game", L"FixedSizeWindowY", 1080, fpath.c_str());
+		if (!((640 <= m_fixedWidth && m_fixedWidth <= 7680) && (480 <= m_fixedHeight && m_fixedHeight <= 4320)))
+		{
+			m_fixedWidth = 1920;
+			m_fixedHeight = 1080;
+		}
+	}
 }
 
 void NUIWindow::InitializeRenderBacking()
@@ -562,8 +574,8 @@ void NUIWindow::UpdateFrame()
 
 		if (IsFixedSizeWindow())
 		{
-			resX = 1920;
-			resY = 1080;
+			resX = m_fixedWidth;
+			resY = m_fixedHeight;
 		}
 
 		if (m_width != resX || m_height != resY)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
The purpose is to be able to change the resolution setting of Fixed-sizeNUI, which is one of the items in the FiveM settings.
The current implementation is fixed at 1920x1080, and when playing in 4K, the game cannot be set to 4K and the size of the NUI to WQHD, which lacks scalability, so this modification will make it possible.


### How is this PR achieving the goal
By defining FixedSizeWindowX and FixedSizeWindowY in CitizenFX.ini, the resolution can be changed to any desired resolution.
If not defined, the resolution will be 1920x1080.
FixedSizeWindowX ranges is 640-7680
FixedSizeWindowY range is 480-4320
If this range is exceeded, the default is 1920x1080.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
N/A

### Supplement
I was thinking of loading ini within NUIWindow::UpdateFrame(), but I thought it was not a good idea because UpdateFrame is a function that is called frequently.
As a result, we implemented it in a way that the file is loaded in Initialized and the value is held in a variable.
If there are any problems with this implementation, please let us know.
I am new to programming and may have implemented it incorrectly. My apologies.