### PR TITLE
feat(scripting/v8): expose msgpack codec globally for custom type sup…

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -50,6 +50,9 @@ const EXT_LOCALFUNCREF = 11;
 	const pack = data => msgpack.encode(data, { codec });
 	const unpack = data => msgpack.decode(data, { codec });
 
+	// Expose codec globally to allow adding custom types
+	global.msgpack_codec = codec;
+	
 	// store for use by natives.js
 	global.msgpack_pack = pack;
 	global.msgpack_unpack = unpack;


### PR DESCRIPTION
### Goal of this PR
Expose the msgpack codec globally to enable developers to easily add custom serializers and deserializers, enhancing flexibility for handling custom types in FiveM scripts.


### How is this PR achieving the goal
This PR adds a new global variable, global.msgpack_codec, which provides direct access to the existing msgpack codec. Developers can use this to register custom types via addExtPacker and addExtUnpacker while maintaining backward compatibility with the current global.msgpack_pack and global.msgpack_unpack functions.


### This PR applies to the following area(s)
- Core scripting framework
- Data serialization/deserialization using msgpack

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:**: 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
No specific issues reported for this feature addition.