### PR TITLE
tweak(client): move product info to shared file

### DIFF
--- a/code/client/citicore/FileMapping.Win32.cpp
+++ b/code/client/citicore/FileMapping.Win32.cpp
@@ -468,11 +468,11 @@ static BOOL WINAPI GetFileVersionInfoWStub(_In_ LPCWSTR lptstrFilename, _Reserve
 	{
 		if (StrStrIW(lptstrFilename, L"Social Club\\SocialClub") != NULL)
 		{
-			g_nextFileVersion = {2, 0, 9, 0};
+			g_nextFileVersion = SOCIAL_CLUB_VERSION;
 		}
 		else if (StrStrIW(lptstrFilename, L"Social Club\\libcef.dll") != NULL)
 		{
-			g_nextFileVersion = {85, 3, 9, 0};
+			g_nextFileVersion = SOCIAL_CLUB_CEF_VERSION;
 		}
 	}
 

--- a/code/client/launcher/Bootstrap.cpp
+++ b/code/client/launcher/Bootstrap.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 
 #include <CfxState.h>
+#include <CfxProductInfo.h>
 #include <HostSharedData.h>
 
 #include <citversion.h>
@@ -83,7 +84,11 @@ bool Bootstrap_DoBootstrap()
 
 	auto fetchContent = [&contentHeaders, &bootstrapVersion](const std::string& updateChannel)
 	{
+#ifdef UPDATE_NAME
+		return DL_RequestURL(va(CONTENT_URL "/heads/" UPDATE_NAME "/%s?time=%lld", updateChannel, _time64(NULL)), bootstrapVersion, sizeof(bootstrapVersion), contentHeaders);
+#else
 		return DL_RequestURL(va(CONTENT_URL "/heads/" CONTENT_NAME "/%s?time=%lld", updateChannel, _time64(NULL)), bootstrapVersion, sizeof(bootstrapVersion), contentHeaders);
+#endif
 	};
 
 	int result = fetchContent(GetUpdateChannel());

--- a/code/client/launcher/Download.cpp
+++ b/code/client/launcher/Download.cpp
@@ -11,6 +11,7 @@
 #include "ErrorFormat.Win32.h"
 
 #include <CfxLocale.h>
+#include <CfxProductInfo.h>
 
 // the maximum number of concurrent downloads
 #define MAX_CONCURRENT_DOWNLOADS 6

--- a/code/client/launcher/GameCache.cpp
+++ b/code/client/launcher/GameCache.cpp
@@ -9,6 +9,7 @@
 
 #if defined(LAUNCHER_PERSONALITY_MAIN) || defined(LAUNCHER_PERSONALITY_GAME) || defined(COMPILING_GLUE)
 #include <CfxState.h>
+#include <CfxProductInfo.h>
 #include <HostSharedData.h>
 
 #if defined(LAUNCHER_PERSONALITY_MAIN) || defined(COMPILING_GLUE)

--- a/code/client/launcher/GameSelect.cpp
+++ b/code/client/launcher/GameSelect.cpp
@@ -13,6 +13,7 @@
 #include <CfxLocale.h>
 
 #include <HostSharedData.h>
+#include <CfxProductInfo.h>
 #include <CfxState.h>
 
 #include <wrl.h>

--- a/code/client/launcher/Installer.cpp
+++ b/code/client/launcher/Installer.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 
 #include <CfxLocale.h>
+#include <CfxProductInfo.h>
 
 #include "launcher.rc.h"
 
@@ -64,13 +65,7 @@ static std::wstring GetRootPath()
 
 	if (!appDataPath.empty())
 	{
-#ifdef GTA_FIVE
-		appDataPath += L"\\FiveM";
-#elif defined(IS_RDR3)
-		appDataPath += L"\\RedM";
-#else
-		appDataPath += L"\\Cfx.re";
-#endif
+		appDataPath += L"\\" PRODUCT_NAME;
 
 		CreateDirectory(appDataPath.c_str(), nullptr);
 	}

--- a/code/client/launcher/LauncherConfig.h
+++ b/code/client/launcher/LauncherConfig.h
@@ -11,30 +11,18 @@
 #define CONTENT_URL_WIDE L"https://content.cfx.re/updates"
 
 #if defined(GTA_NY)
-#define PRODUCT_NAME L"LibertyM"
-#define CONTENT_NAME "libertym"
 #define GAME_EXECUTABLE L"GTAIV.exe"
 #define EXE_TEXT_SIZE 0xA7181A
 #define EXE_RDATA_SIZE 0x1BCD03
 #define EXE_DATA_SIZE 0xC6B50C
 #elif defined(PAYNE)
-#define PRODUCT_NAME L"CitizenPayne"
-#define CONTENT_NAME "paynefx"
 #define GAME_EXECUTABLE L"MaxPayne3.exe"
 #elif defined(GTA_FIVE)
-#define PRODUCT_NAME L"FiveM"
 #define GAME_EXECUTABLE L"GTA5.exe"
-#define CONTENT_NAME "fivereborn"
 #elif defined(IS_RDR3)
-#define PRODUCT_NAME L"RedM"
-#define CONTENT_NAME "redm"
 #define GAME_EXECUTABLE L"RDR2.exe"
 #elif defined(IS_LAUNCHER)
-#define PRODUCT_NAME L"Cfx.re Launcher"
 #define GAME_EXECUTABLE L"DUMMY.exe"
-#define CONTENT_NAME "launcher"
 #else
-#define PRODUCT_NAME L"Unknown CitizenFX Game"
 #define GAME_EXECUTABLE L"Game.exe"
-#define CONTENT_NAME "unk"
 #endif

--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -34,6 +34,7 @@
 #include "ErrorFormat.Win32.h"
 
 #include <CfxLocale.h>
+#include <CfxProductInfo.h>
 #include <filesystem>
 
 void InitializeDummies();

--- a/code/client/launcher/MiniDump.cpp
+++ b/code/client/launcher/MiniDump.cpp
@@ -19,6 +19,7 @@
 #include <CfxLocale.h>
 #include <CfxState.h>
 #include <CfxSubProcess.h>
+#include <CfxProductInfo.h>
 #include <HostSharedData.h>
 
 using namespace google_breakpad;

--- a/code/client/launcher/Updater.cpp
+++ b/code/client/launcher/Updater.cpp
@@ -9,6 +9,7 @@
 
 #if defined(LAUNCHER_PERSONALITY_MAIN) || defined(COMPILING_GLUE)
 #include <CfxLocale.h>
+#include <CfxProductInfo.h>
 #include <tinyxml2.h>
 
 #include <stdint.h>

--- a/code/client/launcher/UpdaterUI.cpp
+++ b/code/client/launcher/UpdaterUI.cpp
@@ -24,6 +24,7 @@
 #include <roapi.h>
 
 #include <CfxState.h>
+#include <CfxProductInfo.h>
 #include <HostSharedData.h>
 
 #include <boost/algorithm/string.hpp>

--- a/code/client/launcher/ViabilityChecks.cpp
+++ b/code/client/launcher/ViabilityChecks.cpp
@@ -8,6 +8,7 @@
 #include <shellapi.h>
 #include <shlobj.h>
 
+#include <CfxProductInfo.h>
 #if defined(LAUNCHER_PERSONALITY_MAIN)
 #include <CfxLocale.h>
 #endif

--- a/code/client/shared/ROSSuffix.h
+++ b/code/client/shared/ROSSuffix.h
@@ -2,3 +2,13 @@
 
 #define ROS_SUFFIX "_b576"
 #define ROS_SUFFIX_W L"_b576"
+
+//Social Club DLL versions
+#ifndef GTA_NY
+#define SOCIAL_CLUB_VERSION {2, 0, 9, 0}
+#define SOCIAL_CLUB_CEF_VERSION {85, 3, 9, 0}
+#else
+//LibertyM uses an older version of Social Club
+#define SOCIAL_CLUB_VERSION {2, 0, 7, 9}
+#define SOCIAL_CLUB_CEF_VERSION {83, 5, 0, 0}
+#endif

--- a/code/client/shared/Utils.Win32.cpp
+++ b/code/client/shared/Utils.Win32.cpp
@@ -11,6 +11,7 @@
 #include <direct.h>
 #include <io.h>
 
+#include <CfxProductInfo.h>
 #include <CfxState.h>
 #include <HostSharedData.h>
 
@@ -33,11 +34,8 @@ fwPlatformString GetAbsoluteCitPath()
 		{
 			if (GetFileAttributes((citizenPath + L"CoreRT.dll").c_str()) == INVALID_FILE_ATTRIBUTES)
 			{
-#ifdef IS_RDR3
-				if (!CreateDirectory((citizenPath + L"RedM.app").c_str(), nullptr))
-#else
-				if (!CreateDirectory((citizenPath + L"FiveM.app").c_str(), nullptr))
-#endif
+
+				if (!CreateDirectory((citizenPath + PRODUCT_NAME ".app").c_str(), nullptr))
 				{
 					DWORD error = GetLastError();
 
@@ -52,12 +50,7 @@ fwPlatformString GetAbsoluteCitPath()
 		// is this subdirectory-based Citizen? if so, append the subdirectory
 		if (GetFileAttributes((citizenPath + L"CoreRT.dll").c_str()) == INVALID_FILE_ATTRIBUTES)
 		{
-			std::wstring subPath = citizenPath +
-#ifdef IS_RDR3
-								   L"RedM.app";
-#else
-								   L"FiveM.app";
-#endif
+			std::wstring subPath = citizenPath + PRODUCT_NAME ".app";
 
 			if (GetFileAttributes(subPath.c_str()) != INVALID_FILE_ATTRIBUTES && (GetFileAttributes(subPath.c_str()) & FILE_ATTRIBUTE_DIRECTORY) != 0)
 			{

--- a/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
@@ -11,6 +11,7 @@
 #include <ResourceManager.h>
 #include <ResourceMetaDataComponent.h>
 
+#include <CfxProductInfo.h>
 #include <VFSManager.h>
 
 #if __has_include(<CrossBuildRuntime.h>) && defined(_WIN32)
@@ -209,21 +210,7 @@ static InitFunction initFunction([] ()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_GAME_NAME", [](fx::ScriptContext& context)
 	{
-		const char* gameName =
-#ifdef IS_FXSERVER
-		"fxserver"
-#elif defined(GTA_FIVE)
-		"fivem"
-#elif defined(GTA_NY)
-		"libertym"
-#elif defined(IS_RDR3)
-		"redm"
-#else
-		"unknown"
-#endif
-		;
-
-		context.SetResult<const char*>(gameName);
+		context.SetResult<const char*>(CONTENT_NAME);
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_GAME_BUILD_NUMBER", [](fx::ScriptContext& context)

--- a/code/components/citizen-scripting-mono-v2/src/MonoComponentHost.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoComponentHost.cpp
@@ -25,7 +25,7 @@
 #include <mono/metadata/threads.h>
 
 #define CITIZENFX_CORE "CitizenFX.Core"
-#define CITIZENFX_GAME_NATIVE "CitizenFX." PRODUCT_NAME ".Native"
+#define CITIZENFX_GAME_NATIVE "CitizenFX." PRODUCT_NAME_NARROW ".Native"
 
 namespace fx::mono
 {

--- a/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
+++ b/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
@@ -15,18 +15,7 @@
 #include <CoreConsole.h>
 
 #include <EASTL/fixed_hash_map.h>
-
-#ifdef IS_FXSERVER
-#define PRODUCT_NAME "Server"
-#elif defined(GTA_FIVE)
-#define PRODUCT_NAME "FiveM"
-#elif defined(IS_RDR3)
-#define PRODUCT_NAME "RedM"
-#elif defined(GTA_NY)
-#define PRODUCT_NAME "LibertyM"
-#else
-static_assert(false, "No native wrapper dll set for this game or program, are you missing a preprocessor definition?");
-#endif
+#include <CfxProductInfo.h>
 
 #ifndef _WIN32
 #define FX_API 

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -33,8 +33,8 @@ const wchar_t* const MonoComponentHostShared::s_platformAssemblies[] = {
 	L"System.Core.dll",
 	L"CitizenFX.Core.dll",
 	//L"CitizenFX.Core.Client.dll",
-	L"CitizenFX." PRODUCT_NAME ".dll",
-	L"CitizenFX." PRODUCT_NAME ".NativeImpl.dll",
+	L"CitizenFX." PRODUCT_NAME_NARROW ".dll",
+	L"CitizenFX." PRODUCT_NAME_NARROW ".NativeImpl.dll",
 };
 #endif
 

--- a/code/components/font-renderer/src/GtaGameInterface.cpp
+++ b/code/components/font-renderer/src/GtaGameInterface.cpp
@@ -16,6 +16,7 @@
 #include <Hooking.h>
 #include <CL2LaunchMode.h>
 #include <CfxReleaseInfo.h>
+#include <CfxProductInfo.h>
 
 #include "memdbgon.h"
 
@@ -394,13 +395,10 @@ static InitFunction initFunction([] ()
 				return L"";
 			};
 
-			brandName = L"FiveM";
+			brandName = PRODUCT_NAME;
+#ifndef GTA_NY
 			brandingEmoji = getDayEmoji();
-
-#if defined(IS_RDR3)
-			brandName = L"RedM";
-#elif defined(GTA_NY)
-			brandName = L"LibertyM";
+#else
 			brandingEmoji = L"\U0001F5FD";
 #endif
 

--- a/code/shared/CfxProductInfo.h
+++ b/code/shared/CfxProductInfo.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#pragma once
+
+#if defined(GTA_NY)
+#define PRODUCT_NAME L"LibertyM"
+#define PRODUCT_NAME_NARROW "LibertyM"
+#define CONTENT_NAME "libertym"
+#elif defined(GTA_FIVE)
+#define PRODUCT_NAME L"FiveM"
+#define PRODUCT_NAME_NARROW "FiveM"
+#define CONTENT_NAME "fivem"
+//FiveM uses legacy name 'fivereborn' when checking updates.
+#define UPDATE_NAME "fivereborn"
+#elif defined(IS_RDR3)
+#define PRODUCT_NAME L"RedM"
+#define PRODUCT_NAME_NARROW "RedM"
+#define CONTENT_NAME "redm"
+#elif defined(IS_FXSERVER)
+#define PRODUCT_NAME L"Server"
+#define PRODUCT_NAME_NARROW "Server"
+#define CONTENT_NAME "fxserver"
+#elif defined(IS_LAUNCHER)
+#define PRODUCT_NAME L"Cfx.re Launcher"
+#define CONTENT_NAME "launcher"
+#else
+static_assert(false, "No recognized program definition found, are you missing a preprocessor definition?");
+#endif


### PR DESCRIPTION
### Goal of this PR
Cleans up information about CFX products such as FiveM, RedM, LibertyM and FXServer into its own header file in shared. Allowing for it to be used across the entire project. Also refactors Social Club Version information into ROSSuffix.h with other ROS information.

### How is this PR achieving the goal

By creating CfxProductInfo.h and placing information about each of CFX product such as PRODUCT_NAME(_LOWER) and CONTENT_NAME. Along with refactoring several files to make use of these. Also defining UPDATE_NAME for FiveM as it uses 'fivereborn' when checking for updates.

### This PR applies to the following area(s)
FiveM, RedM, Server

### Successfully tested on

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
