### PR TITLE
feat(gameinput): put txAdmin keys mappings at the top

### DIFF
--- a/code/components/gta-core-five/src/GameInput.cpp
+++ b/code/components/gta-core-five/src/GameInput.cpp
@@ -1179,6 +1179,24 @@ static void GetMappingCategoryInputs(uint32_t* categoryId, atArray<uint32_t>& co
 		std::vector<std::pair<std::string, std::tuple<std::string, std::string>>> sortedBindings(g_registeredBindings.begin(), g_registeredBindings.end());
 		std::sort(sortedBindings.begin(), sortedBindings.end(), [](const auto& left, const auto& right)
 		{
+
+			const std::string& leftTag = std::get<0>(std::get<1>(left));
+			const std::string& rightTag = std::get<0>(std::get<1>(right));
+			
+			// txAdmin key mappings needs to be at the top of the list.
+			bool leftIsTxAdmin = (leftTag == "monitor");
+			bool rightIsTxAdmin = (rightTag == "monitor");
+
+			if (leftIsTxAdmin && rightIsTxAdmin)
+			{
+				return true;
+			}
+
+			if (!leftIsTxAdmin && rightIsTxAdmin)
+			{
+				return false;
+			}
+
 			// #TODO: Unicode-aware comparison
 			return std::get<1>(left.second) < std::get<1>(right.second);
 		});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Actually, @tabarra added # in his key mappings to have the txAdmin key mappings at the top of the FiveM key settings. This PR aims to fix this so Tabarra doesn't have to do this workaround


### How is this PR achieving the goal
By checking the tag (resourceName) is monitor (txAdmin), if it's the case we are returning true


### This PR applies to the following area(s)
FiveM


### Successfully tested on
![image](https://github.com/user-attachments/assets/86a6ac00-86a8-4d0b-96d4-f57816614a4f)
Here is a screen where i did the test with a resource called ns_carrierheist

**Game builds:** 3258

**Platforms:** Windows,


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


