### PR TITLE
tweak(mono-rt2): Use null coalescing for Write & WriteLine

### DIFF
--- a/code/client/clrcore-v2/Debug.cs
+++ b/code/client/clrcore-v2/Debug.cs
@@ -51,12 +51,12 @@ namespace CitizenFX.Core
 
 		[SecuritySafeCritical]
 		public static void Write(string data) => ScriptInterface.Print(s_debugName, data);
-		public static void Write(object obj) => Write(obj.ToString());
+		public static void Write(object obj) => Write(obj?.ToString());
 		public static void Write(string format, params object[] args) => Write(string.Format(format, args));
 
 		public static void WriteLine() => Write("\n");
 		public static void WriteLine(string data) => Write(data + "\n");
-		public static void WriteLine(object obj) => Write(obj.ToString() + "\n");
+		public static void WriteLine(object obj) => Write(obj?.ToString() + "\n");
 		public static void WriteLine(string format, params object[] args) => Write(string.Format(format, args) + "\n");
 
 		internal static void PrintError(Exception what, string where = null)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This fixes an error if a null value is accidently passed into Debug.WriteLine


### How is this PR achieving the goal

Using simple Null coalescing on the ToString call


### This PR applies to the following area(s)
ScRT: C# v2

### Successfully tested on
Tested the code seperate from the game, it prints nothing instead of causing a NullReferenceException.


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


