### PR TITLE
fix(ui-build): Fix for `Cannot read properties of null (reading 'focus')`

### DIFF
--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -105,7 +105,7 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		frameEscapeFunctions[frameName] = () => {
 			setTimeout(() => {
 				if (document.activeElement == document.body) {
-					frame.contentWindow.focus();
+					frame?.contentWindow?.focus();
 				}
 			}, 32);
 		}

--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -105,6 +105,7 @@ registerFrameFunction(function(msg, frameName, frameUrl)
 		frameEscapeFunctions[frameName] = () => {
 			setTimeout(() => {
 				if (document.activeElement == document.body) {
+					// Added questions marks to avoid throwing error while something is null
 					frame?.contentWindow?.focus();
 				}
 			}, 32);


### PR DESCRIPTION
### Goal of this PR
When NUI is initializing in nui console you always see:
```
Uncaught TypeError: Cannot read properties of null (reading 'focus')
    at root.html:108:26
(anonymous) @ root.html:108
setTimeout (async)
frameEscapeFunctions.<computed> @ root.html:106
```
This error is regarding to line: `frame.contentWindow.focus();` and i'm just added question marks to avoid displaying this error.


### How is this PR achieving the goal
As above I'm just added question marks, so when frame or frame.contentWindow is null nothing happen.


### This PR applies to the following area(s)
ui-build

