### PR TITLE
fix(scripting-mono-v2): allow scheduling from non-main threads

### DIFF
--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -278,7 +278,6 @@ namespace CitizenFX.Core
 #else
 			if (inputMapper != null && inputParameter != null)
 			{
-				Debug.WriteLine(command);
 				Native.CoreNatives.RegisterKeyMapping(command, description, inputMapper, inputParameter);
 			}
 			m_commands.Add(new KeyValuePair<int, DynFunc>(ReferenceFunctionManager.CreateCommand(command, dynFunc, false), dynFunc));

--- a/code/client/clrcore-v2/Interop/Types/ScriptSharedData.cs
+++ b/code/client/clrcore-v2/Interop/Types/ScriptSharedData.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace CitizenFX.Core
+{
+	[StructLayout(LayoutKind.Explicit)]
+	internal struct ScriptSharedData
+	{
+		/// <summary>
+		/// Next time when our host needs to call in again
+		/// </summary>
+		[FieldOffset(0)] public ulong m_scheduledTime;
+
+		/// <summary>
+		/// Same as <see cref="m_scheduledTime"/> but used in methods like <see cref="Interlocked.CompareExchange(ref long, long, long)" /> who miss a <see cref="ulong"/> overload.
+		/// </summary>
+		[FieldOffset(0)] public long m_scheduledTimeAsLong;
+	};
+}

--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security;
+using System.Threading;
 
 #if IS_FXSERVER
 using ContextType = CitizenFX.Core.fxScriptContext;
@@ -12,8 +12,6 @@ using ContextType = CitizenFX.Core.RageScriptContext;
 
 /*
 * Notes while working on this environment:
-*  - Scheduling: any function that can potentially add tasks to the C#'s scheduler needs to return the time
-*    of when it needs to be activated again, which then needs to be scheduled in the core scheduler (bookmark).
 */
 
 namespace CitizenFX.Core
@@ -24,6 +22,8 @@ namespace CitizenFX.Core
 		internal static int InstanceId { get; private set; }
 		internal static string ResourceName { get; private set; }
 		internal static CString CResourceName { get; private set; }
+
+		private static unsafe ScriptSharedData* s_sharedData;
 
 		#region Callable from C#
 
@@ -71,16 +71,37 @@ namespace CitizenFX.Core
 		[SecurityCritical]
 		internal static unsafe bool ReadAssembly(string file, out byte[] assembly, out byte[] symbols) => ReadAssembly(s_runtime, file, out assembly, out symbols);
 
+		/// <summary>
+		/// Schedule a call-in at the given time, uses CAS to make sure we only overwrite if the given time is earlier than the stored one.
+		/// </summary>
+		/// <param name="time">Next time to request a call in</param>
+		[SecuritySafeCritical]
+		internal static unsafe void RequestTick(ulong time)
+		{			
+			ulong prevTime = (ulong)Interlocked.Read(ref s_sharedData->m_scheduledTimeAsLong);
+			while (time < prevTime)
+			{
+				prevTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
+			}
+		}
+
+		/// <summary>
+		/// Schedule a call-in for the next frame.
+		/// </summary>
+		[SecuritySafeCritical]
+		public static unsafe void RequestTickNextFrame() => s_sharedData->m_scheduledTime = 0UL; // 64 bit read/writes – while aligned – are atomic on 64 bit machines
+
 		#endregion
 
 		#region Called by Native
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
-		internal static void Initialize(string resourceName, UIntPtr runtime, int instanceId)
+		private static unsafe void Initialize(string resourceName, UIntPtr runtime, int instanceId, ScriptSharedData* sharedData)
 		{
 			s_runtime = runtime;
 			InstanceId = instanceId;
 			ResourceName = resourceName;
 			CResourceName = resourceName;
+			s_sharedData = sharedData;
 
 			Resource.Current = new Resource(resourceName);
 			Debug.Initialize(resourceName);
@@ -93,7 +114,7 @@ namespace CitizenFX.Core
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
-		internal static ulong Tick(ulong hostTime, bool profiling)
+		internal static void Tick(ulong hostTime, bool profiling)
 		{
 			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
@@ -107,12 +128,10 @@ namespace CitizenFX.Core
 			{
 				Debug.PrintError(e, "Tick()");
 			}
-
-			return Scheduler.NextTaskTime();
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
-		internal static unsafe ulong TriggerEvent(string eventName, byte* argsSerialized, int serializedSize, string sourceString, ulong hostTime, bool profiling)
+		internal static unsafe void TriggerEvent(string eventName, byte* argsSerialized, int serializedSize, string sourceString, ulong hostTime, bool profiling)
 		{
 			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
@@ -136,30 +155,24 @@ namespace CitizenFX.Core
 					EventsManager.IncomingEvent(eventName, sourceString, origin, argsSerialized, serializedSize, args);
 				}
 			}
-			
-			return Scheduler.NextTaskTime();
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
-		internal static unsafe ulong LoadAssembly(string name, ulong hostTime, bool profiling)
+		internal static unsafe void LoadAssembly(string name, ulong hostTime, bool profiling)
 		{
 			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 
 			ScriptManager.LoadAssembly(name, true);
-
-			return Scheduler.NextTaskTime();
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]
-		internal static unsafe ulong CallRef(int refIndex, byte* argsSerialized, uint argsSize, out IntPtr retvalSerialized, out uint retvalSize, ulong hostTime, bool profiling)
+		internal static unsafe void CallRef(int refIndex, byte* argsSerialized, uint argsSize, out IntPtr retvalSerialized, out uint retvalSize, ulong hostTime, bool profiling)
 		{
 			Scheduler.CurrentTime = (TimePoint)hostTime;
 			Profiler.IsProfiling = profiling;
 
 			ReferenceFunctionManager.IncomingCall(refIndex, argsSerialized, argsSize, out retvalSerialized, out retvalSize);
-
-			return Scheduler.NextTaskTime();
 		}
 
 		[SecurityCritical, SuppressMessage("System.Diagnostics.CodeAnalysis", "IDE0051", Justification = "Called by host")]

--- a/code/components/citizen-scripting-mono-v2/include/ScriptSharedData.h
+++ b/code/components/citizen-scripting-mono-v2/include/ScriptSharedData.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <atomic>
+
+namespace fx::mono
+{
+struct ScriptSharedData
+{
+public:
+	std::atomic<uint64_t> m_scheduledTime = ~uint64_t(0);
+};
+}


### PR DESCRIPTION
### Goal of this PR
Enable scheduling tick calls from non-main threads, this is necessary to call back into the runtime (on the main thread) after external libraries used async/await with `Task/Task<T>` and we had nothing else scheduled. This didn't work before.

### How is this PR achieving the goal
By removing its dependency on the Bookmark system (not thread-safe) and replacing it with a simplified version that achieves the same goal, but thread-safe.

### This PR applies to the following area(s)
ScRT: C#

### Successfully tested on
Server and client

**Game builds:** 2802

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes thorium-cfx/mono_v2_get_started#23