### PR TITLE
fix(game/five): netGameEvent and atDNetEventNode PoolSize Values

### DIFF
--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -511,11 +511,11 @@
 						</Item>
 						<Item>
 							<PoolName>netGameEvent</PoolName>
-							<PoolSize value="511"/>
+							<PoolSize value="711"/>
 						</Item>
 						<Item>
 							<PoolName>atDNetEventNode</PoolName>
-							<PoolSize value="511"/>
+							<PoolSize value="711"/>
 						</Item>
 
 						<Item>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Attempt to resolve https://github.com/citizenfx/fivem/issues/2843 netGameEvent poolsize client crashing with limit reached on latest builds such as 3258.

### How is this PR achieving the goal
Increase of netGameEvent + atDNetEventNode PoolSize values to meet stronger demands. Due to client crashes reaching the current limit quite often in latest builds.


### This PR applies to the following area(s)
FiveM - gameconfig.xml

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

`fixes` https://github.com/citizenfx/fivem/issues/2843
