### PR TITLE
fix(ros): update RGSC_GET_VERSION_INFO to pretend to be 2.3.2.5

### DIFF
--- a/code/components/ros-patches-five/src/LegitimacyNui.cpp
+++ b/code/components/ros-patches-five/src/LegitimacyNui.cpp
@@ -553,7 +553,7 @@ function RGSC_GET_TITLE_ID()
 function RGSC_GET_VERSION_INFO()
 {
 	return JSON.stringify({
-		Version: '2.1.6.5',
+		Version: '2.3.2.5',
 		TitleVersion: ''
 	});
 }


### PR DESCRIPTION
### Goal of this PR
I have encountered an issue where the client incorrectly thinks it is running version 2.1.6.5. Due to a new update that requires version 2.3.2.5, this discrepancy is causing compatibility problems and unexpected behavior in dependent systems.

### How is this PR achieving the goal
To address this issue, updating the `RGSC_GET_VERSION_INFO` function to return version 2.3.2.5, regardless of the actual version. This change will stop the client from thinking it's on version 2.1.6.5 and ensure compatibility with the new update.


### This PR applies to the following area(s)
FiveM, ROS

**Game builds:** Not applicable

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Didn't find any reports.


