### PR TITLE
feat(onesync/helicopters): serialize helicopters datanodes

### DIFF
--- a/code/components/citizen-server-impl/include/ScriptDeprecations.h
+++ b/code/components/citizen-server-impl/include/ScriptDeprecations.h
@@ -7,7 +7,10 @@ namespace fx
 enum class ScriptDeprecations : uint8_t
 {
 	// The client old net id is used inside the playerConnect event, the 'source' from the script runtime should be used instead
-	CLIENT_EVENT_OLD_NET_ID
+	CLIENT_EVENT_OLD_NET_ID,
+
+	// It's not possible to get the heli tail rotor health, it's the heli rear rotor health, GET_HELI_REAR_ROTOR_HEALTH should be used instead
+	GET_HELI_TAIL_ROTOR_HEALTH
 };
 
 template<ScriptDeprecations TDeprecation>

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -252,14 +252,6 @@ struct CDoorScriptGameStateDataNodeData
 	bool holdOpen;
 };
 
-struct CHeliControlDataNodeData
-{
-	bool engineOff;
-
-	bool hasLandingGear;
-	uint32_t landingGearState;
-};
-
 struct CPlayerCameraNodeData
 {
 	int camMode;
@@ -609,7 +601,41 @@ struct CPlayerGameStateNodeData
 struct CHeliHealthNodeData
 {
 	int mainRotorHealth;
-	int tailRotorHealth;
+	int rearRotorHealth;
+
+	bool boomBroken;
+	bool canBoomBreak;
+	bool hasCustomHealth;
+
+	int bodyHealth;
+	int gasTankHealth;
+	int engineHealth;
+
+	float mainRotorDamage;
+	float rearRotorDamage;
+	float tailRotorDamage;
+
+	bool disableExplosionFromBodyDamage;
+};
+
+struct CHeliControlDataNodeData
+{
+	float yawControl;
+	float pitchControl;
+	float rollControl;
+	float throttleControl;
+
+	bool engineOff;
+
+	bool hasLandingGear;
+	uint32_t landingGearState;
+
+	bool isThrusterModel;
+	float thrusterSideRCSThrottle;
+	float thrusterThrottle;
+
+	bool hasVehicleTask;
+	bool lockedToXY;
 };
 
 struct CVehicleSteeringNodeData
@@ -683,8 +709,6 @@ public:
 
 	virtual CDoorScriptGameStateDataNodeData* GetDoorScriptGameState() = 0;
 
-	virtual CHeliControlDataNodeData* GetHeliControl() = 0;
-
 	virtual CPlayerCameraNodeData* GetPlayerCamera() = 0;
 
 	virtual CPlayerWantedAndLOSNodeData* GetPlayerWantedAndLOS() = 0;
@@ -728,6 +752,8 @@ public:
 	virtual CDummyObjectCreationNodeData* GetDummyObjectState() = 0;
 
 	virtual CHeliHealthNodeData* GetHeliHealth() = 0;
+
+	virtual CHeliControlDataNodeData* GetHeliControl() = 0;
 
 	virtual CVehicleSteeringNodeData* GetVehicleSteeringData() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -1985,52 +1985,69 @@ struct CDoorScriptGameStateDataNode
 	}
 };
 
-struct CHeliHealthDataNode
+struct CHeliHealthDataNode : GenericSerializeDataNode<CHeliHealthDataNode>
 {
 	CHeliHealthNodeData data;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+    bool Serialize(Serializer& s)
 	{
-		data.mainRotorHealth = state.buffer.Read<int>(17);
-		data.tailRotorHealth = state.buffer.Read<int>(17);
+		s.Serialize(17, data.mainRotorHealth);
+		s.Serialize(17, data.rearRotorHealth);
 
-		bool boomBroken = state.buffer.ReadBit();
+		s.Serialize(data.boomBroken);
+		s.Serialize(data.canBoomBreak);
+		s.Serialize(data.hasCustomHealth);
+
+		if (data.hasCustomHealth)
+		{
+			s.Serialize(17, data.bodyHealth);
+			s.Serialize(17, data.gasTankHealth);
+			s.Serialize(17, data.engineHealth);
+		}
+
+		s.SerializeSigned(11, 100.0f, data.mainRotorDamage);
+		s.SerializeSigned(11, 100.0f, data.rearRotorDamage);
+		s.SerializeSigned(11, 100.0f, data.tailRotorDamage);
+
+		s.Serialize(data.disableExplosionFromBodyDamage);
 
 		return true;
 	}
 };
 
