### PR TITLE
tweak(cfx/nui): convar filtering logic with shouldVarBeShown helper + add `sv_replaceExeToSwitchBuilds`

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -187,20 +187,20 @@ function getSortableName(searchableName: string): string {
     .toLowerCase();
 }
 
-function shouldVarBeShown(key: string): boolean {
-  const convars: string[] = [
-    'sv_lan',
-    'mapname', 
-    'onesync', 
-    'gametype', 
-    'sv_maxClients',
-    'sv_poolSizesIncrease', 
-    'sv_enhancedHostSupport',  
-    'sv_disableClientReplays', 
-    'sv_replaceExeToSwitchBuilds',
-  ];
+const convars = new Set([
+  'sv_lan',
+  'mapname', 
+  'onesync', 
+  'gametype', 
+  'sv_maxClients',
+  'sv_poolSizesIncrease', 
+  'sv_enhancedHostSupport',  
+  'sv_disableClientReplays', 
+  'sv_replaceExeToSwitchBuilds',
+]);
 
-  return !convars.includes(key);
+function shouldVarBeShown(key: string): boolean {
+  return !convars.has(key);
 }
 
 type VarsView = Partial<

--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -187,6 +187,22 @@ function getSortableName(searchableName: string): string {
     .toLowerCase();
 }
 
+function shouldVarBeShown(key: string): boolean {
+  const convars: string[] = [
+    'sv_lan',
+    'mapname', 
+    'onesync', 
+    'gametype', 
+    'sv_maxClients',
+    'sv_poolSizesIncrease', 
+    'sv_enhancedHostSupport',  
+    'sv_disableClientReplays', 
+    'sv_replaceExeToSwitchBuilds',
+  ];
+
+  return !convars.includes(key);
+}
+
 type VarsView = Partial<
   Pick<
     IServerView,
@@ -294,21 +310,11 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
       }
       case key === 'sv_pureLevel': {
         view.pureLevel = value as ServerPureLevel;
-
         continue;
       }
-
-      case key === 'sv_poolSizesIncrease':
-      case key === 'sv_disableClientReplays':
-      case key === 'onesync':
-      case key === 'gametype':
-      case key === 'mapname':
-      case key === 'sv_enhancedHostSupport':
-      case key === 'sv_lan':
-      case key === 'sv_maxClients': {
+      case !shouldVarBeShown(key): {
         continue;
       }
-
       case lckey.includes('banner_'):
       case lckey.includes('sv_project'):
       case lckey.includes('version'):


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This change aims to simplify and centralize the logic for filtering out specific server configuration variables (convars).
By creating a helper function (shouldVarBeShown), we reduce redundancy and improve readability.

With these changes it also includes the new convar `sv_replaceExeToSwitchBuilds` 

### How is this PR achieving the goal

Replacing multiple cases in the processServerDataVariables function with a single call to shouldVarBeShown, resulting in cleaner and more maintainable code.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM/RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


