### PR TITLE
tweak(ext/cfx-ui): Hide rateLimiter_* ConVar's

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -308,7 +308,7 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
       case key === 'sv_maxClients': {
         continue;
       }
-
+      case lckey.includes('ratelimiter_'):
       case lckey.includes('banner_'):
       case lckey.includes('sv_project'):
       case lckey.includes('version'):


### PR DESCRIPTION
Inspired by (https://github.com/citizenfx/fivem/pull/2867) this hides all rateLimiter related ConVar's in the server info view

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Showing this information to the end-user isn't really helpful, so we hide it.
![image](https://github.com/user-attachments/assets/ec9231ab-49df-48d7-b546-31c25e9e6579)
### How is this PR achieving the goal

Adding an exception for "rateLimiter_*" in the server info aggregation function.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

cfx-ui


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** Not applicable

**Platforms:** Windows (Client)


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues

.

