### PR TITLE
fix(system-resources/chat): scroll to bottom and show chat on new message

### DIFF
--- a/ext/system-resources/resources/chat/html/App.ts
+++ b/ext/system-resources/resources/chat/html/App.ts
@@ -115,19 +115,22 @@ export default defineComponent({
     window.addEventListener("message", this.listener);
   },
   watch: {
-    messages() {
-      if (this.hideState !== ChatHideStates.AlwaysHide) {
-        if (this.showWindowTimer) {
-          clearTimeout(this.showWindowTimer);
+    messages: {
+      handler() {
+        if (this.hideState !== ChatHideStates.AlwaysHide) {
+          if (this.showWindowTimer) {
+            clearTimeout(this.showWindowTimer);
+          }
+          this.showWindow = true;
+          this.resetShowWindowTimer();
         }
-        this.showWindow = true;
-        this.resetShowWindowTimer();
-      }
 
-      const messagesObj = this.$refs.messages as HTMLDivElement;
-      this.$nextTick(() => {
-        messagesObj.scrollTop = messagesObj.scrollHeight;
-      });
+        const messagesObj = this.$refs.messages as HTMLDivElement;
+        this.$nextTick(() => {
+          messagesObj.scrollTop = messagesObj.scrollHeight;
+        });
+      },
+      deep: true
     }
   },
   computed: {


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Currently, when using the included system-resource chat, it does not update the scroll position of the chat window, nor does it unhide the chat window when new chat messages are received.


### How is this PR achieving the goal

With the change from Vue 2 to Vue 3, watchers were changed to be shallow, so they only react when a new value is assigned but won't trigger when changing a nested value. By setting the watcher to be a deep watcher again, the chat now scrolls automatically to the last message and shows up briefly when in 'when active' mode.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Server, system-resources: chat


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Server build:** 8823 

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


