### PR TITLE
tweak(extra-natives/five): sanitize mission train creation

### DIFF
--- a/code/components/extra-natives-five/include/Train.h
+++ b/code/components/extra-natives-five/include/Train.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <atArray.h>
+
+namespace rage
+{
+struct CTrackNode
+{
+public:
+	float m_x, m_y, m_z;
+	float m_unk;
+	uint8_t m_unk1;
+	int m_station;
+};
+
+struct CTrainTrack
+{
+public:
+	// This has never changed.
+	static const int kMaxTracks = 27;
+
+	uint32_t m_hash;
+	bool m_enabled;
+	bool m_isLooped;
+	bool m_stopsAtStation;
+	bool m_MPStopsAtStation;
+	uint32_t m_speed;
+	uint32_t m_brakeDistance;
+
+	int m_nodeCount;
+	CTrackNode* m_nodes;
+
+	uint8_t m_pad[8];
+
+	bool m_disableAmbientTrains;
+	uint8_t m_pad2[0x220];
+
+	// Helper functions
+	static bool AreAllTracksDisabled();
+};
+
+struct CTrainConfig
+{
+	struct CarriageData
+	{
+		uint32_t m_hash;
+		uint8_t m_pad[0xE];
+	};
+
+	uint32_t m_hash;
+	uint8_t m_pad[0x1A];
+	atArray<CarriageData> m_carriages;
+};
+
+struct CTrainConfigData
+{
+	atArray<CTrainConfig> m_trainConfigs;
+};
+}


### PR DESCRIPTION
### Goal of this PR

Prevent client crashes when using the CREATE_MISSION_TRAIN native.

### How is this PR achieving the goal

By adding checks that are missing with the original native implementation. Such as invalid train variations (that do not exist in trains.xml), required carriage models not being loaded, and checking to ensure that there is at least a single track enabled to create a train on (this wouldn't crash the client, but would rather return a native error in the console which could be confusing to users).

This PR also moves some Train structs from TrackNatives to a Train header file to reduce code duplication 

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** 1604, 2060, 2372, 2545, 2699, 2802, 3095, 3258, 3407

**Platforms:** Windows

I've created a repro resource to reproduce the crashes and their new behaviour with this PR. 
[train-crash-test.zip](https://github.com/user-attachments/files/18026708/train-crash-test.zip)

### Checklist

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.

### Fixes issues

