### PR TITLE
fix(game/five): verify pickup weapon component is valid on creation ( again, but proper )

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.InvalidPickupCreation.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.InvalidPickupCreation.cpp
@@ -3,6 +3,7 @@
 #include <jitasm.h>
 #include <Hooking.h>
 #include <Hooking.Stubs.h>
+#include <CrossBuildRuntime.h>
 
 static void (*origCPedModelInfo__SetupPedBuoyancyInfo)(void* BuoyancyInfo, const void* pCapsuleInfo, const void* FragType, bool bIsWeightless);
 
@@ -66,5 +67,57 @@ static HookFunction hookFunction([]
 	{
 		// CPedModelInfo::SetupPedBuoyancyInfo doesn't check that FragType isn't null.
 		origCPedModelInfo__SetupPedBuoyancyInfo = hook::trampoline(hook::get_call(hook::get_pattern("45 33 C9 4C 8B C0 48 8B D3 E8", 0x9)), &CPedModelInfo__SetupPedBuoyancyInfo);
+	}
+
+	// Not present on 1604 and we don't care about builds between 1604 and 2060
+	if (xbr::IsGameBuildOrGreater<2060>())
+	{
+		// Test for a valid weapon component info pointer before de-referencing it.
+		static struct : jitasm::Frontend
+		{
+			uint8_t vtableOffset;
+
+			void Init(intptr_t location)
+			{
+				vtableOffset = *(uint8_t*)(location + 0x8);
+			}
+
+			void InternalMain() override
+			{
+				test(rbx, rbx);								// if ( rbx )
+				jz("skip");									// {
+															//
+				// * original code                          //
+				mov(rax, qword_ptr[rbx]);					//
+															//        [run original code]
+				mov(rcx, rbx);								//
+															//
+				mov(rax, qword_ptr[rax + vtableOffset]);	//
+				call(rax);									//
+				// * original code END                      //
+															//
+															// }
+				L("skip");									//
+															//
+				ret();										//
+			}
+
+		} patchStub;
+
+		// mov rax, [rbx]
+		auto location = hook::get_pattern<char>("7E ? 33 DB 48 8B 03", 4);
+
+		patchStub.Init(reinterpret_cast<intptr_t>(location));
+
+		/*
+		 * nop:
+		 *
+		 * mov rax, [rbx]
+		 * mov rcx, rbx
+		 * call    qword ptr [rax+38h]
+		 */
+		hook::nop(location, 9);
+
+		hook::call(location, patchStub.GetCode());
 	}
 });


### PR DESCRIPTION
### Goal of this PR

Prevent crash caused by invalid pickup weapon components on pickup creation.

This is an improvement on #2797 which was absolutely garbage.


### How is this PR achieving the goal

Adds proper validations on pickup creation


### This PR applies to the following area(s)

FiveM


### Successfully tested on

**Game builds:** 2060, 2699, 2802, 3095, 3258

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

Fixes GTA5_b3095.exe!sub_141163854 (0x456)
