### PR TITLE
fix(scripting/mono-v2): validate app domain before removing ref

### DIFF
--- a/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
@@ -379,6 +379,12 @@ result_t MonoScriptRuntime::RemoveRef(int32_t refIndex)
 {
 	fx::PushEnvironment env(this);
 	MonoComponentHost::EnsureThreadAttached();
+
+	if (m_appDomain == nullptr)
+	{
+		return FX_E_INVALIDARG;
+	}
+
 	MonoDomainScope scope(m_appDomain);
 
 	MonoException* exc = nullptr;


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix a crash that occurred when an export declared in lua code was executed from C# v2 from the same resource multiple times, the issue with more details is here: https://github.com/thorium-cfx/mono_v2_get_started/issues/32


### How is this PR achieving the goal

It seems that there are times that `m_appDomain` is destroyed when the script is stopped, but RemoveRef is still called a little after the C# script is destroyed, therefore RemoveRef is called when `m_appDomain` is null and results in the crash.
I don't know if there is a better solution for this.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: C#


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes [#32](https://github.com/thorium-cfx/mono_v2_get_started/issues/32)