### PR TITLE
tweak(system_resources/chat):Hide invalid command in chat

### DIFF
--- a/ext/system-resources/resources/chat/sv_chat.lua
+++ b/ext/system-resources/resources/chat/sv_chat.lua
@@ -212,12 +212,10 @@ AddEventHandler('_chat:messageEntered', function(author, color, message, mode)
 end)
 
 AddEventHandler('__cfx_internal:commandFallback', function(command)
-    local name = GetPlayerName(source)
-
-    -- route the message as if it were a /command
-    routeMessage(source, name, '/' .. command, nil, true)
-
     CancelEvent()
+    -- local name = GetPlayerName(source)
+    -- route the message as if it were a /command
+    -- routeMessage(source, name, '/' .. command, nil, true)-- do not send message if command doesnt exist
 end)
 
 -- player join messages


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

users often type invalid commands and this fallback allows to still be posted as message and everyone can see it.
it will fill the whole chat just with these and can become quite annoying
many users in my community ask how to remove this.


### How is this PR achieving the goal

removes the fallback message when a command is not valid 


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM/FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


