### PR TITLE
fix(voip/mumble): Only clear voice target channels if mumble is conne…

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -1069,9 +1069,9 @@ static HookFunction hookFunction([]()
 							return target.users.size() > 0 && std::find(target.users.begin(), target.users.end(), targetName) != target.users.end();
 						});
 					}
-				}
 
-				g_mumbleClient->UpdateVoiceTarget(id, vtConfigs[id]);
+					g_mumbleClient->UpdateVoiceTarget(id, vtConfigs[id]);
+				}
 			}
 		});
 


### PR DESCRIPTION
…cted

This is the same behavior as all other target natives

Really small change, seems to be an oversight, not sure if this causd

### Goal of this PR
This makes the behavior of all the voice target natives the same. This is the only native which calls UpdateVoiceTarget when not connected.


### How is this PR achieving the goal

By not Updating the voice targets if mumble is not connected.


### This PR applies to the following area(s)
FiveM & RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 9073

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
None


