### PR TITLE
tweak(gameserver): Don't enforce sessionmanager with OneSync

### DIFF
--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -1372,23 +1372,4 @@ static InitFunction initFunction([]()
 		instance->SetComponent(new fx::PeerAddressRateLimiterStore(instance->GetComponent<console::Context>().GetRef()));
 		instance->SetComponent(new HostVoteCount());
 	});
-
-	fx::ServerInstanceBase::OnServerCreate.Connect([](fx::ServerInstanceBase* instance)
-	{
-		Instance<net::UvLoopManager>::Get()->GetOrCreate("svMain")->EnqueueCallback([instance]() 
-		{			
-			se::ScopedPrincipal principalScope(se::Principal{ "system.console" });
-			auto consoleCtx = instance->GetComponent<console::Context>();
-
-			if (instance->GetComponent<fx::GameServer>()->GetGameName() == fx::GameName::RDR3)
-			{
-				consoleCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", "sessionmanager-rdr3" });
-			}
-			else
-			{
-				consoleCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", "sessionmanager" });
-			}
-		});
-
-	}, INT32_MAX);
 });

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -7961,5 +7961,17 @@ static InitFunction initFunction([]()
 				routeEvent();
 			}
 		} });
+
+		auto consoleCtx = instance->GetComponent<console::Context>();
+
+		// start sessionmanager
+		if (gameServer->GetGameName() == fx::GameName::RDR3)
+		{
+			consoleCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", "sessionmanager-rdr3" });
+		}
+		else if (!g_oneSyncEnabledVar->GetValue() && g_oneSyncVar->GetValue() == fx::OneSyncState::Off)
+		{
+			consoleCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", "sessionmanager" });
+		}
 	}, 999999);
 });


### PR DESCRIPTION
### Goal of this PR
This disables the forced start of the 'sessionmanager' resource when OneSync is enabled and the game type is GTA V.

### How is this PR achieving the goal
Unlike RDR2, GTA V does not require any logic that is implemented in the 'sessionmanager' resource when running with OneSync enabled. The Lua scheduler implementation for invoking remote function references in https://github.com/citizenfx/fivem/blob/76e67bd59382996a816b66eb5e9760bda2560863/data/shared/citizen/scripting/lua/scheduler.lua#L567 that uses sessionmanager as a script host is deprecated and not functional, so this should not break anything.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Server), Linux

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
Resolves #2876 