### PR TITLE
Feat(nui): Allow DUI Keyboard Input

### DIFF
--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -364,6 +364,7 @@ namespace nui
 
 	bool OVERLAY_DECL HasCursor();
 	bool OVERLAY_DECL HasFocus();
+	bool OVERLAY_DECL HasDuiFocus();
 	bool OVERLAY_DECL HasFocusKeepInput();
 	void OVERLAY_DECL GiveFocus(const std::string& frameName, bool hasFocus, bool hasCursor = false);
 	void OVERLAY_DECL OverrideFocus(bool hasFocus);

--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -300,6 +300,16 @@ static InitFunction initFunction([] ()
 			}
 		}
 
+		void GiveFocus(const bool* keepInput)
+		{
+			nui::GiveFocus(m_autogenHandle, keepInput, false);
+		}
+
+		bool HasFocus()
+		{
+			return nui::HasDuiFocus();
+		}
+
 	private:
 		cef_mouse_button_type_t GetButton(const char* button)
 		{
@@ -338,6 +348,8 @@ static InitFunction initFunction([] ()
 		.AddMethod("SEND_DUI_MOUSE_DOWN", &NUIWindowWrapper::InjectMouseDown)
 		.AddMethod("SEND_DUI_MOUSE_UP", &NUIWindowWrapper::InjectMouseUp)
 		.AddMethod("SEND_DUI_MOUSE_WHEEL", &NUIWindowWrapper::InjectMouseWheel)
+		.AddMethod("SET_DUI_KEYBOARD_INPUT", &NUIWindowWrapper::GiveFocus)
+		.AddMethod("DUI_HAS_KEYBOARD_INPUT", &NUIWindowWrapper::HasFocus)
 		.AddMethod("DESTROY_DUI", &NUIWindowWrapper::Destroy);		
 
 	// this *was* a multiset before but some resources would not correctly pair set/unset and then be stuck in 'set' state
@@ -412,7 +424,8 @@ static InitFunction initFunction([] ()
 
 	fx::ScriptEngine::RegisterNativeHandler("IS_NUI_FOCUSED", [] (fx::ScriptContext& context)
 	{
-		context.SetResult(nui::HasFocus());
+		const bool isFocused = !nui::HasDuiFocus() && nui::HasFocus();
+		context.SetResult(isFocused);
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("IS_NUI_FOCUS_KEEPING_INPUT", [] (fx::ScriptContext& context)

--- a/ext/native-decls/DuiHasKeyboardInput.md
+++ b/ext/native-decls/DuiHasKeyboardInput.md
@@ -1,0 +1,15 @@
+
+---
+ns: CFX
+apiset: client
+---
+## DUI_HAS_KEYBOARD_INPUT
+
+```c
+BOOL DUI_HAS_KEYBOARD_INPUT(long duiObject);
+```
+Returns the current DUI focus state previously set with `SET_DUI_KEYBOARD_INPUT`.
+## Parameters
+* **duiObject**: The DUI browser handle.
+## Return value
+True or false.

--- a/ext/native-decls/SetDuiKeyboardInput.md
+++ b/ext/native-decls/SetDuiKeyboardInput.md
@@ -1,0 +1,14 @@
+
+---
+ns: CFX
+apiset: client
+---
+## SET_DUI_KEYBOARD_INPUT
+
+```c
+void SET_DUI_KEYBOARD_INPUT(long duiObject, BOOL keepInput);
+```
+Allows the DUI object to have keyboard input, similar to NUI Focus
+## Parameters
+* **duiObject**: The DUI browser handle.
+* **keepInput**: Whether the DUI object should have input.


### PR DESCRIPTION
### Goal of this PR
A better version of: PR #2195 , to add the ability to use keyboard inputs in DUI.
Please See [this forums post](https://forum.cfx.re/t/dui-nui-request-for-send-dui-key-down-send-dui-key-up/5166146) for why this ability would be very useful.

Currently keyboard inputs are:
A. impossible on any external sites
B. very janky and too specific (having to apply the code to each individual input) on internal UI

### How is this PR achieving the goal
This PR adds 2 brand new natives:
`SET_DUI_KEYBOARD_INPUT` - Works the same way as NUI focus, but for DUI
`KEYBOARD_HAS_KEYBOARD_INPUT` - to check if the dui is currently focused or not


### This PR applies to the following area(s)
Natives,
NUI,
DUI

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ x] Code compiles and has been tested successfully.
- [ x] Code explains itself well and/or is documented.
- [ x] My commit message explains what the changes do and what they are for.
- [ x] No extra compilation warnings are added by these changes.


