### PR TITLE
feat(core/five): sanitization for attachments on remote peds

### DIFF
--- a/code/components/gta-core-five/component.json
+++ b/code/components/gta-core-five/component.json
@@ -10,7 +10,8 @@
 		"rage:input:five",
 		"rage:device:five",
 		"rage:graphics:five",
-		"vendor:minhook"
+		"vendor:minhook",
+		"scripting"
 	],
 	"provides": []
 }

--- a/code/components/gta-core-five/src/PatchAttachCD2545.cpp
+++ b/code/components/gta-core-five/src/PatchAttachCD2545.cpp
@@ -1,11 +1,12 @@
 #include <StdInc.h>
 #include <Hooking.h>
 #include "CrossBuildRuntime.h"
+#include <ScriptEngine.h>
+#include "ICoreGameInit.h"
 
 //
-// This patch forces a tunable (seen starting at b2545) preventing applying
-// of ped-to-ped attachment data to networked peds to be 'off', returning the
-// old behavior for compatibility.
+// This patches multiple checks that prevent the application of entity-to-ped
+// attachment data to networked peds so it can be dynamically toggled.
 //
 
 static bool ReturnFalse()
@@ -13,12 +14,19 @@ static bool ReturnFalse()
 	return false;
 }
 
+static bool g_disableRemotePedAttachment = false;
+
+static bool ReturnState()
+{
+	return g_disableRemotePedAttachment;
+}
+
 static HookFunction hookFunction([]()
 {
 	if (xbr::IsGameBuildOrGreater<2545>())
 	{
-		auto location = hook::get_pattern<char>("BA E7 8F A5 1E B9 BD C5 AF E3 E8");
-		hook::call(location + 23, ReturnFalse);
+		const auto location = hook::get_pattern<char>("BA E7 8F A5 1E B9 BD C5 AF E3 E8");
+		hook::call(location + 23, ReturnState);
 
 		// This call was removed in 2802.0
 		if (!xbr::IsGameBuildOrGreater<2802>())
@@ -26,7 +34,21 @@ static HookFunction hookFunction([]()
 			hook::call(location + 61, ReturnFalse);
 		}
 
-		auto attachEntityToEntityTunable = hook::get_pattern<char>("BA 37 89 3D 8A B9 BD C5 AF E3");
+		const auto attachEntityToEntityTunable = hook::get_pattern<char>("BA 37 89 3D 8A B9 BD C5 AF E3");
 		hook::call(attachEntityToEntityTunable + 23, ReturnFalse);
 	}
+});
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("ONESYNC_ENABLE_REMOTE_ATTACHMENT_SANITIZATION", [](fx::ScriptContext& context)
+	{
+		const bool enable = context.GetArgument<bool>(0);
+		g_disableRemotePedAttachment = enable;
+	});
+
+	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]()
+	{
+		g_disableRemotePedAttachment = false;
+	});
 });

--- a/ext/native-decls/OnesyncEnableRemoteAttachmentSanitization.md
+++ b/ext/native-decls/OnesyncEnableRemoteAttachmentSanitization.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## ONESYNC_ENABLE_REMOTE_ATTACHMENT_SANITIZATION
+
+```c
+void ONESYNC_ENABLE_REMOTE_ATTACHMENT_SANITIZATION(BOOL enable);
+```
+
+Toggles a check that prevents attaching (networked) entities to remotely owned peds. This is disabled by default.
+
+## Parameters
+* **enable**: Whether to enable sanitization.


### PR DESCRIPTION
### Goal of this PR
This PR introduces the ability to toggle checks that prevent entity-to-ped attachments on remotely owned peds. These checks are disabled by default in FiveM.

### How is this PR achieving the goal
A new native function, `OnesyncEnableRemoteAttachmentSanitization`, has been added to allow toggling of these attachment checks at runtime.

The value resets to the default state ('off') upon player disconnect.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 2545, 3258

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
Requested by @slashkeyvalue in: https://discord.com/channels/779705925577080842/779739506286002196/1301027817483538453 (Cfx.re Engineering Group)