### PR TITLE
fix(server/state): properly reassign entities that are set to `EntityOrphanMode::KeepEntity`

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -963,6 +963,14 @@ public:
 		return scriptHash;
 	}
 
+	/// <summary>
+	/// Checks of the entity is set to be kept by the server via orphan mode or by being owned by a server script.
+	/// </summary>
+	inline bool ShouldServerKeepEntity()
+	{
+		return IsOwnedByServerScript() || orphanMode == EntityOrphanMode::KeepEntity;
+	}
+
 	inline bool IsOwnedByScript()
 	{
 		return GetScriptHash() != 0;

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1515,7 +1515,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 					if (entityClient && entityClient->GetNetId() == client->GetNetId())
 					{
 						// if this entity is owned by a server script, reassign to nobody and wait until someone else owns it
-						if (entity->IsOwnedByServerScript())
+						if (entity->ShouldServerKeepEntity())
 						{
 							ReassignEntity(entity->handle, {});
 						}
@@ -2812,10 +2812,9 @@ bool ServerGameState::MoveEntityToCandidate(const fx::sync::SyncEntityPtr& entit
 
 		if (candidates.empty()) // no candidate?
 		{
-			GS_LOG("no candidates for entity %d, assigning as unowned\n", entity->handle);
-
-			if (entity->IsOwnedByServerScript())
+			if (entity->ShouldServerKeepEntity())
 			{
+				GS_LOG("no candidates for entity %d, assigning as unowned\n", entity->handle);
 				ReassignEntity(entity->handle, {});
 			}
 			else
@@ -2924,8 +2923,7 @@ void ServerGameState::HandleClientDrop(const fx::ClientSharedPtr& client, uint16
 				{
 					ReassignEntity(entity->handle, firstOwner);
 				}
-				// we don't want to add these to the list to remove if they're set to be kept when orphaned
-				else if (entity->orphanMode != sync::KeepEntity)
+				else
 				{
 					toErase.insert(entity->handle);
 				}


### PR DESCRIPTION
- this swaps `MoveEntityToCanidate` to use `ShouldServerKeepEntity` instead of having specific logic for orphan mode
- makes 'entitiesToDestroy' use `ShouldServerKeepEntity` instead of `IsOwnedByServerScript`so we reassign if orphan mode is set to keep the entity

### Goal of this PR
Properly reassign the entity to the server in certain situations where it would previously not happen

### How is this PR achieving the goal
Add a new function that uses the original script check & entity orphan checks

### This PR applies to the following area(s)
Server

### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
