### PR TITLE
feat(native/getbuild): new native to get the version of FXServer

### DIFF
--- a/code/components/citizen-server-impl/include/BuildInfo.h
+++ b/code/components/citizen-server-impl/include/BuildInfo.h
@@ -1,0 +1,8 @@
+namespace fx
+{
+class BuildInfo
+{
+public:
+	static int GetBuildNumber();
+};
+}

--- a/code/components/citizen-server-impl/src/BuildInfo.cpp
+++ b/code/components/citizen-server-impl/src/BuildInfo.cpp
@@ -1,0 +1,9 @@
+#include "StdInc.h"
+#include "BuildInfo.h"
+#include <cfx_version.h>
+
+int fx::BuildInfo::GetBuildNumber()
+{
+	const char* lastPeriod = strchr(GIT_TAG, '.');
+	return lastPeriod == nullptr ? 0 : strtol(lastPeriod + 1, nullptr, 10);
+}

--- a/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/InfoHttpHandler.cpp
@@ -26,6 +26,8 @@
 
 #include "ForceConsteval.h"
 
+#include "BuildInfo.h"
+
 using json = nlohmann::json;
 
 inline uint32_t SwapLong(uint32_t x)
@@ -166,8 +168,7 @@ void InfoHttpHandlerComponentLocals::AttachToObject(fx::ServerInstanceBase* inst
 	maxClientsVar = instance->AddVariable<int>("sv_maxClients", ConVar_ServerInfo, 30);
 	iconVar = instance->AddVariable<std::string>("sv_icon", ConVar_Internal, "");
 	versionVar = instance->AddVariable<std::string>("version", ConVar_Internal, "FXServer-" GIT_DESCRIPTION);
-	const char* lastPeriod = strrchr(GIT_TAG, '.');
-	int versionBuildNo = lastPeriod == nullptr ? 0 : strtol(lastPeriod + 1, nullptr, 10);
+	int versionBuildNo = fx::BuildInfo::GetBuildNumber();
 	versionBuildNoVar = instance->AddVariable<int>("buildNumber", ConVar_Internal, versionBuildNo);
 	crashCmd = instance->AddCommand("_crash", []()
 	{

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -37,6 +37,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "BuildInfo.h"
+
 #if defined(_DEBUG) && defined(_WIN32)
 #include <shellapi.h>
 #endif
@@ -874,6 +876,10 @@ void fx::ServerEventComponent::TriggerClientEvent(const std::string_view& eventN
 
 static InitFunction initFunction2([]()
 {
+	fx::ScriptEngine::RegisterNativeHandler("GET_BUILD_NUMBER", [](fx::ScriptContext& context)
+	{
+		return fx::BuildInfo::GetBuildNumber();
+	});
 	fx::ScriptEngine::RegisterNativeHandler("PRINT_STRUCTURED_TRACE", [](fx::ScriptContext& context)
 	{
 		std::string_view jsonData = context.CheckArgument<const char*>(0);

--- a/ext/native-decls/GetBuildNumber.md
+++ b/ext/native-decls/GetBuildNumber.md
@@ -1,0 +1,38 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_BUILD_NUMBER
+
+```c
+int GET_BUILD_NUMBER();
+```
+
+**Note:** This build number is not the same as the client `gamebuild`. This build refers to the artifact version of `FXServer`
+
+## Return value
+Returns the build number of FXServer.
+
+## Examples
+```lua
+local serverVersion = GetBuildNumber()
+if serverVersion < 10309 then
+    print("Your FXServer is outdated, please update.")
+end
+```
+
+```js
+const serverVersion = GetBuildNumber();
+if (serverVersion < 10309) {
+    console.log("Your FXServer is outdated, please update.");
+}
+```
+
+```cs
+using static CitizenFX.Core.Native.API;
+
+int serverVersion = GetBuildNumber();
+if (serverVersion < 10309) {
+    Debug.WriteLine("Your FXServer is outdated, please update.");
+}
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Introduce a native to get the build number of FXServer

### How is this PR achieving the goal

By creating a class BuildInfo in the file BuildInfo.cpp who is a getter to get the version of FXServer (the code was taken from the server command "version")


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FXServer


### Successfully tested on

Couldn't be tested since we can't get the version of FXServer when building it

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


