### PR TITLE
up AnimStore limit to 31000

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -138,7 +138,7 @@
 						</Item>
 						<Item>
 							<PoolName>AnimStore</PoolName>
-							<PoolSize value="21000"/>
+							<PoolSize value="31000"/>
 						</Item>
 						<Item>
 							<PoolName>CGameScriptResource</PoolName>


### PR DESCRIPTION
### Goal of this PR
Currently using build 2802 to switch to the newer build 3095 I have a lot of problems with animations transmitting too many animations, so it would be good to increase this limit so as not to need to remove content.

### How is this PR achieving the goal

the pr archive the goal increasing the value...

### This PR applies to the following area(s)
FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
