### PR TITLE
fix(game/five): updateBusySpinner thread constraint check

### DIFF
--- a/code/components/loading-screens-five/src/HookLoadingScreens.cpp
+++ b/code/components/loading-screens-five/src/HookLoadingScreens.cpp
@@ -483,6 +483,12 @@ static InitFunction initFunction([] ()
 		{
 			if (*g_scaleformMgr)
 			{
+				if (GetCurrentThreadId() != g_mainThreadId)
+				{
+					trace("Error: BusySpinner update called from non-main thread!\n");
+					return;
+				}
+
 				setupBusySpinner(1);
 				*spinnerDep = true;
 				updateBusySpinner();

--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -411,8 +411,6 @@ static hook::cdecl_stub<bool(wchar_t, int)> ProcessWMChar([]()
 static ReverseGameInputState lastInput;
 static ReverseGameInputState curInput;
 
-static bool g_mainThreadId;
-
 #include <queue>
 
 extern void DoPatchMouseScrollDelta();

--- a/code/components/rage-nutsnbolts-five/include/nutsnbolts.h
+++ b/code/components/rage-nutsnbolts-five/include/nutsnbolts.h
@@ -15,6 +15,8 @@
 
 #define HAS_EARLY_GAME_FRAME
 
+extern NUTSNBOLTS_EXPORT DWORD g_mainThreadId;
+
 extern NUTSNBOLTS_EXPORT fwEvent<> OnLookAliveFrame;
 extern NUTSNBOLTS_EXPORT fwEvent<> OnGameFrame;
 extern NUTSNBOLTS_EXPORT fwEvent<> OnEarlyGameFrame;

--- a/code/components/rage-nutsnbolts-five/src/FrameHook.cpp
+++ b/code/components/rage-nutsnbolts-five/src/FrameHook.cpp
@@ -13,6 +13,8 @@
 #include <ICoreGameInit.h>
 #include <CrossBuildRuntime.h>
 
+DWORD g_mainThreadId;
+
 fwEvent<> OnLookAliveFrame;
 fwEvent<> OnEarlyGameFrame;
 fwEvent<> OnGameFrame;
@@ -64,7 +66,6 @@ static uint32_t g_lastCriticalFrame;
 static std::mutex g_gameFrameMutex;
 static std::mutex g_earlyGameFrameMutex;
 static std::mutex g_criticalFrameMutex;
-static DWORD g_mainThreadId;
 static bool g_executedOnMainThread;
 
 // NOTE: depends indirectly on GameProfiling.cpp in gta:core!


### PR DESCRIPTION
### Goal of this PR
Prevent crashes caused by reading from a nullptr when `updateBusySpinner` is called from the Render thread.

### How is this PR achieving the goal
Although the root cause of this issue requires further investigation, this PR provides a temporary fix to prevent crashes when `updateBusySpinner` is unexpectedly called from the Render thread instead of the Main thread. This call causes a subsequent function to return a nullptr due to failing thread constraint checks in native game code.

The only potential side effect of this fix is missing updates to the busy spinner during the loading of addon data files, but this is still better than outright crashing.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #2850