### PR TITLE
tweak(scripting/lua): speed up lua event serialization.

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -158,9 +158,6 @@ Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 	local lastSource = _G.source
 	_G.source = eventSource
 	
-	-- deserialize the event structure (so that we end up adding references to delete later on)
-	local data = msgpack_unpack(eventPayload)
-	
 	-- if this is a net event and we don't allow this event to be triggered from the network, return
 	if eventSource:sub(1, 3) == 'net' then
 		if not eventHandlerEntry.safeForNet then
@@ -177,11 +174,14 @@ Citizen.SetEventRoutine(function(eventName, eventPayload, eventSource)
 		_G.source = tonumber(eventSource:sub(14))
 	end
 
+	-- deserialize the event structure (so that we end up adding references to delete later on)
+	local data = msgpack_unpack(eventPayload)
+	
 	-- return an empty table if the data is nil
 	if not data then
 		data = {}
 	end
-
+		
 	-- reset serialization
 	deserializingNetEvent = nil
 


### PR DESCRIPTION
If there are no event handlers for the event, there is no need to unpack or set the source as they will never be used.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Significantly speeds up event serialization when there are no handlers available.


### How is this PR achieving the goal

By returning early when there are no event handlers available.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** b3095

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->