### PR TITLE
feat(scripting/state): add `GET_GAME_POOL` server side parity

### DIFF
--- a/ext/native-decls/GetGamePool.md
+++ b/ext/native-decls/GetGamePool.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 ---
 ## GET_GAME_POOL
 


### PR DESCRIPTION
### Goal of this PR
Have server parity for `GET_GAME_POOL`


### How is this PR achieving the goal
Implements `GET_GAME_POOL` and fixes possible issues with `GET_ALL_*` native possibly returning entities that will be marked for cleanup or cleanup finalization 


### This PR applies to the following area(s)
Server

### Successfully tested on
**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
