### PR TITLE
tweak(codegen): set VAR_STRING as an unsupported type for OAL

### DIFF
--- a/ext/natives/codegen_out_native_lua.lua
+++ b/ext/natives/codegen_out_native_lua.lua
@@ -9,7 +9,10 @@ local unsupList = {
 	'SET_OBJECT_AS_NO_LONGER_NEEDED',
 	'SET_PED_AS_NO_LONGER_NEEDED',
 	'SET_VEHICLE_AS_NO_LONGER_NEEDED',
-	'SET_MISSION_TRAIN_AS_NO_LONGER_NEEDED'
+	'SET_MISSION_TRAIN_AS_NO_LONGER_NEEDED',
+	-- RDR3: This function can take multiple different types which OAL doesn't
+	-- currently support.
+	'VAR_STRING'
 }
 
 local unsup = {}


### PR DESCRIPTION
### Goal of this PR
Allow `VAR_STRING` to be used on RDR when using OAL


### How is this PR achieving the goal
Marks it as 'unsupported' so it wont be generated as a supported native for OAL


### This PR applies to the following area(s)
RedM


### Successfully tested on
This was only tested that it doesn't add to the map in `NativesRDR.h`

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes the issue @outsider31000 reported
