### PR TITLE
fix(native-decls): fix invalid operator in Lua examples

### DIFF
--- a/ext/native-decls/AddStateBagChangeHandler.md
+++ b/ext/native-decls/AddStateBagChangeHandler.md
@@ -58,7 +58,7 @@ AddStateBagChangeHandler("blockTasks", null, async (bagName, key, value /* boole
 AddStateBagChangeHandler("blockTasks", nil, function(bagName, key, value) 
     local entity = GetEntityFromStateBagName(bagName)
     -- Whoops, we don't have a valid entity!
-    if entity === 0 then return end
+    if entity == 0 then return end
     -- We don't want to freeze the entity position if the entity collision hasn't loaded yet
     while not HasCollisionLoadedAroundEntity(entity) do
         -- The entity went out of our scope before the collision loaded

--- a/ext/native-decls/GetEntityFromStateBagName.md
+++ b/ext/native-decls/GetEntityFromStateBagName.md
@@ -37,7 +37,7 @@ AddStateBagChangeHandler("blockTasks", null, async (bagName, key, value /* boole
 AddStateBagChangeHandler("blockTasks", nil, function(bagName, key, value) 
     local entity = GetEntityFromStateBagName(bagName)
     -- Whoops, we don't have a valid entity!
-    if entity === 0 then return end
+    if entity == 0 then return end
     -- We don't want to freeze the entity position if the entity collision hasn't loaded yet
     while not HasCollisionLoadedAroundEntity(entity) do
         -- The entity went out of our scope before the collision loaded


### PR DESCRIPTION
### Goal of this PR

This PR fixes 2 invalid Lua examples using === instead of ==, in Lua the strict '===' operator does not exists


### How is this PR achieving the goal

By removing one "=" to achieve a correct check for invalid entity


### This PR applies to the following area(s)

Native docs

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.