### PR TITLE
feat(voip/mumble): Add MUMBLE_DOES_CHANNEL_EXIST native

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -1151,6 +1151,20 @@ static HookFunction hookFunction([]()
 			}
 		});
 
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_DOES_CHANNEL_EXIST", [](fx::ScriptContext& context) {
+			auto channel = context.GetArgument<int>(0);
+
+			if (g_mumble.connected)
+			{
+				auto channelName = fmt::sprintf("Game Channel %d", channel);
+				context.SetResult<bool>(g_mumbleClient->DoesChannelExist(channelName));
+			}
+			else
+			{
+				context.SetResult<bool>(false);
+			}
+		});
+
 		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_ADD_VOICE_TARGET_PLAYER", [](fx::ScriptContext& context)
 		{
 			auto id = context.GetArgument<int>(0);

--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -121,6 +121,8 @@ public:
 
 	virtual void RemoveListenChannel(const std::string& channelName) = 0;
 
+	virtual bool DoesChannelExist(const std::string& channelName) = 0;
+
 	virtual std::shared_ptr<lab::AudioContext> GetAudioContext(const std::string& name) = 0;
 
 	// settings

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -104,6 +104,8 @@ public:
 
 	virtual void RemoveListenChannel(const std::string& channelName) override;
 
+	virtual bool DoesChannelExist(const std::string& channelName) override;
+
 	virtual std::shared_ptr<lab::AudioContext> GetAudioContext(const std::string& name) override;
 
 	virtual void SetClientVolumeOverride(const std::wstring& clientName, float volume) override;

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -349,9 +349,10 @@ void MumbleClient::Initialize()
 
 							if (!t.channel.empty())
 							{
+								std::wstring wname = ToWide(t.channel);
 								for (auto& channelPair : m_state.GetChannels())
 								{
-									if (channelPair.second.GetName() == ToWide(t.channel))
+									if (channelPair.second.GetName() == wname)
 									{
 										vt->set_channel_id(channelPair.first);
 									}
@@ -688,6 +689,21 @@ std::string MumbleClient::GetVoiceChannelFromServerId(uint32_t serverId)
 	});
 
 	return retString;
+}
+
+bool MumbleClient::DoesChannelExist(const std::string& channelName)
+{
+	std::wstring wname = ToWide(channelName);
+
+	for (const auto& channel : m_state.GetChannels())
+	{
+		if (channel.second.GetName() == wname)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void MumbleClient::GetTalkers(std::vector<std::string>* referenceIds)

--- a/code/components/voip-mumble/src/MumbleClientState_Channel.cpp
+++ b/code/components/voip-mumble/src/MumbleClientState_Channel.cpp
@@ -62,8 +62,7 @@ void MumbleClientState::ProcessChannelState(MumbleProto::ChannelState& channelSt
 		if (channelIt == m_channels.end())
 		{
 			auto channel = MumbleChannel(m_client, channelState);
-
-			m_channels.insert(std::make_pair(id, channel));
+			m_channels.emplace(id, channel);
 
 			auto name = channel.GetName();
 

--- a/ext/native-decls/MumbleDoesChannelExist.md
+++ b/ext/native-decls/MumbleDoesChannelExist.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## MUMBLE_DOES_CHANNEL_EXIST
+
+```c
+void MUMBLE_DOES_CHANNEL_EXIST(int channel);
+```
+
+Check whether specified channel exists on the Mumble server.
+
+## Parameters
+* **channel**: A game voice channel ID.

--- a/ext/native-decls/MumbleDoesChannelExist.md
+++ b/ext/native-decls/MumbleDoesChannelExist.md
@@ -5,10 +5,13 @@ apiset: client
 ## MUMBLE_DOES_CHANNEL_EXIST
 
 ```c
-void MUMBLE_DOES_CHANNEL_EXIST(int channel);
+BOOL MUMBLE_DOES_CHANNEL_EXIST(int channel);
 ```
 
 Check whether specified channel exists on the Mumble server.
 
 ## Parameters
 * **channel**: A game voice channel ID.
+
+## Return value
+True if the specific channel exists. False otherwise.


### PR DESCRIPTION
### Goal of this PR
To add the ability to check if channels exist, which is usefull to avoid issue #2677

Additionally changed the insert call for channels to emplace (same way as done in users) and cache the widened channel name before a for loop where this was not done yet.


### How is this PR achieving the goal

It adds the native `MUMBLE_DOES_CHANNEL_EXIST` which allows scripts to check if a mumble channel exists before executing a native on said channel ensuring that the native actually has effect.

### This PR applies to the following area(s)
FiveM & RedM (voip/mumble)

### Successfully tested on

**Game builds:** 9073

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2677 


