### PR TITLE
feat(extra-natives): add `CNetObject` to `GET_GAME_POOL`

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -962,7 +962,7 @@ static void Init()
 			desiredType = EntityType::Ped;	
 		else if (poolName == "CVehicle")
 			desiredType = EntityType::Vehicle;
-		else if (poolName == "CObject")
+		else if (poolName == "CObject" || poolName == "CNetObject")
 			desiredType = EntityType::Object;
 
 		for (auto& entity : gameState->m_entityList)

--- a/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
+++ b/code/components/extra-natives-five/src/PoolTraversalNatives.cpp
@@ -141,7 +141,7 @@ struct PickupPoolTraits
 	}
 };
 
-template<typename TTraits>
+template<typename TTraits, bool NetworkOnly = false>
 static void SerializePool(fx::ScriptContext& context)
 {
 	std::vector<uint32_t> guids;
@@ -152,6 +152,14 @@ static void SerializePool(fx::ScriptContext& context)
 		TTraits::ObjectType* entry = pool->GetAt(i);
 		if (entry)
 		{
+			if (NetworkOnly)
+			{
+				if (!entry->GetNetObject())
+				{
+					continue;
+				}
+			}
+
 			uint32_t guid = TTraits::getScriptGuid(entry);
 			if (guid != 0)
 			{
@@ -282,6 +290,8 @@ static InitFunction initFunction([]()
 			SerializePool<PedPoolTraits>(context);
 		else if (pool.compare("CObject") == 0)
 			SerializePool<ObjectPoolTraits>(context);
+		else if (pool.compare("CNetObject") == 0)
+			SerializePool<ObjectPoolTraits, true>(context);
 		else if (pool.compare("CPickup") == 0)
 			SerializePool<PickupPoolTraits>(context);
 		else if (pool.compare("CVehicle") == 0)

--- a/ext/native-decls/GetGamePool.md
+++ b/ext/native-decls/GetGamePool.md
@@ -18,6 +18,7 @@ follows:
 ### Supported pools
 * `CPed`: Peds (including animals) and players.
 * `CObject`: Objects (props), doors, and projectiles.
+* `CNetObject`: Networked objects
 * `CVehicle`: Vehicles.
 * `CPickup`: Pickups.
 


### PR DESCRIPTION
### Goal of this PR
Give a fast path for calls to `GET_GAME_POOL` that only want to get networked objects (which can be a max of 80 objects), reducing the serialization/de-serialization overhead for this native call.

Getting entities from `GetGamePool("CObject")` can be costly due to the fact that this pool will include map objects too, which can lead to this table being thousands of objects long.

This doesn't include networked variants for `CPed` and `CVehicle` because these are more often times going to be networked, where as `CObject` is more likely to be client local objects

### How is this PR achieving the goal
This adds a new fast path `CNetObject` which should only return objects that are networked

<details>
   <summary>Test Example</summary>
   
```lua
CreateThread(function()
    local networkedObjects = GetGamePool("CNetObject")
    for i = 1, #networkedObjects do
        local obj = networkedObjects[i]
        SetEntityAsMissionEntity(obj, true, false)
        DeleteEntity(obj)
    end
end)

local trackedObjectIds = {}
local logged = {}
CreateThread(function()
    local model = `prop_boombox_01`

    RequestModel(model)
    while not HasModelLoaded(model) do
        Wait(0)
    end

    while true do
        local networkedObjects = GetGamePool("CNetObject")
        print("netobj", #networkedObjects)

        for i = 1, #networkedObjects do
            local obj = networkedObjects[i]
            if trackedObjectIds[obj] then
                trackedObjectIds[obj] = false
                print("got tracked object", obj)
            end
        end

        local obj = GetGamePool("CObject")
        print("obj", #obj)

        local pedPos = GetEntityCoords(PlayerPedId())
        local obj = CreateObject(model, pedPos, true, true, false)
        if obj ~= 0 then
            trackedObjectIds[obj] = true
        end

        Wait(1000)
    end
end)
```
</details>


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