-struct CHeliControlDataNode
+struct CHeliControlDataNode : GenericSerializeDataNode<CHeliControlDataNode>
 {
-	CHeliControlDataNodeData data;
+    CHeliControlDataNodeData data;
 
-	bool Parse(SyncParseState& state)
-	{
-		float yawControl = state.buffer.ReadSignedFloat(8, 1.0f);
-		float pitchControl = state.buffer.ReadSignedFloat(8, 1.0f);
-		float rollControl = state.buffer.ReadSignedFloat(8, 1.0f);
-		float throttleControl = state.buffer.ReadFloat(8, 2.0f);
+    template<typename Serializer>
+    bool Serialize(Serializer& s)
+    {
+        s.SerializeSigned(8, 1.0f, data.yawControl);
+        s.SerializeSigned(8, 1.0f, data.pitchControl);
+        s.SerializeSigned(8, 1.0f, data.rollControl);
+        s.Serialize(8, 2.0f, data.throttleControl);
 
-		data.engineOff = state.buffer.ReadBit();
+        s.Serialize(data.engineOff);
 
-		data.hasLandingGear = state.buffer.ReadBit();
-		if (data.hasLandingGear)
-		{
-			data.landingGearState = state.buffer.Read<uint32_t>(3);
-		}
+        s.Serialize(data.hasLandingGear);
+        if (data.hasLandingGear)
+        {
+            s.Serialize(3, data.landingGearState);
+        }
 
-		bool isThrusterModel = state.buffer.ReadBit();
-		if (isThrusterModel)
-		{
-			float thrusterSideRCSThrottle = state.buffer.ReadSignedFloat(9, 1.0f);
-			float thrusterThrottle = state.buffer.ReadSignedFloat(9, 1.0f);
-		}
+        s.Serialize(data.isThrusterModel);
+        if (data.isThrusterModel)
+        {
+            s.SerializeSigned(9, 1.0f, data.thrusterSideRCSThrottle);
+            s.SerializeSigned(9, 1.0f, data.thrusterThrottle);
+        }
 
-		bool hasVehicleTask = state.buffer.ReadBit();
-		bool unk8 = state.buffer.ReadBit();
+        s.Serialize(data.hasVehicleTask);
+        s.Serialize(data.lockedToXY);
 
-		return true;
-	}
+        return true;
+    }
 };
 
 struct CObjectCreationDataNode

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -6,6 +6,7 @@
 
 #include <ResourceManager.h>
 #include <ScriptEngine.h>
+#include <ScriptDeprecations.h>
 
 #include <ScriptSerialization.h>
 #include <MakeClientFunction.h>
@@ -1580,27 +1581,6 @@ static void Init()
 		return true;
 	}));
 
-	fx::ScriptEngine::RegisterNativeHandler("GET_LANDING_GEAR_STATE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
-	{
-		int gearState = 0;
-
-		if (entity->type == fx::sync::NetObjEntityType::Heli)
-		{
-			auto state = entity->syncTree->GetHeliControl();
-			if (state->hasLandingGear)
-			{
-				gearState = state->landingGearState;
-			}
-		}
-		else if (entity->type == fx::sync::NetObjEntityType::Plane)
-		{
-			auto state = entity->syncTree->GetPlaneGameState();
-			gearState = state ? state->landingGearState : 0;
-		}
-
-		return gearState;
-	}));
-
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_LOCK_ON_TARGET", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		int lockOnHandle = 0;
@@ -1716,9 +1696,150 @@ static void Init()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_TAIL_ROTOR_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
+		fx::WarningDeprecationf<fx::ScriptDeprecations::GET_HELI_TAIL_ROTOR_HEALTH>("natives", "GET_HELI_TAIL_ROTOR_HEALTH is deprecated because there is no tail motor. Use GET_HELI_REAR_ROTOR_HEALTH instead.\n");
 		auto heliHealth = entity->syncTree->GetHeliHealth();
 
