### PR TITLE
tweak(clrcore-v2): Attempted to maximize coroutine scheduler performance.

### DIFF
--- a/code/client/clrcore-v2/Coroutine/BinaryHeap.cs
+++ b/code/client/clrcore-v2/Coroutine/BinaryHeap.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+
+namespace CitizenFX.Core
+{
+    public class BinaryHeap<T> where T : IComparable<T>
+    {
+        private T[] heap;
+        private int count;
+
+        public BinaryHeap(int capacity = 16)
+        {
+            heap = new T[capacity];
+        }
+
+        public int Count => count;
+
+        public void Enqueue(T item)
+        {
+            if (count == heap.Length)
+            {
+                Resize(2 * heap.Length);
+            }
+
+            heap[count] = item;
+            HeapifyUp(count);
+            count++;
+        }
+
+        public T Dequeue()
+        {
+            if (count == 0)
+            {
+                throw new InvalidOperationException("Heap is empty");
+            }
+
+            T item = heap[0];
+            heap[0] = heap[count - 1];
+            count--;
+            HeapifyDown(0);
+
+            if (count < heap.Length / 4)
+            {
+                Resize(heap.Length / 2);
+            }
+
+            return item;
+        }
+
+        public T Peek()
+        {
+            if (count == 0)
+            {
+                throw new InvalidOperationException("Heap is empty");
+            }
+
+            return heap[0];
+        }
+
+        private void HeapifyUp(int index)
+        {
+            while (index > 0)
+            {
+                int parentIndex = (index - 1) / 2;
+                if (heap[parentIndex].CompareTo(heap[index]) <= 0)
+                {
+                    break;
+                }
+
+                Swap(parentIndex, index);
+                index = parentIndex;
+            }
+        }
+
+        private void HeapifyDown(int index)
+        {
+            while (true)
+            {
+                int leftChildIndex = 2 * index + 1;
+                int rightChildIndex = 2 * index + 2;
+                int smallest = index;
+
+                if (leftChildIndex < count && heap[leftChildIndex].CompareTo(heap[smallest]) < 0)
+                {
+                    smallest = leftChildIndex;
+                }
+
+                if (rightChildIndex < count && heap[rightChildIndex].CompareTo(heap[smallest]) < 0)
+                {
+                    smallest = rightChildIndex;
+                }
+
+                if (smallest == index)
+                {
+                    break;
+                }
+
+                Swap(smallest, index);
+                index = smallest;
+            }
+        }
+
+        private void Swap(int i, int j)
+        {
+            T temp = heap[i];
+            heap[i] = heap[j];
+            heap[j] = temp;
+        }
+
+        private void Resize(int capacity)
+        {
+            T[] newHeap = new T[capacity];
+            Array.Copy(heap, newHeap, count);
+            heap = newHeap;
+        }
+    }
+}

--- a/code/client/clrcore-v2/Coroutine/Coroutine.cs
+++ b/code/client/clrcore-v2/Coroutine/Coroutine.cs
@@ -153,7 +153,7 @@ namespace CitizenFX.Core
 	}
 
 	[AsyncMethodBuilder(typeof(CoroutineBuilder))]
-	public partial class Coroutine
+	public partial class Coroutine : IComparable<Coroutine>
 	{
 		public enum State : uint
 		{
@@ -262,6 +262,11 @@ namespace CitizenFX.Core
 		}
 
 		public CoroutineAwaiter GetAwaiter() => new CoroutineAwaiter(this);
+
+		public int CompareTo(Coroutine other)
+		{
+		    return Time.CompareTo(other.Time);
+		}
 	}
 
 	public interface ICoroutineAwaiter {}

