### PR TITLE
feat(gamestate/server): serverEntityCreated event

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3271,6 +3271,20 @@ auto ServerGameState::CreateEntityFromTree(sync::NetObjEntityType type, const st
 		m_entitiesById[id] = entity;
 	}
 
+	const auto evComponent = m_instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::ResourceEventManagerComponent>();
+
+	/*NETEV serverEntityCreated SERVER
+	/#*
+	 * A server-side event that is triggered when an entity has been created by a server-side script.
+	 *
+	 * Unlike "entityCreated" the newly created entity may not yet have an assigned network owner.
+	 *
+	 * @param entity - The created entity handle.
+	 #/
+	declare function serverEntityCreated(handle: number): void;
+	*/
+	evComponent->QueueEvent2("serverEntityCreated", { }, MakeScriptHandle(entity));
+
 	return entity;
 }
 


### PR DESCRIPTION
### Goal of this PR
This introduces a new server-side event called `serverEntityCreated` that gets called when a server-side script creates a new entity with invoking natives like `CREATE_VEHICLE_SERVER_SETTER`.

### How is this PR achieving the goal
Triggering `serverEntityCreated` when we create an entity on the server-side per synctree initialization. 

### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
resolves #2658 