### PR TITLE
tweak(minidump): don't report crashes if we're in debug mode

### DIFF
--- a/code/components/citizen-server-impl/src/ServerWatchdog.cpp
+++ b/code/components/citizen-server-impl/src/ServerWatchdog.cpp
@@ -114,7 +114,7 @@ void PlatformBark(const std::string& loopName)
 		return;
 	}
 
-	BOOL success = MiniDumpWriteDump((HANDLE)SnapshotHandle,
+	[[maybe_unused]] BOOL success = MiniDumpWriteDump((HANDLE)SnapshotHandle,
 		GetCurrentProcessId(),
 		hFile,
 		(MINIDUMP_TYPE)(MiniDumpWithProcessThreadData | MiniDumpWithUnloadedModules | MiniDumpWithThreadInfo),
@@ -128,6 +128,7 @@ void PlatformBark(const std::string& loopName)
 
 	if (success)
 	{
+#ifndef _DEBUG
 		std::map<std::wstring, std::wstring> parameters;
 
 		std::wstring responseBody;
@@ -143,6 +144,7 @@ void PlatformBark(const std::string& loopName)
 				console::Printf("server", "Uploaded a live hang dump to the CitizenFX crash reporting service. The report ID is %s.\n", ToNarrow(responseBody));
 			}
 		}		
+#endif
 	}
 }
 

--- a/code/server/launcher/src/ServerMiniDump.cpp
+++ b/code/server/launcher/src/ServerMiniDump.cpp
@@ -138,13 +138,13 @@ void InitializeDumpServer(int inheritedHandle, int parentPid)
 			}
 		}
 
-		std::map<std::wstring, std::wstring> parameters;
+		[[maybe_unused]] std::map<std::wstring, std::wstring> parameters;
 		parameters[L"sentry[release]"] = ToWide(GIT_TAG);
 
-		std::wstring responseBody;
-		int responseCode;
+		[[maybe_unused]] std::wstring responseBody;
+		[[maybe_unused]] int responseCode;
 
-		std::map<std::wstring, std::wstring> files;
+		[[maybe_unused]] std::map<std::wstring, std::wstring> files;
 		files[L"upload_file_minidump"] = dumpPath;
 
 		{
@@ -180,6 +180,7 @@ void InitializeDumpServer(int inheritedHandle, int parentPid)
 			printf("In addition to this, a full dump file has been generated at %s.\n\n", ToNarrow(full_dump_path).c_str());
 		}
 
+#ifndef _DEBUG
 		bool uploadCrashes = true;
 
 		if (uploadCrashes && HTTPUpload::SendMultipartPostRequest(L"https://sentry.fivem.net/api/3/minidump/?sentry_key=15f0687e23d74681b5c1f80a0f3a00ed", parameters, files, nullptr, &responseBody, &responseCode))
@@ -190,6 +191,7 @@ void InitializeDumpServer(int inheritedHandle, int parentPid)
 		{
 			printf("Failed to automatically report the crash. Please submit the crash dump to the project developers.\n");
 		}
+#endif
 
 		printf("=================================================================\n");
 
@@ -346,6 +348,9 @@ void InitializeDumpServer(int serverFd, int pipeFd)
 
 	CrashGenerationServer::OnClientDumpRequestCallback dumpCallback = [](void*, const ClientInfo* client, const std::string* dumpPath)
 	{
+		printf("\n\n=================================================================\n\x1b[31mFXServer crashed.\x1b[0m\nA dump can be found at %s.\n", dumpPath->c_str());
+
+#ifndef _DEBUG
 		std::map<std::string, std::string> parameters;
 		parameters["sentry[release]"] = GIT_TAG;
 
@@ -354,8 +359,6 @@ void InitializeDumpServer(int serverFd, int pipeFd)
 
 		std::map<std::string, std::string> files;
 		files["upload_file_minidump"] = *dumpPath;
-
-		printf("\n\n=================================================================\n\x1b[31mFXServer crashed.\x1b[0m\nA dump can be found at %s.\n", dumpPath->c_str());
 
 		bool uploadCrashes = true;
 		std::string ed;
@@ -368,6 +371,7 @@ void InitializeDumpServer(int serverFd, int pipeFd)
 		{
 			printf("Failed to automatically report the crash. Please submit the crash dump to the project developers.\n");
 		}
+#endif
 
 		printf("=================================================================\n");
 	};


### PR DESCRIPTION
### Goal of this PR
Ignore mindumps when in debug mode so I don't upload useless dumps

### How is this PR achieving the goal
Disables HTTP request when in debug mode


### This PR applies to the following area(s)
Server

### Successfully tested on
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.