### PR TITLE
tweak(legacy-net/resources): check for gameinit on server-command

### DIFF
--- a/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
+++ b/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
@@ -775,10 +775,19 @@ void NetLibraryResourcesComponent::AttachToObject(NetLibrary* netLibrary)
 		});
 	});
 
+	static bool gameLoaded = false;
+
+	Instance<ICoreGameInit>::Get()->OnGameFinalizeLoad.Connect([]()
+	{
+		gameLoaded = true;
+	});
+
 	static bool inSessionReset = false;
 
 	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]()
 	{
+		gameLoaded = false;
+
 		AddCrashometry("reset_resources", "true");
 
 		inSessionReset = true;
@@ -804,7 +813,7 @@ void NetLibraryResourcesComponent::AttachToObject(NetLibrary* netLibrary)
 
 	console::GetDefaultContext()->GetCommandManager()->FallbackEvent.Connect([netLibrary](const std::string& cmd, const ProgramArguments& args, const std::string& context)
 	{
-		if (netLibrary->GetConnectionState() != NetLibrary::CS_ACTIVE)
+		if (netLibrary->GetConnectionState() != NetLibrary::CS_ACTIVE || !gameLoaded)
 		{
 			return true;
 		}


### PR DESCRIPTION
### Goal of this PR
This ensures that the "same thread" constraint in SendNetPacket stays valid. (We don't need to send server-commands before full game init. anyway).

### How is this PR achieving the goal
Blocking server-commands before we are fully initialized (Render->MainThrd switch).

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/