### PR TITLE
fix(ci/windows): Downgrade MSVC build tools

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -44,6 +44,22 @@ jobs:
           git pull origin $GITHUB_REF:PR_BRANCH --depth=1
           git submodule update --jobs=$JOB_SLOTS --init --depth=1
         
+      - name: Downgrade MSVC build tools
+        if: ${{ env.PLATFORM == 'windows' }}
+        shell: pwsh
+        run: |
+          # Temporary workaround till build toolchain is updated
+          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          
+          # Remove latest version
+          $Arguments = ('modify', '--installPath', "`"$InstallPath`"", '--remove', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '--remove', 'Microsoft.VisualStudio.Component.VC.ATL', '--quiet', '--norestart', '--nocache')
+          Start-Process -FilePath vs_installer.exe -ArgumentList $Arguments -Wait
+          
+          # Install last supported version (v14.40-17.10)
+          $Arguments = ('modify', '--installPath', "`"$InstallPath`"", '--add', 'Microsoft.VisualStudio.Component.VC.14.40.17.10.x86.x64', '--add', 'Microsoft.VisualStudio.Component.VC.14.40.17.10.ATL', '--quiet', '--norestart', '--nocache')
+          Start-Process -FilePath vs_installer.exe -ArgumentList $Arguments -Wait
+        
       - name: Dependencies
         shell: bash
         run: |


### PR DESCRIPTION
### Goal of this PR
Github Actions running on 'windows-latest' get shipped with VS 2022 C++ x64/x86 build tools v14.41-17.11 which includes various breaking changes that make building on the CI pipeline fail.

### How is this PR achieving the goal
Github Actions doesn't allow to use older image versions, so we downgrade VS build tools to v14.40-17.10 manually as a temporary fix. This only downgrades necessary components to avoid increasing the build time any further.

This can be reverted once the build tool chain got updated.

### This PR applies to the following area(s)
CI, Building

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Github Actions - Windows Latest

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/