### PR TITLE
feat(data): Increased PoolSizes `ROPE` 12 -> 32 & `ropeData` 8 -> 24

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -3131,7 +3131,7 @@
 						</Item>
 						<Item>
 							<ResourceTypeName>ROPE</ResourceTypeName>
-							<ExpectedMaximum value="12"/>
+							<ExpectedMaximum value="32"/>
 						</Item>
 						<Item>
 							<ResourceTypeName>CAMERA</ResourceTypeName>

--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -686,6 +686,10 @@
 							<PoolName>scrGlobals</PoolName>
 							<PoolSize value="15080000"/>
 						</Item>
+						<Item>
+							<PoolName>ropeData</PoolName>
+							<PoolSize value="24"/>
+						</Item>
 					</Entries>
 				</PoolSizes>
 


### PR DESCRIPTION
### Goal of this PR
When using ropes, we ran into some limitations and the poolSize might've been the cause. Also when using the `SetRopesCreateNetworkWorldState` native, we were receiving errors of the pool size being full. I couldn't find anything related to the `CNetworkRopeWorldStateData` pool and how it could be edited/increased, so thought it might be using the normal `ROPE` pool


### How is this PR achieving the goal
A simple pool size increase in `gameconfig.xml`. RDR has a size of 48, GTA originally had a size of 12 and I bumped it up to 32.

### This PR applies to the following area(s)
FiveM


### Successfully tested on
N/A

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->
Wasn't able to compile - didn't have the environment setup for it, but this change _shouldn't_ impact compilation anyways?
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.