### PR TITLE
fix(ext/cfx-ui): added exception for sv_disableClientReplays

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -272,6 +272,7 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
         continue;
       }
 
+      case key === 'sv_disableClientReplays':
       case key === 'onesync':
       case key === 'gametype':
       case key === 'mapname':


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Remove server variable from filtered object to prevent rendering it in the component.


### How is this PR achieving the goal

Added exception for new server variable in transformers file


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes #2367


