### PR TITLE
feat(extra-natives/five): train station natives

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -316,6 +316,7 @@ static int VehicleDamageStructOffset;
 static bool* g_trainsForceDoorsOpen;
 static int TrainDoorCountOffset;
 static int TrainDoorArrayPointerOffset;
+static int TrainFlagOffset;
 
 static int VehicleRepairMethodVtableOffset;
 
@@ -588,6 +589,7 @@ static HookFunction initFunction([]()
 		WheelHealthOffset = *hook::get_pattern<uint32_t>("75 24 F3 0F 10 ? ? ? 00 00 F3 0F", 6);
 		LightMultiplierGetOffset = *hook::get_pattern<uint32_t>("00 00 48 8B CE F3 0F 59 ? ? ? 00 00 F3 41", 9);
 		VehicleRepairMethodVtableOffset = *hook::get_pattern<uint32_t>("C1 E8 19 A8 01 74 ? 48 8B 81", -14);
+		TrainFlagOffset = *hook::get_pattern<uint32_t>("80 8B ? ? ? ? ? 8B 05 ? ? ? ? FF C8", 2);
 	}
 
 	{
@@ -1465,6 +1467,10 @@ static HookFunction initFunction([]()
 
 		GetTrainDoor(train, doorIndex)->ratio = ratio;
 	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_TRAIN_STOP_AT_STATIONS", std::bind(writeVehicleMemoryBit<&TrainFlagOffset, 4>, _1, "SET_TRAIN_STOP_AT_STATIONS"));
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_TRAIN_STOP_AT_STATIONS", std::bind(readVehicleMemoryBit<&TrainFlagOffset, 4>, _1, "DOES_TRAIN_STOP_AT_STATIONS"));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_WHEEL_X_OFFSET", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
 	{

--- a/ext/native-decls/DoesTrainStopAtStations.md
+++ b/ext/native-decls/DoesTrainStopAtStations.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DOES_TRAIN_STOP_AT_STATIONS
+
+```c
+BOOL DOES_TRAIN_STOP_AT_STATIONS(Vehicle train);
+```
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+True if the train stops at stations. False otherwise

--- a/ext/native-decls/SetTrainStopAtStations.md
+++ b/ext/native-decls/SetTrainStopAtStations.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_TRAIN_STOP_AT_STATIONS
+
+```c
+void SET_TRAIN_STOP_AT_STATIONS(Vehicle train, BOOL state);
+```
+
+Toggles a train's ability to stop at stations
+
+## Parameters
+* **train**: The train handle
+* **state**: True to make the train stop at stations. False to make the train not stop at stations


### PR DESCRIPTION
### Goal of this PR

Allows for mission trains (trains created with CREATE_MISSION_TRAIN) to stop at stations. Enabling for the same behaviour as non-mission trains. This removes the need for scripts to implement their own logic which may not play well with multiple players/owners 


### How is this PR achieving the goal

By creating SET_TRAIN_STOP_AT_STATIONS which allows ScRT to directly toggle a flag deciding if a train should stop at stations


### This PR applies to the following area(s)

FiveM, Natives


### Successfully tested on

**Game builds:**  1604, 2372, 2699, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

