### PR TITLE
feat(extra-natives/five): support for cl_crosshair_t command

### DIFF
--- a/code/components/conhost-v2/include/ProductionWhitelist.h
+++ b/code/components/conhost-v2/include/ProductionWhitelist.h
@@ -36,4 +36,5 @@ static std::vector<std::string> g_prodCommandsWhitelist{
 	"cl_crosshair_dynamic_splitalpha_innermod",
 	"cl_crosshair_dynamic_splitalpha_outermod",
 	"cl_crosshair_dynamic_maxdist_splitratio",
+	"cl_crosshair_t"
 };

--- a/code/components/extra-natives-five/src/DrawImNatives.cpp
+++ b/code/components/extra-natives-five/src/DrawImNatives.cpp
@@ -3254,6 +3254,7 @@ static ConVar<bool> cl_crosshairdot("cl_crosshairdot", ConVar_Archive, true);
 static ConVar<float> cl_crosshair_dynamic_splitalpha_innermod("cl_crosshair_dynamic_splitalpha_innermod", ConVar_Archive, 1.f);
 static ConVar<float> cl_crosshair_dynamic_splitalpha_outermod("cl_crosshair_dynamic_splitalpha_outermod", ConVar_Archive, 0.5f);
 static ConVar<float> cl_crosshair_dynamic_maxdist_splitratio("cl_crosshair_dynamic_maxdist_splitratio", ConVar_Archive, 0.35f);
+static ConVar<bool> cl_crosshair_t("cl_crosshair_t", ConVar_Archive, false);
 
 static void DoCrosshairDraw()
 {
@@ -3476,15 +3477,20 @@ static void DoCrosshairDraw()
 	DrawCrosshairRect(r, g, b, flLineAlphaInner, iOuterLeft, y0, iInnerLeft, y1, bAdditive);
 	DrawCrosshairRect(r, g, b, flLineAlphaInner, iInnerRight, y0, iOuterRight, y1, bAdditive);
 
-	// draw vertical crosshair lines
-	int iInnerTop = iCenterY - iInnerCrossDist - iBarThickness / 2;
-	int iInnerBottom = iInnerTop + 2 * iInnerCrossDist + iBarThickness;
-	int iOuterTop = iInnerTop - iBarSizeInner;
+	// draw bottom vertical crosshair line
+	int iInnerBottom = iCenterY + iInnerCrossDist - iBarThickness / 2;
 	int iOuterBottom = iInnerBottom + iBarSizeInner;
 	int x0 = iCenterX - iBarThickness / 2;
 	int x1 = x0 + iBarThickness;
-	DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iOuterTop, x1, iInnerTop, bAdditive);
-	DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iInnerBottom, x1, iOuterBottom, bAdditive);
+	DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iCenterY, x1, iOuterBottom, bAdditive);
+
+	// draw top vertical crosshair line if cl_crosshair_t is disabled
+	if (!cl_crosshair_t.GetValue())
+	{
+		int iInnerTop = iCenterY - iInnerCrossDist - iBarThickness / 2;
+		int iOuterTop = iInnerTop - iBarSizeInner;
+		DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iOuterTop, x1, iInnerTop, bAdditive);
+	}
 
 	// draw dot
 	if (cl_crosshairdot.GetValue())


### PR DESCRIPTION
### Goal of this PR

This PR aims to implement support for the `cl_crosshair_t` [command from CS:GO](https://totalcsgo.com/commands/clcrosshairt). The `cl_crosshair_t` command allows players to customize their crosshair to a "T" style by removing the top line of the crosshair.

### How is this PR achieving the goal

- **Command Implementation**: Added the `cl_crosshair_t` command to toggle the "T" style crosshair.
  ```cpp
  static ConVar<bool> cl_crosshair_t("cl_crosshair_t", ConVar_Archive, false);
  ```

- **Drawing Logic Update**: Modified the `DoCrosshairDraw` function to conditionally skip drawing the top vertical line of the crosshair when `cl_crosshair_t` is enabled.
  ```cpp
  // draw top vertical crosshair line if cl_crosshair_t is disabled
  if (!cl_crosshair_t.GetValue())
  {
      int iInnerTop = iCenterY - iInnerCrossDist - iBarThickness / 2;
      int iOuterTop = iInnerTop - iBarSizeInner;
      DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iOuterTop, x1, iInnerTop, bAdditive);
  }
  ```

- **Whitelist Update**: Added `cl_crosshair_t` to the `g_prodCommandsWhitelist` to ensure the command is recognized and can be used.
  ```cpp
  static std::vector<std::string> g_prodCommandsWhitelist{
      ...
      "cl_crosshair_t" // Added command
  };
  ```

### This PR applies to the following area(s)

- FiveM

### Successfully tested on

**Game builds:** 

**Platforms:** Windows

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.