### PR TITLE
fix(server): don't invoke cfx_internal:serverPrint on empty string

### DIFF
--- a/code/components/citizen-server-impl/src/packethandlers/ServerCommandPacketHandler.cpp
+++ b/code/components/citizen-server-impl/src/packethandlers/ServerCommandPacketHandler.cpp
@@ -115,6 +115,11 @@ bool ServerCommandPacketHandler::Process(fx::ServerInstanceBase* instance, const
 
 			fx::ScopeDestructor destructor([&]()
 			{
+				if (printString.empty())
+				{
+					return;
+				}
+
 				msgpack::sbuffer sb;
 
 				msgpack::packer<msgpack::sbuffer> packer(sb);


### PR DESCRIPTION
### Goal of this PR
This resolves the reported issue of blank lines cluttering the client console output.
![image](https://github.com/user-attachments/assets/e29e94eb-b46c-49e2-85c9-9f99b048982f)

### How is this PR achieving the goal
Discarding empty data previously sent to the client, preventing unnecessary "empty line" entries from appearing in the client console.

### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** Not applicable
**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/