### PR TITLE
fix(gamestate/server): add array bounds checks and fix native decl.

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -490,7 +490,7 @@ struct CVehicleGameStateNodeData
 	bool sirenOn;
 	int lockStatus;
 	int doorsOpen;
-	int doorPositions[1 << 7];
+	int doorPositions[7];
 	bool isStationary;
 	bool lightsOn;
 	bool highbeamsOn;

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -652,7 +652,13 @@ static void Init()
 
 		if (context.GetArgumentCount() > 1 && doorsOpen)
 		{
-			doorStatus = vn->doorPositions[context.GetArgument<int>(1)];
+			const int index = context.GetArgument<int>(1);
+			if (index < 0 || index > 6)
+			{
+				return doorStatus;
+			}
+
+			doorStatus = vn->doorPositions[index];
 		}
 
 		return doorStatus;
@@ -716,9 +722,14 @@ static void Init()
 		bool tyreBurst = false;
 		bool wheelsFine = vn->tyresFine;
 
-		if (!wheelsFine && context.GetArgumentCount() > 1)
+		if (!wheelsFine)
 		{
-			int tyreID = context.GetArgument<int>(1);
+			const int tyreID = context.GetArgument<int>(1);
+			if (tyreID < 0 || tyreID > 15)
+			{
+				return tyreBurst;
+			}
+
 			bool completely = context.GetArgument<bool>(2);
 
 			int tyreStatus = vn->tyreStatus[tyreID];
@@ -1219,7 +1230,11 @@ static void Init()
     {
         auto vn = entity->syncTree->GetVehicleGameState();
 
-        int seatArg = context.GetArgument<int>(1) + 2;
+		const int seatArg = context.GetArgument<int>(1) + 2;
+		if (seatArg < 0 || seatArg > 31)
+		{
+			return 0;
+		}
 
         // get the current resource manager
         auto resourceManager = fx::ResourceManager::GetCurrent();
@@ -1248,7 +1263,11 @@ static void Init()
     {
         auto vn = entity->syncTree->GetVehicleGameState();
 
-        int seatArg = context.GetArgument<int>(1) + 2;
+		const int seatArg = context.GetArgument<int>(1) + 2;
+		if (seatArg < 0 || seatArg > 31)
+		{
+			return 0;
+		}
 
         // get the current resource manager
         auto resourceManager = fx::ResourceManager::GetCurrent();

--- a/ext/native-decls/GetVehicleDoorStatus.md
+++ b/ext/native-decls/GetVehicleDoorStatus.md
@@ -5,12 +5,14 @@ apiset: server
 ## GET_VEHICLE_DOOR_STATUS
 
 ```c
-int GET_VEHICLE_DOOR_STATUS(Vehicle vehicle);
+int GET_VEHICLE_DOOR_STATUS(Vehicle vehicle, cs_split int doorIndex);
 ```
 
+Returns the open position of the specified door on the target vehicle.
 
 ## Parameters
-* **vehicle**: 
+- **vehicle**: The target vehicle.
+- **doorIndex**: Index of door to check (0-6).
 
 ## Return value
 A number from 0 to 7.


### PR DESCRIPTION
### Goal of this PR
This PR addresses two issues: missing bounds checks that allowed reading out-of-bounds memory, and a missing parameter in the native declaration of `GET_VEHICLE_DOOR_STATUS`.

### How is this PR achieving the goal
- Introduced checks to ensure that array indices are within valid bounds before accessing data, preventing out-of-bounds reads.
- Updated the native declaration of `GET_VEHICLE_DOOR_STATUS` to include the missing `doorIndex` parameter.
- Corrected array size for `doorPositions` in `CVehicleGameStateNodeData`.

### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows (Server)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
Reported here: https://discord.com/channels/779705925577080842/779739477642838036/1304152704137826304 (Cfx.re Engineering Group)