### PR TITLE
fix(voip/mumble): Voice cracking on high load

### DIFF
--- a/code/components/voip-mumble/src/MumbleAudioInput.cpp
+++ b/code/components/voip-mumble/src/MumbleAudioInput.cpp
@@ -96,6 +96,8 @@ void MumbleAudioInput::ThreadFunc()
 {
 	SetThreadName(-1, "[Mumble] Audio Input Thread");
 
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+
 	// initialize COM for the current thread
 	CoInitialize(nullptr);
 

--- a/code/components/voip-mumble/src/MumbleAudioOutput.cpp
+++ b/code/components/voip-mumble/src/MumbleAudioOutput.cpp
@@ -1469,6 +1469,8 @@ void MumbleAudioOutput::ThreadFunc()
 
 	mmcssHandle = AvSetMmThreadCharacteristics(L"Audio", &mmcssTaskIndex);
 
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+
 	// initialize COM for the current thread
 	CoInitialize(nullptr);
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix voice cracking on high load

### How is this PR achieving the goal

Setting a higher thread priority for Mumble voice. These changes need to be tested on Canary; I can't see any other way to conduct large-scale tests. I tried to create this issue using two RedM clients and running a CPU stress test in the background, but there was no way to replicate this on my PC and my friend's PC.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #2742`, `resolves #234`, `closes #345`. -->
fixes #2742


