### PR TITLE
tweak(data/rdr3): Increase InteriorProxy pool size

### DIFF
--- a/data/client_rdr/citizen/common/data/gameconfig.xml
+++ b/data/client_rdr/citizen/common/data/gameconfig.xml
@@ -1167,7 +1167,7 @@
 				</Item>
                 <Item>
                   <PoolName>InteriorProxy</PoolName>
-                  <PoolSize value="450"/>
+                  <PoolSize value="900"/>
                 </Item>
                 <Item>
                   <PoolName>IplStore</PoolName>


### PR DESCRIPTION
### Goal of this PR

RDR has 394 vanilla MLOs
This limit let only 56 custom MLOs

Fivem InteriorProxy pool size is currently at 9060


### How is this PR achieving the goal

By increasing pool size value in gameconfig


### This PR applies to the following area(s)

RedM


### Successfully tested on

**Game builds:** all

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
