### PR TITLE
fix(game/five): verify pickup weapon component is valid on creation

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.InvalidPickupCreation.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.InvalidPickupCreation.cpp
@@ -3,6 +3,7 @@
 #include <jitasm.h>
 #include <Hooking.h>
 #include <Hooking.Stubs.h>
+#include <CrossBuildRuntime.h>
 
 static void (*origCPedModelInfo__SetupPedBuoyancyInfo)(void* BuoyancyInfo, const void* pCapsuleInfo, const void* FragType, bool bIsWeightless);
 
@@ -66,5 +67,57 @@ static HookFunction hookFunction([]
 	{
 		// CPedModelInfo::SetupPedBuoyancyInfo doesn't check that FragType isn't null.
 		origCPedModelInfo__SetupPedBuoyancyInfo = hook::trampoline(hook::get_call(hook::get_pattern("45 33 C9 4C 8B C0 48 8B D3 E8", 0x9)), &CPedModelInfo__SetupPedBuoyancyInfo);
+	}
+
+	// Not present on 1604 and we don't care about builds between 1604 and 2060
+	if (xbr::IsGameBuildOrGreater<2060>())
+	{
+		// Test for a valid weapon component info pointer before de-referencing it.
+		static struct : jitasm::Frontend
+		{
+			intptr_t retFail;
+			intptr_t retSuccess;
+
+			void Init(intptr_t location)
+			{
+				retFail = location + 14;
+				retSuccess = location + 6;
+			}
+
+			void InternalMain() override
+			{
+				test(rbx, rbx);				// if ( rbx )
+				jz("fail");					// {
+											//
+				// * original code			//
+				mov(rax, qword_ptr[rbx]);	//
+											//		[run original code]
+				mov(rcx, rbx);				//
+				// * original code END		//
+											//
+				mov(rax, retSuccess);		//
+				jmp(rax);					//
+											// }
+				L("fail");					//
+				mov(rax, retFail);			//
+				jmp(rax);					//
+			}
+
+		} patchStub;
+
+		// mov rax, [rbx]
+		auto location = hook::get_pattern<char>("7E ? 33 DB 48 8B 03", 4);
+
+		patchStub.Init(reinterpret_cast<intptr_t>(location));
+
+		/*
+		* nop:
+		* 
+		* mov rax, [rbx]
+		* mov rcx, rbx
+		*/
+		hook::nop(location, 6);
+
+		hook::jump_rcx(location, patchStub.GetCode());
 	}
 });


### PR DESCRIPTION
### Goal of this PR

Prevent crash caused by invalid pickup weapon components on pickup creation.


### How is this PR achieving the goal

Adds proper validations on pickup creation


### This PR applies to the following area(s)

FiveM


### Successfully tested on

**Game builds:** 2060, 3095

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

Fixes `GTA5_b3095.exe!sub_141163854 (0x456)`
