### PR TITLE
fix(game/five): fixes a crash caused by colliding objects without a drawhandler

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.DrawHandler.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.DrawHandler.cpp
@@ -1,0 +1,45 @@
+#include <StdInc.h>
+
+#include <jitasm.h>
+#include <Hooking.h>
+
+static HookFunction hookFunction([]
+{
+	// Fixes a crash when an entity collides and has no drawhandler ( when invisible for e.g )
+
+	auto location = hook::get_pattern<uint8_t>("48 8B 58 ? EB ? 48 8B D9");
+
+	static struct : jitasm::Frontend
+	{
+		intptr_t location;
+		intptr_t retSuccess;
+		intptr_t retFail;
+
+		void Init(intptr_t location)
+		{
+			this->location = location;
+			this->retSuccess = location + 0x9;
+			this->retFail = location + 0x30;
+		}
+
+		void InternalMain() override
+		{
+			mov(rax, qword_ptr[rsi + 0x50]);	// rax = rsi + 0x50;
+			mov(rbx, qword_ptr[rax + 0x30]);	// creature = rax + 0x30;
+												//
+			test(rbx, rbx);						// if ( creature ) 
+			jz("fail");							// {
+												//
+			mov(rax, retSuccess);				//		[run original code]
+			jmp(rax);							//
+												//
+			L("fail");							//	}
+			mov(rax, retFail);					//
+			jmp(rax);							//
+		}
+	} patchStub;
+
+	patchStub.Init(reinterpret_cast<intptr_t>(location));
+	hook::nop(location, 6);
+	hook::jump(location, patchStub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR

When colliding, some objects may hit a codepath that expects a crCreature to be created and that requires the entity to have a valid drawhandler, which invisible objects might not/won't have.


### How is this PR achieving the goal

Checks for a valid crCreature before running some object collision logic.


### This PR applies to the following area(s)

FiveM


### Successfully tested on

**Game builds:** 2372, 3095.

**Platforms:** Windows.


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes uncle-oklahoma-king