### PR TITLE
Improved RequestTick

### DIFF
--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -87,14 +87,11 @@ namespace CitizenFX.Core
 			ulong prevTime = (ulong)Interlocked.Read(ref s_sharedData->m_scheduledTimeAsLong);
 			while (time < prevTime)
 		    {
-		        // Attempt to update the scheduled time
 		        ulong updatedTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
-
-		        // If the exchange was successful, exit the loop
+		  
 		        if (updatedTime == prevTime)
 		            return;
 
-		        // Update prevTime for the next iteration
 		        prevTime = updatedTime;
 		    }
 		}

--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -86,9 +86,17 @@ namespace CitizenFX.Core
 		{			
 			ulong prevTime = (ulong)Interlocked.Read(ref s_sharedData->m_scheduledTimeAsLong);
 			while (time < prevTime)
-			{
-				prevTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
-			}
+		    {
+		        // Attempt to update the scheduled time
+		        ulong updatedTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
+
+		        // If the exchange was successful, exit the loop
+		        if (updatedTime == prevTime)
+		            return;
+
+		        // Update prevTime for the next iteration
+		        prevTime = updatedTime;
+		    }
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Avoids unnecessary iterations and reduces the chance of potential infinite loops in high contention scenarios with the RequestTick method.

### How is this PR achieving the goal

Problems:

Redundant CompareExchange: In the original method the CompareExchange operation updates prevTime regardless of whether the exchange was successful or not. This can lead to unnecessary iterations if prevTime is not successfully updated.

Potential Infinite Loop: If CompareExchange continually fails due to high contention, the loop could potentially run indefinitely, although unlikely in most practical scenarios.

Fix:

The check 'if (updatedTime == prevTime)' ensures that the loop exits immediately after a successful CompareExchange, avoiding unnecessary iterations and can prevent potential infinite loops in high contention scenarios.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, clrcore-v2


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

Improvement may fix any potential problems.
