### PR TITLE
feat(extra-natives/five): GET_VEHICLE_GEAR_RATIO and SET_VEHICLE_GEAR_RATIO 

### DIFF
--- a/ext/native-decls/GetVehicleGearRatio.md
+++ b/ext/native-decls/GetVehicleGearRatio.md
@@ -1,0 +1,38 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_GEAR_RATIO
+
+```c
+float GET_VEHICLE_GEAR_RATIO(Vehicle vehicle, int gear);
+```
+Gets vehicles gear ratio on choosen gear.
+
+## Parameters
+* **vehicle**: The vehicle handle.
+* **gear**: The vehicles gear you want to get.
+
+## Examples
+```lua
+local Vehicle = GetVehiclePedIsIn(PlayerPedId(-1))
+local currentGear = GetVehicleCurrentGear(Vehicle)
+
+print(GetVehicleGearRatio(Vehicle, currentGear)) -- will print current vehicle gear to console
+```
+
+```js
+const Vehicle = GetVehiclePedIsIn(PlayerPedId(-1));
+const currentGear = GetVehicleCurrentGear(Vehicle);
+
+console.log(GetVehicleGearRatio(Vehicle, currentGear)); // will print current vehicle gear to console
+```
+
+```cs
+using static CitizenFX.Core.API;
+
+Vehicle veh = Game.PlayerPed.CurrentVehicle;
+int currentGear = GetVehicleCurrentGear(veh.Handle);
+
+Debug.WriteLine($"{GetVehicleGearRatio(veh.Handle, currentGear)}");
+```

--- a/ext/native-decls/GetVehicleGearRatio.md
+++ b/ext/native-decls/GetVehicleGearRatio.md
@@ -1,12 +1,14 @@
 ---
 ns: CFX
 apiset: client
+game: gta5
 ---
 ## GET_VEHICLE_GEAR_RATIO
 
 ```c
 float GET_VEHICLE_GEAR_RATIO(Vehicle vehicle, int gear);
 ```
+
 Gets vehicles gear ratio on choosen gear.
 
 ## Parameters
@@ -14,25 +16,26 @@ Gets vehicles gear ratio on choosen gear.
 * **gear**: The vehicles gear you want to get.
 
 ## Examples
+
 ```lua
-local Vehicle = GetVehiclePedIsIn(PlayerPedId(-1))
+local vehicle = GetVehiclePedIsIn(PlayerPedId(-1))
 local currentGear = GetVehicleCurrentGear(Vehicle)
 
-print(GetVehicleGearRatio(Vehicle, currentGear)) -- will print current vehicle gear to console
+print(GetVehicleGearRatio(vehicle, currentGear)) -- will print current vehicle gear to console
 ```
 
 ```js
-const Vehicle = GetVehiclePedIsIn(PlayerPedId(-1));
+const vehicle = GetVehiclePedIsIn(PlayerPedId(-1));
 const currentGear = GetVehicleCurrentGear(Vehicle);
 
-console.log(GetVehicleGearRatio(Vehicle, currentGear)); // will print current vehicle gear to console
+console.log(GetVehicleGearRatio(vehicle, currentGear)); // will print current vehicle gear to console
 ```
 
 ```cs
 using static CitizenFX.Core.API;
 
-Vehicle veh = Game.PlayerPed.CurrentVehicle;
-int currentGear = GetVehicleCurrentGear(veh.Handle);
+Vehicle vehicle = Game.PlayerPed.CurrentVehicle;
+int currentGear = GetVehicleCurrentGear(vehicle.Handle);
 
-Debug.WriteLine($"{GetVehicleGearRatio(veh.Handle, currentGear)}");
+Debug.WriteLine($"{GetVehicleGearRatio(vehicle.Handle, currentGear)}");
 ```

