### PR TITLE
feat(server/node): serialize finished data nodes

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -600,6 +600,13 @@ struct CHeliHealthNodeData
 	int tailRotorHealth;
 };
 
+struct CSubmarineGameStateNodeData
+{
+    float yawControl;
+    float pitchControl;
+    float ascentControl;
+};
+
 struct CVehicleSteeringNodeData
 {
 	float steeringAngle;
@@ -674,6 +681,8 @@ public:
 	virtual CHeliControlDataNodeData* GetHeliControl() = 0;
 
 	virtual CPlayerCameraNodeData* GetPlayerCamera() = 0;
+
+    virtual CSubmarineGameStateNodeData* GetSubmarineControl() = 0;
 
 	virtual CPlayerWantedAndLOSNodeData* GetPlayerWantedAndLOS() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1493,14 +1493,14 @@ struct CVehicleAngVelocityDataNode
 	}
 };
 
-struct CVehicleSteeringDataNode
+struct CVehicleSteeringDataNode : GenericSerializeDataNode<CVehicleSteeringDataNode>
 {
 	CVehicleSteeringNodeData data;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+    bool Serialize(Serializer& s)
 	{
-		data.steeringAngle = state.buffer.ReadSignedFloat(10, 1.0f);
-
+        s.SerializeSigned(10, 1.0f, data.steeringAngle);
 		return true;
 	}
 };
@@ -2684,13 +2684,16 @@ struct CPlaneControlDataNode
 
 struct CSubmarineGameStateDataNode { };
 
-struct CSubmarineControlDataNode
+struct CSubmarineControlDataNode : GenericSerializeDataNode<CSubmarineControlDataNode>
 {
-	bool Parse(SyncParseState& state)
+    CSubmarineGameStateNodeData data;
+
+    template<typename Serializer>
+    bool Serialize(Serializer& s)
 	{
-		float yawControl = state.buffer.ReadSignedFloat(8, 1.0f);
-		float pitchControl = state.buffer.ReadSignedFloat(8, 1.0f);
-		float ascentControl = state.buffer.ReadSignedFloat(8, 1.0f);
+        s.SerializeSigned(8, 1.0f, data.yawControl);
+        s.SerializeSigned(8, 1.0f, data.pitchControl);
+        s.SerializeSigned(8, 1.0f, data.ascentControl);
 
 		return true;
 	}
@@ -3668,6 +3671,13 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, false>
 
 		return (hasNode) ? &node->data : nullptr;
 	}
+
+    virtual CSubmarineGameStateNodeData* GetSubmarineControl() override
+    {
+        auto [hasNode, node] = this->template GetData<CSubmarineGameStateDataNode>();
+
+        return (hasNode) ? &node->data : nullptr;
+    }
 
 	virtual CPlayerCameraNodeData* GetPlayerCamera() override
 	{

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -388,15 +388,16 @@ struct CDoorCreationDataNode
 	}
 };
 
-struct CVehicleSteeringDataNode
+struct CVehicleSteeringDataNode : GenericSerializeDataNode<CVehicleSteeringDataNode>
 {
 	CVehicleSteeringNodeData data;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+    bool Serialize(Serializer& s)
 	{
-		data.steeringAngle = state.buffer.ReadSignedFloat(10, 1.0f);
+        s.SerializeSigned(10, 1.0f, data.steeringAngle);
 
-		return true;
+        return true;
 	}
 };
 
@@ -1135,6 +1136,11 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 	{
 		return nullptr;
 	}
+
+    virtual CSubmarineGameStateNodeData* GetSubmarineControl() override
+    {
+        return nullptr;
+    }
 
 	virtual CHeliControlDataNodeData* GetHeliControl() override
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Instead of using Parse/Unparse, for CSubmarineGameStateDataNode/CVehicleSteeringDataNode we are using Serialize since those data nodes don't contain more data
...


### How is this PR achieving the goal
By replacing Parse by Serialize
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM, Server
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


Sorry for whitespaces, couldn't find a way (who is working) to push the commit without the whitespace thing
