### PR TITLE
fix(gamestate/server): Populate CGlobalFlagsDataNode on object create

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -128,7 +128,29 @@ struct CAutomobileCreationDataNode
 	}
 };
 
-struct CGlobalFlagsDataNode { };
+struct CGlobalFlagsDataNode
+{
+	uint32_t globalFlags;
+	uint32_t token;
+
+	bool Parse(SyncParseState& state)
+	{
+		globalFlags = state.buffer.Read<uint32_t>(8);
+		token = state.buffer.Read<uint32_t>(5);
+
+		return true;
+	}
+
+	bool Unparse(SyncUnparseState& state)
+	{
+		rl::MessageBuffer& buffer = state.buffer;
+
+		buffer.Write<uint32_t>(8, globalFlags);
+		buffer.Write<uint32_t>(5, token);
+
+		return true;
+	}
+};
 
 struct CDynamicEntityGameStateDataNode : GenericSerializeDataNode<CDynamicEntityGameStateDataNode>
 {

--- a/code/components/citizen-server-impl/src/state/ServerSetters.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerSetters.cpp
@@ -210,7 +210,7 @@ std::shared_ptr<sync::SyncTreeBase> MakeObject(uint32_t model, float posX, float
 		cdn.m_hasInitPhysics = dynamic;
 	});
 
-	SetupNode(tree, [resourceHash](sync::CObjectSectorPosNode& cdn)
+	SetupNode(tree, [](sync::CObjectSectorPosNode& cdn)
 	{
 		cdn.highRes = true;
 	});
@@ -223,6 +223,12 @@ std::shared_ptr<sync::SyncTreeBase> MakeObject(uint32_t model, float posX, float
 
 		glm::quat q = glm::quat(glm::vec3(0.0f, 0.0f, heading * 0.01745329252f));
 		node.data.quat.Load(q.x, q.y, q.z, q.w);
+	});
+
+	SetupNode(tree, [](sync::CGlobalFlagsDataNode& node)
+	{
+		node.globalFlags = 4;
+		node.token = 0;
 	});
 
 	SetupNode(tree, [resourceHash](sync::CEntityScriptInfoDataNode& cdn)


### PR DESCRIPTION
### Goal of this PR
Fixes a client-crash when calling physics-altering natives on an object that was created by `CreateObjectNoOffset` on the server-side.


### How is this PR achieving the goal
We now populate the `CGlobalFlagsDataNode` with the needed flag bits on object creation so the owning client doesn't crash when pushing node updates in the 'Update' method.


### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** 2060, 2699, 3095

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2583