--- a/ext/native-decls/SetVehicleGearRatio.md
+++ b/ext/native-decls/SetVehicleGearRatio.md
@@ -1,0 +1,63 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_VEHICLE_GEAR_RATIO
+
+```c
+void SET_VEHICLE_GEAR_RATIO(Vehicle vehicle, int gear, float ratio);
+```
+Sets the vehicles gear ratio on choosen gear, reverse gear needs to be a negative float and forward moving gear needs to be a positive float. Refer to the examples if confused.
+## Parameters
+* **vehicle**: The vehicle handle.
+* **gear**: The vehicles gear you want to change.
+* **ratio**: The gear ratio you want to use.
+
+## Examples
+```lua
+local function Set8SpeedVehicleGears(Vehicle)
+    SetVehicleGearRatio(Vehicle, 0, -3.32)  -- reverse gear at -3.21:1
+    SetVehicleGearRatio(Vehicle, 1, 4.71)   -- 1st gear at 4.71:1
+    SetVehicleGearRatio(Vehicle, 2, 3.14)   -- 2nd gear at 3.14:1
+    SetVehicleGearRatio(Vehicle, 3, 2.11)   -- 3rd gear at 2.11:1
+    SetVehicleGearRatio(Vehicle, 4, 1.67)   -- 4th gear at 1.67:1
+    SetVehicleGearRatio(Vehicle, 5, 1.29)   -- 5th gear at 1.29:1
+    SetVehicleGearRatio(Vehicle, 6, 1.0)    -- 6th gear at 1.0:1
+    SetVehicleGearRatio(Vehicle, 7, 0.84)   -- 7th gear at 0.84:1
+    SetVehicleGearRatio(Vehicle, 8, 0.67)   -- 8th gear at 0.67:1
+    return
+end
+```
+
+```js
+function Set8SpeedVehicleGears(Vehicle) {
+    SetVehicleGearRatio(Vehicle, 0, -3.32);  // reverse gear at -3.21:1
+    SetVehicleGearRatio(Vehicle, 1, 4.71);   // 1st gear at 4.71:1
+    SetVehicleGearRatio(Vehicle, 2, 3.14);   // 2nd gear at 3.14:1
+    SetVehicleGearRatio(Vehicle, 3, 2.11);   // 3rd gear at 2.11:1
+    SetVehicleGearRatio(Vehicle, 4, 1.67);   // 4th gear at 1.67:1
+    SetVehicleGearRatio(Vehicle, 5, 1.29);   // 5th gear at 1.29:1
+    SetVehicleGearRatio(Vehicle, 6, 1.0);    // 6th gear at 1.0:1
+    SetVehicleGearRatio(Vehicle, 7, 0.84);   // 7th gear at 0.84:1
+    SetVehicleGearRatio(Vehicle, 8, 0.67);   // 8th gear at 0.67:1
+    return;
+}
+```
+
+```cs
+using static CitizenFX.Core.API;
+
+public static void Set8SpeedVehicleGears(int Vehicle)
+{
+    SetVehicleGearRatio(Vehicle, 0, -3.32);  // reverse gear at -3.21:1
+    SetVehicleGearRatio(Vehicle, 1, 4.71);   // 1st gear at 4.71:1
+    SetVehicleGearRatio(Vehicle, 2, 3.14);   // 2nd gear at 3.14:1
+    SetVehicleGearRatio(Vehicle, 3, 2.11);   // 3rd gear at 2.11:1
+    SetVehicleGearRatio(Vehicle, 4, 1.67);   // 4th gear at 1.67:1
+    SetVehicleGearRatio(Vehicle, 5, 1.29);   // 5th gear at 1.29:1
+    SetVehicleGearRatio(Vehicle, 6, 1.0);    // 6th gear at 1.0:1
+    SetVehicleGearRatio(Vehicle, 7, 0.84);   // 7th gear at 0.84:1
+    SetVehicleGearRatio(Vehicle, 8, 0.67);   // 8th gear at 0.67:1
+    return;
+}
+```

--- a/ext/native-decls/SetVehicleGearRatio.md
+++ b/ext/native-decls/SetVehicleGearRatio.md
@@ -1,19 +1,23 @@
 ---
 ns: CFX
 apiset: client
+game: gta5
 ---
 ## SET_VEHICLE_GEAR_RATIO
 
 ```c
 void SET_VEHICLE_GEAR_RATIO(Vehicle vehicle, int gear, float ratio);
 ```
+
 Sets the vehicles gear ratio on choosen gear, reverse gear needs to be a negative float and forward moving gear needs to be a positive float. Refer to the examples if confused.
+
 ## Parameters
 * **vehicle**: The vehicle handle.
 * **gear**: The vehicles gear you want to change.
 * **ratio**: The gear ratio you want to use.
 
 ## Examples
+
 ```lua
 local function Set8SpeedVehicleGears(Vehicle)
     SetVehicleGearRatio(Vehicle, 0, -3.32)  -- reverse gear at -3.21:1
@@ -25,7 +29,6 @@ local function Set8SpeedVehicleGears(Vehicle)
     SetVehicleGearRatio(Vehicle, 6, 1.0)    -- 6th gear at 1.0:1
     SetVehicleGearRatio(Vehicle, 7, 0.84)   -- 7th gear at 0.84:1
     SetVehicleGearRatio(Vehicle, 8, 0.67)   -- 8th gear at 0.67:1
-    return
 end
 ```
 
@@ -40,7 +43,6 @@ function Set8SpeedVehicleGears(Vehicle) {
     SetVehicleGearRatio(Vehicle, 6, 1.0);    // 6th gear at 1.0:1
     SetVehicleGearRatio(Vehicle, 7, 0.84);   // 7th gear at 0.84:1
     SetVehicleGearRatio(Vehicle, 8, 0.67);   // 8th gear at 0.67:1
-    return;
 }
 ```
 
@@ -58,6 +60,5 @@ public static void Set8SpeedVehicleGears(int Vehicle)
     SetVehicleGearRatio(Vehicle, 6, 1.0);    // 6th gear at 1.0:1
     SetVehicleGearRatio(Vehicle, 7, 0.84);   // 7th gear at 0.84:1
     SetVehicleGearRatio(Vehicle, 8, 0.67);   // 8th gear at 0.67:1
-    return;
 }
 ```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

These new natives will allow developers to create scripts to create custom gear ratios for vehicles.


### How is this PR achieving the goal

I added the memory editing stuff to VehicleExtraNatives.cpp to allow me to create the 2 new natives.

### The natives
float GetVehicleGearRatio(Vehicle vehicle, int gear);
void SetVehicleGearRatio(Vehicle vehicle, int gear, float ratio);

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, Vehicle, Lua, JS, C#


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:**  3095,2944,2802,2699,2612,2545,2372,2189,2060,1604

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.