-		return heliHealth ? float(heliHealth->tailRotorHealth) : 0.0f;
+		return heliHealth ? float(heliHealth->rearRotorHealth) : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_REAR_ROTOR_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? float(heliHealth->rearRotorHealth) : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_HELI_TAIL_BOOM_BROKEN", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->boomBroken : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_HELI_TAIL_BOOM_BREAKABLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->canBoomBreak : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_BODY_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->bodyHealth : 1000; // Since the custom health bit wasn't trigger, we are returning the default value. 
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_GAS_TANK_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->gasTankHealth : 1000; // TODO: Read the gas tank health from the vehicle health datanode. 
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_ENGINE_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->engineHealth : 1000; // Since the custom health bit wasn't trigger, we are returning the default value.
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_MAIN_ROTOR_DAMAGE_SCALE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->mainRotorDamage : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_REAR_ROTOR_DAMAGE_SCALE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->rearRotorDamage : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_TAIL_ROTOR_DAMAGE_SCALE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->tailRotorDamage : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_DISABLE_EXPLODE_FROM_BODY_DAMAGE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliHealth = entity->syncTree->GetHeliHealth();
+
+		return heliHealth ? heliHealth->disableExplosionFromBodyDamage : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_LANDING_GEAR_STATE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		int gearState = 0;
+
+		if (entity->type == fx::sync::NetObjEntityType::Heli)
+		{
+			auto state = entity->syncTree->GetHeliControl();
+			if (state->hasLandingGear)
+			{
+				gearState = state->landingGearState;
+			}
+		}
+		else if (entity->type == fx::sync::NetObjEntityType::Plane)
+		{
+			auto state = entity->syncTree->GetPlaneGameState();
+			gearState = state ? state->landingGearState : 0;
+		}
+
+		return gearState;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_YAW_CONTROL", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->yawControl : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_PITCH_CONTROL", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->pitchControl : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_ROLL_CONTROL", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->rollControl : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_THROTTLE_CONTROL", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->throttleControl : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_THRUSTER_SIDE_RCS_THROTTLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->thrusterSideRCSThrottle : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_THRUSTER_THROTTLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? heliControl->thrusterThrottle : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_IS_HELI_ENGINE_RUNNING", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto heliControl = entity->syncTree->GetHeliControl();
+
+		return heliControl ? !heliControl->engineOff : false;
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_STEERING_ANGLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)

