### PR TITLE
feat(net): Configurable peer timeout

### DIFF
--- a/code/components/citizen-server-impl/include/GameServer.h
+++ b/code/components/citizen-server-impl/include/GameServer.h
@@ -274,6 +274,12 @@ namespace fx
 
 		ServerInstanceBase* m_instance;
 
+		uint32_t m_peerTimeout = 30000;
+
+		std::shared_ptr<ConVar<uint32_t>> m_peerTimeoutVar;
+
+		std::shared_ptr<ConsoleCommand> m_peerTimeoutCmd;
+
 		std::shared_ptr<ConsoleCommand> m_heartbeatCommand;
 
 		std::shared_ptr<ConVar<std::string>> m_listingIpOverride;

--- a/code/components/citizen-server-impl/include/GameServerNet.h
+++ b/code/components/citizen-server-impl/include/GameServerNet.h
@@ -28,7 +28,7 @@ namespace fx
 
 		virtual net::PeerAddress GetAddress() = 0;
 
-		virtual void OnSendConnectOK() = 0;
+		virtual void OnSendConnectOK(uint32_t timeout) = 0;
 	};
 	using NetPeerStackBuffer = FixedBuffer<NetPeerBase, 32>;
 
@@ -75,6 +75,8 @@ namespace fx
 		{
 			return false;
 		}
+
+		virtual void SetPeerTimeout(uint32_t timeout) = 0;
 	};
 
 	fwRefContainer<GameServerNetBase> CreateGSNet(fx::GameServer* server);

--- a/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
+++ b/code/components/citizen-server-impl/src/GameServerNet.ENet.cpp
@@ -127,7 +127,7 @@ namespace fx
 			return GetPeerAddress(peer->address);
 		}
 
-		virtual void OnSendConnectOK() override
+		virtual void OnSendConnectOK(const uint32_t timeout) override
 		{
 			auto peer = GetPeer();
 
@@ -140,7 +140,7 @@ namespace fx
 			enet_peer_throttle_configure(peer, 1000, ENET_PEER_PACKET_THROTTLE_SCALE, 0);
 
 			// all-but-disable the backoff-based timeout, and set the hard timeout to 30 seconds
-			enet_peer_timeout(peer, 10000000, 10000000, 30000);
+			enet_peer_timeout(peer, 10000000, 10000000, timeout);
 		}
 
 	private:
@@ -552,6 +552,14 @@ namespace fx
 		virtual int GetClientVersion() override
 		{
 			return 2;
+		}
+
+		virtual void SetPeerTimeout(const uint32_t timeout) override
+		{
+			for (const auto& [handle, peer] : m_peerHandles)
+			{
+				enet_peer_timeout(peer, 10000000, 10000000, timeout);
+			}
 		}
 
 	private:

--- a/code/components/gta-net-five/src/NetHook.cpp
+++ b/code/components/gta-net-five/src/NetHook.cpp
@@ -816,8 +816,20 @@ static void RunGameFrame()
 	}
 }
 
+static void OnPeerTimeoutChange(internal::ConsoleVariableEntry<uint32_t>* peerTimeoutVar)
+{
+	const uint32_t timeout = peerTimeoutVar->GetRawValue();
+
+	if (g_netLibrary)
+	{
+		g_netLibrary->SetPeerTimeout(timeout);
+	}
+}
+
 static HookFunction initFunction([]()
 {
+	static ConVar<uint32_t> peerTimeoutVar("sv_peerTimeout", ConVar_Replicated, 30000, OnPeerTimeoutChange);
+
 	g_netLibrary = NetLibrary::Create();
 
 	Instance<NetLibrary>::Set(g_netLibrary);

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -307,6 +307,8 @@ public:
 
 	void SetHost(uint16_t netID, uint32_t base);
 
+	void SetPeerTimeout(uint32_t timeout);
+
 	void DownloadsComplete();
 
 	bool IsPendingInGameReconnect();

--- a/code/components/net/include/NetLibraryImplBase.h
+++ b/code/components/net/include/NetLibraryImplBase.h
@@ -43,6 +43,8 @@ public:
 
 	virtual void SendConnect(const std::string& token, const std::string& connectData) = 0;
 
+	virtual void SetPeerTimeout(uint32_t timeout) = 0;
+
 	virtual bool HasTimedOut() = 0;
 
 	virtual bool IsDisconnected() { return false; }

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -497,6 +497,14 @@ void NetLibrary::SetHost(uint16_t netID, uint32_t base)
 	m_hostBase = base;
 }
 
+void NetLibrary::SetPeerTimeout(const uint32_t timeout)
+{
+	if (const auto impl = GetImpl())
+	{
+		impl->SetPeerTimeout(timeout);
+	}
+}
+
 void NetLibrary::SetBase(uint32_t base)
 {
 	m_serverBase = base;


### PR DESCRIPTION
### Goal of this PR
Clients that don't send or accept data for a longer period of time can have a negative impact on the gameplay behavior of specific game modes (especially PVP-focused), due to the nature of existing RAGE net code and missing patches for any server-authoritative control over synced entity data that is game-state critical (position correction, damage control system, etc.)

Some examples:
- Player 'teleporting': clients that reconnect before timing out do not get reset to the last known server position
- Dropped damage data: clients that don't receive game frame updates don't have their entity states updated afterward.
- ...

While the goal should be to have some sort of correction for these types of desync issues, this is probably not accomplishable in the short run. In the meantime, we can allow servers to define shorter (or longer) peer timeout values to at least give them some sort of countermeasure for the above-described problems, as the default value of 30 seconds is quite long.

### How is this PR achieving the goal
This change introduces a new replicated ConVar named 'sv_peerTimeout' that allows to configure a per-server peer timeout, which can be set via the (server-sided) console command 'set_peer_timeout [timeout]'.

The (client-sided) enet timeout will get reset to the default value of 30 seconds after disconnect.

### This PR applies to the following area(s)
FiveM, Server, Net

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/