### PR TITLE
tweak(mono-rt2): Return Complete Coroutine when no data is returned

### DIFF
--- a/code/client/clrcore-v2/Interop/LocalFunction.cs
+++ b/code/client/clrcore-v2/Interop/LocalFunction.cs
@@ -71,7 +71,7 @@ namespace CitizenFX.Core
 				return Coroutine<object>.Completed(result);
 			}
 
-			return null;
+			return Coroutine<object>.Completed(null);
 		}
 	}
 }


### PR DESCRIPTION
This allows awaiting exports without a null check.

### Goal of this PR
In the current implementation of exports exports might return null instead of a coroutine, which is the case for exports which execute within a tick (so no wait calls) and don't return a value.
Simply returning a Completed Coroutine with a null value fixes this issue.


### How is this PR achieving the goal
By returning a completed coroutine with a null value.

### This PR applies to the following area(s)
ScRt: C# v2

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


