### PR TITLE
Add new valid Epic installation path for gameselect process

### DIFF
--- a/code/client/launcher/GameSelect.cpp
+++ b/code/client/launcher/GameSelect.cpp
@@ -205,6 +205,7 @@ std::optional<int> EnsureGamePath()
 #if defined(GTA_FIVE)
 			{ L"InstallFolderSteam", L"SOFTWARE\\WOW6432Node\\Rockstar Games\\GTAV", 5 },
 			{ L"InstallFolderEpic", L"SOFTWARE\\Rockstar Games\\Grand Theft Auto V", 0 },
+			{ L"InstallFolderEpic", L"SOFTWARE\\WOW6432Node\\Rockstar Games\\Grand Theft Auto V", 0 },
 #elif defined(IS_RDR3)
 			{ L"InstallFolderSteam", L"SOFTWARE\\WOW6432Node\\Rockstar Games\\Red Dead Redemption 2", strlen("Red Dead Redemption 2") },
 #elif defined(GTA_NY)


### PR DESCRIPTION
### Goal of this PR

This PR adds a new path for Epic games installation for the game selection process. As we've got more issues about wrong IVPath in the discord guild recently


### How is this PR achieving the goal

Adds another "folderAttempt" entry with a recent valid Epic games Registry value, see : 
![image](https://github.com/user-attachments/assets/c9acffd5-a962-4558-8b92-9fad80654004)


### This PR applies to the following area(s)

FiveM

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.