### PR TITLE
fix(scripting/lua): Fix not closing to-be-closed variables on error

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -994,15 +994,39 @@ bool LuaScriptRuntime::RunBookmark(uint64_t bookmark)
 			}                        
 
 			static auto formatStackTrace = fx::ScriptEngine::GetNativeHandler(HashString("FORMAT_STACK_TRACE"));
-			auto stack = FxNativeInvoke::Invoke<const char*>(formatStackTrace, nullptr, 0);
 			std::string stackData = "(nil stack trace)";
-			
-			if (stack)
+
+			try
 			{
-				stackData = stack;
+				auto stack = FxNativeInvoke::Invoke<const char*>(formatStackTrace, nullptr, 0);
+				if (stack)
+				{
+					stackData = stack;
+				}
 			}
+			catch (...)
+			{
+				// We already have stackData set so we don't need to do anything
+			}
+
 			ScriptTrace("^1SCRIPT ERROR: %s^7\n", err);
 			ScriptTrace("%s", stackData);
+#if LUA_VERSION_NUM >= 504
+			int resetStatus = lua_resetthread(thread);
+
+			std::string resetErr = "error object is not a string";
+			if (lua_type(thread, -1) == LUA_TSTRING)
+			{
+				resetErr = lua_tostring(thread, -1);
+			}
+
+			// We can't just check whether the resetStatus is OK because
+			// if there was no error lua_resetthread returns the same status it received
+			if (resetStatus != resumeValue || resetErr != err)
+			{
+				ScriptTrace("^1Error while closing to-be-closed variables: %s^7\n", resetErr);
+			}
+#endif
 		}
 
 		luaL_unref(L, LUA_REGISTRYINDEX, bookmark);


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Call `__close` metamethod on to-be-closed variables ([added in Lua 5.4](https://www.lua.org/manual/5.4/manual.html#3.3.8)) when an uncaught error occurs. Before this change variables would be closed only if the function/event/script execution ended without an error.


### How is this PR achieving the goal
This PR calls the `lua_resetthread` method, when handling an error case, which unwinds the stack and closes all to-be-closed variables present there.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

