### PR TITLE
fix(extra-natives/five): fix crosshair bottom line drawn incorrectly

### DIFF
--- a/code/components/extra-natives-five/src/DrawImNatives.cpp
+++ b/code/components/extra-natives-five/src/DrawImNatives.cpp
@@ -3482,7 +3482,7 @@ static void DoCrosshairDraw()
 	int iOuterBottom = iInnerBottom + iBarSizeInner;
 	int x0 = iCenterX - iBarThickness / 2;
 	int x1 = x0 + iBarThickness;
-	DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iCenterY, x1, iOuterBottom, bAdditive);
+	DrawCrosshairRect(r, g, b, flLineAlphaInner, x0, iInnerBottom, x1, iOuterBottom, bAdditive);
 
 	// draw top vertical crosshair line if cl_crosshair_t is disabled
 	if (!cl_crosshair_t.GetValue())


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

there is a recent issue introduced that causes the bottom line of the crosshair to render incorrectly
![image](https://github.com/user-attachments/assets/dea415e0-fd23-479b-8827-bcdc8df24f96)
the bottom line ignores the gap and starts in at the center

### How is this PR achieving the goal
made use of `iInnerBottom` for the line start instead of `iCenterY`


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
not tested

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes an issue introduced in #2544
