### PR TITLE
fix(clcore-v2): Fix ReplicateMethodAccessException for Callbacks

### DIFF
--- a/code/client/clrcore-v2/Interop/LocalFunction.cs
+++ b/code/client/clrcore-v2/Interop/LocalFunction.cs
@@ -41,6 +41,7 @@ namespace CitizenFX.Core
 			return CoreNatives.DuplicateFunctionReference(m_reference);
 		}
 
+		[SecuritySafeCritical]
 		internal unsafe Coroutine<object> Invoke(object[] args)
 		{
 			object[] returnData = MsgPackDeserializer.DeserializeArray(ScriptInterface.InvokeFunctionReference(m_reference, new InPacket(args).value));


### PR DESCRIPTION
Decorate LocalFunction.Invoke with SecuritySafeCritical to fix callbacks throwing ReplicateMethodAccessException

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix ``ReplicateMethodAccessException`` being thrown when a callback is being used.

### How is this PR achieving the goal

The erroring function ``LocalFunction.Invoke`` is decorated as ``SecuritySafeCritical``


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: C#, FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** b3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

fixes #2749