### PR TITLE
tweak(compiler/linux): build portability

### DIFF
--- a/code/components/net-base/include/Net.h
+++ b/code/components/net-base/include/Net.h
@@ -1,4 +1,17 @@
-﻿#pragma once
+#pragma once
+
+#ifdef htonl
+#undef htonl
+#endif
+#ifdef htons
+#undef htons
+#endif
+#ifdef ntohl
+#undef ntohl
+#endif
+#ifdef ntohs
+#undef ntohs
+#endif
 
 namespace net
 {

--- a/code/server/launcher/src/Main.cpp
+++ b/code/server/launcher/src/Main.cpp
@@ -10,7 +10,9 @@
 #include "Server.h"
 
 #ifndef _WIN32
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #endif
 


### PR DESCRIPTION
### Goal of this PR
On some systems (like Ubuntu) netinet headers get included by default. In those cases, we are re-defining system macros without undefining them first, which makes building fail.

This fixes building on native Ubuntu, so this *should* revive Github Runners once again.
https://github.com/tens0rfl0w/fivem/actions/runs/11621071896/job/32364102250

### How is this PR achieving the goal
- Guarding `_GNU_SOURCE` macro
- Undefining `__bswap_*` macros before re-defining them

### This PR applies to the following area(s)
Source compiling (Linux)

### Successfully tested on
**Game builds:** Not applicable 

**Platforms:** Linux (Github Runners - ubuntu-20.04)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/