### PR TITLE
fix(onesync): CPlayerGameStateDataNode for b3095

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -3072,6 +3072,11 @@ struct CPlayerGameStateDataNode
 			state.buffer.ReadBit();
 		}
 
+		if (Is3095())
+		{
+			state.buffer.ReadBit();
+		}
+
 		auto unk70 = state.buffer.ReadBit();
 
 		if (unk70)
@@ -3177,6 +3182,13 @@ struct CPlayerGameStateDataNode
 		}
 
 		int unk101 = state.buffer.Read<int>(13);
+		
+		if (Is3095())
+		{
+			state.buffer.Read<int>(8);
+			state.buffer.Read<int>(8);
+		}
+
 		auto unk102 = state.buffer.ReadBit();
 		auto noCollision = state.buffer.ReadBit();
 		auto unk104 = state.buffer.ReadBit();


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix some server-side natives that return invalid values on game build >= 3095 like:
`GET_PLAYER_INVINCIBLE`
`GET_PLAYER_WEAPON_DAMAGE_MODIFIER`
`GET_PLAYER_MELEE_WEAPON_DAMAGE_MODIFIER`


### How is this PR achieving the goal

Adding a missing bit reading operation on `CPlayerGameStateDataNode` for >= b3095


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 2944, 3095, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Fixes #2748
