### PR TITLE
fix(nui/core): set user-agent for imgur URLs

### DIFF
--- a/code/components/nui-core/src/NUIClient.cpp
+++ b/code/components/nui-core/src/NUIClient.cpp
@@ -410,6 +410,25 @@ auto NUIClient::OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<Ce
 		}
 	}
 
+	// Imgur started blocking CitizenFX in the user-agent
+	{
+		CefURLParts parts;
+		if (CefParseURL(request->GetURL(), parts))
+		{
+			auto hostString = CefString(&parts.host).ToString();
+
+			if (boost::algorithm::ends_with(hostString, "imgur.com"))
+			{
+				CefRequest::HeaderMap headers;
+				request->GetHeaderMap(headers);
+	
+				headers.erase("User-Agent");
+				headers.emplace("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36");
+				request->SetHeaderMap(headers);
+			}
+		}
+	}
+
 #if !defined(_DEBUG)
 	if (frame->IsMain())
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix imgur images in NUI.



### How is this PR achieving the goal

Imgur recently started blocking requests with `CitizenFX` in the user-agent, responding with status code 429. This overrides the user-agent for requests to imgur.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 2944

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.