--- a/code/client/clrcore-v2/Coroutine/HashedBinaryHeap.cs
+++ b/code/client/clrcore-v2/Coroutine/HashedBinaryHeap.cs
@@ -7,11 +7,17 @@ namespace CitizenFX.Core
     {
         private BinaryHeap<Coroutine> heap;
         private Dictionary<Coroutine, int> indices;
+        private int initialCapacity;
+        private int maxCapacity;
+        private int minCapacity;
 
         public HashedBinaryHeap(int capacity)
         {
-            heap = new BinaryHeap<Coroutine>(capacity);
-            indices = new Dictionary<Coroutine, int>(capacity);
+            initialCapacity = capacity;
+            maxCapacity = 1024;
+            minCapacity = 16;
+            heap = new BinaryHeap<Coroutine>(initialCapacity);
+            indices = new Dictionary<Coroutine, int>(initialCapacity);
         }
 
         public int Count => heap.Count;
@@ -20,12 +26,14 @@ namespace CitizenFX.Core
         {
             heap.Enqueue(coroutine);
             indices[coroutine] = heap.Count - 1;
+            ResizeHeap();
         }
 
         public Coroutine Dequeue()
         {
             Coroutine coroutine = heap.Dequeue();
             indices.Remove(coroutine);
+            ResizeHeap();
             return coroutine;
         }
 
@@ -35,12 +43,40 @@ namespace CitizenFX.Core
             {
                 heap.Dequeue();
                 indices.Remove(coroutine);
+                ResizeHeap();
             }
         }
 
         public Coroutine Peek()
         {
             return heap.Peek();
+        }
+
+        private void ResizeHeap()
+        {
+            int currentCount = heap.Count;
+            int capacity = heap.Capacity;
+
+            if (currentCount > capacity * 0.75)
+            {
+                int newCapacity = Math.Min(maxCapacity, capacity * 2);
+                BinaryHeap<Coroutine> newHeap = new BinaryHeap<Coroutine>(newCapacity);
+                foreach (Coroutine coroutine in heap)
+                {
+                    newHeap.Enqueue(coroutine);
+                }
+                heap = newHeap;
+            }
+            else if (currentCount < capacity * 0.25)
+            {
+                int newCapacity = Math.Max(minCapacity, capacity / 2);
+                BinaryHeap<Coroutine> newHeap = new BinaryHeap<Coroutine>(newCapacity);
+                foreach (Coroutine coroutine in heap)
+                {
+                    newHeap.Enqueue(coroutine);
+                }
+                heap = newHeap;
+            }
         }
     }
 }

--- a/code/client/clrcore-v2/Coroutine/HashedBinaryHeap.cs
+++ b/code/client/clrcore-v2/Coroutine/HashedBinaryHeap.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace CitizenFX.Core
+{
+    public class HashedBinaryHeap
+    {
+        private BinaryHeap<Coroutine> heap;
+        private Dictionary<Coroutine, int> indices;
+
+        public HashedBinaryHeap(int capacity)
+        {
+            heap = new BinaryHeap<Coroutine>(capacity);
+            indices = new Dictionary<Coroutine, int>(capacity);
+        }
+
+        public int Count => heap.Count;
+
+        public void Enqueue(Coroutine coroutine)
+        {
+            heap.Enqueue(coroutine);
+            indices[coroutine] = heap.Count - 1;
+        }
+
+        public Coroutine Dequeue()
+        {
+            Coroutine coroutine = heap.Dequeue();
+            indices.Remove(coroutine);
+            return coroutine;
+        }
+
+        public void Remove(Coroutine coroutine)
+        {
+            if (indices.TryGetValue(coroutine, out int index))
+            {
+                heap.Dequeue();
+                indices.Remove(coroutine);
+            }
+        }
+
+        public Coroutine Peek()
+        {
+            return heap.Peek();
+        }
+    }
+}

--- a/code/client/clrcore-v2/Coroutine/Scheduler.cs
+++ b/code/client/clrcore-v2/Coroutine/Scheduler.cs
@@ -1,212 +1,132 @@
 using System;
