### PR TITLE
tweak(server): ignore resources that have a name starting with '.' in resource scan

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResourceList.cpp
+++ b/code/components/citizen-server-impl/src/ServerResourceList.cpp
@@ -110,6 +110,13 @@ void ServerResourceList::ScanResources(const std::string& resourceRoot, ScanResu
 					else if (scannedNow.find(findData.name) == scannedNow.end())
 					{
 						const auto& resourceName = findData.name;
+
+						// ignore hidden folders
+						if (resourceName[0] == '.')
+						{
+							continue;
+						}
+
 						scannedNow.emplace(resourceName, resPath);
 
 						auto oldRes = m_manager->GetResource(resourceName, false);


### PR DESCRIPTION
### Goal of this PR

Like the .git folder, we ignore the .github folder from the resource scan so git repos with a .github folder do not result in a warning during a resource scan.

### How is this PR achieving the goal

Adding an additional check to the resource scan loop so that resources with the name ".github" are skipped.


### This PR applies to the following area(s)

Server


### Successfully tested on

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.