### PR TITLE
fix(client): Cleanup various static sig patterns and put them in Hook…

### DIFF
--- a/code/components/extra-natives-five/src/NuiAudioSink.cpp
+++ b/code/components/extra-natives-five/src/NuiAudioSink.cpp
@@ -1074,14 +1074,15 @@ namespace rage
 		static audCategoryControllerManager* GetInstance();
 	};
 
+	static audCategoryControllerManager** g_audCategoryControllerManager = nullptr;
 	audCategoryControllerManager* audCategoryControllerManager::GetInstance()
 	{
-#ifdef GTA_FIVE
-		static auto patternRef = hook::get_address<audCategoryControllerManager**>(hook::get_pattern("45 33 C0 BA 90 1C E2 44 E8", -4));
-#elif IS_RDR3
-		static auto patternRef = hook::get_address<audCategoryControllerManager**>(hook::get_pattern("48 8B 0D ? ? ? ? E8 ? ? ? ? 8B 15 ? ? ? ? 48 8D 0D ? ? ? ? E8", 3));
-#endif
-		return *patternRef;
+		if (!g_audCategoryControllerManager)
+		{
+			return nullptr;
+		}
+
+		return *g_audCategoryControllerManager;
 	}
 
 	static hook::thiscall_stub<char*(audCategoryControllerManager*, uint32_t)> _audCategoryControllerManager_CreateController([]()
@@ -1108,6 +1109,8 @@ namespace rage
 		initParamVal = hook::get_address<uint8_t*>(hook::get_pattern("BA 11 CC 23 C3 E8 ? ? ? ? 48 8D", 0x16));
 
 		audDriver::sm_Mixer = hook::get_address<audMixerDevice**>(hook::get_pattern("75 64 44 0F B7 45 06 48 8B 0D", 10));
+
+		g_audCategoryControllerManager = hook::get_address<audCategoryControllerManager**>(hook::get_pattern("45 33 C0 BA 90 1C E2 44 E8", -4));
 #elif IS_RDR3
 		g_frontendAudioEntity = hook::get_address<audEntityBase*>(hook::get_pattern("48 8D 0D ? ? ? ? E8 ? ? ? ? 45 84 E4 74 ? 39 1D"), 3, 7);
 
@@ -1116,6 +1119,8 @@ namespace rage
 		initParamVal = hook::get_address<uint8_t*>(hook::get_pattern("8A 05 ? ? ? ? 48 8B CF F3 0F 11 45 ? 88 45 66"), 2, 6);
 
 		audDriver::sm_Mixer = hook::get_address<audMixerDevice**>(hook::get_pattern("48 8B 05 ? ? ? ? 44 38 8C 01 ? ? ? ? 0F"), 3, 7);
+
+		g_audCategoryControllerManager = hook::get_address<audCategoryControllerManager**>(hook::get_pattern("48 8B 0D ? ? ? ? E8 ? ? ? ? 8B 15 ? ? ? ? 48 8D 0D ? ? ? ? E8", 3));
 #endif
 	});
 #ifdef GTA_FIVE

--- a/code/components/gta-net-five/src/NetHook.cpp
+++ b/code/components/gta-net-five/src/NetHook.cpp
@@ -373,16 +373,10 @@ static hook::cdecl_stub<void(int, int, int)> hostGame([] () -> void*
 	return (void*)hook::get_adjusted(0x1410494F8);
 });
 
+static void** g_networkMgrPtr = nullptr;
 static void* getNetworkManager()
 {
-	static void** networkMgrPtr = nullptr;
-
-	if (networkMgrPtr == nullptr)
-	{
-		networkMgrPtr = hook::get_address<void**>(hook::get_pattern("84 C0 74 2E 48 8B 0D ? ? ? ? 48 8D 54 24 20", 7));
-	}
-
-	return *networkMgrPtr;
+	return *g_networkMgrPtr;
 }
 
 struct OnlineAddress
@@ -1078,6 +1072,9 @@ static HookFunction initFunction([]()
 			doTickNextFrame = false;
 		}
 	});
