### PR TITLE
Improve Lua error handling

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -476,7 +476,7 @@ local function doStackFormat(err)
 		return nil
 	end
 
-	return '^1SCRIPT ERROR: ' .. err .. "^7\n" .. fst
+	return string.format('^1SCRIPT ERROR: %s^7\n%s', err or '', fst)
 end
 
 Citizen.SetCallRefRoutine(function(refId, argsSerialized)


### PR DESCRIPTION
### Goal of this PR
- Respect the `__tostring` metamethod on tables when outputting an error message.
- Prevent errors when no value is passed to the `error` function.

### How is this PR achieving the goal

Magic.

### This PR applies to the following area(s)
- ScRT: Lua

### Successfully tested on
**Platforms:** Window

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Resolves #2359.


