### PR TITLE
feat(gameState): Add relevant players culling native

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -1314,10 +1314,22 @@ struct GameStateClientData
 	uint32_t routingBucket = 0;
 
 	float playerCullingRadius = 0.0f;
+
+	std::bitset<1000000> playerCullingRelevantPlayers;
 	
 	inline float GetPlayerCullingRadius()
 	{
 		return playerCullingRadius;
+	}
+
+	inline std::vector<uint32_t> GetPlayerCullingRelevantPlayers()
+	{
+		return playerCullingRelevantPlayers;
+	}
+
+	inline bool GetPlayerCullingIsRelevantPlayer(uint32_t playerId)
+	{
+		return playerCullingRelevantPlayers.test(playerId);
 	}
 
 	GameStateClientData()

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1220,6 +1220,11 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 				}
 			}
 
+			if (isRelevant && entity->type == sync::NetObjEntityType::Player && !clientDataUnlocked->GetPlayerCullingRelevantPlayers().none())
+			{
+				isRelevant = clientDataUnlocked->GetPlayerCullingIsRelevantPlayer(entityClient->GetNetId());
+			}
+
 			// if we own this entity, we need to assign as relevant.
 			// -> even if not client-script, as if it isn't, we'll end up stuck without migrating it
 			if (ownsEntity/* && entity->IsOwnedByClientScript()*/)

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1505,6 +1505,36 @@ static void Init()
 		return true;
 	}));
 
+ 	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_CULLING_RELEVANT_PLAYERS", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
+ 	{
+ 		if (context.GetArgumentCount() > 1)
+ 		{
+ 			std::bitset<1000000> players;
+ 			if (context.GetArgument<int>(1) != 0)
+ 			{
+ 				for (int i = 1; i < context.GetArgumentCount(); i  )
+ 				{
+ 					int value = context.GetArgument<int>(i);
+ 					players.set(value);
+ 				}
+ 			}
+ 
+ 			// get the current resource manager
+ 			auto resourceManager = fx::ResourceManager::GetCurrent();
+ 
+ 			// get the owning server instance
+ 			auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+ 
+ 			// get the server's game state
+ 			auto gameState = instance->GetComponent<fx::ServerGameState>();
+ 
+ 			auto [lock, clientData] = gameState->ExternalGetClientData(client);
+ 			clientData->playerCullingRelevantPlayers = players;
+ 		}
+ 
+ 		return true;
+ 	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_IGNORE_REQUEST_CONTROL_FILTER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		if (context.GetArgumentCount() > 1)

--- a/ext/native-decls/SetPlayerCullingReleventPlayers.md
+++ b/ext/native-decls/SetPlayerCullingReleventPlayers.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_PLAYER_CULLING_RELEVANT_PLAYERS
+
+```c
+void SET_PLAYER_CULLING_RELEVANT_PLAYERS(char* playerSrc, int playerTarget);
+```
+
+Sets the culling relevent players list for the specified player.
+Set to `0` to reset.
+
+## Parameters
+* **playerSrc**: The player to set the culling players for.
+* **playerTarget**: The players you want cull. (You can pass many net ids)
+
+## Examples
+
+```lua
+RegisterServerEvent("cullingPlayers")
+AddEventHandler("cullingPlayers", function(list)
+  local Source = source
+  for i, v in ipairs(list) do
+     list[i] = tonumber(v)
+  end
+  SetPlayerCullingRelevantPlayers(Source, table.unpack(list))
+end)
+```


### PR DESCRIPTION
### Goal of this PR

The game has a hard cap on displaying culled players (128 for FiveM, 32 for RedM).
This native allows server owners to control which players can be seen by others.
Since the culling radius does not prioritize displaying the closest players, this native allow server owners to implement their own logic to filter culled players.


### How is this PR achieving the goal

Add native to set players net ids list for each players to be culled


### This PR applies to the following area(s)

Server


### Successfully tested on

Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

