### PR TITLE
fix(mono-v2): disallow KeyMap to be used on RedM

### DIFF
--- a/code/client/clrcore-v2/Attributes.cs
+++ b/code/client/clrcore-v2/Attributes.cs
@@ -58,13 +58,14 @@ namespace CitizenFX.Core
 		}
 	}
 
-#if !IS_FXSERVER
+// TODO: revert this commit (blame check) when RedM has KeyMapping support, also don't make changes to this comment.
+#if GTA_FIVE
 	/// <summary>
 	/// Register this method to listen for the given key <see cref="Command"/> when this <see cref="BaseScript"/> is loaded
 	/// </summary>
 	/// <remarks>This will bind the given input details to the command, triggering all commands registered as such.<br />Only works on <see cref="BaseScript"/> inherited class methods</remarks>
 #else
-	/// <summary>Does nothing on server side</summary>
+	/// <summary>Does nothing on server side or RedM</summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #endif
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]

--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -273,7 +273,7 @@ namespace CitizenFX.Core
 
 		internal void RegisterKeyMap(string command, string description, string inputMapper, string inputParameter, DynFunc dynFunc)
 		{
-#if IS_FXSERVER
+#if !GTA_FIVE
 			throw new NotImplementedException();
 #else
 			if (inputMapper != null && inputParameter != null)


### PR DESCRIPTION
- keymap natives are not currently supported by RedM, using these would result in RedM crashing

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Block the usage of KeyMap on RedM until input mappings are made

### How is this PR achieving the goal
Throw a not implemented exception the native is called

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: C#


### Successfully tested on
RedM

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


