### PR TITLE
Update gameconfig.xml to increase audio bank limit

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -57,7 +57,7 @@
 						</Item>
 						<Item>
 						  <PoolName>AudioHeap</PoolName>
-						  <PoolSize value="195"/>
+						  <PoolSize value="300"/>
 						</Item>
 						<Item>
 							<PoolName>BlendshapeStore</PoolName>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
with this update it will unlock audio banks limit currently i tested with 195 audio banks and when ever i got above then ( n number of audio banks i created ) **n** sounds will get stop working randomly
...


### How is this PR achieving the goal
after this server can insert more audio banks if they want
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


