### PR TITLE
feat(fivem/state): add ConVar & Native to disallow server created entities being deleted by the client

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1376,6 +1376,25 @@ static void Init()
 		return int(entity->routingBucket);
 	}));
 
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_REJECTS_CLIENT_DELETION", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (!entity->serverCreated)
+		{
+			return false;
+		}
+
+		if (context.GetArgumentCount() > 1)
+		{
+			auto rejectClientDelete = context.GetArgument<bool>(1);
+
+			entity->rejectClientDeletion = rejectClientDelete;
+		}
+
+		return true;
+	}));
+
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_ROUTING_BUCKET", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		if (context.GetArgumentCount() > 1)

--- a/ext/native-decls/SetEntityRejectClientDeletion.md
+++ b/ext/native-decls/SetEntityRejectClientDeletion.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_ENTITY_REJECTS_CLIENT_DELETION
+
+```c
+void SET_ENTITY_REJECTS_CLIENT_DELETION(Entity entity, bool rejectClientDelete);
+```
+
+This native only works on server-created vehicles.
+
+Sets a flag for the server to reject any client side deletion of this entity.
+
+This currently *doesn't* stop the entity from being deleted on the calling client, it will just recreate the entity for the caller and reset the relevant state on the server.
+
+This flag will default to the value of "sv_disallowClientDelete" when the entity was created
+
+## Parameters
+* **entity**: The entity to reject deletion of
+* **rejectClientDelete**: A boolean of whether the server should reject client delete, or accept it


### PR DESCRIPTION
### Goal of this PR
Disallow server-created entities from being deleted by clients when `sv_disallowClientDelete` is set to true.


### How is this PR achieving the goal
Adds a new check to `ProcessCloneRemove` to block the deletion of the server spawned created and recreate the entity for the calling client.

The way this is done isn't perfect (the entity will flicker for the person requesting the delete) but this shouldn't have any possible regressions (hopefully)

### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


