### PR TITLE
feat(netsync): serialize CVehicleCreationDataNode

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -14,7 +14,7 @@
 
 namespace fx::sync
 {
-struct CVehicleCreationDataNode
+struct CVehicleCreationDataNode : GenericSerializeDataNode<CVehicleCreationDataNode>
 {
 	uint32_t m_model;
 	ePopType m_popType;
@@ -25,67 +25,27 @@ struct CVehicleCreationDataNode
 	uint32_t m_creationToken;
 	bool m_needsToBeHotwired;
 	bool m_tyresDontBurst;
-	bool m_unk5;
+	bool m_usesSpecialFlightMode;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
 	{
-		uint32_t model = state.buffer.Read<uint32_t>(32);
-		m_model = model;
+		s.Serialize(32, m_model);
+		s.Serialize(4, (uint8_t&)m_popType);
 
-		uint8_t popType = state.buffer.Read<uint8_t>(4);
-		m_popType = (ePopType)popType;
-
-		m_randomSeed = state.buffer.Read<int>(16);
+		s.Serialize(16, m_randomSeed);
 
 		if (m_popType - 6 <= 1)
 		{
-			// false
-			m_carBudget = state.buffer.ReadBit();
+			s.Serialize(m_carBudget);
 		}
 
-		// 1000
-		m_maxHealth = state.buffer.Read<int>(19);
-
-		// 0
-		m_vehicleStatus = state.buffer.Read<int>(3);
-
-		// [timestamp]
-		m_creationToken = state.buffer.Read<uint32_t>(32);
-
-		// false, false, false
-		m_needsToBeHotwired = state.buffer.ReadBit();
-		m_tyresDontBurst = state.buffer.ReadBit();
-		m_unk5 = state.buffer.ReadBit();
-
-		return true;
-	}
-
-	bool Unparse(sync::SyncUnparseState& state)
-	{
-		auto& buffer = state.buffer;
-		buffer.Write<uint32_t>(32, m_model);
-		buffer.Write<uint8_t>(4, (uint8_t)m_popType);
-
-		buffer.Write<int>(16, m_randomSeed);
-
-		if (m_popType - 6 <= 1)
-		{
-			buffer.WriteBit(m_carBudget);
-		}
-
-		// 1000
-		buffer.Write<int>(19, m_maxHealth);
-
-		// 0
-		buffer.Write<int>(3, m_vehicleStatus);
-
-		// [timestamp]
-		buffer.Write<uint32_t>(32, m_creationToken);
-
-		// false, false, false
-		buffer.WriteBit(m_needsToBeHotwired);
-		buffer.WriteBit(m_tyresDontBurst);
-		buffer.WriteBit(m_unk5);
+		s.Serialize(19, m_maxHealth);
+		s.Serialize(3, m_vehicleStatus);
+		s.Serialize(32, m_creationToken);
+		s.Serialize(m_needsToBeHotwired);
+		s.Serialize(m_tyresDontBurst);
+		s.Serialize(m_usesSpecialFlightMode);
 
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/state/ServerSetters.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerSetters.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<sync::SyncTreeBase> MakeAutomobile(uint32_t model, float posX, f
 		cdn.m_randomSeed = rand();
 		cdn.m_tyresDontBurst = false;
 		cdn.m_vehicleStatus = 2;
-		cdn.m_unk5 = false;
+		cdn.m_usesSpecialFlightMode = false;
 	});
 
 	SetupNode(tree, [](sync::CAutomobileCreationDataNode& cdn)
@@ -131,7 +131,7 @@ std::shared_ptr<sync::SyncTreeBase> MakeVehicle(uint32_t model, float posX, floa
 		cdn.m_randomSeed = rand();
 		cdn.m_tyresDontBurst = false;
 		cdn.m_vehicleStatus = 2;
-		cdn.m_unk5 = false;
+		cdn.m_usesSpecialFlightMode = false;
 	});
 
 	if constexpr (std::is_same_v<TTree, sync::CAutomobileSyncTree> ||


### PR DESCRIPTION
### Goal of this PR
* Serialize CVehicleCreationDataNode

### How is this PR achieving the goal
* Serialize CVehicleCreationDataNode instead of Parsing/Unparsing and checking this data node was complete (was checked on the 3258 dump)
* m_unk5 was usesSpecialFlightMode (when the vehicle is a plane and use the special flight mode)



### This PR applies to the following area(s)
FXServer


### Successfully tested on
Was tested on 2944 & 3095 by creating a vehicle server-side (and checking if the vehicle was created successfully)

Here is the code i used to do the test
```lua
RegisterCommand("test", function(source)
    local player = GetPlayerPed(source)
    local coords = GetEntityCoords(player)

    local veh = CreateVehicleServerSetter(`shamal`, "plane", coords.x, coords.y, coords.z, 0)
    print(DoesEntityExist(veh)) -- return true
end, false)
```

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

