### PR TITLE
fix(clr/shared): fix GetGamePool for server

### DIFF
--- a/code/client/clrcore-v2/Game/Shared/Game.cs
+++ b/code/client/clrcore-v2/Game/Shared/Game.cs
@@ -53,11 +53,7 @@ namespace CitizenFX.Core
 		private static readonly Dictionary<Type, string> s_entityTypeMap = new Dictionary<Type, string>
 		{
 			{ typeof(Ped), "CPed" },
-#if !MONO_V2 || IS_RDR3
 			{ typeof(Prop), "CObject" },
-#else
-			{ typeof(Object), "CObject" },
-#endif
 			{ typeof(Pickup), "CPickup" },
 			{ typeof(Vehicle), "CVehicle" }
 		};

--- a/code/client/clrcore-v2/Game/Shared/Game.cs
+++ b/code/client/clrcore-v2/Game/Shared/Game.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if GTA_FIVE || IS_RDR3
 
 #if MONO_V2
 #if IS_RDR3
 using CitizenFX.RedM.Native;
 namespace CitizenFX.RedM
+#elif IS_FXSERVER
+using CitizenFX.Server.Native;
+namespace CitizenFX.Server
 #else // IS_GTA
 using CitizenFX.FiveM.Native;
 namespace CitizenFX.FiveM
@@ -54,7 +56,9 @@ namespace CitizenFX.Core
 		{
 			{ typeof(Ped), "CPed" },
 			{ typeof(Prop), "CObject" },
+#if !IS_FXSERVER
 			{ typeof(Pickup), "CPickup" },
+#endif
 			{ typeof(Vehicle), "CVehicle" }
 		};
 
@@ -91,6 +95,3 @@ namespace CitizenFX.Core
 		}
 	}
 }
-
-#endif
-// END GTA_FIVE || IS_RDR3

--- a/code/client/clrcore/Server/Entity.cs
+++ b/code/client/clrcore/Server/Entity.cs
@@ -3,7 +3,6 @@ using System;
 #if MONO_V2
 using CitizenFX.Core;
 using API = CitizenFX.Server.Native.Natives;
-using Prop = CitizenFX.Server.Object;
 using compat_int_uint = System.UInt32;
 using compat_int_entity_type = CitizenFX.Shared.EntityType;
 #else

--- a/code/client/clrcore/Server/Prop.cs
+++ b/code/client/clrcore/Server/Prop.cs
@@ -1,20 +1,16 @@
 #if MONO_V2
 namespace CitizenFX.Server
-{
-	public sealed class Object : Entity, Shared.IObject
-	{
-		public Object(int handle) : base(handle)
-		{
-		}
-	}
 #else
 namespace CitizenFX.Core
+#endif
 {
 	public sealed class Prop : Entity
-	{
+#if MONO_V2
+	, Shared.IObject
+#endif
+{
 		public Prop(int handle) : base(handle)
 		{
 		}
 	}
-#endif
 }


### PR DESCRIPTION
### Goal of this PR
Fix bug for `mono_rt2` server implementation introduced in https://github.com/citizenfx/fivem/pull/2488 (and temp fixed in https://github.com/citizenfx/fivem/commit/3768dc04fa2d53030f0d52b362340c2b7ed2131b)

This also changes the server variant for `mono_rt2` from Object -> Prop fixing an oversight in https://github.com/citizenfx/fivem/pull/2731

This relies on on other changes so this will be marked as a draft for now.

### How is this PR achieving the goal
Properly use server namespaces for native invokes

### This PR applies to the following area(s)
Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


