### PR TITLE
fix(nui): hide mouse cursor when the css cursor property is set to none

### DIFF
--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -365,6 +365,8 @@ namespace nui
 	bool OVERLAY_DECL HasCursor();
 	bool OVERLAY_DECL HasFocus();
 	bool OVERLAY_DECL HasFocusKeepInput();
+	void OVERLAY_DECL SetCursorHidden(bool isHidden);
+	bool OVERLAY_DECL IsCursorHidden();
 	void OVERLAY_DECL GiveFocus(const std::string& frameName, bool hasFocus, bool hasCursor = false);
 	void OVERLAY_DECL OverrideFocus(bool hasFocus);
 	void OVERLAY_DECL KeepInput(bool keepInput);

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -25,6 +25,7 @@ extern nui::GameInterface* g_nuiGi;
 
 static bool g_hasFocus = false;
 static bool g_hasCursor = false;
+static bool g_isCursorHidden = false;
 bool g_keepInput = false;
 static bool g_hasOverriddenFocus = false;
 extern bool g_mainUIFlag;
@@ -139,6 +140,16 @@ namespace nui
 		return g_keepInput;
 	}
 
+	void SetCursorHidden(bool isHidden)
+	{
+		g_isCursorHidden = isHidden;
+	}
+
+	bool IsCursorHidden()
+	{
+		return g_isCursorHidden;
+	}
+
 	void GiveFocus(const std::string& frameName, bool hasFocus, bool hasCursor)
 	{
 		if (!HasFocus() && hasFocus)
@@ -152,6 +163,7 @@ namespace nui
 
 		g_hasFocus = hasFocus;
 		g_hasCursor = hasCursor;
+		g_isCursorHidden = false;
 	}
 
 	void OverrideFocus(bool hasFocus)

--- a/code/components/nui-core/src/NUIClient.cpp
+++ b/code/components/nui-core/src/NUIClient.cpp
@@ -251,12 +251,18 @@ extern HCURSOR g_defaultCursor;
 
 bool NUIClient::OnCursorChange(CefRefPtr<CefBrowser> browser, CefCursorHandle cursor, cef_cursor_type_t type, const CefCursorInfo& custom_cursor_info)
 {
-	if (!cursor || type == CT_POINTER)
+	if (type == CT_NONE)
 	{
+		nui::SetCursorHidden(true);
+	}
+	else if (!cursor || type == CT_POINTER)
+	{
+		nui::SetCursorHidden(false);
 		g_nuiGi->SetHostCursor(g_defaultCursor);
 	}
 	else
 	{
+		nui::SetCursorHidden(false);
 		g_nuiGi->SetHostCursor(cursor);
 	}
 

--- a/code/components/nui-core/src/NUIRenderCallbacks.cpp
+++ b/code/components/nui-core/src/NUIRenderCallbacks.cpp
@@ -123,7 +123,7 @@ static HookFunction initFunction([] ()
 		}
 
 		// are we in any situation where we need a cursor?
-		bool needsNuiCursor = (nui::HasCursor()) && !g_shouldHideCursor;
+		bool needsNuiCursor = (nui::HasCursor()) && !(nui::IsCursorHidden()) && !g_shouldHideCursor;
 		g_nuiGi->SetHostCursorEnabled(needsNuiCursor);
 
 		// we set the host cursor above unconditionally- this is for cases where the host cursor isn't sufficient


### PR DESCRIPTION
### Goal of this PR
Hide the mouse cursor when it is over an element with css property `cursor: none`.


### How is this PR achieving the goal
It checks in the `OnCursorChange` handler if the type is `CT_NONE` and changes `g_isCursorHidden` accordingly, which is added to the checks performed in `NUIRenderCallback.cpp` to determine whether the cursor should be displayed.


### This PR applies to the following area(s)

FiveM, RedM, NUI


### Successfully tested on

**Platforms:** Windows


### Checklist

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.