### PR TITLE
feat(gamestate/server): train sync node getters

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -637,18 +637,18 @@ struct CTrainGameStateDataNodeData
 	bool isEngine;
 	bool isCaboose;
 
-	bool unk12;
+	bool isMissionTrain;
 
 	bool direction;
 
-	bool unk14;
+	bool hasPassengerCarriages;
 
 	bool renderDerailed;
 
 	// 2372 {
-	bool unk198;
-	bool unk224;
-	bool unk199;
+	bool allowRemovalByPopulation;
+	bool highPrecisionBlending;
+	bool stopAtStations;
 	// }
 
 	bool forceDoorsOpen;

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2909,20 +2909,30 @@ struct CTrainGameStateDataNode : GenericSerializeDataNode<CTrainGameStateDataNod
 		s.Serialize(3, data.trainState);
 
 		s.Serialize(data.isEngine);
-		s.Serialize(data.isCaboose);
-		s.Serialize(data.unk12);
-		s.Serialize(data.direction);
-		s.Serialize(data.unk14);
-		s.Serialize(data.renderDerailed);
 
-		if (Is2372()) // Sequence of bits need to be verified for 2732
+		//2372 inserted a bool between isEngine and isCaboose
+		if (Is2372())
 		{
-			s.Serialize(data.unk198);
-			s.Serialize(data.unk224);
-			s.Serialize(data.unk199);
+			//Modified by 0x2310A8F9421EBF43
+			s.Serialize(data.allowRemovalByPopulation);
 		}
 
+		s.Serialize(data.isCaboose);
+		s.Serialize(data.isMissionTrain);
+		s.Serialize(data.direction);
+		s.Serialize(data.hasPassengerCarriages);
+		s.Serialize(data.renderDerailed);
+
 		s.Serialize(data.forceDoorsOpen);
+
+		if (Is2372())
+		{ 
+			// Set on population trains or with SET_TRAIN_STOP_AT_STATIONS
+			s.Serialize(data.stopAtStations);
+
+			// Modified by _NETWORK_USE_HIGH_PRECISION_VEHICLE_BLENDING
+			s.Serialize(data.highPrecisionBlending);
+		}
 
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1805,6 +1805,98 @@ static void Init()
 		return train ? train->carriageIndex : -1;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_STATE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->trainState : -1;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_TRAIN_CABOOSE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->isCaboose : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_TRAIN_STOP_AT_STATIONS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->stopAtStations : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_CRUISE_SPEED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->cruiseSpeed : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_TRACK_INDEX", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->trackId : -1;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_FORWARD_CARRIAGE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		if (!train)
+		{
+			return uint32_t(0);
+		}
+
+		if (train->isEngine)
+		{
+			return uint32_t(0);
+		}
+
+		auto resourceManager = fx::ResourceManager::GetCurrent();
+
+		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+
+		auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+		auto forwardCarriage = gameState->GetEntity(0, train->linkedToForwardId);
+
+		return forwardCarriage ? gameState->MakeScriptHandle(forwardCarriage) : 0;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_BACKWARD_CARRIAGE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		if (!train)
+		{
+			return uint32_t(0);
+		}
+
+		if (train->isCaboose)
+		{
+			return uint32_t(0);
+		}
+
+		auto resourceManager = fx::ResourceManager::GetCurrent();
+
+		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+
+		auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+		auto backwardCarriage = gameState->GetEntity(0, train->linkedToBackwardId);
+
+		return backwardCarriage ? gameState->MakeScriptHandle(backwardCarriage) : 0;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_DIRECTION", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->direction : false;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_FAKE_WANTED_LEVEL", MakePlayerEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto pn = entity->syncTree->GetPlayerWantedAndLOS();

--- a/ext/native-decls/DoesTrainStopAtStations.md
+++ b/ext/native-decls/DoesTrainStopAtStations.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 game: gta5
 ---
 ## DOES_TRAIN_STOP_AT_STATIONS

--- a/ext/native-decls/GetTrainBackwardCarriage.md
+++ b/ext/native-decls/GetTrainBackwardCarriage.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_TRAIN_BACKWARD_CARRIAGE
+
+```c
+int GET_TRAIN_BACKWARD_CARRIAGE(Vehicle train);
+``` 
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The handle of the carriage behind this train in the chain. Otherwise returns 0 if the train is the caboose of the chain. 

--- a/ext/native-decls/GetTrainCruiseSpeed.md
+++ b/ext/native-decls/GetTrainCruiseSpeed.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 game: gta5
 ---
 ## GET_TRAIN_CRUISE_SPEED

--- a/ext/native-decls/GetTrainDirection.md
+++ b/ext/native-decls/GetTrainDirection.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 game: gta5
 ---
 ## GET_TRAIN_DIRECTION

--- a/ext/native-decls/GetTrainForwardCarriage.md
+++ b/ext/native-decls/GetTrainForwardCarriage.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_TRAIN_FORWARD_CARRIAGE
+
+```c
+int GET_TRAIN_FORWARD_CARRIAGE(Vehicle train);
+``` 
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The handle of the carriage in front of this train in the chain. Otherwise returns 0 if the train has no carriage in front of it 

--- a/ext/native-decls/GetTrainState.md
+++ b/ext/native-decls/GetTrainState.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 game: gta5
 ---
 ## GET_TRAIN_STATE

--- a/ext/native-decls/GetTrainTrackIndex.md
+++ b/ext/native-decls/GetTrainTrackIndex.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 game: gta5
 ---
 ## GET_TRAIN_TRACK_INDEX
@@ -8,7 +8,9 @@ game: gta5
 ```c
 int GET_TRAIN_TRACK_INDEX(Vehicle train);
 ``` 
+
 ## Parameters
 * **train**: The train handle
+
 ## Return value
 The track index the train is currently on.

--- a/ext/native-decls/IsTrainCaboose.md
+++ b/ext/native-decls/IsTrainCaboose.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## IS_TRAIN_CABOOSE
+
+```c
+bool IS_TRAIN_CABOOSE(Vehicle train);
+``` 
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+Returns true if the train is the caboose of the chain.


### PR DESCRIPTION
### Goal of this PR

Correct CTrainGameStateDataNode for >b2372 and implement several server getter natives for trains

### How is this PR achieving the goal

By finishing CTrainGameStateDataNode and correcting the order for >b2372 Originally PR'd alongside server-setter trains (#2322). And implementing getter natives to allow server scripts to take advantage of this with the following natives:

GET_TRAIN_STATE
IS_TRAIN_CABOOSE
DOES_TRAIN_STOP_AT_STATIONS
GET_TRAIN_CRUISE_SPEED
GET_TRAIN_TRACK_INDEX
GET_TRAIN_FORWARD_CARRIAGE
GET_TRAIN_BACKWARD_CARRIAGE
GET_TRAIN_DIRECTION

### This PR applies to the following area(s)

FiveM, Server, Natives

### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows

Provided is a resource created to test these new server natives to ensure they work as intended [train-servers-node.zip](https://github.com/user-attachments/files/18030317/train-servers-node.zip)

### Checklist

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.

### Fixes issues

