### PR TITLE
feat(clrcore): add implicit conversion from int to CString in Player

### DIFF
--- a/code/client/clrcore-v2/Shared/Player.cs
+++ b/code/client/clrcore-v2/Shared/Player.cs
@@ -11,11 +11,22 @@ namespace CitizenFX.Shared
 		internal Player()
 		{
 		}
-		
+
 		/// <summary>
 		/// Gets the handle of this player
 		/// </summary>
 		public int Handle => int.Parse(m_handle);
+
+		/// <summary>
+		/// Converts a <see cref="Player"/> to a <see cref="CString"/> using its <see langword="int"/> <see cref="Handle"/>.
+		/// </summary>
+		/// <param name="player">
+		/// The <see cref="Player"/> to convert.
+		/// </param>
+		public static implicit operator CString(Player player)
+		{
+			return player.Handle.ToString();
+		}
 #else
 	public abstract class Player : Core.Native.Input.Primitive
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR adds an implicit conversion from `int` to `CString` in the `Player` class as a quality of life (QoL) improvement on the server side. This allows for direct conversion without the need to explicitly call `Handle.ToString()`.

See : https://github.com/thorium-cfx/mono_v2_get_started/issues/37

It might be interesting to add this implicit conversion to other entities as well.

### How is this PR achieving the goal

This PR adds an implicit operator CString(Player player).
With this change, you can now do the following:

```csharp
Player p1 = new Player(1);
Natives.ThisCoolNative(p1, "hello", 1234); // ThisCoolNative(CString, CString, int)
```

### This PR applies to the following area(s)
Server, ScRT: C#

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** Latest

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

resolves https://github.com/thorium-cfx/mono_v2_get_started/issues/37