### PR TITLE
Minor fixes for trains, use `IsEntityValid` for other calls checking if the entity exists

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -857,7 +857,6 @@ enum EntityOrphanMode : uint8_t
 	DeleteOnOwnerDisconnect = 1,
 	KeepEntity = 2,
 };
-
 struct SyncEntityState
 {
 	using TData = std::variant<int, float, bool, std::string>;
@@ -1357,6 +1356,10 @@ public:
 	
 	void GetFreeObjectIds(const fx::ClientSharedPtr& client, uint8_t numIds, std::vector<uint16_t>& freeIds);
 
+#ifdef STATE_FIVE
+	void IterateTrainLink(const sync::SyncEntityPtr& train, std::function<bool(sync::SyncEntityPtr&)> fn, bool callOnInitialEntity = true);
+#endif
+
 	void ReassignEntity(uint32_t entityHandle, const fx::ClientSharedPtr& targetClient, std::unique_lock<std::shared_mutex>&& lock = {});
 
 	bool SetEntityStateBag(uint8_t playerId, uint16_t objectId, std::function<std::shared_ptr<StateBag>()> createStateBag) override;
@@ -1371,7 +1374,51 @@ private:
 	void ReassignEntityInner(uint32_t entityHandle, const fx::ClientSharedPtr& targetClient, std::unique_lock<std::shared_mutex>&& lock = {});
 
 public:
-	void DeleteEntity(const fx::sync::SyncEntityPtr& entity);
+
+	template<bool IgnoreTrainChecks = false>
+	void DeleteEntity(const fx::sync::SyncEntityPtr& entity)
+	{
+		if (entity->type == sync::NetObjEntityType::Player || !entity->syncTree)
+		{
+			return;
+		}
+
+		// can only be used on FiveM, RDR doesn't have its sync nodes filled out
+#ifdef STATE_FIVE
+		// this will be ignored by DELETE_TRAIN so calling on any part of the train will delete the entire thing
+		if constexpr (!IgnoreTrainChecks)
+		{
+
+			if (entity->type == sync::NetObjEntityType::Train;
+				auto trainState = entity->syncTree->GetTrainState())
+			{
+				// don't allow the deletion of carriages until we can modify sync node data and overwrite the linked forward/linked backwards state
+				if (trainState->engineCarriage && trainState->engineCarriage != entity->handle)
+				{
+					return;
+				}
+			}
+		}
+#endif
+
+		gscomms_execute_callback_on_sync_thread([=]()
+		{
+#ifdef STATE_FIVE
+			if (entity->type == sync::NetObjEntityType::Train)
+			{
+				// recursively delete every part of the train
+				IterateTrainLink(entity, [=](fx::sync::SyncEntityPtr& train)
+				{
+					RemoveClone({}, train->handle);
+
+					return true;
+				});
+				return;
+			}
+#endif
+			RemoveClone({}, entity->handle);
+		});
+	}
 
 	void ClearClientFromWorldGrid(const fx::ClientSharedPtr& targetClient);
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1166,34 +1166,16 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 
 				if (auto engine = GetTrain(this, trainState->engineCarriage))
 				{
-					{
+					IterateTrainLink(entity, [&isRelevant, isRelevantViaPos](sync::SyncEntityPtr& train) {
 						float position[3];
-						engine->syncTree->GetPosition(position);
+						train->syncTree->GetPosition(position);
 
 						glm::vec3 entityPosition(position[0], position[1], position[2]);
-						if (isRelevantViaPos(engine, entityPosition))
-						{
-							isRelevant = true;
-						}
-					}
+						isRelevant = isRelevantViaPos(train, entityPosition);
 
-					// if not via the engine, try the next-train chain
-					if (!isRelevant)
-					{
-						for (auto link = GetNextTrain(this, engine); link; link = GetNextTrain(this, link))
-						{
-							float position[3];
-							link->syncTree->GetPosition(position);
-
-							glm::vec3 entityPosition(position[0], position[1], position[2]);
-
-							if (isRelevantViaPos(link, entityPosition))
-							{
-								isRelevant = true;
-								break;
-							}
-						}
-					}
+						// if we're not still relevant then we should keep going
+						return !isRelevant;
+					});
 				}
 			}
 #endif
@@ -2645,6 +2627,65 @@ void ServerGameState::ReassignEntityInner(uint32_t entityHandle, const fx::Clien
 	}
 }
 
