### PR TITLE
feat(mono-rt2): add NuiEvent attribute

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -116,6 +116,32 @@ namespace CitizenFX.Core
 			Binding = binding;
 		}
 	}
+	
+#if !IS_FXSERVER
+	/// <summary>
+	/// Register this method to listen for the given <see cref="CallbackName"/> when this <see cref="BaseScript"/> is loaded
+	/// if <see cref="IsRawCallback"/> is specified this will use a raw NUI callback instead
+	/// </summary>
+	/// <remarks>Only works on <see cref="BaseScript"/> inherited class methods</remarks>
+#else
+	/// <summary>Does nothing on server side</summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	public class NuiCallbackAttribute : Attribute
+	{
+		public string CallbackName { get; }
+		public bool IsRawCallback { get; }
+		public NuiCallbackAttribute(string callbackName, bool isRawCallback = false)
+		{
+			CallbackName = callbackName;
+			if (isRawCallback)
+			{
+				throw new NotImplementedException("Raw Nui Callbacks are not currently implemented");
+			}
+			IsRawCallback = isRawCallback;
+		}
+	}
 
 	/// <summary>
 	/// Register this method to listen for the given <see cref="Export"/> when this <see cref="BaseScript"/> is loaded

--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -34,6 +34,8 @@ namespace CitizenFX.Core
 		}
 
 		private readonly List<KeyValuePair<int, DynFunc>> m_commands = new List<KeyValuePair<int, DynFunc>>();
+		
+		private readonly Dictionary<string, DynFunc> m_nuiCallbacks = new Dictionary<string, DynFunc>();
 
 #if REMOTE_FUNCTION_ENABLED
 		private readonly List<RemoteHandler> m_persistentFunctions = new List<RemoteHandler>();
@@ -100,6 +102,9 @@ namespace CitizenFX.Core
 							case KeyMapAttribute keyMap:
 								RegisterKeyMap(keyMap.Command, keyMap.Description, keyMap.InputMapper, keyMap.InputParameter, Func.CreateCommand(this, method, keyMap.RemapParameters));
 								break;
+							case NuiCallbackAttribute nuiCallback:
+								RegisterNuiCallback(nuiCallback.CallbackName, Func.Create(this, method));
+								break;
 #endif
 							case ExportAttribute export:
 								Exports.Add(export.Export, Func.Create(this, method), export.Binding);
@@ -140,6 +145,11 @@ namespace CitizenFX.Core
 					ReferenceFunctionManager.SetDelegate(m_commands[i].Key, m_commands[i].Value);
 				}
 
+				foreach (var nuiCallback in m_nuiCallbacks)
+				{
+					Native.CoreNatives.RegisterNuiCallback(nuiCallback.Key, nuiCallback.Value);
+				}
+				
 				EventHandlers.Enable();
 				Exports.Enable();
 
@@ -170,6 +180,11 @@ namespace CitizenFX.Core
 				for (int i = 0; i < m_commands.Count; ++i)
 				{
 					ReferenceFunctionManager.SetDelegate(m_commands[i].Key, (_0, _1) => null);
+				}
+				
+				foreach (var nuiCallback in m_nuiCallbacks)
+				{
+					Native.CoreNatives.RemoveNuiCallback(nuiCallback.Key);
 				}
 
 				EventHandlers.Disable();
@@ -283,7 +298,90 @@ namespace CitizenFX.Core
 			m_commands.Add(new KeyValuePair<int, DynFunc>(ReferenceFunctionManager.CreateCommand(command, dynFunc, false), dynFunc));
 #endif
 		}
+		
+		#endregion
+		
+		#region NUI Callback registration
 
