### PR TITLE
tweak(gamestate/server): allow blocking of ScriptEntityStateChangeEvent

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -95,6 +95,9 @@ static bool g_networkedSoundsEnabled;
 static std::shared_ptr<ConVar<bool>> g_networkedPhoneExplosionsEnabledVar;
 static bool g_networkedPhoneExplosionsEnabled;
 
+static std::shared_ptr<ConVar<bool>> g_networkedScriptEntityStatesEnabledVar;
+static bool g_networkedScriptEntityStatesEnabled;
+
 static std::shared_ptr<ConVar<int>> g_requestControlVar;
 static std::shared_ptr<ConVar<int>> g_requestControlSettleVar;
 
@@ -7125,6 +7128,14 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 			return false;
 		};
 	}
+
+	if (eventType == SCRIPT_ENTITY_STATE_CHANGE_EVENT)
+	{
+		return []()
+		{
+			return g_networkedScriptEntityStatesEnabled;
+		};
+	}
 #endif
 
 #ifdef STATE_FIVE
@@ -7219,6 +7230,8 @@ static InitFunction initFunction([]()
 		g_networkedSoundsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedSounds", ConVar_None, true, &g_networkedSoundsEnabled);
 
 		g_networkedPhoneExplosionsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedPhoneExplosions", ConVar_None, false, &g_networkedPhoneExplosionsEnabled);
+
+		g_networkedScriptEntityStatesEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedScriptEntityStates", ConVar_None, true, &g_networkedScriptEntityStatesEnabled);
 
 		g_requestControlVar = instance->AddVariable<int>("sv_filterRequestControl", ConVar_None, (int)RequestControlFilterMode::NoFilter, (int*)&g_requestControlFilterState);
 		g_requestControlSettleVar = instance->AddVariable<int>("sv_filterRequestControlSettleTimer", ConVar_None, 30000, &g_requestControlSettleDelay);


### PR DESCRIPTION
### Goal of this PR
* This game event is sent when a client tries to change state values on a remotely owned entity.
* Allow to block this game event from being routed to target clients to prevent potential abusive uses.

### How is this PR achieving the goal
Introducing a new ConVar called 'sv_enableNetworkedScriptEntityStates' that allows blocking of the 'SCRIPT_ENTITY_STATE_CHANGE_EVENT' game event (routing is enabled by default).

### This PR applies to the following area(s)
FiveM, RedM, Server

### Successfully tested on
**Game builds:** 2699

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2553 


