### PR TITLE
fix(statebag): only try to erase if the key existed before

### DIFF
--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -275,13 +275,16 @@ void StateBagImpl::SetKeyInternal(int source, std::string_view key, std::string_
 {
 	{
 		std::unique_lock _(m_dataMutex);
-		if (data[0] == MsgPackNil)
+		const bool isNilData = data[0] == MsgPackNil;
+
+		if (auto it = m_data.find(key); it != m_data.end())
 		{
-			m_data.erase(std::string { key });
-		}
-		else if (auto it = m_data.find(key); it != m_data.end())
-		{
-			if (data != it->second)
+			// if we're set to null *and we are existing* we should just delete ourselves
+			if (isNilData)
+			{
+				m_data.erase(std::string { key });
+			}
+			else if (data != it->second)
 			{
 				it->second = data;
 			}
@@ -292,6 +295,12 @@ void StateBagImpl::SetKeyInternal(int source, std::string_view key, std::string_
 		}
 		else
 		{
+			// if we're nil we don't want to emplace, or replicate, as we would just be sent back a packet to delete ourselves
+			if (isNilData)
+			{
+				return;
+			}
+
 			m_data.emplace(key, data);
 		}
 	}


### PR DESCRIPTION
Since we would always check for the `Nil` packet at the start of the `if` chain we would *always* send this to the server or client. 

This changes the behavior to only erase if the key existed in the first place, and if it didn't then we will just do an early return so we don't replicate the data (and possibly hit the rate limiter).


### Goal of this PR
Reduce the amount of packets sent to the server whenever the state bag doesn't already exist


### How is this PR achieving the goal
Fix the checks to take into account that the key could not exist

### This PR applies to the following area(s)
FiveM, RedM, Server


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->
This hasn't been tested 

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes an oversight in PR #2717
