### PR TITLE
Workaround for ped component expression mods limit in FiveM

### DIFF
--- a/code/components/gta-core-five/src/PatchPedCompExpressionsLimit.cpp
+++ b/code/components/gta-core-five/src/PatchPedCompExpressionsLimit.cpp
@@ -1,0 +1,24 @@
+#include <StdInc.h>
+#include <Hooking.h>
+
+//
+// This patch fixes a bug where 32-bit component indices were clamped to 8 bits in
+// ped component expression mods related functions. This issue is similar to the one
+// described in "PatchPedPropsLimit.cpp", mainly the "overflow" effect, but it only
+// affects ped component expression mods.
+//
+
+static HookFunction hookFunction([]()
+{
+	{
+		auto location = hook::get_pattern<char>("44 0F B6 F7 0F B6 7B 08 48 8B B0");
+		constexpr uint8_t payload[] = { 0x44, 0x8B, 0xF7, 0x90 }; // "mov r14d, edi" and "nop".
+		memcpy(location, payload, sizeof(payload)); // replace "movzx r14d, dil".
+	}
+
+	{
+		auto location = hook::get_pattern<char>("44 0F B6 FE 0F B6 77 08 8B D6 45");
+		constexpr uint8_t payload[] = { 0x44, 0x8B, 0xFE, 0x90 }; // "mov r15d, esi" and "nop".
+		memcpy(location, payload, sizeof(payload)); // replace "movzx r15d, sil".
+	}
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR aims to fix a bug where 32-bit component indices were clamped to 8 bits in ped component expression mods related functions, which was breaking expression mods on components with indices greater than 255.


### How is this PR achieving the goal

This goal is achieved by patching certain functions to prevent them from clamping component indices to 8 bits.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604, 2060, 2189, 2372, 2545, 2612, 2699, 2802, 2944, 3095 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

Addresses the problem reported in this forum topic:
https://forum.cfx.re/t/increase-255-limit-for-ped-heel-height/5229225
