### PR TITLE
Improve documentation for the Heading property with usage example

### DIFF
--- a/code/client/clrcore/Server/Entity.cs
+++ b/code/client/clrcore/Server/Entity.cs
@@ -61,10 +61,24 @@ namespace CitizenFX.Core
 			}
 		}
 		/// <summary>
-		/// Gets or sets the heading of this <see cref="Entity"/>.
+		/// Represents the <see cref="Entity"/> orientation in the game world, expressed in degrees.
 		/// </summary>
+		/// <remarks>
+		/// The <see cref="Heading"/> property allows getting or setting the current orientation (direction) of the <see cref="Entity"/>.
+		/// Orientation is measured in degrees on the horizontal plane, where 0 degrees corresponds to North,
+		/// 90 degrees to East, 180 degrees to South, and 270 degrees to West.
+		/// <para>
+		/// Example Usage:
+		/// <code>
+		/// var myVehicle = new Vehicle("adder", new Vector3(0, 0, 0), 0.0f); // Example vehicle creation
+		/// float originalHeading = myVehicle.Heading; // Retrieve current heading
+		/// myVehicle.Heading = 180.0f; // Set new heading to South
+		/// Console.WriteLine($"Changed vehicle heading from {originalHeading} to {myVehicle.Heading} degrees.");
+		/// </code>
+		/// </para>
+		/// </remarks>
 		/// <value>
-		/// The heading in degrees.
+  		/// The <see cref="Heading"/> of the the <see cref="Entity"/> in degrees, as a <see cref="float"/>. Valid values range from 0.0 to 360.0.
 		/// </value>
 		public float Heading
 		{


### PR DESCRIPTION
Improve documentation for the Heading property with usage example

This commit enhances the Heading property in the Entity class by providing detailed documentation that includes a concise usage example. The updated comments clarify the purpose and usage of the property, showcasing how to get and set an entity's orientation in the game world. Additionally, the documentation now includes a practical example within the remarks section, demonstrating the property's application in changing an entity's heading. This improvement aims to facilitate better understanding and utilization of the Heading property by developers.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

...


### How is this PR achieving the goal

...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


