### PR TITLE
tweak(clrcore): add missing LicensePlateStyle enum types

### DIFF
--- a/code/client/clrcore/External/Vehicle.cs
+++ b/code/client/clrcore/External/Vehicle.cs
@@ -26,12 +26,19 @@ namespace CitizenFX.Core
 	}
 	public enum LicensePlateStyle
 	{
-		BlueOnWhite1 = 3,
-		BlueOnWhite2 = 0,
+		BlueOnWhite1 = 0,
+ 		YellowOnBlack = 1,
+   		YellowOnBlue = 2,
+		BlueOnWhite2 = 3,
 		BlueOnWhite3 = 4,
-		YellowOnBlack = 1,
-		YellowOnBlue = 2,
-		NorthYankton = 5
+		NorthYankton = 5,
+  		ECola = 6,
+		LasVenturas = 7,
+  		LibertyCity = 8,
+		LSCarMeet = 9,
+  		LSPanic = 10,
+		LSPounders = 11,
+  		Sprunk = 12
 	}
 	public enum LicensePlateType
 	{


### PR DESCRIPTION
Add new license plate style indexes to `LicensePlateStyle` enum.
Since they where added to the [Native Docs](https://github.com/citizenfx/natives/pull/1120), they should of been added to the C# enum list at the same time.

### Goal of this PR
Adding the new license plate styles from the latest DLC

...


### This PR applies to the following area(s)
FiveM, ScRT: C#

...


### Successfully tested on
Latest

**Game builds:** Latest

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



