### PR TITLE
fix: vehicle sync tree causing getters to return the wrong values

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -671,7 +671,6 @@ struct CVehicleAppearanceDataNode : GenericSerializeDataNode<CVehicleAppearanceD
         s.Serialize(8, data.wheelColour);
         s.Serialize(8, data.interiorColour);
         s.Serialize(8, data.dashboardColour);
-        s.Serialize(8, data.primaryColour);
 
         s.Serialize(data.isPrimaryColourRGB);
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
- Fixing getting the wrong values returned when using server getters like `GET_VEHICLE_NUMBER_PLATE_TEXT`


### How is this PR achieving the goal
- Removing the second serialization of `data.primaryColour` which seems to be a small copy & paste mistake. Added with the following pr: #2785


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
- FiveM, Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
- Couldn't test it myself, but comparing the new and old synctree only showed this difference between them.


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
- Not working server getters like `GET_VEHICLE_NUMBER_PLATE_TEXT`
