### PR TITLE
tweak(data/rdr3): Increase FragmentStore, CAmbientMaskVolume, CAmbientMaskVolumeDoor pool size

### DIFF
--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -74,7 +74,7 @@
                 </Item>
                 <Item>
                     <PoolName>CAmbientMaskVolume</PoolName>
-                    <PoolSize value="5150"/>
+                    <PoolSize value="50000"/>
                 </Item>
 				<Item>
                     <PoolName>CAmbientMaskVolumeEntity</PoolName>
@@ -82,7 +82,7 @@
                 </Item>
 				<Item>
 				<PoolName>CAmbientMaskVolumeDoor</PoolName>
-                    <PoolSize value="925"/>
+                    <PoolSize value="50000"/>
                 </Item>
                 <Item>
                     <PoolName>CArmSolver</PoolName>
@@ -1107,7 +1107,7 @@
                 </Item>
                 <Item>
                   <PoolName>FragmentStore</PoolName>
-                  <PoolSize value="8756"/>
+                  <PoolSize value="67500"/>
                 </Item>
                 <Item>
                   <PoolName>fwScriptGuid</PoolName>


### PR DESCRIPTION
Increase FragmentStore, CAmbientMaskVolume, CAmbientMaskVolumeDoor pool size

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR allow to create more YFTs, and AMVs

### How is this PR achieving the goal

Editing gameconfig.xml


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Redm


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 

1311, 1355, 1436, 1491

**Platforms:** 

Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ x] Code compiles and has been tested successfully.
- [ x] Code explains itself well and/or is documented.
- [ x] My commit message explains what the changes do and what they are for.
- [ x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


