### PR TITLE
fix(clcore): Adjust "==" and "!=" operators to fix null reference exceptions

### DIFF
--- a/code/client/clrcore/External/Game.cs
+++ b/code/client/clrcore/External/Game.cs
@@ -1025,7 +1025,7 @@ namespace CitizenFX.Core
 
 			public static bool operator ==(WeaponHudStats left, WeaponHudStats right)
 			{
-				return left.Equals(right);
+				return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 			}
 
 			public static bool operator !=(WeaponHudStats left, WeaponHudStats right)
@@ -1101,7 +1101,7 @@ namespace CitizenFX.Core
 
 			public static bool operator ==(WeaponComponentHudStats left, WeaponComponentHudStats right)
 			{
-				return left.Equals(right);
+				return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 			}
 
 			public static bool operator !=(WeaponComponentHudStats left, WeaponComponentHudStats right)

--- a/code/client/clrcore/External/Model.cs
+++ b/code/client/clrcore/External/Model.cs
@@ -429,11 +429,11 @@ namespace CitizenFX.Core
 
 		public static bool operator ==(Model left, Model right)
 		{
-			return left.Equals(right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 		}
 		public static bool operator !=(Model left, Model right)
 		{
-			return !left.Equals(right);
+			return !(left==right);
 		}
 	}
 }

--- a/code/client/clrcore/External/RelationshipGroup.cs
+++ b/code/client/clrcore/External/RelationshipGroup.cs
@@ -109,7 +109,7 @@ namespace CitizenFX.Core
 
 		public static bool operator ==(RelationshipGroup left, RelationshipGroup right)
 		{
-			return left.Equals(right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 		}
 		public static bool operator !=(RelationshipGroup left, RelationshipGroup right)
 		{

--- a/code/client/clrcore/External/WeaponAsset.cs
+++ b/code/client/clrcore/External/WeaponAsset.cs
@@ -125,11 +125,11 @@ namespace CitizenFX.Core
 
 		public static bool operator ==(WeaponAsset left, WeaponAsset right)
 		{
-			return left.Equals(right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(right);
 		}
 		public static bool operator !=(WeaponAsset left, WeaponAsset right)
 		{
-			return !left.Equals(right);
+			return !(left==right);
 		}
 	}
 }

--- a/code/client/clrcore/Math/Matrix.cs
+++ b/code/client/clrcore/Math/Matrix.cs
@@ -3091,7 +3091,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator ==(Matrix left, Matrix right)
         {
-            return left.Equals(ref right);
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
         }
 
         /// <summary>
@@ -3102,7 +3102,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator !=(Matrix left, Matrix right)
         {
-            return !left.Equals(ref right);
+            return !(left==right);
         }
 
         /// <summary>

--- a/code/client/clrcore/Math/Matrix3x3.cs
+++ b/code/client/clrcore/Math/Matrix3x3.cs
@@ -1951,7 +1951,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator ==(Matrix3x3 left, Matrix3x3 right)
         {
-            return left.Equals(ref right);
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
         }
 
         /// <summary>
@@ -1962,7 +1962,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator !=(Matrix3x3 left, Matrix3x3 right)
         {
-            return !left.Equals(ref right);
+            return !(left==right);
         }
         
         /// <summary>

--- a/code/client/clrcore/Math/Quaternion.cs
+++ b/code/client/clrcore/Math/Quaternion.cs
@@ -1294,7 +1294,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator ==(Quaternion left, Quaternion right)
         {
-            return left.Equals(ref right);
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
         }
 
         /// <summary>
@@ -1305,7 +1305,7 @@ namespace CitizenFX.Core
         /// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
         public static bool operator !=(Quaternion left, Quaternion right)
         {
-            return !left.Equals(ref right);
+            return !(left==right);
         }
 
         /// <summary>

--- a/code/client/clrcore/Math/Vector2.cs
+++ b/code/client/clrcore/Math/Vector2.cs
@@ -1384,7 +1384,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator ==(Vector2 left, Vector2 right)
 		{
-			return left.Equals(ref right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
 		}
 
 		/// <summary>
@@ -1395,7 +1395,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator !=(Vector2 left, Vector2 right)
 		{
-			return !left.Equals(ref right);
+			return !(left==right);
 		}
 
 		/// <summary>

--- a/code/client/clrcore/Math/Vector3.cs
+++ b/code/client/clrcore/Math/Vector3.cs
@@ -1652,7 +1652,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator ==(Vector3 left, Vector3 right)
 		{
-			return left.Equals(ref right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
 		}
 
 		/// <summary>
@@ -1663,7 +1663,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator !=(Vector3 left, Vector3 right)
 		{
-			return !left.Equals(ref right);
+			return !(left==right);
 		}
 
 		/// <summary>

--- a/code/client/clrcore/Math/Vector4.cs
+++ b/code/client/clrcore/Math/Vector4.cs
@@ -1292,7 +1292,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator ==(Vector4 left, Vector4 right)
 		{
-			return left.Equals(ref right);
+			return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.Equals(ref right);
 		}
 
 		/// <summary>
@@ -1303,7 +1303,7 @@ namespace CitizenFX.Core
 		/// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
 		public static bool operator !=(Vector4 left, Vector4 right)
 		{
-			return !left.Equals(ref right);
+			return !(left==right);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix potential null reference exceptions in clcore.

### How is this PR achieving the goal

Instead of using ``left.Equals(right)`` where left could be null, leading to a null reference exception, we check both left and right for being null before.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM, Client, ScRT: C#

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

fixes #1312 