+#ifdef STATE_FIVE
+/// <summary>
+/// Takes the initialTrain and if its the engine train, iterates down the train link from the train, if it's not then it will try to get the engine
+/// </summary>
+/// <param name="initialTrain">The initial to start the iteration from, this will get the engine entity internally, if the engine doesn't exist it will early return as there's no valid part in the link to start from.</param>
+/// <param name="fn">The function to call, if the function returns `true` it will keep iterating, if it returns `false` it will stop</param>
+/// <param name="callOnInitialEntity">Whether the function should do the `fn` call on the initialTrain</param>
+void ServerGameState::IterateTrainLink(const sync::SyncEntityPtr& initialTrain, std::function<bool(sync::SyncEntityPtr&)> fn, bool callOnInitialEntity)
+{
+	// for most stuff we want to call on the intial entity
+	if (callOnInitialEntity)
+	{
+		if (!fn(const_cast<sync::SyncEntityPtr&>(initialTrain)))
+		{
+			return;
+		}
+	}
+
+	if (auto trainState = initialTrain->syncTree->GetTrainState())
+	{
+		auto recurseTrain = [=](const fx::sync::SyncEntityPtr& train)
+		{
+			for (auto link = GetNextTrain(this, train); link; link = GetNextTrain(this, link))
+			{
+				// this is expected to make sure that the initial train & the link trains are not called twice
+				// since this could lead to double locking the client mutex in ReassignEntity
+				// we also ignore the train sent via the call to `recurseTrain` as we should've called `fn` before here
+				if (link->handle == initialTrain->handle)
+				{
+					continue;
+				}
+
+				// if the function returns true then we should stop iterating
+				if (!fn(link))
+				{
+					return;
+				}
+			}
+		};
+
+		if (trainState->isEngine)
+		{
+			recurseTrain(initialTrain);
+		}
+		else if (trainState->engineCarriage && trainState->engineCarriage != initialTrain->handle)
+		{
+			if (auto engine = GetTrain(this, trainState->engineCarriage))
+			{
+				if (!fn(engine))
+				{
+					return;
+				}
+				recurseTrain(engine);
+			}
+		}
+	}
+}
+#endif
+
 void ServerGameState::ReassignEntity(uint32_t entityHandle, const fx::ClientSharedPtr& targetClient, std::unique_lock<std::shared_mutex>&& lock)
 {
 	ReassignEntityInner(entityHandle, targetClient, std::move(lock));
@@ -2657,39 +2698,19 @@ void ServerGameState::ReassignEntity(uint32_t entityHandle, const fx::ClientShar
 		// game code works as follows:
 		// -> if train isEngine, enumerate the entire list backwards and migrate that one along
 		// -> if not isEngine, migrate the engine
-		if (auto trainState = train->syncTree->GetTrainState())
-		{
-			auto reassignEngine = [this, &targetClient, entityHandle](const fx::sync::SyncEntityPtr& train)
-			{
-				for (auto link = GetNextTrain(this, train); link; link = GetNextTrain(this, link))
-				{
-					// this check should prevent the following two states:
-					// 1. double-locking clientMutex
-					// 2. reassigning the same entity twice
-					if (link->handle != entityHandle)
-					{
-						// we directly use ReassignEntityInner here to ensure no infinite recursion
-						ReassignEntityInner(link->handle, targetClient);
-					}
-				}
-			};
 
-			if (trainState->isEngine)
-			{
-				reassignEngine(train);
-			}
-			else if (trainState->engineCarriage && trainState->engineCarriage != entityHandle)
-			{
-				// reassign the engine carriage
-				ReassignEntityInner(trainState->engineCarriage, targetClient);
 
-				// get the engine and reassign based on that
-				if (auto engine = GetTrain(this, trainState->engineCarriage))
-				{
-					reassignEngine(engine);
-				}
-			}
-		}
+		// This call expects link-handle != entityHandle
+		// This will prevent
+		// 1. double-locking clientMutex
+		// 2. reassigning the same entity twice
+		IterateTrainLink(train, [=](const fx::sync::SyncEntityPtr& link) {
+
+			// we directly use ReassignEntityInner here to ensure no infinite recursion
+			ReassignEntityInner(link->handle, targetClient);
+
+			return true;
+		}, false);
 	}
 #endif
 }
