### PR TITLE
fix(clr/shared): remove preprocessor stuff for Object

### DIFF
--- a/code/client/clrcore-v2/Game/Shared/Game.cs
+++ b/code/client/clrcore-v2/Game/Shared/Game.cs
@@ -53,11 +53,7 @@ namespace CitizenFX.Core
 		private static readonly Dictionary<Type, string> s_entityTypeMap = new Dictionary<Type, string>
 		{
 			{ typeof(Ped), "CPed" },
-#if !MONO_V2 || IS_RDR3
 			{ typeof(Prop), "CObject" },
-#else
-			{ typeof(Object), "CObject" },
-#endif
 			{ typeof(Pickup), "CPickup" },
 			{ typeof(Vehicle), "CVehicle" }
 		};


### PR DESCRIPTION
As of https://github.com/citizenfx/fivem/pull/2731 this is no longer needed.

### Goal of this PR
Allow rt2 to properly take `Prop` for `GetGamePool`


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


