### PR TITLE
fix(txd): bump txd pool size

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -462,7 +462,7 @@
 						</Item>
 						<Item>
 							<PoolName>TxdStore</PoolName>
-							<PoolSize value="105500"/>
+							<PoolSize value="115500"/>
 						</Item>
 						<Item>
 							<PoolName>CNetObjVehicle</PoolName>


### PR DESCRIPTION
The primary purpose of this commit is to prevent crashes in the two most recent DLCs caused by addon TXDs. After version 2802, the limits were not updated. As a result, many servers are unable to upgrade to the latest DLCs due to TXD limitations. This bump will extend support up to version 2944 with a reasonable set of TXDs. However, further increases will be necessary if we plan to support versions 3095 and 3258.

solves [#2724](https://github.com/citizenfx/fivem/issues/2724)

 Code compiles and has been tested successfully.
 Code explains itself well and/or is documented.
 My commit message explains what the changes do and what they are for.
 No extra compilation warnings are added by these changes.