### PR TITLE
feat(extra-natives/five): SetDeployOutriggers native

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -1876,6 +1876,19 @@ static HookFunction initFunction([]()
 		}
 	});
 
+	using CVehicle_SetDeployOutriggers_t = void(__fastcall*)(fwEntity* vehicle, bool deploy);
+	void* deployOutriggersFunctionAddress = hook::get_pattern("48 83 EC ? 38 91 ? ? ? ? 74 ? 88 91 ? ? ? ? 48 8B 89");
+	const auto CVehicle_SetDeployOutriggers = reinterpret_cast<CVehicle_SetDeployOutriggers_t>(deployOutriggersFunctionAddress);
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_DEPLOY_OUTRIGGERS", [=](fx::ScriptContext& context)
+	{
+		if (fwEntity* vehicle = getAndCheckVehicle(context, "SET_DEPLOY_OUTRIGGERS"))
+		{
+			const auto deploy = context.GetArgument<bool>(1);
+			CVehicle_SetDeployOutriggers(vehicle, deploy);
+		}
+	});
+
 	MH_Initialize();
 	MH_CreateHook(hook::get_pattern("E8 ? ? ? ? 8A 83 DA 00 00 00 24 0F 3C 02", -0x32), DeleteVehicleWrap, (void**)&g_origDeleteVehicle);
 	MH_CreateHook(hook::get_pattern("80 7A 4B 00 45 8A F9", -0x1D), DeleteNetworkCloneWrap, (void**)&g_origDeleteNetworkClone);

--- a/ext/native-decls/SetDeployOutriggers.md
+++ b/ext/native-decls/SetDeployOutriggers.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_DEPLOY_OUTRIGGERS
+
+```c
+void SET_DEPLOY_OUTRIGGERS(Vehicle vehicle, bool deploy);
+```
+
+Sets whether the outriggers of a vehicle are deployed or retracted.
+
+## Parameters
+* **vehicle**: The target vehicle.
+* **deploy**: Whether to deploy or retract the outriggers.


### PR DESCRIPTION
### Goal of this PR
New native to allow deploying/retracting the outriggers of a vehicle via script. This was requested ages ago somewhere, so why not😄 

### How is this PR achieving the goal
Implementing a new custom native that allows invoking `CVehicle::SetDeployOutriggers` manually.

### This PR applies to the following area(s)
FiveM, Natives

### Successfully tested on
**Game builds:** 1604, 2060, 2372, 2612, 2802, 3258

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/