### PR TITLE
Don't mention gameconfig in pool errors in RedM

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -247,11 +247,7 @@ static void* PoolAllocateWrap(atPoolBase* pool, uint64_t unk)
 
 		AddCrashometry("pool_error", "%s (%d)", poolName, pool->GetSize());
 
-		std::string extraWarning = (poolName.find("0x") == std::string::npos)
-			? fmt::sprintf(" (you need to raise %s PoolSize in common/data/gameconfig.xml)", poolName)
-			: "";
-
-		FatalErrorNoExcept("%s Pool Full, Size == %d%s", poolName, pool->GetSize(), extraWarning);
+		FatalErrorNoExcept("%s Pool Full, Size == %d", poolName, pool->GetSize());
 	}
 
 	return value;


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The goal of this PR is to prevent pool error crashes from confusing our players.
See [67d0d60](https://github.com/citizenfx/fivem/commit/67d0d60fc2da64a82c8a0c08d5c1fe5d2c374940) for more details.



### How is this PR achieving the goal

By removing the confusing extra warning.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1311, 1355, 1436, 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


