### PR TITLE
tweak(scripting/v8): better error messages for ref calls

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -8,6 +8,7 @@ const EXT_LOCALFUNCREF = 11;
 	let boundaryIdx = 1;
 	let lastBoundaryStart = null;
 	const isDuplicityVersion = IsDuplicityVersion();
+	const currentResourceName = GetCurrentResourceName();
 
 	// temp
 	global.FormatStackTrace = function (args, argLength) {
@@ -76,13 +77,30 @@ const EXT_LOCALFUNCREF = 11;
 
 	function refFunctionUnpacker(refSerialized) {
 		const fnRef = Citizen.makeFunctionReference(refSerialized);
+		const invoker = GetInvokingResource();
 
 		return function (...args) {
 			return runWithBoundaryEnd(() => {
-				const retvals = unpack(fnRef(pack(args)));
+				let retvals = null;
+				try {
+					retvals = unpack(fnRef(pack(args)));
+				} catch (e) {
+				}
 
 				if (retvals === null) {
-					throw new Error('Error in nested ref call.');
+					let errorMessage = `Error in nested ref call for ${currentResourceName}. `
+					// invoker can be null, we don't want to give an even worse
+					// error by erroring here :P
+					if (invoker) {
+						errorMessage += `${currentResourceName} tried to call a function reference in ${invoker} but the reference wasn't valid. `
+						if (GetResourceState(invoker) !== "started") {
+							errorMessage += `And ${invoker} isn't started, was the resource restarted mid call?`
+						} else {
+							errorMessage += `(did ${invoker} restart recently?)`
+						}
+					}
+
+					throw new Error(errorMessage);
 				}
 
 				switch (retvals.length) {
@@ -519,7 +537,7 @@ const EXT_LOCALFUNCREF = 11;
 	const getExportEventName = (resource, name) => `__cfx_export_${resource}_${name}`;
 
 	on(`on${eventType}ResourceStart`, (resource) => {
-		if (resource === GetCurrentResourceName()) {
+		if (resource === currentResourceName) {
 			const numMetaData = GetNumResourceMetadata(resource, exportKey) || 0;
 
 			for (let i = 0; i < numMetaData; i++) {
@@ -582,7 +600,7 @@ const EXT_LOCALFUNCREF = 11;
 
 				const [exportName, func] = args;
 
-				on(getExportEventName(GetCurrentResourceName(), exportName), (setCB) => {
+				on(getExportEventName(currentResourceName, exportName), (setCB) => {
 					setCB(func);
 				});
 			},


### PR DESCRIPTION
### Goal of this PR
Improve error messages when unpacking function unpacker

Currently if you error in this section of code on the server you get a hard to use stack trace that doesn't provide you any insights

![image](https://github.com/user-attachments/assets/d213bda4-bc13-410e-872d-d9710570dad4)



### How is this PR achieving the goal
1. Cache the resource that originally called an export to x resource
2. Catch unpack if it errors and return the default null
3. Warn the end user if the resource recently restarted, or point them in the right direction as ref calls should only be invalidated on resource restart.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: js


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.