### PR TITLE
tweak(conhost): use circular_buffer instead of ImVector

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -684,7 +684,7 @@ auto msec()
 
 struct MiniConsole : CfxBigConsole
 {
-	ImVector<std::chrono::milliseconds> ItemTimes;
+	boost::circular_buffer<std::chrono::milliseconds> ItemTimes{ 2500 };
 
 	ConVar<std::string>* m_miniconChannels;
 	std::string m_miniconLastValue;


### PR DESCRIPTION
### Goal of this PR
Fix crash when printing a large amount of things to console (2501+) due to `ItemTimes` using a `ImVector` instead of `circular_buffer`.

```lua
-- this expects you to have run `con_miniconChannels "script:*"` prior
CreateThread(function()
  for i = 1, 5000 do
    print("test", i)
  end
end)
```

### How is this PR achieving the goal
Replace `ImVector` with a `circular_buffer` so that it properly caps out at `2500` items instead of allowing it to infinity expand as a Vector, causing a crash later when it tries to remove `Items` and `ItemKeys` because they are properly restricted to `2500` items and will try to remove past the bounds if `Items`.

https://github.com/citizenfx/fivem/blob/705cd7901ac03c5a0d1e1355d94e84046309b80d/code/components/conhost-v2/src/ConsoleHostGui.cpp#L729-L734


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM/RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** N/A


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


