### PR TITLE
tweak(game/fivem/loadscreen): Initialize the player for RAGE with manual shutdown

### DIFF
--- a/code/components/loading-screens-five/src/LoadingScreens.cpp
+++ b/code/components/loading-screens-five/src/LoadingScreens.cpp
@@ -160,8 +160,6 @@ static HookFunction hookFunction([]()
 
 			fx::ScriptEngine::RegisterNativeHandler("SHUTDOWN_LOADING_SCREEN_NUI", [=](fx::ScriptContext& ctx)
 			{
-				loadsThread.doSetup = true;
-
 				endLoadingScreens();
 			});
 
@@ -333,6 +331,14 @@ void LoadsThread::DoRun()
 {
 	if (ShouldSkipLoading())
 	{
+		if (doShutdown && !autoShutdownNui)
+		{
+			// SET_ENTITY_COORDS Init the player for RAGE sake
+			NativeInvoke::Invoke<0x06843DA7060A026B, int>(NativeInvoke::Invoke<0xD80958FC74E988A6, int>(), 0.0f, 0.0f, 0.0f, false, false, false, false);
+
+			doShutdown = false;
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
### Goal of this PR

Sets the Players Ped to 0,0,0; this makes RAGE render/activate game mechanics (Map, Entities, Entity dependent natives, UI).
Also, it removes setting the `doSetup` condition, as this code is unrelated and not reachable via manual shutdown.

### How is this PR achieving the goal

Sets the Players Ped to 0,0,0
Remove `loadsThread.doSetup = true;`, in ShutdownLoadingScreenNui


### This PR applies to the following area(s)

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1, 2060, 3258

**Platforms:** Windows Client


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Additional Information

Current (Only distant cars, water, weather, and time are present & entities are static if spawned):
![Screenshot 2024-11-25 002808](https://github.com/user-attachments/assets/0447f2be-a868-4488-b1e5-45a510d7ec02)

New (Playable game state):
![Screenshot 2024-11-25 012400](https://github.com/user-attachments/assets/0d472b58-efef-463f-b3c2-048414b0dd23)

Most people don't see this behaviour, as spawn managers/menus set the coords. 

