### PR TITLE
Better gamer tag crew component fix for b3095

### DIFF
--- a/code/components/citizen-playernames-five/src/HookGamerInfo.cpp
+++ b/code/components/citizen-playernames-five/src/HookGamerInfo.cpp
@@ -186,12 +186,6 @@ struct PatternPair
 	int offset;
 };
 
-template<typename T, T Value>
-static T Return()
-{
-	return Value;
-}
-
 static HookFunction hookFunction([]()
 {
 	const size_t gamerInfoSize = (xbr::IsGameBuildOrGreater<2060>()) ? sizeof(CGamerInfo<2060>) : sizeof(CGamerInfo<1604>);
@@ -409,8 +403,8 @@ static HookFunction hookFunction([]()
 		LimitPatch(hook::pattern("83 FB ? 77 ? 48 69 DB").count(1).get(0).get<void>(0));
 		LimitPatch(hook::pattern("83 FB 33 77 74 48 8B FB").count(1).get(0).get<void>(0));
 
-		// There's a new unknown "privilege" check that needs to be patched.
-		hook::jump(hook::get_pattern("84 C0 74 04 32 C0 EB 11 48 8B D6", -0x21), Return<bool, true>);
+		// There's a new unknown "privilege" check that needs to be patched. Nuking the whole code block.
+		hook::nop(hook::get_pattern("8A CB E8 ? ? ? ? 48 85 C0 74 22 48 8B"), 0x2A);
 	}
 	else
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The fix introduced in d1b35aa (#2358) didn't resolve some broken scenarios. This PR is meant to resolve everything.



### How is this PR achieving the goal

Reworking the original fix to cover all possible scenarios where gamer tags weren't working as intended on b3095.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


