### PR TITLE
fix(ext/cfx-ui): South Korea system locale

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -24,8 +24,17 @@ class MpMenuIntlService implements IIntlService {
     const [language, country] = systemLocale.split('-');
 
     if (!country) {
+      const lcLanguage = language.toLowerCase();
+      const ucLanguage = language.toUpperCase();
+
+      // Special case for Korean locale: On some systems, the Korean locale might be returned as `ko`,
+      // but it should be standardized to `ko-KR` for consistency with South Korean regional settings.
+      if (lcLanguage === 'ko') {
+        return 'ko-KR';
+      }
+
       // Windows has some locales such as `pl` which should expand to `pl-PL`
-      return `${language.toLowerCase()}-${language.toUpperCase()}`;
+      return `${lcLanguage}-${ucLanguage}`;
     }
 
     return systemLocale;


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Clarify the South Korea server


### How is this PR achieving the goal
Currently, the South Korea server is not displayed on the home screen. If the country is ko-KO, please set it to ko-KR to resolve this issue.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** ALL

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.