### PR TITLE
feat(nui): add `SET_NUI_ZINDEX`

### DIFF
--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -425,6 +425,36 @@ static InitFunction initFunction([] ()
 		context.SetResult(nui::HasFocusKeepInput());
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("SET_NUI_ZINDEX", [](fx::ScriptContext& context)
+	{
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_FAILED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			return;
+		}
+
+		fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+		if (!resource)
+		{
+			return;
+		}
+
+		fwRefContainer<ResourceUI> resourceUI = resource->GetComponent<ResourceUI>();
+		if (!resourceUI.GetRef() || !resourceUI->HasFrame())
+		{
+			return;
+		}
+
+		if (resource->GetName().find('"') != std::string::npos)
+		{
+			return;
+		}
+
+		int zIndex = context.GetArgument<int>(0);
+		nui::PostRootMessage(fmt::sprintf(R"({ "type": "setZIndex", "frameName": "%s", "zIndex": "%d" })", resource->GetName(), zIndex));
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_NUI_FOCUS", [] (fx::ScriptContext& context)
 	{
 		fx::OMPtr<IScriptRuntime> runtime;

--- a/ext/native-decls/SetNuiZindex.md
+++ b/ext/native-decls/SetNuiZindex.md
@@ -1,0 +1,13 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_NUI_ZINDEX
+
+```c
+void SET_NUI_ZINDEX(int zIndex);
+```
+Set the z-index of the NUI resource.
+
+## Parameters
+* **zIndex**: New z-index value.

--- a/ext/ui-build/data/root.html
+++ b/ext/ui-build/data/root.html
@@ -55,6 +55,11 @@ registerPushFunction(function(type, ...args) {
 				handoverBlob = data.data;
 			} else if (data.type == 'setServerAddress') {
 				serverAddress = data.data;
+			} else if (data.type == 'setZIndex') {
+				const { frameName, zIndex } = data;
+				if (frameName in citFrames) {
+					citFrames[frameName].style.zIndex = zIndex;
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Set the z-index for the NUI resource.


### How is this PR achieving the goal
You can set the z-index of an NUI resource with `SET_NUI_Z_INDEX`.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.