@@ -4399,16 +4420,6 @@ void ServerGameState::HandleGameStateAck(fx::ServerInstanceBase* instance, const
 	}
 }
 
-void ServerGameState::DeleteEntity(const fx::sync::SyncEntityPtr& entity)
-{
-	if (entity->type != sync::NetObjEntityType::Player && entity->syncTree)
-	{
-		gscomms_execute_callback_on_sync_thread([=]() 
-		{
-			RemoveClone({}, entity->handle);
-		});
-	}
-}
 
 void ServerGameState::SendPacket(int peer, net::packet::StateBagPacket& packet)
 {

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -19,6 +19,12 @@ void DisownEntityScript(const fx::sync::SyncEntityPtr& entity);
 
 static void Init()
 {
+
+	static auto IsEntityValid = [](const fx::sync::SyncEntityPtr& entity) {
+		// if we're deleting or finalizing our deletion then we don't want to be included in the list
+		return entity && !entity->deleting && !entity->finalizing;
+	};
+
 	auto makeEntityFunction = [](auto fn, uintptr_t defaultValue = 0)
 	{
 		return [=](fx::ScriptContext& context)
@@ -43,7 +49,7 @@ static void Init()
 
 			auto entity = gameState->GetEntity(id);
 
-			if (!entity)
+			if (!IsEntityValid(entity))
 			{
 				throw std::runtime_error(va("Tried to access invalid entity: %d", id));
 
@@ -131,7 +137,7 @@ static void Init()
 
 		auto entity = gameState->GetEntity(id);
 
-		if (!entity)
+		if (!IsEntityValid(entity))
 		{
 			context.SetResult(false);
 			return;
@@ -163,7 +169,7 @@ static void Init()
 
 		auto entity = gameState->GetEntity(id);
 
-		if (!entity || entity->finalizing || entity->deleting)
+		if (!IsEntityValid(entity))
 		{
 			context.SetResult(false);
 			return;
@@ -197,7 +203,7 @@ static void Init()
 
 		auto entity = gameState->GetEntity(0, id);
 
-		if (!entity)
+		if (!IsEntityValid(entity))
 		{
 			context.SetResult(0);
 			return;
@@ -253,7 +259,7 @@ static void Init()
 
 		auto entity = gameState->GetEntity(id);
 
-		if (!entity)
+		if (!IsEntityValid(entity))
 		{
 			throw std::runtime_error(va("Tried to access invalid entity: %d", id));
 		}
@@ -1067,11 +1073,6 @@ static void Init()
 
 		return result;
 	}));
-
-	static auto IsEntityValid = [](const fx::sync::SyncEntityPtr& entity) {
-		// if we're deleting or finalizing our deletion then we don't want to be included in the list
-		return entity && !entity->deleting && !entity->finalizing;
-	};
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_GAME_POOL", [](fx::ScriptContext& context)
 	{

--- a/ext/native-decls/DeleteEntity.md
+++ b/ext/native-decls/DeleteEntity.md
@@ -10,5 +10,7 @@ void DELETE_ENTITY(Entity entity);
 
 Deletes the specified entity.
 
+**NOTE**: For trains this will only work if called on the train engine, it will not work on its carriages.
+
 ## Parameters
 * **entity**: The entity to delete.

--- a/ext/native-decls/DeleteTrain.md
+++ b/ext/native-decls/DeleteTrain.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: server
+---
+## DELETE_TRAIN
+
+```c
+void DELETE_TRAIN(Entity entity);
+```
+
+Deletes the specified `entity` and any carriage its attached to, or that is attached to it.
+
+## Parameters
+* **entity**: The carriage to delete.


### PR DESCRIPTION
### Goal of this PR
Fix some oversights in some code regarding entity validation, trains, and how deletions for trains are handled, and how setting orphan mode is handled for trains

### How is this PR achieving the goal
Make code that iterates over trains more generic so we can re-use it throughout more code.

Make calls that were previously just checking for `!entity` also check for if the entity is being deleted, fixes some cases

When called on trains `SET_ENTITY_ORPHAN_MODE` will also set the orphan mode for all trains attached, fixing the possibility of partial deletes from a train not being relevant.

Change `DELETE_ENTITY` to not allow it to be called on train carriages, as we don't have a way to write to the sync node of the current train that one of its links no longer exists, this could lead to broken state and possibly cause weird issues.

Add `DELETE_TRAIN` which when called on *any* part of the train will delete the entire train.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Server

### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



