### PR TITLE
fix(natives): Vector3 will generate a tuple type instead of an array …

### DIFF
--- a/ext/natives/codegen_out_dts.lua
+++ b/ext/natives/codegen_out_dts.lua
@@ -103,7 +103,7 @@ local function printReturnType(type)
 	elseif type.nativeType == 'float' then
 		return 'number'
 	elseif type.nativeType == 'vector3' then
-		return 'number[]'
+		return '[number, number, number]'
 	elseif type.nativeType == 'int' then
 		return 'number'
 	elseif type.nativeType == 'object' then


### PR DESCRIPTION
### Goal of this PR
The vector3 type has until now been generated as an array type. In my opinion it should be generated as a tuple type instead.
The reason i think the tuple type is a better option is because it can be used properly with the spread operator in functions that takes in the x, y and z component (ref picture below)



![image](https://github.com/citizenfx/fivem/assets/19311856/b8beaea3-7d90-49cb-8a95-f9c0d6d1863f)


### How is this PR achieving the goal

...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


