### PR TITLE
feat(data): Add fwPortalSceneGraphNode pool to gameconfig

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -293,6 +293,10 @@
 							<PoolSize value="900"/>
 						</Item>
 						<Item>
+							<PoolName>fwPortalSceneGraphNode</PoolName>
+							<PoolSize value="1500"/>
+						</Item>
+						<Item>
 							<PoolName>InteriorProxy</PoolName>
 							<PoolSize value="9060"/>
 						</Item>


### PR DESCRIPTION
Currently by default, fwPortalSceneGraphNode is set to 400, servers with many interiors and in turn lots of portals, this can cause a game crash. its possible to simply add this pool to the config to increase it.

currently it says "Unknown Pool full - 400", which makes sense because fwPortalSceneGraphNode is missing from the config therefore its unknown.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Adding the pool to the gameconfig and increasing its value to prevent game crashes with many interiors loaded

...


### How is this PR achieving the goal

making the pool accessable to the gameconfig.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


