### PR TITLE
 tweak(ext/cfx-ui): Add monitor to non-displayed-resources in server list

### DIFF
--- a/ext/cfx-ui/src/cfx/base/serverUtils.ts
+++ b/ext/cfx-ui/src/cfx/base/serverUtils.ts
@@ -237,6 +237,7 @@ const NON_DISPLAY_SERVER_RESOURCE_NAMES = new Set([
   '_cfx_internal',
   'hardcap',
   'sessionmanager',
+  'monitor'
 ]);
 export function shouldDisplayServerResource(resourceName: string): boolean {
   return !NON_DISPLAY_SERVER_RESOURCE_NAMES.has(resourceName);


### PR DESCRIPTION
### Goal of this PR
Just adding monitor to the non-displayed resource to the serverlist, to make it look a bit cleaner for servers with less resources

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.