### PR TITLE
Update transformers.ts

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
+++ b/ext/cfx-ui/src/cfx/common/services/servers/transformers.ts
@@ -289,10 +289,6 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
         view.bannerDetail = value;
         continue;
       }
-      case key === 'can_review': {
-        view.canReview = Boolean(value);
-        continue;
-      }
       case key === 'onesync_enabled': {
         view.onesyncEnabled = value === 'true';
         continue;
@@ -307,6 +303,16 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
         view.pureLevel = value as ServerPureLevel;
         continue;
       }
+      case key === 'ServerReviewsEnabled': {
+        view.canReview = value.toLowerCase() !== 'false';
+        continue;
+      }
+      case key === 'can_review': {
+        if (view.canReview === undefined) {
+          view.canReview = Boolean(value);
+        }
+        continue;
+      }
       case !shouldVarBeShown(key): {
         continue;
       }
@@ -319,6 +325,9 @@ export function processServerDataVariables(vars?: IServer['data']['vars']): Vars
     }
 
     view.variables![key] = value;
+  }
+  if (view.canReview === undefined) {
+    view.canReview = true;
   }
 
   return view;


### PR DESCRIPTION
Add convar for ServerReviewsEnabled (Boolean) true/false to enable or disable reviews.

### Goal of this PR
Allows server owners to set a convar `ServerReviewsEnabled` to either true or false (default to true).
This will then allow/deny from new reviews being posted/submitted.

...


### How is this PR achieving the goal
By introducing a new convar ServerReviewsEnabled, if set to true it will allow new reviews, if set to false it will not allow these to be submitted.
...


### This PR applies to the following area(s)
FiveM
...


### Successfully tested on
Successfull compilation on local build.

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://github.com/citizenfx/fivem/pull/2979 - Will be fixed by not hardlocking it, but rather allowing server owners themselves to decide.


