### PR TITLE
fix(game/five): cNetObjPhys vtable index for 3258

### DIFF
--- a/code/components/gta-streaming-five/src/GameEventHooks.cpp
+++ b/code/components/gta-streaming-five/src/GameEventHooks.cpp
@@ -338,7 +338,11 @@ static HookFunction hookFunction([]()
 		void** cNetObjPhys_vtable = hook::get_address<void**>(hook::get_pattern<unsigned char>("88 44 24 20 E8 ? ? ? ? 33 C9 48 8D 05", 14));
 		int vtableIdx = 0;
 
-		if (xbr::IsGameBuildOrGreater<2802>())
+		if (xbr::IsGameBuildOrGreater<3258>())
+		{
+			vtableIdx = 137;
+		}
+		else if (xbr::IsGameBuildOrGreater<2802>())
 		{
 			vtableIdx = 136;
 		}


### PR DESCRIPTION
### Goal of this PR
vtable indices have changed on 3258. This breaks the patch for fall damage not triggering `CEventNetworkEntityDamage`.

### How is this PR achieving the goal
Correcting the vtable index.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows (Client)


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #2779