### PR TITLE
tweak(ext/cfx-ui): allow automated accounts for servers feeds

### DIFF
--- a/ext/cfx-ui/src/cfx/common/services/activity/ActiveActivityPubFeed.ts
+++ b/ext/cfx-ui/src/cfx/common/services/activity/ActiveActivityPubFeed.ts
@@ -171,8 +171,12 @@ export class ActiveActivityPubFeed {
       },
     });
 
-    if (!isObject<IActivityPubAccount>(account) || !(account.type === 'Person' || account.type === 'Service')) {
-      throw new Error(`Unknown or invalid account for pub ${this.id}`);
+    if (!isObject<IActivityPubAccount>(account)) {
+      throw new Error(`Invalid account response for pub ${this.id}`);
+    }
+
+    if (account.type !== 'Person' && account.type !== 'Service') {
+      throw new Error(`Unknown or invalid account type ${account.type} for pub ${this.id}`);
     }
 
     if (!account.outbox) {

--- a/ext/cfx-ui/src/cfx/common/services/activity/ActiveActivityPubFeed.ts
+++ b/ext/cfx-ui/src/cfx/common/services/activity/ActiveActivityPubFeed.ts
@@ -171,7 +171,7 @@ export class ActiveActivityPubFeed {
       },
     });
 
-    if (!isObject<IActivityPubAccount>(account) || account.type !== 'Person') {
+    if (!isObject<IActivityPubAccount>(account) || !(account.type === 'Person' || account.type === 'Service')) {
       throw new Error(`Unknown or invalid account for pub ${this.id}`);
     }
 
@@ -254,7 +254,7 @@ export class ActiveActivityPubFeed {
 type nay = any;
 
 export interface IActivityPubAccount {
-  type: 'Person' | string;
+  type: 'Person' | 'Service' | string;
 
   outbox: string;
 


### PR DESCRIPTION
### Goal of this PR

While debugging an issue with a [user on the forums](https://forum.cfx.re/t/how-to-server-feed-dedicated-space-on-fivem-social/5199841/13?u=theindra), noticed that accounts marked as "Automated" in Mastodon fail to load in the servers feeds. This is because these accounts are [returned as](https://github.com/mastodon/mastodon/blob/72a4da83fdd2ac8a089cde208149792108783d97/app/serializers/activitypub/actor_serializer.rb#L53-L54) type `Service` in the ActivityPub response, while the code only checks for `Person` currently.

### How is this PR achieving the goal

Allows ActivityPub users with both `Person` and `Service` type.


### This PR applies to the following area(s)

CfxUI

### Successfully tested on

**Game builds:** N/A

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
