### PR TITLE
tweak(cfx/nui): Hide server reviews *for now*

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -290,7 +290,7 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
         continue;
       }
       case key === 'can_review': {
-        view.canReview = Boolean(value);
+        view.canReview = false; // disable server reviews for the time being
         continue;
       }
       case key === 'onesync_enabled': {


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

server reviews are mostly a year old we could stop them from showing for now, until there's plans to bring them back.


### How is this PR achieving the goal

Hidding reviews since they are a year old mostly.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM/FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->