+		internal void RegisterNuiCallback(string callbackName, DynFunc dynFunc)
+		{
+#if IS_FXSERVER
+			throw new NotImplementedException();
+#endif
+			m_nuiCallbacks.Add(callbackName, dynFunc);
+			Native.CoreNatives.RegisterNuiCallback(callbackName, dynFunc);
+		}
+
+		/// <summary>
+		/// Registers the NUI callback and binds it to the the <see cref="BaseScript"/>
+		/// </summary>
+		/// <param name="callbackName">the NUI callback to add</param>
+		/// <param name="delegateFn">The function to bind the callback to, the callback will be invoked with an ExpandoObject containing the data and a <see cref="Callback"/> </param>
+#if IS_FXSERVER
+		/// <summary>Does nothing on server side</summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+		public void RegisterNuiCallback(string callbackName, Delegate delegateFn)
+		{
+#if IS_FXSERVER
+			throw new NotImplementedException();
+#endif
+			DynFunc dynFunc = Func.Create(delegateFn);
+			m_nuiCallbacks.Add(callbackName, dynFunc);
+			Native.CoreNatives.RegisterNuiCallback(callbackName, dynFunc);
+		}
+		
+		/// <summary>
+		/// Unregisters the NUI callback from the <see cref="BaseScript"/>
+		/// </summary>
+		/// <param name="callbackName">the NUI callback to remove</param>
+#if IS_FXSERVER
+		/// <summary>Does nothing on server side</summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+		public void UnregisterNuiCallback(string callbackName)
+		{
+#if IS_FXSERVER
+			throw new NotImplementedException();
+#endif
+			m_nuiCallbacks.Remove(callbackName);
+			Native.CoreNatives.RemoveNuiCallback(callbackName);
+		}
+		
+		/// <summary>
+		/// Registers a NUI callback to the specified <paramref name="callbackName"/>
+		/// </summary>
+		/// <param name="callbackName">the event that the callback will bind to</param>
+		/// <param name="delegateFn">The function to bind the callback to, the callback will be invoked with an ExpandoObject containing the data and a <see cref="Callback"/> </param>
+#if IS_FXSERVER
+		/// <summary>Does nothing on server side</summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+		public static void AddNuiCallback(string callbackName, Delegate delegateFn)
+		{
+#if IS_FXSERVER
+			throw new NotImplementedException();
+#endif
+			Native.CoreNatives.RegisterNuiCallback(callbackName, delegateFn);
+		}
+
+		/// <summary>
+		/// Removes the NUI callback for the specified <paramref namem="callbackName"/>
+		/// </summary>
+		/// <param name="callbackName">the callback event that will be removed</param>
+#if IS_FXSERVER
+		/// <summary>Does nothing on server side</summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+		public static void RemoveNuiCallback(string callbackName) 
+		{
+#if IS_FXSERVER
+			throw new NotImplementedException();
+#else
+			Native.CoreNatives.RemoveNuiCallback(callbackName);
+#endif
+		}
+		
 		#endregion
 
 		#region Script loading

--- a/code/client/clrcore-v2/Native/Native.cs
+++ b/code/client/clrcore-v2/Native/Native.cs
@@ -15,6 +15,8 @@ namespace CitizenFX.Core.Native
 		private static UIntPtr s_0x637f4c75;
 		private static UIntPtr s_0x8d50e33a;
 		private static UIntPtr s_0x91310870;
+		private static UIntPtr s_registerNuiCallback; // 0xc59b980c
+		private static UIntPtr s_unregisterRawNuiCallback; // 0x7fb46432
 #if IS_FXSERVER
 		private static UIntPtr s_0x2f7a49e6;
 		private static UIntPtr s_0x70b35890;
@@ -34,12 +36,23 @@ namespace CitizenFX.Core.Native
 		}
 
 		[SecuritySafeCritical]
-		internal static unsafe void RegisterCommand(CString commandName, InFunc handler, bool restricted)
+		internal static unsafe void RegisterNuiCallback(CString callbackName, InFunc handler)
 		{
-			fixed (byte* p_commandName = commandName?.value, p_handler = &handler.value[0])
+			fixed (byte* p_callbackType = callbackName?.value, p_handler = &handler.value[0])
 			{
-				ulong* __data = stackalloc ulong[] { (ulong)p_commandName, (ulong)p_handler, N64.Val(restricted) };
-				ScriptContext.InvokeNative(ref s_0x5fa79b0f, 0x5fa79b0f, __data, 3); // REGISTER_COMMAND
+				ulong* __data = stackalloc ulong[] { (ulong)p_callbackType, (ulong)p_handler };
+				ScriptContext.InvokeNative(ref s_registerNuiCallback, 0xc59b980c, __data, 2); // REGISTER_NUI_CALLBACK
+			}
+		}
+		
+		
+		[SecuritySafeCritical]
+		internal static unsafe void RemoveNuiCallback(CString callbackName)
+		{
+			fixed (byte* p_callbackType = callbackName?.value)
+			{
+				ulong* __data = stackalloc ulong[] { (ulong)p_callbackType };
+				ScriptContext.InvokeNative(ref s_unregisterRawNuiCallback, 0x7fb46432, __data, 1); // UNREGISTER_RAW_NUI_CALLBACK
 			}
 		}
 
@@ -53,6 +66,16 @@ namespace CitizenFX.Core.Native
 			{
 				ulong* __data = stackalloc ulong[] { (ulong)p_commandString, (ulong)p_description, (ulong)p_defaultMapper, (ulong)p_defaultParameter };
 				ScriptContext.InvokeNative(ref s_0xd7664fd1, 0xd7664fd1, __data, 4);
+			}
+		}
+		
+		[SecuritySafeCritical]
+		internal static unsafe void RegisterCommand(CString commandName, InFunc handler, bool restricted)
+		{
+			fixed (byte* p_commandName = commandName?.value, p_handler = &handler.value[0])
+			{
+				ulong* __data = stackalloc ulong[] { (ulong)p_commandName, (ulong)p_handler, N64.Val(restricted) };
+				ScriptContext.InvokeNative(ref s_0x5fa79b0f, 0x5fa79b0f, __data, 3); // REGISTER_COMMAND
 			}
 		}
 


### PR DESCRIPTION
- allows the client to use `[NuiEvent("NuiEventName")]` to receive Nui messages

### Goal of this PR
Add similar attributes as used by `EventHandler` for Nui

### How is this PR achieving the goal
Adds new `NuiEventAttribute` and registers it via `RegisterNuiCallback`

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: C#

### Successfully tested on
RedM

**Game builds:** N/A

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


