### PR TITLE
fix(github/ci): Checkout correct repo and branch on PR open

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -3,6 +3,8 @@ name: CI Build all products
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build_all:
     strategy:
@@ -40,8 +42,8 @@ jobs:
           # Call each git command individually, preventing unnecessary checkouts
           git init .
           git config core.symlinks true
-          git remote add origin https://github.com/$GITHUB_REPOSITORY.git
-          git pull origin $GITHUB_REF:PR_BRANCH --depth=1
+          git remote add origin ${{github.event.pull_request.head.repo.clone_url}}
+          git pull origin ${{github.event.pull_request.head.ref}} --depth=1
           git submodule update --jobs=$JOB_SLOTS --init --depth=1
         
       - name: Dependencies

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -1,10 +1,10 @@
 name: Validate PR
+
 on:
   pull_request_target:
     types: [ reopened, opened, edited, synchronize, ready_for_review ]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   input_validation:
     name: Validate PR details
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
@@ -181,6 +183,8 @@ jobs:
   
   post_build:
     name: Post Build PR actions
+    permissions:
+      pull-requests: write
     if: always()
     needs: [ build_all, input_validation ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Goal of this PR
To fix the Git checkout behavior in the GitHub Actions workflow, ensuring that changes from pull requests are tested correctly and enhancing security by limiting permissions for the Action Run.

### How is this PR achieving the goal
This PR modifies the checkout process to correctly fetch the branch and repository associated with the pull request instead of the upstream master branch. This ensures that the changes introduced by the PR are properly validated. Additionally, the Action Run's permissions have been restricted, reducing the risk of accidental unauthorized requests in the future.

### This PR applies to the following area(s)
Github CI

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Github Actions

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/