### PR TITLE
feat(redm/script): add patch for overriding train tracks and trolley cables from resource

### DIFF
--- a/code/components/citizen-resources-gta/src/ResourcesTest.cpp
+++ b/code/components/citizen-resources-gta/src/ResourcesTest.cpp
@@ -57,6 +57,11 @@ namespace streaming
 	void RemoveDataFileFromLoadList(const std::string& type, const std::string& path);
 
 	void SetNextLevelPath(const std::string& path);
+
+#if defined(IS_RDR3)
+	void SetTrainTrackFilePath(const std::string& path);
+	void SetTrolleyCableFilePath(const std::string& path);
+#endif
 }
 #endif
 
@@ -187,6 +192,18 @@ static InitFunction initFunction([] ()
 			{
 				streaming::SetNextLevelPath(resourceRoot + meta.second);
 			}
+
+#if defined(IS_RDR3)
+			for (auto& meta : metaData->GetEntries("replace_traintrack_file"))
+			{
+				streaming::SetTrainTrackFilePath(resourceRoot + meta.second);
+			}
+
+			for (auto& meta : metaData->GetEntries("replace_trolley_cable_file"))
+			{
+				streaming::SetTrolleyCableFilePath(resourceRoot + meta.second);
+			}
+#endif
 
 			if (!RangeLengthMatches(metaData->GetEntries("data_file"), metaData->GetEntries("data_file_extra")))
 			{

--- a/code/components/gta-core-rdr3/src/PatchTrainTrackFileOverride.cpp
+++ b/code/components/gta-core-rdr3/src/PatchTrainTrackFileOverride.cpp
@@ -1,0 +1,76 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <Hooking.Patterns.h>
+#include <GameInit.h>
+
+//
+// The tracks that vehicles like trains and the Saint Denis trolley follow, as well as the cables dangling
+// above the trolley's route, are defined in a plain-text format stored in several *.dat files. These files
+// are in turn referenced by filepath by an XML file - traintracks.xml for vehicles, trolleyCableTracks.xml for the cables.
+// 
+// There is currently no way to fully replace the track data within the *.dat files, nor to modify or override the XML files.
+// This patch introduces a way to replace the XML files, allowing for fully custom rail (and trolley cable?) networks.
+// We intercept all calls to LoadTrackXML(), and if one of the override filepaths is valid, we use it instead of the default
+// path. To set these override filenames, the resource must define either (or both) of the following statements:
+// 
+// * replace_traintrack_file 'path/to/traintracks.xml'
+// 
+// * replace_trolley_cable_file 'path/to/trolleyCableTracks.xml'
+//
+
+#define DEFAULT_TRACK_FILE  "common:/data/levels/rdr3/traintracks.xml"
+#define DEFAULT_CABLES_FILE "common:/data/levels/rdr3/trolleyCableTracks.xml"
+
+static std::string g_overrideTrainTrackFilePath   = "";
+static std::string g_overrideTrolleyCableFilePath = "";
+
+namespace streaming
+{
+	// Sets a resource override for traintracks.xml and enables train track replacement.
+	void DLL_EXPORT SetTrainTrackFilePath(const std::string& path)
+	{
+		g_overrideTrainTrackFilePath = path;
+	}
+
+	// Sets a resource override for trolleyCableTracks.xml and enables trolley cable replacement.
+	void DLL_EXPORT SetTrolleyCableFilePath(const std::string& path)
+	{
+		g_overrideTrolleyCableFilePath = path;
+	}
+}
+
+typedef __int64 CTrainTrackPool; // Typedef for clarity on LoadTrackXML()'s parameters.
+
+static void (*g_origLoadTrackXML)(const char*, CTrainTrackPool*);
+static void LoadTrackXML(const char* origXmlFileName, CTrainTrackPool* dstPool)
+{
+    if (!g_overrideTrainTrackFilePath.empty() && strcmp(origXmlFileName, DEFAULT_TRACK_FILE) == 0)
+    {
+		trace("Replacing default traintracks.xml with %s\n", g_overrideTrainTrackFilePath.data());
+        g_origLoadTrackXML(g_overrideTrainTrackFilePath.data(), dstPool);
+    }
+	else if (!g_overrideTrolleyCableFilePath.empty() && strcmp(origXmlFileName, DEFAULT_CABLES_FILE) == 0)
+	{
+		trace("Replacing default trolleyCableTracks.xml with %s\n", g_overrideTrolleyCableFilePath.data());
+		g_origLoadTrackXML(g_overrideTrolleyCableFilePath.data(), dstPool);
+	}
+	else
+	{
+		g_origLoadTrackXML(origXmlFileName, dstPool);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	{
+        auto location = hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 8D 0D ? ? ? ? E8 ? ? ? ? EB 44"));
+        g_origLoadTrackXML = hook::trampoline(location, LoadTrackXML);
+	}
+
+	OnKillNetworkDone.Connect([]()
+	{
+		g_overrideTrainTrackFilePath.clear();
+		g_overrideTrolleyCableFilePath.clear();
+	});
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Allow a resource developer to replace the default `traintracks.xml` and `trolleyCableTracks.xml` files, thus allowing for RedM servers to have proper custom train tracks. And trolley cables, if so desired.

### How is this PR achieving the goal

The fxmanifest metadata statements `replace_traintrack_file <path>` and `replace_trolley_cable_file <path>` have been added. When present, they store their paths to global variables in a patch, located at `gta-core-rdr3/src/PatchTrainTrackFileOverride.cpp`. The patch intercepts any calls to `LoadTrackXML()`, and if either of the override paths are valid, it will pass *them* into the track loading native rather than the default filepaths that were passed in.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM, Server, ScRT: Lua

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** b1311, b1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

resolves #2424 