-using System.Threading;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CitizenFX.Core
 {
-	public class Scheduler
-	{
-		/// <summary>
-		/// Current time of this scheduler
-		/// </summary>
-		public static TimePoint CurrentTime { get; internal set; }
+    public class Scheduler
+    {
+        private HashedBinaryHeap coroutineHeap;
+        private readonly object lockObject = new object();
+        private TimePoint currentTime;
+        private bool isRunning;
+        private Thread mainThread;
+        private ThreadPool threadPool;
+        private int threadPoolSize;
 
-		/// <summary>
-		/// Thread onto which all coroutines will run and be put back to
-		/// </summary>
-		internal static Thread MainThread { get; private set; }
+        public Scheduler(int initialCapacity = 16)
+        {
+            coroutineHeap = new HashedBinaryHeap(initialCapacity);
+            currentTime = new TimePoint(0);
+            mainThread = Thread.CurrentThread;
+            threadPoolSize = Environment.ProcessorCount;
+            threadPool = new ThreadPool(threadPoolSize);
+        }
 
-		/// <summary>
-		/// Current time of the scheduler, set per frame.
-		/// </summary>
-		private static readonly LinkedList<Tuple<ulong, Action>> s_queue = new LinkedList<Tuple<ulong, Action>>();
+        public void Schedule(Coroutine coroutine)
+        {
+            lock (lockObject)
+            {
+                coroutineHeap.Enqueue(coroutine);
+            }
+        }
 
-		/// <summary>
-		/// Double buffered array for non-ordered scheduling
-		/// </summary>
-		private static List<Action> s_nextFrame = new List<Action>();
-		private static List<Action> s_nextFrameProcessing = new List<Action>();
+        public void Unschedule(Coroutine coroutine)
+        {
+            lock (lockObject)
+            {
+                coroutineHeap.Remove(coroutine);
+            }
+        }
 
-		internal static void Initialize()
-		{
-			MainThread = Thread.CurrentThread;
-		}
+        public void Run()
+        {
+            isRunning = true;
 
-		/// <summary>
-		/// Schedule an action to be run on the next frame
-		/// </summary>
-		/// <param name="coroutine">Action to execute</param>
-		public static void Schedule(Action coroutine)
-		{
-			if (coroutine != null)
-			{
-				lock (s_nextFrame)
-				{
-					s_nextFrame.Add(coroutine);
-					ScriptInterface.RequestTickNextFrame();
-				}
-			}
-			else
-				throw new ArgumentNullException(nameof(coroutine));
-		}
+            while (isRunning)
+            {
+                TimePoint nextTime = GetNextTime();
 
-		/// <summary>
-		/// Schedule an action to be run at the first frame at or after the specified time
-		/// </summary>
-		/// <param name="coroutine">Action to execute</param>
-		/// <param name="delay">Time when it should be executed, see <see cref="CurrentTime"/></param>
-		public static void Schedule(Action coroutine, ulong delay) => Schedule(coroutine, CurrentTime + delay);
+                if (nextTime != null)
+                {
+                    currentTime = nextTime;
 
-		/// <summary>
-		/// Schedule an action to be run at the first frame at or after the specified time
-		/// </summary>
-		/// <param name="coroutine">Action to execute</param>
-		/// <param name="time">Time when it should be executed, see <see cref="CurrentTime"/></param>
-		public static void Schedule(Action coroutine, TimePoint time)
-		{
-			if (time <= CurrentTime) // e.g.: Coroutine.Wait(0u) or Coroutine.Delay(0u)
-			{
-				Schedule(coroutine);
-			}
-			else if (coroutine != null)
-			{
-				lock (s_queue)
-				{
-					// linear ordered insert, performance improvement might be a binary tree (i.e.: priority queue)
-					var it = s_queue.First;
-					if (it != null)
-					{
-						// if added to the front, we'll also need to request for a tick/call-in
-						if (time < it.Value.Item1)
-						{
-							s_queue.AddFirst(new Tuple<ulong, Action>(time, coroutine));
-							ScriptInterface.RequestTick(time);
+                    List<Coroutine> coroutinesToRun = GetCoroutinesToRun();
 
-							return;
-						}
+                    AdjustThreadPoolSize();
 
-						// check next
-						for (it = it.Next; it != null; it = it.Next)
-						{
-							if (time < it.Value.Item1)
-							{
-								s_queue.AddBefore(it, new Tuple<ulong, Action>(time, coroutine));
-								return;
-							}
-						}
-					}
-					else
-						ScriptInterface.RequestTick(time); // no tasks were scheduled, so this needs to request a call-in
+                    foreach (Coroutine coroutine in coroutinesToRun)
+                    {
+                        if (coroutine.CancelToken.CancelOrThrowIfRequested())
+                        {
+                            // Handle cancellation
+                            Unschedule(coroutine);
+                            // Perform any necessary cleanup
+                            continue;
+                        }
 
-					s_queue.AddLast(new Tuple<ulong, Action>(time, coroutine));
-				}
-			}
-			else
-				throw new ArgumentNullException(nameof(coroutine));
-		}
+                        threadPool.QueueUserWorkItem(RunCoroutine, coroutine);
+                    }
+                }
+                else
+                {
+                    isRunning = false;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Removes scheduled coroutine from the scheduler (except for the next frame list)
-		/// </summary>
-		/// <param name="coroutine">Coroutine to remove</param>
-		/// <param name="time">Max scheduled time we consider searching to</param>
-		/// <exception cref="ArgumentNullException"></exception>
-		internal static void Unschedule(Action coroutine, TimePoint time)
-		{
-			if (time > CurrentTime) // e.g.: Coroutine.Wait(0u) or Coroutine.Delay(0u)
-			{
-				lock (s_queue)
-				{
-					for (var it = s_queue.First; it != null; it = it.Next)
-					{
-						if (it.Value.Item1 > time)
-						{
-							return; // list is ordered so we'll not find it after this scheduled item
-						}
-						else if (it.Value.Item2 == coroutine)
-						{
-							s_queue.Remove(it);
-							return;
-						}
-					}
-				}
-			}
-			else
-				throw new ArgumentNullException(nameof(coroutine));
-		}
+        private TimePoint GetNextTime()
+        {
+            lock (lockObject)
+            {
+                if (coroutineHeap.Count > 0)
+                {
+                    return coroutineHeap.Peek().Time;
+                }
+                else
+                {
+                    return new TimePoint(0); // Return a default TimePoint
+                }
+            }
+        }
 
-		/// <summary>
-		/// Execute all scheduled coroutines
-		/// </summary>
-		internal static void Update()
-		{
-			ulong timeNow = CurrentTime;
+        private List<Coroutine> GetCoroutinesToRun()
+        {
+            lock (lockObject)
+            {
+                List<Coroutine> coroutinesToRun = new List<Coroutine>();
 
-			// all next frame coroutines
-			{
-				s_nextFrameProcessing = Interlocked.Exchange(ref s_nextFrame, s_nextFrameProcessing);
+                while (coroutineHeap.Count > 0 && coroutineHeap.Peek().Time.m_time <= currentTime.m_time)
+                {
+                    Coroutine coroutine = coroutineHeap.Dequeue();
+                    coroutinesToRun.Add(coroutine);
+                }
 
-				for (int i = 0; i < s_nextFrameProcessing.Count; i++)
-				{
-					try
-					{
-						s_nextFrameProcessing[i]();
-					}
-					catch (Exception ex)
-					{
-						Debug.WriteLine(ex.ToString());
-					}
-				}
+                return coroutinesToRun;
+            }
+        }
 
-				s_nextFrameProcessing.Clear();
-			}
+        private void RunCoroutine(object state)
+        {
+            Coroutine coroutine = (Coroutine)state;
+            coroutine.GetAwaiter().GetResult();
+        }
 
-			lock (s_queue)
-			{
-				// scheduled coroutines (ordered)
-				for (var it = s_queue.First; it != null;)
-				{
-					var current = it.Value;
+        private void AdjustThreadPoolSize()
+        {
+            int currentCount = coroutineHeap.Count;
+            int currentThreadPoolSize = threadPool.GetMaxThreads();
 
-					if (current.Item1 <= timeNow)
-					{
-						s_queue.Remove(it); // make sure we remove this one before any subsequent scheduling can happen
-						it = s_queue.First; // next is now over here, making use of the CPU cached results to keep performance
-
-						try
-						{
-							current.Item2();
-						}
-						catch (Exception ex)
-						{
-							Debug.WriteLine(ex.ToString());
-						}
-					}
-					else
-					{
-						ScriptInterface.RequestTick(current.Item1);
-						return;
-					}
-				}
-			}
-		}
-
-		/// <summary>
-		/// Time in milliseconds when the next action needs to be activated
-		/// </summary>
-		/// <returns>Delay in milliseconds or ~0ul (<see cref="ulong.MaxValue"/>) if there's nothing to run</returns>
-		internal static ulong NextTaskTime()
-		{
-			if (s_nextFrame.Count != 0)
-			{
-				return CurrentTime;
-			}
-			else if (s_queue.Count != 0)
-			{
-				return s_queue.First.Value.Item1;
-			}
-			
-			return ulong.MaxValue;
-		}
-	}
+            if (currentCount > currentThreadPoolSize * 0.75)
+            {
+                int newThreadPoolSize = Math.Min(Environment.ProcessorCount * 2, currentThreadPoolSize * 2);
+                threadPool = new ThreadPool(newThreadPoolSize);
+            }
+            else if (currentCount < currentThreadPoolSize * 0.25)
+            {
+                int newThreadPoolSize = Math.Max(Environment.ProcessorCount, currentThreadPoolSize / 2);
+                threadPool = new ThreadPool(newThreadPoolSize);
+            }
+        }
+    }
 }

--- a/code/client/clrcore-v2/Coroutine/ThreadPool.cs
+++ b/code/client/clrcore-v2/Coroutine/ThreadPool.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+
+namespace CitizenFX.Core
+{
+    public class ThreadPool
+    {
+        private readonly SemaphoreSlim semaphore;
+        private readonly int maxThreads;
+        private readonly Thread[] threads;
+
+        public ThreadPool(int maxThreads)
+        {
+            this.maxThreads = maxThreads;
+            semaphore = new SemaphoreSlim(maxThreads, maxThreads);
+            threads = new Thread[maxThreads];
+
+            for (int i = 0; i < maxThreads; i++)
+            {
+                threads[i] = new Thread(ThreadProc);
+                threads[i].Start();
+            }
+        }
+
+        public void QueueUserWorkItem(WaitCallback callback, object state)
+        {
+            semaphore.Wait();
+
+            Thread thread = GetAvailableThread();
+            thread.Start(new ThreadState(callback, state));
+        }
+
+        private Thread GetAvailableThread()
+        {
+            foreach (Thread thread in threads)
+            {
+                if (thread.ThreadState == ThreadState.WaitSleepJoin)
+                {
+                    return thread;
+                }
+            }
+
+            throw new InvalidOperationException("No available threads in the thread pool.");
+        }
+
+        private void ThreadProc()
+        {
+            while (true)
+            {
+                ThreadState state = (ThreadState)Thread.GetData(Thread.GetNamedDataSlot("state"));
+
+                if (state != null)
+                {
+                    try
+                    {
+                        state.Callback(state.State);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Handle exception
+                    }
+                    finally
+                    {
+                        Thread.SetData(Thread.GetNamedDataSlot("state"), null);
+                        semaphore.Release();
+                    }
+                }
+                else
+                {
+                    Thread.Sleep(1); // Sleep for 1 millisecond
+                }
+            }
+        }
+
+        private class ThreadState
+        {
+            public WaitCallback Callback { get; set; }
+            public object State { get; set; }
+
+            public ThreadState(WaitCallback callback, object state)
+            {
+                Callback = callback;
+                State = state;
+            }
+        }
+
+        public int GetMaxThreads()
+        {
+            return maxThreads;
+        }
+    }
+}

--- a/code/client/clrcore-v2/ScriptInterface.cs
+++ b/code/client/clrcore-v2/ScriptInterface.cs
@@ -87,8 +87,11 @@ namespace CitizenFX.Core
 			ulong prevTime = (ulong)Interlocked.Read(ref s_sharedData->m_scheduledTimeAsLong);
 			while (time < prevTime)
 			{
-				prevTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
-			}
+		        ulong updatedTime = (ulong)Interlocked.CompareExchange(ref s_sharedData->m_scheduledTimeAsLong, (long)time, (long)prevTime);
+		        if (updatedTime == prevTime)
+		            return;
+		        prevTime = updatedTime;
+		    }
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

I used Meta Llama 3.1-405B AI to optimize the performance of the coroutine scheduler. Albeit at increased complexity but theoretically provides a significant improvement to performance while still being compatible with Mono 4.8. The purpose of this pull request is NOT to merge to main but for those who maintain this repo to discuss and look over it.

### How is this PR achieving the goal

Uses a HashedBinaryHeap and ThreadPool to maximize performance of the coroutine scheduler.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: C#


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


