### PR TITLE
feat(state): add NET_TO_* and *_TO_NET helpers

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -95,7 +95,7 @@ static void Init()
 		context.SetResult(true);
 	});
 
-	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_ENTITY_FROM_NETWORK_ID", [](fx::ScriptContext& context)
+	auto getEntityFromNetworkId = [](fx::ScriptContext& context)
 	{
 		// get the current resource manager
 		auto resourceManager = fx::ResourceManager::GetCurrent();
@@ -124,7 +124,13 @@ static void Init()
 		}
 
 		context.SetResult(gameState->MakeScriptHandle(entity));
-	});
+	};
+
+	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_ENTITY_FROM_NETWORK_ID", getEntityFromNetworkId);
+	fx::ScriptEngine::RegisterNativeHandler("NET_TO_VEH", getEntityFromNetworkId);
+	fx::ScriptEngine::RegisterNativeHandler("NET_TO_PED", getEntityFromNetworkId);
+	fx::ScriptEngine::RegisterNativeHandler("NET_TO_OBJ", getEntityFromNetworkId);
+	fx::ScriptEngine::RegisterNativeHandler("NET_TO_ENT", getEntityFromNetworkId);
 
 	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_ENTITY_OWNER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
@@ -466,10 +472,16 @@ static void Init()
 		}
 	});
 
-	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_NETWORK_ID_FROM_ENTITY", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	auto getNetworkIdFromEntity = makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		return entity->handle & 0xFFFF;
-	}));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("NETWORK_GET_NETWORK_ID_FROM_ENTITY", getNetworkIdFromEntity);
+	fx::ScriptEngine::RegisterNativeHandler("VEH_TO_NET", getNetworkIdFromEntity);
+	fx::ScriptEngine::RegisterNativeHandler("OBJ_TO_NET", getNetworkIdFromEntity);
+	fx::ScriptEngine::RegisterNativeHandler("PED_TO_NET", getNetworkIdFromEntity);
+	fx::ScriptEngine::RegisterNativeHandler("ENT_TO_NET", getNetworkIdFromEntity);
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_HASH_KEY", [](fx::ScriptContext& context)
 	{

--- a/ext/native-decls/EntToNet.md
+++ b/ext/native-decls/EntToNet.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## ENT_TO_NET
+
+```c
+int ENT_TO_NET(Entity handle);
+```
+
+## Parameters
+* **handle**: the entity handle to get the net id of
+
+## Return value
+The net id for the specified entity.

--- a/ext/native-decls/NetToEnt.md
+++ b/ext/native-decls/NetToEnt.md
@@ -2,10 +2,10 @@
 ns: CFX
 apiset: server
 ---
-## NETWORK_GET_ENTITY_FROM_NETWORK_ID
+## NET_TO_ENT
 
 ```c
-Entity NETWORK_GET_ENTITY_FROM_NETWORK_ID(int netId);
+Entity NET_TO_ENT(int netId);
 ```
 
 ## Parameters

--- a/ext/native-decls/NetToObj.md
+++ b/ext/native-decls/NetToObj.md
@@ -2,10 +2,10 @@
 ns: CFX
 apiset: server
 ---
-## NETWORK_GET_ENTITY_FROM_NETWORK_ID
+## NET_TO_OBJ
 
 ```c
-Entity NETWORK_GET_ENTITY_FROM_NETWORK_ID(int netId);
+Entity NET_TO_OBJ(int netId);
 ```
 
 ## Parameters

--- a/ext/native-decls/NetToPed.md
+++ b/ext/native-decls/NetToPed.md
@@ -2,10 +2,10 @@
 ns: CFX
 apiset: server
 ---
-## NETWORK_GET_ENTITY_FROM_NETWORK_ID
+## NET_TO_PED
 
 ```c
-Entity NETWORK_GET_ENTITY_FROM_NETWORK_ID(int netId);
+Entity NET_TO_PED(int netId);
 ```
 
 ## Parameters

--- a/ext/native-decls/NetToVeh.md
+++ b/ext/native-decls/NetToVeh.md
@@ -2,10 +2,10 @@
 ns: CFX
 apiset: server
 ---
-## NETWORK_GET_ENTITY_FROM_NETWORK_ID
+## NET_TO_VEH
 
 ```c
-Entity NETWORK_GET_ENTITY_FROM_NETWORK_ID(int netId);
+Vehicle NET_TO_VEH(int netId);
 ```
 
 ## Parameters

--- a/ext/native-decls/NetworkGetNetworkIdFromEntity.md
+++ b/ext/native-decls/NetworkGetNetworkIdFromEntity.md
@@ -8,8 +8,8 @@ apiset: server
 int NETWORK_GET_NETWORK_ID_FROM_ENTITY(Entity entity);
 ```
 
-
 ## Parameters
-* **entity**: 
+* **entity**: the entity to get the network id of
 
 ## Return value
+The net id for the specified entity.

--- a/ext/native-decls/ObjToNet.md
+++ b/ext/native-decls/ObjToNet.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## OBJ_TO_NET
+
+```c
+int OBJ_TO_NET(Entity handle);
+```
+
+## Parameters
+* **handle**: the entity handle to get the net id of
+
+## Return value
+The net id for the specified entity.

--- a/ext/native-decls/PedToNet.md
+++ b/ext/native-decls/PedToNet.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## PED_TO_NET
+
+```c
+int PED_TO_NET(Ped handle);
+```
+
+## Parameters
+* **handle**: the entity handle to get the net id of
+
+## Return value
+The net id for the specified entity.

--- a/ext/native-decls/VehToNet.md
+++ b/ext/native-decls/VehToNet.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## VEH_TO_NET
+
+```c
+int VEH_TO_NET(Vehicle handle);
+```
+
+## Parameters
+* **handle**: the entity handle to get the net id of
+
+## Return value
+The net id for the specified entity.


### PR DESCRIPTION
### Goal of this PR

Add the same helpers that the client has to convert to/from network ids instead if having to use the extremely verbose `NetworkGetEntityFromNetworkId` and `NetworkGetNetworkIdFromEntity`

### How is this PR achieving the goal
Adds the same helpers from the client

### This PR applies to the following area(s)
Server


### Successfully tested on

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.