### PR TITLE
fix(game/five): fix vehicle cloth not rendering

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.FakeParachuteProp.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.FakeParachuteProp.cpp
@@ -134,7 +134,7 @@ static HookFunction hookFunction([]
 				mov(al, byte_ptr[rax + 0xA]);		//
 				and(al, 0xF);						//
 				cmp(al, 3);							//        if ( ((shader + 0xA) & 0xF) == 3 /* vehicle */ )
-				jz("fail");							//        {
+				jnz("fail");						//        {
 													//
 				mov(rax, retSuccess);				//
 				jmp(rax);							//            [run original code]


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The patch introduced in https://github.com/citizenfx/fivem/commit/4f294e49262fb3b095163553d463d089f30c83cd was checking `type != 3` instead of the intended `type == 3`, which disabled the vehicle cloth rendering.

### How is this PR achieving the goal

Correct the patch to check for `type == 3`.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues

Fixes #2977.
