### PR TITLE
feat(core/profiler): add natives exposing start/stop recording

### DIFF
--- a/code/components/citizen-scripting-core/src/Profiler.cpp
+++ b/code/components/citizen-scripting-core/src/Profiler.cpp
@@ -949,6 +949,20 @@ static InitFunction initFunction([]()
 		ctx.SetResult<int>(profiler->IsRecording());
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("PROFILER_START_RECORDING", [](fx::ScriptContext& ctx)
+	{
+		static auto profiler = fx::ResourceManager::GetCurrent()->GetComponent<fx::ProfilerComponent>();
+		const int frames = ctx.GetArgument<int>(0);
+		const char* resource = ctx.GetArgument<char*>(1);
+		profiler->StartRecording(frames ? frames : -1, resource);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("PROFILER_STOP_RECORDING", [](fx::ScriptContext& ctx)
+	{
+		static auto profiler = fx::ResourceManager::GetCurrent()->GetComponent<fx::ProfilerComponent>();
+		profiler->StopRecording();
+	});
+
 	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* res)
 	{
 		auto resname = res->GetName();

--- a/ext/native-decls/ProfilerStartRecording.md
+++ b/ext/native-decls/ProfilerStartRecording.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: shared
+---
+## PROFILER_START_RECORDING
+
+```c
+void PROFILER_START_RECORDING(int frames, char* resourceName);
+```
+
+Starts recording on the profiler.
+
+## Parameters
+* **frames**: The amount of frames to record for, -1 to record until calling [PROFILER_STOP_RECORDING](#_0x2d29dea5)
+* **resourceName**: The resource to record for, or null to record every resource.

--- a/ext/native-decls/ProfilerStopRecording.md
+++ b/ext/native-decls/ProfilerStopRecording.md
@@ -1,0 +1,11 @@
+---
+ns: CFX
+apiset: shared
+---
+## PROFILER_STOP_RECORDING
+
+```c
+void PROFILER_STOP_RECORDING();
+```
+
+Stops the profiler if its currently recording.


### PR DESCRIPTION
- currently trying to do recordings can only be done via console commands, which can be tedious
- this adds `PROFILER_START_RECORDING` and `PROFILER_STOP_RECORDING` to allow automating profiler captures

### Goal of this PR
Allow resources to start/stop recording to allow for easier automation of testing performance of code


### How is this PR achieving the goal
Exposes `PROFILER_START_RECORDING` and `PROFILER_STOP_RECORDING`


### This PR applies to the following area(s)
Natives, SCRT


### Successfully tested on
C#

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.