### PR TITLE
tweak(console): Improve keyboard focus

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -406,7 +406,6 @@ struct CfxBigConsole : FiveMConsoleBase
 
 			// Input field in the first column
 			ImGui::PushItemWidth(-FLT_MIN);
-			bool reclaim_focus = false;
 			if (ImGui::InputText("##_Input", InputBuf, _countof(InputBuf),
 				ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CallbackCompletion | ImGuiInputTextFlags_CallbackHistory, &TextEditCallbackStub, (void*)this))
 			{
@@ -417,7 +416,6 @@ struct CfxBigConsole : FiveMConsoleBase
 				if (InputBuf[0])
 					ExecCommand(InputBuf);
 				strcpy(InputBuf, "");
-				reclaim_focus = true;
 			}
 			ImGui::PopItemWidth();
 
@@ -431,6 +429,11 @@ struct CfxBigConsole : FiveMConsoleBase
 			{
 				OpenLogFile();
 				shouldOpenLog = false;
+			}
+
+			if (ImGui::IsItemHovered() || (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) && !ImGui::IsAnyItemActive() && !ImGui::IsMouseClicked(0)))
+			{
+				ImGui::SetKeyboardFocusHere(-1);
 			}
 
 			bool preAutoScrollValue = AutoScrollEnabled;


### PR DESCRIPTION
### Goal of this PR
This improves the focus logic of the text input field in the client console. We now focus the input field when:
- Opening the console
- Hovering over the input field
- Whenever the console gains focus and no other clickable or input-taking item is active

### How is this PR achieving the goal
Changing the focus logic for the console input field.

### This PR applies to the following area(s)
FiveM, RedM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #2887 