### PR TITLE
feat(scripting/lua): redm oal natives

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptNatives.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptNatives.cpp
@@ -1484,8 +1484,10 @@ struct LuaNativeContext
 #endif
 
 #if INCLUDE_FXV2_NATIVES
-#if !defined(IS_FXSERVER) && defined(GTA_FIVE)
+#if defined(GTA_FIVE)
 #include "Natives.h"
+#elif defined(IS_RDR3)
+#include "NativesRDR.h"
 #elif defined(IS_FXSERVER)
 #include "NativesServer.h"
 #endif
@@ -1493,7 +1495,7 @@ struct LuaNativeContext
 
 LUA_SCRIPT_LINKAGE lua_CFunction Lua_GetNative(lua_State* L, const char* name)
 {
-#if INCLUDE_FXV2_NATIVES && (defined(GTA_FIVE) || defined(IS_FXSERVER))
+#if INCLUDE_FXV2_NATIVES && !defined(GTA_NY)
 	auto it = natives.find(name);
 	return (it != natives.end()) ? it->second : nullptr;
 #else


### PR DESCRIPTION
### Goal of this PR

Introduces faster OAL natives for RedM when using ``use_experimental_fxv2_oal true`` on the Lua 5.4 ScRT 

### How is this PR achieving the goal

By including the ``NativesRDR.h`` header file that is compiled and copied into citizen-scripting-lua/src. 

### This PR applies to the following area(s)

RedM, ScRT: Lua


### Successfully tested on

**Game builds:**  1491.18

**Platforms:** Windows

Tested with scripts utilising Lua 5.3, MonoV1, JS and Lua 5.4 (without OAL) ScRT's. With all behaving as intended

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.