+
+
+	g_networkMgrPtr = hook::get_address<void**>(hook::get_pattern("84 C0 74 2E 48 8B 0D ? ? ? ? 48 8D 54 24 20", 7));
 });
 
 static uint64_t* g_globalNetSecurityKey;

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1036,9 +1036,9 @@ static hook::cdecl_stub<void()> _reloadMapIfNeeded([]()
 	return hook::get_pattern("74 1F 48 8D 0D ? ? ? ? E8 ? ? ? ? 48 8D 0D ? ? ? ? E8 ? ? ? ? C6 05", -0xB);
 });
 
+static char* loadChangeSet = nullptr;
 static void ReloadMapStoreNative()
 {
-	static auto loadChangeSet = hook::get_pattern<char>("48 81 EC 50 03 00 00 49 8B F0 4C", -0x18);
 	uint8_t origCode[0x4F3];
 	memcpy(origCode, loadChangeSet, sizeof(origCode));
 
@@ -3301,6 +3301,8 @@ DLL_IMPORT extern fwEvent<> PreSetupLoadingScreens;
 static HookFunction hookFunction([]()
 {
 #ifdef GTA_FIVE
+	loadChangeSet = hook::get_pattern<char>("48 81 EC 50 03 00 00 49 8B F0 4C", -0x18);
+
 	PreSetupLoadingScreens.Connect([]()
 	{
 		FlushCustomAssets();

--- a/code/components/gta-streaming-five/src/PatchPackfileLimit.cpp
+++ b/code/components/gta-streaming-five/src/PatchPackfileLimit.cpp
@@ -65,47 +65,41 @@ static void SetStreamingInterface(char* si)
 }
 
 static void(*g_origStreamerTick)(void*, void*);
-
+static int32_t* g_CustomStreamerTickLoc = nullptr;
 static void CustomStreamerTick(void* a1, void* a2)
 {
-	static auto patternLoc = hook::get_pattern<int32_t>("4D 8B A4 C7 ? ? ? ? 4C 8D 45 58 49 8B 04 24", 4);
-
-	auto oldLoc = *patternLoc;
-	*patternLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
+	auto oldLoc = *g_CustomStreamerTickLoc;
+	*g_CustomStreamerTickLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
 
 	g_origStreamerTick(a1, a2);
 
-	*patternLoc = oldLoc;
+	*g_CustomStreamerTickLoc = oldLoc;
 }
 
 static void*(*g_origQueueStrTask)(uint32_t a1, void* a2, int a3, int a4, void* a5, void* a6, void* a7, uint32_t a8, void* a9, int a10);
-
+static int32_t* g_CustomQueueStrTaskLoc = nullptr;
 static void* CustomQueueStrTask(uint32_t a1, void* a2, int a3, int a4, void* a5, void* a6, void* a7, uint32_t a8, void* a9, int a10)
 {
-	static auto patternLoc = hook::get_pattern<int32_t>("4C 8B BC C1 ? ? ? ? 4D 85 FF 0F 84", 4);
-
-	auto oldLoc = *patternLoc;
-	*patternLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
+	auto oldLoc = *g_CustomQueueStrTaskLoc;
+	*g_CustomQueueStrTaskLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
 
 	auto rv = g_origQueueStrTask(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
 
-	*patternLoc = oldLoc;
+	*g_CustomQueueStrTaskLoc = oldLoc;
 
 	return rv;
 }
 
 static void*(*g_origQueueSemaTask)(uint32_t a1, void* a2, int a3, int a4, void* a5, uint32_t a6, int a7);
-
+static int32_t* g_CustomQueueSemaTaskLoc = nullptr;
 static void* CustomQueueSemaTask(uint32_t a1, void* a2, int a3, int a4, void* a5, uint32_t a6, int a7)
 {
-	static auto patternLoc = hook::get_pattern<int32_t>("4C 8B BC C1 ? ? ? ? 4D 85 FF 0F 84", 4);
-
-	auto oldLoc = *patternLoc;
-	*patternLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
+	auto oldLoc = *g_CustomQueueSemaTaskLoc;
+	*g_CustomQueueSemaTaskLoc = (intptr_t)rage__fiCollection__sm_Collections - hook::get_adjusted(0x140000000);
 
 	auto rv = g_origQueueSemaTask(a1, a2, a3, a4, a5, a6, a7);
 
-	*patternLoc = oldLoc;
+	*g_CustomQueueSemaTaskLoc = oldLoc;
 
 	return rv;
 }
@@ -192,5 +186,9 @@ static HookFunction hookFunction([]()
 		hook::set_call(&g_origSetStreamingInterface, location);
 		hook::call(location, SetStreamingInterface);
 	}
+
+	g_CustomStreamerTickLoc = hook::get_pattern<int32_t>("4D 8B A4 C7 ? ? ? ? 4C 8D 45 58 49 8B 04 24", 4);
+	g_CustomQueueStrTaskLoc = hook::get_pattern<int32_t>("4C 8B BC C1 ? ? ? ? 4D 85 FF 0F 84", 4);
+	g_CustomQueueSemaTaskLoc = hook::get_pattern<int32_t>("4C 8B BC C1 ? ? ? ? 4D 85 FF 0F 84", 4);
 });
 #endif

--- a/code/components/gta-streaming-five/src/Streaming.cpp
+++ b/code/components/gta-streaming-five/src/Streaming.cpp
@@ -89,6 +89,8 @@ namespace rage
 		void RegisterObject(uint32_t* fileIdx, const char* registerName, uint32_t handle, uint32_t collectionId, void* unk, bool unk2, void* unk3, bool unk4);
 	};
 
+	static strStreamingInfoManager* g_strStreamingInfoMgr = nullptr;
+
 	class strStreamingEngine
 	{
 	public:
@@ -107,8 +109,7 @@ namespace rage
 
 	strStreamingInfoManager* strStreamingEngine::GetInfo()
 	{
-		static auto mgr = hook::get_address<strStreamingInfoManager*>(hook::get_pattern<char>("B2 01 48 8B CD 45 8A E0 4D 0F 45 F9 E8", -0x25) + 0xBA);
-		return mgr;
+		return g_strStreamingInfoMgr;
 	}
 }
 
@@ -246,6 +247,8 @@ static HookFunction hookFunction([] ()
 	}
 
 	_rage_pgStreamer_ctor = (decltype(_rage_pgStreamer_ctor))hook::get_pattern("48 8B CB 33 D2 41 B8 00 02 00 00 E8", -0x29);
+
+	rage::g_strStreamingInfoMgr = hook::get_address<rage::strStreamingInfoManager*>(hook::get_pattern<char>("B2 01 48 8B CD 45 8A E0 4D 0F 45 F9 E8", -0x25) + 0xBA);
 
 	// start off fiCollection packfiles at 2, not 1
 	hook::put<uint32_t>(hook::get_pattern("41 0F B7 D2 4C 8D"), 0x01528D41); // lea    edx,[r10+0x1]

--- a/code/components/rage-device-five/src/fiAssetManager.cpp
+++ b/code/components/rage-device-five/src/fiAssetManager.cpp
@@ -5,10 +5,10 @@
 
 namespace rage
 {
+static fiAssetManager* g_assetManager = nullptr;
 fiAssetManager* fiAssetManager::GetInstance()
 {
-	static auto instance = hook::get_address<fiAssetManager*>(hook::get_pattern("75 62 48 8D 0D ? ? ? ? 48 8B D6 E8", 5));
-	return instance;
+	return g_assetManager;
 }
 
 static hook::thiscall_stub<void(fiAssetManager*, const char*)> _pushFolder([]()
@@ -31,3 +31,8 @@ void fiAssetManager::PopFolder()
 	return _popFolder(this);
 }
 }
+
+static HookFunction hookFunction([]() 
+{
+	rage::g_assetManager = hook::get_address<rage::fiAssetManager*>(hook::get_pattern("75 62 48 8D 0D ? ? ? ? 48 8B D6 E8", 5));
+});

--- a/code/components/rage-graphics-five/src/DrawCommands.cpp
+++ b/code/components/rage-graphics-five/src/DrawCommands.cpp
@@ -493,6 +493,9 @@ ID3D11DeviceContext* GetD3D11DeviceContext()
 
 namespace rage
 {
+	static void** g_grmTechniquePointer = nullptr;
+	static grmShaderFactory** g_grmShaderFactory = nullptr;
+
 	static hook::cdecl_stub<bool(grmShaderFx*, const char*, void*, bool)> _grmShaderFx_LoadTechnique([]()
 	{
 		return hook::get_pattern("48 8B D9 BA 2E 00 00 00 48 8B CF 45 8A F1", -0x1C);
@@ -505,8 +508,7 @@ namespace rage
 
 	grmShaderFactory* grmShaderFactory::GetInstance()
 	{
-		static auto ptr = hook::get_address<grmShaderFactory**>(hook::get_pattern("84 C0 74 29 48 8B 0D ? ? ? ? 48 8B 01", 7));
-		return *ptr;
+		return *g_grmShaderFactory;
 	}
 
 	static hook::cdecl_stub<void(grmShaderDef*, int, grmShaderFx*)> _grmShaderDef_PushPass([]()
@@ -591,8 +593,7 @@ namespace rage
 
 	void grmShaderFx::PopTechnique()
 	{
-		static void** ptr = hook::get_address<void**>(hook::get_pattern("FF C9 48 C1 E1 05 49 03 09 48 89 0D", 12));
-		*ptr = nullptr;
+		*g_grmTechniquePointer = nullptr;
 	}
 }
 
@@ -707,4 +708,7 @@ static HookFunction hookFunction([] ()
 		hook::put<uint8_t>(location, 0xB8); // write to eax for later
 		hook::put<uint32_t>(location + 1, 0x4000000);
 	}
+
+	rage::g_grmShaderFactory = hook::get_address<rage::grmShaderFactory**>(hook::get_pattern("84 C0 74 29 48 8B 0D ? ? ? ? 48 8B 01", 7));
+	rage::g_grmTechniquePointer = hook::get_address<void**>(hook::get_pattern("FF C9 48 C1 E1 05 49 03 09 48 89 0D", 12));
 });

--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -648,16 +648,13 @@ static void SetInputWrap(int a1, void* a2, void* a3, void* a4)
 #endif
 
 static void (*origIOPadUpdate)(void*, bool);
+static void* ioPadArray = nullptr;
 
 // This hook is used for ReverseGame Gamepad input
 static void rage__ioPad__Update(rage::ioPad* thisptr, bool onlyVibrate)
 {
 	static HostSharedData<ReverseGameData> rgd("CfxReverseGameData");
 	WaitForSingleObject(rgd->inputMutex, INFINITE);
-
-	static char* location = (char*)hook::get_pattern("48 8D 05 ? ? ? ? 48 2B C8 48 B8 AB AA AA AA AA");
-	static int offset = *(int*)(location + 3);
-	static void* ioPadArray = location + offset + 7;
 
 #if 0
 	XINPUT_STATE state;
@@ -804,6 +801,13 @@ static HookFunction hookFunction([]()
 			may = FALSE;
 		}
 	});
+
+	
+	{
+		char* location = (char*)hook::get_pattern("48 8D 05 ? ? ? ? 48 2B C8 48 B8 AB AA AA AA AA");
+		int offset = *(int*)(location + 3);
+		ioPadArray = location + offset + 7;
+	}
 });
 
 fwEvent<HWND, UINT, WPARAM, LPARAM, bool&, LRESULT&> InputHook::DeprecatedOnWndProc;


### PR DESCRIPTION
…Function's.

We had a few rare cases here where sigs would be resolved on-demand.

There is some small overhead from checking each local static variable, but really this was done so that all the sigs are done before going in-game.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Put Most if not all sigs into HookFunctions or function stubs that run at startup.

This means that sigs are ran less conditionally(without needing an option) and at startup time instead of 1st time called.


### How is this PR achieving the goal
By changing some rare cases of sigs not doing this.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Client

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
Did basic testing without hints file and it seemed OK

**Game builds:** Several

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x ] Code compiles and has been tested successfully.
- [ x] Code explains itself well and/or is documented.
- [ x] My commit message explains what the changes do and what they are for.
- [ x] No extra compilation warnings are added by these changes.


