### PR TITLE
feat(gameinput): new sorting algo and new native

### DIFF
--- a/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
@@ -27,6 +27,17 @@ static InitFunction initFunction([]()
 		}
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("SET_KEY_MAPPING_HIDE_RESOURCES", [](fx::ScriptContext& context)
+	{
+		bool hide = context.GetArgument<bool>(0);
+
+		fx::OMPtr<IScriptRuntime> runtime;
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			game::SetKeyMappingHideResources(hide);
+		}
+	});
+
 	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* resource)
 	{
 		resource->OnStart.Connect([resource]()

--- a/code/components/gta-core-five/include/GameInput.h
+++ b/code/components/gta-core-five/include/GameInput.h
@@ -13,4 +13,6 @@ namespace game
 	GAMEINPUT_EXPORT void RegisterBindingForTag(const std::string& tag, const std::string& command, const std::string& languageDesc, const std::string& ioms, const std::string& ioParam);
 
 	GAMEINPUT_EXPORT bool IsControlKeyDown(int control);
+
+	GAMEINPUT_EXPORT void SetKeyMappingHideResources(bool hide);
 }

--- a/ext/native-decls/SetKeyMappingHideResources.md
+++ b/ext/native-decls/SetKeyMappingHideResources.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_KEY_MAPPING_HIDE_RESOURCES
+
+```c
+void SET_KEY_MAPPING_HIDE_RESOURCES(bool hide);
+```
+
+Toggles the visibility of resource names in the FiveM key mapping page.
+
+## Parameters
+* **hide**: `true` will disable the display of resource names, and `false` will enable it.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Actually, @tabarra added # in his key mappings to have the txAdmin key mappings at the top of the FiveM key settings. This PR aims to fix this so Tabarra doesn't have to do this workaround


### How is this PR achieving the goal
If the left is monitor and not the right one, we return true to indicate that the left needs to be placed before the right. If the right one is txAdmin and not the left one, we return false so that the right is placed before the left. Thanks @FabianTerhorst for fixing the sorting logic.

### This PR applies to the following area(s)
FiveM


### Successfully tested on
![image](https://github.com/user-attachments/assets/86a6ac00-86a8-4d0b-96d4-f57816614a4f)
Here is a screenshot where i did the test with a resource called ns_carrierheist.

**Game builds:** 3258

**Platforms:** Windows,


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


