### PR TITLE
feat(rdr): add NETWORK_DOES_ENTITY_EXIST_WITH_NETWORK_ID as a Cfx native

### DIFF
--- a/code/components/gta-core-rdr3/component.json
+++ b/code/components/gta-core-rdr3/component.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"dependencies": [
 		"fx[2]",
+		"citizen:scripting:core",
 		"pool-sizes-state",
 		"rage:allocator",
 		"rage:nutsnbolts",

--- a/ext/native-decls/NetworkDoesEntityExistWithNetworkId.md
+++ b/ext/native-decls/NetworkDoesEntityExistWithNetworkId.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## NETWORK_DOES_ENTITY_EXIST_WITH_NETWORK_ID
+
+```c
+BOOL NETWORK_DOES_ENTITY_EXIST_WITH_NETWORK_ID(int netId);
+```
+
+## Parameters
+* **netId**: The network id to check
+
+## Return value
+Returns `true` if both the network id exist, and the network id has a game object.


### PR DESCRIPTION
### Goal of this PR
Allow the usage of `NETWORK_DOES_ENTITY_EXIST_WITH_NETWORK_ID` without needing to directly invoke `0x18A47D074708FD68`.

This also copies the ScRT warnings to provide more useful warnings.

### How is this PR achieving the goal
Declared the native as a Cfx native and include scripting core warnings.

### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
