### PR TITLE
feat(docs/natives/GetPlayerIdentifier): Improve simple doc

### DIFF
--- a/ext/native-decls/GetPlayerIdentifier.md
+++ b/ext/native-decls/GetPlayerIdentifier.md
@@ -5,12 +5,16 @@ apiset: server
 ## GET_PLAYER_IDENTIFIER
 
 ```c
-char* GET_PLAYER_IDENTIFIER(char* playerSrc, int identifier);
+char* GET_PLAYER_IDENTIFIER(char* playerSrc, int indentiferIndex);
 ```
 
+To get the number of identifiers, use [GET_NUM_PLAYER_IDENTIFIERS](?_0xFF7F66AB)
+
+To get a specific type of identifier, use [GET_PLAYER_IDENTIFIER_BY_TYPE](?_0xA61C8FC6)
 
 ## Parameters
 * **playerSrc**: 
-* **identifier**: 
+* **indentiferIndex**: 
 
 ## Return value
+Returns the identifier at the specific index, if out of bounds returns `null`


### PR DESCRIPTION
### Goal of this PR

Add simple documentation to the native, which has the wrong parameter name, and provide useful information.


### How is this PR achieving the goal

Renames an incorrect parameter name.
Adds a reference on how to get the number of identifiers.
Adds a reference on how to get an identifier by type.
Specify a return value and an OutOfBounds value.


### This PR applies to the following area(s)

Server Native Docs


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
