### PR TITLE
fix(ext/cfx-ui): afterRender not firing for identity service

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/linkedIdentities/linkedIdentities.service.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/linkedIdentities/linkedIdentities.service.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 
 import { ServicesContainer } from 'cfx/base/servicesContainer';
-import { AppContribution } from 'cfx/common/services/app/app.extensions';
+import { AppContribution, registerAppContribution } from 'cfx/common/services/app/app.extensions';
 import { IdentitiesChangeEvent } from 'cfx/common/services/linkedIdentities/events';
 import { ILinkedIdentitiesService } from 'cfx/common/services/linkedIdentities/linkedIdentities.service';
 import { ILinkedIdentity } from 'cfx/common/services/linkedIdentities/types';
@@ -14,6 +14,8 @@ import { IConvarService } from '../convars/convars.service';
 
 export function registerLinkedIdentitiesService(container: ServicesContainer) {
   container.registerImpl(ILinkedIdentitiesService, LinkedIdentitiesService);
+
+  registerAppContribution(container, LinkedIdentitiesService);
 }
 
 @injectable()


### PR DESCRIPTION
### Goal of this PR
This fixes an oversight in a previous change that does not register the afterRender function from linkedIdentities.service in the target list, preventing the main UI from showing any linked identities in the settings pane.

### How is this PR achieving the goal
Re-adding the missing component registration.
<img src="https://github.com/user-attachments/assets/ba651b19-9016-4df2-b47f-60f984abcd86" width="500">
<img src="https://github.com/user-attachments/assets/ad170cab-c52e-4a90-935e-8e34a3aba10e" width="500">

### This PR applies to the following area(s)
cfx-ui

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/