### PR TITLE
tweak(mono-rt2): change script initialization method

### DIFF
--- a/code/client/clrcore-v2/BaseScript.cs
+++ b/code/client/clrcore-v2/BaseScript.cs
@@ -118,7 +118,8 @@ namespace CitizenFX.Core
 				}
 			}
 
-			m_state = State.Initialized | State.Enabled;
+			m_state = State.Initialized;
+			Enable();
 		}
 
 		/// <summary>
@@ -129,7 +130,6 @@ namespace CitizenFX.Core
 			if (m_state == State.Uninitialized)
 			{
 				Initialize();
-				OnEnable();
 			}
 			else if ((m_state & State.Enabled) == 0)
 			{
@@ -234,7 +234,6 @@ namespace CitizenFX.Core
 			{
 				CoroutineRepeat newTick = new CoroutineRepeat(tick, stopOnException);
 				m_tickList.Add(newTick);
-				newTick.Schedule();
 			}
 		}
 
@@ -309,7 +308,6 @@ namespace CitizenFX.Core
 			throw new NotImplementedException();
 #endif
 			m_nuiCallbacks.Add(callbackName, dynFunc);
-			Native.CoreNatives.RegisterNuiCallback(callbackName, dynFunc);
 		}
 
 		/// <summary>
@@ -328,7 +326,6 @@ namespace CitizenFX.Core
 #endif
 			DynFunc dynFunc = Func.Create(delegateFn);
 			m_nuiCallbacks.Add(callbackName, dynFunc);
-			Native.CoreNatives.RegisterNuiCallback(callbackName, dynFunc);
 		}
 		
 		/// <summary>

--- a/code/client/clrcore-v2/Interop/EventsManager.cs
+++ b/code/client/clrcore-v2/Interop/EventsManager.cs
@@ -138,7 +138,6 @@ namespace CitizenFX.Core
 		public EventHandlerSet Add(DynFunc deleg, Binding binding = Binding.Local)
 		{
 			m_handlers.Add(deleg);
-			EventsManager.AddEventHandler(m_eventName, deleg, binding);
 			return this;
 		}
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Change the way scripts are initialized to prevent a BaseClass with the EnableOnLoad(false) attribute from loading ticks, events and nui callbacks.


### How is this PR achieving the goal

First of all I have modified the `Initialize` function, now when I initialize the script it will call the `Enable` function again to load the ticks, events and nui callbacks.
Finally, I have eliminated the functions that recorded ticks, callbacks and events when they were added.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: C#


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes #2476