--- a/ext/native-decls/CanHeliTailBoomBreak.md
+++ b/ext/native-decls/CanHeliTailBoomBreak.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## IS_HELI_TAIL_BOOM_BREAKABLE
+
+```c
+BOOL IS_HELI_TAIL_BOOM_BREAKABLE(Vehicle heli);
+```
+
+This is a getter for [SET_HELI_TAIL_EXPLODE_THROW_DASHBOARD](#_0x3EC8BF18AA453FE9)
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns `true` if the helicopter's tail boom can break, `false` if it cannot.

--- a/ext/native-decls/GetHeliBodyHealth.md
+++ b/ext/native-decls/GetHeliBodyHealth.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_BODY_HEALTH
+
+```c
+int GET_HELI_BODY_HEALTH(Vehicle heli);
+```
+
+**Note** This native will always return `1000.0` unless [SET_VEHICLE_BODY_HEALTH](#_0xB77D05AC8C78AADB), [SET_VEHICLE_ENGINE_HEALTH](#_0x45F6D8EEF34ABEF1), or [SET_VEHICLE_PETROL_TANK_HEALTH](#_0x70DB57649FA8D0D8) have been called with a value greater than `1000.0`.
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns the current health of the helicopter's body.

--- a/ext/native-decls/GetHeliDisableExplodeFromBodyDamage.md
+++ b/ext/native-decls/GetHeliDisableExplodeFromBodyDamage.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_DISABLE_EXPLODE_FROM_BODY_DAMAGE
+
+```c
+BOOL GET_HELI_DISABLE_EXPLODE_FROM_BODY_DAMAGE(Vehicle heli);
+```
+
+This is a getter for [SET_DISABLE_HELI_EXPLODE_FROM_BODY_DAMAGE](#_0xEDBC8405B3895CC9)
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns `true` if the helicopter is set to be protected from exploding due to minor body damage, `false` otherwise.

--- a/ext/native-decls/GetHeliEngineHealth.md
+++ b/ext/native-decls/GetHeliEngineHealth.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_ENGINE_HEALTH
+
+```c
+int GET_HELI_ENGINE_HEALTH(Vehicle heli);
+```
+
+**Note** This native will always return `1000.0` unless [SET_VEHICLE_BODY_HEALTH](#_0xB77D05AC8C78AADB), [SET_VEHICLE_ENGINE_HEALTH](#_0x45F6D8EEF34ABEF1), or [SET_VEHICLE_PETROL_TANK_HEALTH](#_0x70DB57649FA8D0D8) have been called with a value greater than `1000.0`.
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns the current health of the helicopter's engine.

--- a/ext/native-decls/GetHeliGasTankHealth.md
+++ b/ext/native-decls/GetHeliGasTankHealth.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_GAS_TANK_HEALTH
+
+```c
+int GET_HELI_GAS_TANK_HEALTH(Vehicle heli);
+```
+
+**Note** This native will always return `1000.0` unless [SET_VEHICLE_BODY_HEALTH](#_0xB77D05AC8C78AADB), [SET_VEHICLE_ENGINE_HEALTH](#_0x45F6D8EEF34ABEF1), or [SET_VEHICLE_PETROL_TANK_HEALTH](#_0x70DB57649FA8D0D8) have been called with a value greater than `1000.0`.
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns the current health of the helicopter's gas tank.

--- a/ext/native-decls/GetHeliMainRotorDamageScale.md
+++ b/ext/native-decls/GetHeliMainRotorDamageScale.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_MAIN_ROTOR_DAMAGE_SCALE
+
+
+```c
+float GET_HELI_MAIN_ROTOR_DAMAGE_SCALE(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns a value representing the damage scaling factor applied to the helicopter's main rotor. The value ranges from `0.0` (no damage scaling) to` 1.0` (full damage scaling).

--- a/ext/native-decls/GetHeliPitchControl.md
+++ b/ext/native-decls/GetHeliPitchControl.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_PITCH_CONTROL
+
+```c
+float GET_HELI_PITCH_CONTROL(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check.
+
+## Return value
+Returns a value representing the pitch control of the helicopter. The values range from `-1.0` (nose down) to `1.0` (nose up), with `0.0` indicating no pitch input.

--- a/ext/native-decls/GetHeliRearRotorDamageScale.md
+++ b/ext/native-decls/GetHeliRearRotorDamageScale.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_REAR_ROTOR_DAMAGE_SCALE
+
+```c
+float GET_HELI_REAR_ROTOR_DAMAGE_SCALE(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns a value representing the damage scaling factor applied to the helicopter's rear rotor. The value ranges from `0.0` (no damage scaling) to` 1.0` (full damage scaling).

--- a/ext/native-decls/GetHeliRearRotorHealth.md
+++ b/ext/native-decls/GetHeliRearRotorHealth.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_REAR_ROTOR_HEALTH
+
+```c
+float GET_HELI_REAR_ROTOR_HEALTH(Vehicle vehicle);
+```
+
+This native is a getter for [SET_HELI_TAIL_ROTOR_HEALTH](#_0xFE205F38AAA58E5B)
+
+
+## Parameters
+* **vehicle**: The target vehicle.
+
+## Return value
+Returns the health of the helicopter's rear rotor. The maximum health value is `1000`.

--- a/ext/native-decls/GetHeliRollControl.md
+++ b/ext/native-decls/GetHeliRollControl.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_ROLL_CONTROL
+
+```c
+float GET_HELI_ROLL_CONTROL(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check.
+
+## Return value
+Returns a value representing the roll control of the helicopter. The values range from `-1.0` (roll left) to `1.0` (roll right), with `0.0` indicating no roll input.

--- a/ext/native-decls/GetHeliTailRotorDamageScale.md
+++ b/ext/native-decls/GetHeliTailRotorDamageScale.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_TAIL_ROTOR_DAMAGE_SCALE
+
+```c
+float GET_HELI_TAIL_ROTOR_DAMAGE_SCALE(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns a value representing the damage scaling factor applied to the helicopter's tail rotor. The value ranges from `0.0` (no damage scaling) to` 1.0` (full damage scaling).

--- a/ext/native-decls/GetHeliTailRotorHealth.md
+++ b/ext/native-decls/GetHeliTailRotorHealth.md
@@ -1,5 +1,6 @@
 ---
 ns: CFX
+game: gta5
 apiset: server
 ---
 ## GET_HELI_TAIL_ROTOR_HEALTH
@@ -8,9 +9,10 @@ apiset: server
 float GET_HELI_TAIL_ROTOR_HEALTH(Vehicle vehicle);
 ```
 
+**Note**: This native is deprecated, please use [`GET_HELI_REAR_ROTOR_HEALTH`](#_0x33EE6E2B) instead.
 
 ## Parameters
 * **vehicle**: The target vehicle.
 
 ## Return value
-See the client-side [GET_HELI_TAIL_ROTOR_HEALTH](https://docs.fivem.net/natives/?_0xAE8CE82A4219AC8C) for the return value.
+Return the health of the rear rotor of the helicopter, not the tail rotor.

--- a/ext/native-decls/GetHeliThrottleControl.md
+++ b/ext/native-decls/GetHeliThrottleControl.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_THROTTLE_CONTROL
+
+```c
+float GET_HELI_THROTTLE_CONTROL(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check.
+
+## Return value
+Returns a value representing the throttle control of the helicopter. The value ranges from `0.0` (no throttle) to `2.0` (full throttle).

--- a/ext/native-decls/GetHeliYawControl.md
+++ b/ext/native-decls/GetHeliYawControl.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_HELI_YAW_CONTROL
+
+```c
+float GET_HELI_YAW_CONTROL(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check.
+
+## Return value
+Returns a value the yaw control of the helicopter. The value ranges from `-1.0` (yaw left) to `1.0` (yaw right), with `0.0` meaning no yaw input.

--- a/ext/native-decls/GetIsHeliEngineRunning.md
+++ b/ext/native-decls/GetIsHeliEngineRunning.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_IS_HELI_ENGINE_RUNNING
+
+```c
+BOOL GET_IS_HELI_ENGINE_RUNNING(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns `true` if the helicopter's engine is running, `false` if it is not.

--- a/ext/native-decls/GetThrusterSideRcsThrottle.md
+++ b/ext/native-decls/GetThrusterSideRcsThrottle.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_THRUSTER_SIDE_RCS_THROTTLE
+
+```c
+float GET_THRUSTER_SIDE_RCS_THROTTLE(Vehicle jetpack);
+```
+
+## Parameters
+* **jetpack**: The jetpack to check.
+
+## Return value
+Returns a value representing the side RCS (Reaction Control System) throttle of the jetpack. The values range from `0.0` (no throttle) to `1.0` (full throttle).

--- a/ext/native-decls/GetThrusterThrottle.md
+++ b/ext/native-decls/GetThrusterThrottle.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_THRUSTER_THROTTLE
+
+```c
+float GET_THRUSTER_THROTTLE(Vehicle jetpack);
+```
+
+## Parameters
+* **jetpack**: The jetpack to check.
+
+## Return value
+Returns a value representing the main throttle of the jetpack. The values range from `0.0` (no throttle) to `1.0` (full throttle)

--- a/ext/native-decls/IsHeliTailBoomBroken.md
+++ b/ext/native-decls/IsHeliTailBoomBroken.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## IS_HELI_TAIL_BOOM_BROKEN
+
+```c
+BOOL IS_HELI_TAIL_BOOM_BROKEN(Vehicle heli);
+```
+
+## Parameters
+* **heli**: The helicopter to check
+
+## Return value
+Returns `true` if the helicopter's tail boom is broken, `false` if it is intact.


### PR DESCRIPTION
### Goal of this PR
* New getters :
     - GET_THRUSTER_THROTTLE
     - GET_THRUSTER_SIDE_RCS_THROTTLE
     - IS_HELI_TAIL_BOOM_BROKEN
     - GET_IS_HELI_ENGINE_RUNNING
     - GET_HELI_YAW_CONTROL
     - GET_HELI_THROTTLE_CONTROL
     - GET_HELI_TAIL_ROTOR_DAMAGE_SCALE
     - GET_HELI_ROLL_CONTROL
     - GET_HELI_REAR_ROTOR_HEALTH
     - GET_HELI_REAR_ROTOR_DAMAGE_SCALE
     - GET_HELI_PITCH_CONTROL
     - GET_HELI_MAIN_ROTOR_DAMAGE_SCALE
     - GET_HELI_GAS_TANK_HEALTH
     -  GET_HELI_ENGINE_HEALTH
     - GET_HELI_DISABLE_EXPLODE_FROM_BODY_DAMAGE
     - GET_HELI_BODY_HEALTH
     - IS_HELI_TAIL_BOOM_BREAKABLE

`GET_HELI_TAIL_ROTOR_HEALTH` was incorrect, it was reading the rear rotor bit instead of the tail rotor (which doesn't exist). To address this, I created a new native `GET_HELI_REAR_ROTOR_HEALTH` and added a deprecation warning to GET_HELI_TAIL_ROTOR_HEALTH using ScriptDeprecations, as requested by @FabianTerhorst

### How is this PR achieving the goal
By serializing `CHeliHealthDataNode` and `CHeliControlDataNode` and exposing new getters


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, FXServer
...


### Successfully tested on

**Game builds:** 3095 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
