### PR TITLE
feat(net): support dynamic server endpoints using handover

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -1192,7 +1192,7 @@ concurrency::task<void> NetLibrary::ConnectToServer(const std::string& rootUrl)
 					m_connectionState = CS_IDLE;
 					return true;
 				}
-				
+
 				auto rawEndpoints = (node.find("endpoints") != node.end()) ? node["endpoints"] : json{};
 
 				auto continueAfterEndpoints = [=, capNode = node](const json& capEndpointsJson)
@@ -1205,6 +1205,14 @@ concurrency::task<void> NetLibrary::ConnectToServer(const std::string& rootUrl)
 					{
 						// gather endpoints
 						std::vector<std::string> endpoints;
+
+						if (!node["handover"].is_null())
+						{
+							if (!node["handover"]["endpoints"].is_null())
+							{
+								endpointsJson = node["handover"]["endpoints"];
+							}
+						}
 
 						if (!endpointsJson.is_null() && !endpointsJson.is_boolean())
 						{


### PR DESCRIPTION
### Goal of this PR
Allow the server to pass a specific endpoint using deferrals to a specific player.

### How is this PR achieving the goal
- Fetching handover json data and overriding the server's endpoints if an endpoint value exists in handover

### This PR applies to the following area(s)
FiveM & RedM

### Successfully tested on
Tested passing a custom endpoint

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

Documentation about handover https://docs-backend.fivem.net/docs/scripting-manual/nui-development/loading-screens/

```lua
-- Server script
AddEventHandler('playerConnecting', function(_, _, deferrals)
    local source = source

    deferrals.handover({
        endpoints = { "127.0.0.1" }
    })
end)
```

