### PR TITLE
feat(server/state): add `[GET/SET]_ENTITY_ORPHAN_MODE`

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -788,6 +788,13 @@ public:
 	virtual bool IsEntityVisible(bool* visible) = 0;
 };
 
+enum EntityOrphanMode : uint8_t
+{
+	DeleteWhenNotRelevant = 0,
+	DeleteOnOwnerDisconnect = 1,
+	KeepEntity = 2,
+};
+
 struct SyncEntityState
 {
 	using TData = std::variant<int, float, bool, std::string>;
@@ -832,6 +839,7 @@ struct SyncEntityState
 	bool passedFilter = false;
 	bool wantsReassign = false;
 	bool firstOwnerDropped = false;
+	EntityOrphanMode orphanMode = EntityOrphanMode::DeleteWhenNotRelevant;
 
 	std::list<std::function<void(const fx::ClientSharedPtr& ptr)>> onCreationRPC;
 

--- a/ext/native-decls/GetEntityOrphanMode.md
+++ b/ext/native-decls/GetEntityOrphanMode.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_ENTITY_ORPHAN_MODE
+
+```c
+int GET_ENTITY_ORPHAN_MODE(Entity entity);
+```
+
+## Parameters
+* **entity**: The entity to get the orphan mode of
+
+## Return value
+Returns the entities current orphan mode, refer to enum in [SET_ENTITY_ORPHAN_MODE](#_0x489E9162)

--- a/ext/native-decls/SetEntityOrphanMode.md
+++ b/ext/native-decls/SetEntityOrphanMode.md
@@ -1,0 +1,32 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_ENTITY_ORPHAN_MODE
+
+```c
+void SET_ENTITY_ORPHAN_MODE(Entity entity, int orphanMode);
+```
+
+```c
+enum EntityOrphanMode {
+    // Default, this will delete the entity when it isn't relevant to any players
+    // NOTE: this *doesn't* mean when they're no longer in scope
+    DeleteWhenNotRelevant = 0,
+    // The entity will be deleted whenever its original owner disconnects
+    // NOTE: if this is set when the entities original owner has already left it will be
+    // marked for deletion (similar to just calling DELETE_ENTITY)
+    DeleteOnOwnerDisconnect = 1,
+    // The entity will never be deleted by the server when it does relevancy checks
+    // you should only use this on entities that need to be relatively persistent
+    KeepEntity = 2
+}
+```
+
+Sets what happens when the entity is orphaned and no longer has its original owner.
+
+**NOTE**: This native doesn't guarantee the persistence of the entity.
+
+## Parameters
+* **entity**: The entity to set the orphan mode of
+* **orphanMode**: The mode that the server should use for determining if an entity should be removed.


### PR DESCRIPTION
### Goal of this PR
Allow server owners to choose how they want the entity to be treated when it no longer has a valid/relevant owner.

This will allow for servers to use client side `CREATE_*` natives while being able keep the entity relatively persistent like the server setters, and also avoiding some of the known bugs with server-setters.

This will also allow the server owner to have specific entities be deleted whenever they leave the server.

### How is this PR achieving the goal
Add `EntityOrphanMode`s to let the server owner choose how they want an entity to be treated when the entity loses its first owner or is no longer relevant.

### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
