### PR TITLE
feat(ext/cfx-ui): South Korea server country setting

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -21,7 +21,7 @@ export function registerMpMenuIntlService(container: ServicesContainer) {
 class MpMenuIntlService implements IIntlService {
   readonly systemLocale = (() => {
     const systemLocale = mpMenu.systemLanguages[0] || 'en-US';
-    const [language, country] = systemLocale.split('-');
+    let [language, country] = systemLocale.split('-');
 
     if (!country) {
       // Windows has some locales such as `pl` which shou ld expand to `pl-PL`

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -24,8 +24,14 @@ class MpMenuIntlService implements IIntlService {
     const [language, country] = systemLocale.split('-');
 
     if (!country) {
-      // Windows has some locales such as `pl` which should expand to `pl-PL`
-      return `${language.toLowerCase()}-${language.toUpperCase()}`;
+      // Windows has some locales such as `pl` which shou ld expand to `pl-PL`
+      language = `${language.toLowerCase()}-${language.toUpperCase()}`
+
+      // Special case for Korean locale: On some systems, the Korean locale might be returned as `ko-KO`,
+      // but it should be standardized to `ko-KR` for consistency with South Korean regional settings.
+      if (language == "ko-KO") language = "ko-KR";
+      
+      return language;
     }
 
     return systemLocale;

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -21,17 +21,20 @@ export function registerMpMenuIntlService(container: ServicesContainer) {
 class MpMenuIntlService implements IIntlService {
   readonly systemLocale = (() => {
     const systemLocale = mpMenu.systemLanguages[0] || 'en-US';
-    let [language, country] = systemLocale.split('-');
+    const [language, country] = systemLocale.split('-');
 
     if (!country) {
-      // Windows has some locales such as `pl` which shou ld expand to `pl-PL`
-      language = `${language.toLowerCase()}-${language.toUpperCase()}`
-
+      const lcLanguage = language.toLowerCase();
+      const ucLanguage = language.toUpperCase();
+    
       // Special case for Korean locale: On some systems, the Korean locale might be returned as `ko-KO`,
       // but it should be standardized to `ko-KR` for consistency with South Korean regional settings.
-      if (language == "ko-KO") language = "ko-KR";
-      
-      return language;
+      if (lcLanguage === 'ko') {
+        return 'ko-KR';
+      }
+    
+      // Windows has some locales such as `pl` which should expand to `pl-PL`
+      return `${lcLanguage}-${ucLanguage}`;
     }
 
     return systemLocale;


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Clarify the South Korea server


### How is this PR achieving the goal
Currently, the South Korea server is not displayed on the home screen. If the country is ko-KO, please set it to ko-KR to resolve this issue.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** ALL

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


