### PR TITLE
feat(onesync/natives): add GetVehicleHornType

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -391,6 +391,8 @@ struct CVehicleAppearanceNodeData
 
 	int numberPlateTextIndex;
 
+	int hornTypeHash;
+
 	inline CVehicleAppearanceNodeData()
 	{
 		memset(plate, 0, sizeof(plate));

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -889,7 +889,9 @@ struct CVehicleAppearanceDataNode {
 		int numberPlateTextIndex = state.buffer.Read<int>(32);
 		data.numberPlateTextIndex = numberPlateTextIndex;
 
-		int unk20 = state.buffer.Read<int>(32);
+		int hornTypeHash = state.buffer.Read<int>(32);
+		data.hornTypeHash = hornTypeHash;
+
 		bool hasEmblems = state.buffer.ReadBit();
 
 		if (hasEmblems)

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -764,6 +764,13 @@ static void Init()
 		return 1;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_HORN_TYPE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto vn = entity->syncTree->GetVehicleAppearance();
+
+		return vn ? vn->hornTypeHash : 0;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_EXTRA_COLOURS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		if (context.GetArgumentCount() > 2)

--- a/ext/native-decls/GetVehicleHornType.md
+++ b/ext/native-decls/GetVehicleHornType.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_VEHICLE_HORN_TYPE
+
+```c
+Hash GET_VEHICLE_HORN_TYPE(Vehicle vehicle);
+```
+
+This is a getter for the client-side native [`START_VEHICLE_HORN`](https://docs.fivem.net/natives/?_0x9C8C6504B5B63D2C), which allows you to return the horn type of the vehicle.
+
+**Note**: This native only gets the hash value set with `START_VEHICLE_HORN`. If a wrong hash is passed into `START_VEHICLE_HORN`, it will return this wrong hash.
+
+```c
+enum eHornTypes
+{
+    NORMAL = 1330140148,
+    HELDDOWN = -2087385909,
+    AGGRESSIVE = -92810745
+}
+```
+
+## Parameters
+* **vehicle**: The vehicle to check the horn type.
+
+## Return value
+Returns the vehicle horn type hash, or `0` if one is not set.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Adding a server side getter to the client side native `START_VEHICLE_HORN`


### How is this PR achieving the goal

by reading the HornTypeHash bit in the CVehicleAppearance data node.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FXServer/FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095 

**Platforms:** Window

Was tested by using StartVehicleHorn client side, then getting the hornType value server side.

```lua
-- Client side
RegisterCommand("setHorn", function()
  local veh = GetVehiclePedIsIn(PlayerPedId(), false)
  StartVehicleHorn(veh, 1000000, GetHashKey("HELDDOWN"), false)
end)

-- Server Side
RegisterCommand("hornType", function(source, args)
    local playerPed = GetPlayerPed(source)
    local veh = GetVehiclePedIsIn(playerPed, false)
   if GetVehicleHornType(veh) == GetHashKey("HELDDOWN") then
        print("yes")
   end
end)
```

To test it, use this snippet, use the setHorn command, then the hornType command


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


