### PR TITLE
fix(natives/five): weather pointer offset

### DIFF
--- a/code/components/extra-natives-five/src/WeatherNatives.cpp
+++ b/code/components/extra-natives-five/src/WeatherNatives.cpp
@@ -69,7 +69,7 @@ static HookFunction hookFunction([]()
 		hook::set_call(&getWeatherByName, location + 23);
 		hook::call(location + 23, getWeatherByNameHook);
 
-		g_currentWeather = hook::get_address<int*>(location + 30);
+		g_currentWeather = hook::get_address<int*>(location + (xbr::IsGameBuildOrGreater<3095>() ? 51 : 30));
 	}
 
 	{

--- a/code/components/extra-natives-five/src/WeatherNatives.cpp
+++ b/code/components/extra-natives-five/src/WeatherNatives.cpp
@@ -69,7 +69,7 @@ static HookFunction hookFunction([]()
 		hook::set_call(&getWeatherByName, location + 23);
 		hook::call(location + 23, getWeatherByNameHook);
 
-		g_currentWeather = hook::get_address<int*>(location + (xbr::IsGameBuildOrGreater<3095>() ? 51 : 30));
+		g_currentWeather = hook::get_address<int*>(location + (xbr::IsGameBuildOrGreater<3258>() ? 51 : 30));
 	}
 
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix crashes with native `FORCE_SNOW_PASS` due to a new weather addition in build 3258.


### How is this PR achieving the goal

Use a specific offset to get the current weather with build 3095 onwards, due to the addition of a new weather type called `SNOW_HALLOWEEN`.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604, 2060, 2189, 2372, 2545, 2612, 2699, 2802, 2944, 3095, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes #2736, fixes #2711 

