### PR TITLE
tweak(conhost-v2): switch CPU utilization tracking to dynamic scaling

### DIFF
--- a/code/components/conhost-v2/src/DrawPerf.cpp
+++ b/code/components/conhost-v2/src/DrawPerf.cpp
@@ -206,7 +206,7 @@ static InitFunction initFunction([]()
 		if (!cpuQuery)
 		{
 			PdhOpenQuery(NULL, NULL, &cpuQuery);
-			PdhAddEnglishCounter(cpuQuery, L"\\Processor Information(_Total)\\% Processor Time", NULL, &cpuTotal);
+			PdhAddEnglishCounter(cpuQuery, L"\\Processor Information(_Total)\\% Processor Utility", NULL, &cpuTotal);
 			PdhCollectQueryData(cpuQuery);
 		}
 


### PR DESCRIPTION
### Goal of this PR
Starting with Windows 8, Microsoft updated CPU performance counters to use "Processor Utility" instead of "Processor Time" to reflect dynamic frequency scaling (e.g., Intel Turbo Boost, AMD Precision Boost). This causes the in-game metrics to display wrong CPU utilization values.

### How is this PR achieving the goal
This change ensures in-game metrics display those more accurate values.

### This PR applies to the following area(s)
FiveM, RedM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
Reported here: https://discord.com/channels/779705925577080842/1260757053635297381 (Cfx.re Engineering Group)