### PR TITLE
feat(mono-v2): Enable mono v2 on RedM

### DIFF
--- a/data/client_rdr/components.json
+++ b/data/client_rdr/components.json
@@ -25,6 +25,7 @@
 	"citizen:scripting:lua",
 	"citizen:scripting:lua54",
 	"citizen:scripting:mono",
+	"citizen:scripting:mono-v2",
 	"citizen:scripting:v8client",
 	"citizen:scripting:v8node",
 	"gta:core:rdr3",


### PR DESCRIPTION
### Goal of this PR
Enable mono v2 scripting runtime on RedM.

Mind you, it's still in beta, breaking changes and crashes are expected.

### How is this PR achieving the goal
By adding it to the components


### This PR applies to the following area(s)
RedM, ScRT: C#


### Successfully tested on
RedM client up to start up

**Game builds:** None

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues


