### PR TITLE
fix(natives/rpc): Keep code fencing in doc summary

### DIFF
--- a/ext/natives/codegen.lua
+++ b/ext/natives/codegen.lua
@@ -500,7 +500,7 @@ function trim(s)
 	return s:gsub("^%s*(.-)%s*$", "%1")
 end
 
-function parseDocString(native)
+function parseDocString(native, keepCodeFencing)
 	local docString = native.doc
 
 	if not docString then
@@ -515,7 +515,9 @@ function parseDocString(native)
 		summary = ''
 	end
 
-	summary = trim(summary:gsub('^```(.+)```$', '%1'))
+	if not keepCodeFencing then
+		summary = trim(summary:gsub('^```(.+)```$', '%1'))
+	end
 
 	local paramsData = {}
 	local hasParams = false

--- a/ext/natives/codegen_out_markdown.lua
+++ b/ext/natives/codegen_out_markdown.lua
@@ -1,11 +1,10 @@
-
 local json = require('dkjson')
 
 
 local function printFunctionName(native)
-	return native.name:lower():gsub('0x', 'n_0x'):gsub('_(%a)', string.upper):gsub('(%a)(.+)', function(a, b)
-		return a:upper() .. b
-	end)
+    return native.name:lower():gsub('0x', 'n_0x'):gsub('_(%a)', string.upper):gsub('(%a)(.+)', function(a, b)
+        return a:upper() .. b
+    end)
 end
 
 local function printCName(native)
@@ -13,13 +12,13 @@ local function printCName(native)
 end
 
 local function printCType(t, v)
-	local s = t.name:gsub('Ptr', '*')
+    local s = t.name:gsub('Ptr', '*')
 
-	if v and v.pointer then
-		s = s .. '*'
-	end
+    if v and v.pointer then
+        s = s .. '*'
+    end
 
-	return s
+    return s
 end
 
 local keywords = {
@@ -194,7 +193,7 @@ local function printNative(native)
 
         str = str .. ');\n```\n\n'
 
-        local d = parseDocString(native)
+        local d = parseDocString(native, true)
 
         if d and d.summary then
             d.summary = d.summary:gsub('&gt;', '>'):gsub('&lt;', '<'):gsub('&amp;', '&')
@@ -213,7 +212,7 @@ local function printNative(native)
                         firstIndent = line:match("^%s+")
                     end
 
-                    line = line:gsub(firstIndent or '', '')--:gsub('^-+', '')
+                    line = line:gsub(firstIndent or '', '') --:gsub('^-+', '')
                     str = str .. line .. "  \n"
                 end
 
@@ -231,10 +230,10 @@ local function printNative(native)
 
         if d and d.hasParams then
             for _, v in ipairs(d.params) do
-			    args[v[1]] = v[2]
+                args[v[1]] = v[2]
             end
         end
-    
+
         if #native.arguments > 0 then
             str = str .. '## Parameters\n'
 


### PR DESCRIPTION
### Goal of this PR
Removing leading and trailing backticks from the native summary section breaks formatting if the summary only contains formatted code.

### How is this PR achieving the goal
Removal of the regex pattern matching for leading and trailing backticks in the doc string parse function when native md is being generated.

See issue https://github.com/citizenfx/natives/issues/1124 for a showcase of the mismatch between client and server native docs.

### This PR applies to the following area(s)
Natives

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes https://github.com/citizenfx/natives/issues/1124