### PR TITLE
feat(extra-natives/five): train movement natives

### DIFF
--- a/ext/native-decls/GetTrainCruiseSpeed.md
+++ b/ext/native-decls/GetTrainCruiseSpeed.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRAIN_CRUISE_SPEED
+
+```c
+float GET_TRAIN_CRUISE_SPEED(Vehicle train);
+```
+
+Gets the trains desired speed.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The desired cruise speed of the train. Not the speed the train is currently traveling at 

--- a/ext/native-decls/GetTrainDirection.md
+++ b/ext/native-decls/GetTrainDirection.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRAIN_DIRECTION
+
+```c
+BOOL GET_TRAIN_DIRECTION(Vehicle train);
+```
+
+Gets the direction the train is facing 
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+True if the train is moving forward on the track, False otherwise

--- a/ext/native-decls/GetTrainSpeed.md
+++ b/ext/native-decls/GetTrainSpeed.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRAIN_SPEED
+
+```c
+float GET_TRAIN_SPEED(Vehicle train);
+```
+
+Gets the speed the train is currently going.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The current speed of the train

--- a/ext/native-decls/GetTrainState.md
+++ b/ext/native-decls/GetTrainState.md
@@ -1,0 +1,28 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRAIN_STATE
+
+```c
+int GET_TRAIN_STATE(Vehicle train);
+```
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The trains current state
+
+```c
+enum eTrainState
+{
+    MOVING = 0,
+    ENTERING_STATION,
+    OPENING_DOORS,
+    STOPPED,
+    CLOSING_DOORS,
+    LEAVING_STATION,
+}
+```

--- a/ext/native-decls/SetTrainState.md
+++ b/ext/native-decls/SetTrainState.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_TRAIN_STATE
+
+```c
+void SET_TRAIN_STATE(Vehicle train, int state);
+```
+
+## Parameters
+* **train**: The train handle
+* **state**: The trains new state
+
+## Return value
+The trains current state, refer to [GET_TRAIN_STATE](?_0x81b50033)


### PR DESCRIPTION
### Goal of this PR

Introduce a set of getters + a setter for several aspects of train movements. Allows for scripts to get information about the trains current speed, cruise speed, direction and state (e.g. moving, stopping at station, stopped at station and driving away from station) which was previously not possible 

### How is this PR achieving the goal

By creating GET_TRAIN_DIRECTION, GET_TRAIN_STATE, GET_TRAIN_CRUISE_SPEED, GET_TRAIN_SPEED and SET_TRAIN_STATE (to allow for scripts to change the trains current state)

### This PR applies to the following area(s)

FiveM, Natives

### Successfully tested on

**Game builds:** 1604, 3258

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
