### PR TITLE
feat(natives/vehicle): implement getter/setter for vehicle flags

### DIFF
--- a/ext/native-decls/GetVehicleHasFlag.md
+++ b/ext/native-decls/GetVehicleHasFlag.md
@@ -1,0 +1,67 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VEHICLE_HAS_FLAG
+
+```c
+bool GET_VEHICLE_HAS_FLAG(Vehicle vehicle, int flagIndex);
+```
+
+**Note**: Flags are not the same based on your `gamebuild`. Please see [here](https://docs.fivem.net/docs/game-references/vehicle-references/vehicle-flags) to see a complete list of all vehicle flags.
+
+Get vehicle.meta flag by index. Useful examples include `FLAG_LAW_ENFORCEMENT` (31), `FLAG_RICH_CAR` (36), `FLAG_IS_ELECTRIC` (43), `FLAG_IS_OFFROAD_VEHICLE` (48).
+
+## Parameters
+* **vehicle**: The vehicle to obtain flags for.
+* **flagIndex**: Flag index.
+
+## Return value
+A boolean for whether the flag is set.
+
+### Example
+```lua
+local vehicleFlags = {
+    FLAG_SMALL_WORKER = 0,
+    FLAG_BIG = 1,
+    FLAG_NO_BOOT = 2,
+    FLAG_ONLY_DURING_OFFICE_HOURS = 3
+    -- This is just a example, see fivem-docs to see all flags.
+}
+
+local function getAllVehicleFlags(vehicle)
+    local flags = {}
+    for i = 0, 256 do
+        if GetVehicleHasFlag(vehicle, i) then
+            flags[#flags+1] = i
+        end
+    end
+    return flags
+end
+
+local flagsVehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+print(getAllVehicleFlags)
+```
+
+```javascript
+const VEHICLE_FLAGS = {
+    FLAG_SMALL_WORKER: 0,
+    FLAG_BIG: 1,
+    FLAG_NO_BOOT: 2,
+    FLAG_ONLY_DURING_OFFICE_HOURS: 3
+    // This is just a example, see fivem-docs to see all flags.
+};
+
+function getAllVehicleFlags(mVehicle = GetVehiclePedIsIn(PlayerPedId(), false)) {
+    const flags = [];
+    for (let i = 0; i < 204; i++) {
+        if (GetVehicleHasFlag(mVehicle, i)) {
+            flags.push(i);
+        }
+    }
+    return flags;
+}
+
+let flagsVehicle = GetVehiclePedIsIn(PlayerPedId(), false);
+console.log(getAllVehicleFlags);
+```

--- a/ext/native-decls/SetVehicleFlag.md
+++ b/ext/native-decls/SetVehicleFlag.md
@@ -1,0 +1,32 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_VEHICLE_FLAG
+
+```c
+bool SET_VEHICLE_FLAG(Vehicle vehicle, int flagIndex, bool value);
+```
+
+This native is a setter for [`GET_VEHICLE_HAS_FLAG`](#_0xD85C9F57).
+
+## Parameters
+* **vehicle**: The vehicle to set flag for.
+* **flagIndex**: Flag index.
+* **value**: `true` to enable the flag, `false` to disable it.
+
+
+### Example
+```lua
+local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+if not vehicle then return end
+
+SetVehicleFlag(vehicle, 43, true) -- Set the vehicle as electric 
+```
+
+```javascript
+let vehicle = GetVehiclePedIsIn(PlayerPedId(), false);
+if (!vehicle) return;
+
+SetVehicleFlag(vehicle, 43, true);  // Set the vehicle as electric 
+```


### PR DESCRIPTION
### Goal of this PR
Implement natives to set and get vehicle flags. This is the PR of @kams3 with the addition of the setter.

### How is this PR achieving the goal

By reading the specific offset in this signature: 48 85 C0 74 3C 8B 80 ? ? ? ? C1 E8 0F, which exposes vehicle flags on the vehicle. 

This rely on https://github.com/citizenfx/fivem-docs/pull/480

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


