### PR TITLE
feat: allow resources to retrieve the invoking resource of commands

### DIFF
--- a/code/client/citicore/console/Console.CommandHelpers.h
+++ b/code/client/citicore/console/Console.CommandHelpers.h
@@ -7,6 +7,7 @@ class ConsoleCommand
 {
 private:
 	int m_token;
+	std::string m_resource = "internal";
 	ConsoleCommandManager* m_manager;
 
 public:
@@ -30,7 +31,7 @@ public:
 
 		using ConsoleCommandFunction = internal::ConsoleCommandFunction<decltype(functionRef)>;
 
-		m_token = m_manager->Register(name, [=](ConsoleExecutionContext& context) {
+		m_token = m_manager->Register(name, m_resource, [=](ConsoleExecutionContext& context) {
 			return ConsoleCommandFunction::Call(functionRef, context);
 		}, ConsoleCommandFunction::kNumArguments);
 	}

--- a/code/client/citicore/console/Console.Commands.cpp
+++ b/code/client/citicore/console/Console.Commands.cpp
@@ -7,7 +7,7 @@
 #include <IteratorView.h>
 
 ConsoleCommandManager::ConsoleCommandManager(console::Context* parentContext)
-    : m_parentContext(parentContext), m_curToken(0)
+: m_parentContext(parentContext), m_curToken(0)
 {
 }
 
@@ -15,12 +15,12 @@ ConsoleCommandManager::~ConsoleCommandManager()
 {
 }
 
-int ConsoleCommandManager::Register(const std::string& name, const THandler& handler, size_t arity)
+int ConsoleCommandManager::Register(const std::string& name, std::string resource, const THandler& handler, size_t arity)
 {
 	std::unique_lock<std::shared_mutex> lock(m_mutex);
 
 	int token = m_curToken.fetch_add(1);
-	m_entries.insert({name, Entry{name, handler, token, arity}});
+	m_entries.insert({name, Entry{name, handler, resource, token, arity} });
 
 	return token;
 }
@@ -55,7 +55,7 @@ void ConsoleCommandManager::Invoke(const std::string& commandString, const std::
 		return;
 	}
 
-	std::string command        = arguments.Shift();
+	std::string command    = arguments.Shift();
 
 	m_rawCommand = commandString;
 
@@ -167,7 +167,7 @@ void ConsoleCommandManager::ForAllCommands2(const std::function<void(const conso
 		// loop through the commands
 		for (auto& command : m_entries)
 		{
-			console::CommandMetadata md{ command.first, command.second.arity };
+			console::CommandMetadata md{ command.first, command.second.resource, command.second.arity };
 			callback(md);
 		}
 	}

--- a/code/client/citicore/console/Console.Commands.h
+++ b/code/client/citicore/console/Console.Commands.h
@@ -36,7 +36,7 @@ struct ConsoleExecutionContext
 	std::string contextRef;
 
 	inline ConsoleExecutionContext(const ProgramArguments&& arguments, const std::string& contextRef)
-	    : arguments(arguments), contextRef(contextRef)
+		: arguments(arguments), contextRef(contextRef)
 	{
 	}
 };
@@ -50,8 +50,8 @@ public:
 	{
 	}
 
-	inline CommandMetadata(const std::string& name, size_t arity)
-		: m_name(name), m_arity(arity)
+	inline CommandMetadata(const std::string& name, std::string resource, size_t arity)
+		: m_name(name), m_resource(resource), m_arity(arity)
 	{
 	}
 
@@ -65,6 +65,16 @@ public:
 		return m_name;
 	}
 
+	inline const auto GetResourceName() const
+	{
+		return m_resource;
+	}
+
+	inline const bool MatchResourceName(std::string resource) const
+	{
+		return m_resource == resource;
+	}
+
 	inline auto GetArity() const
 	{
 		return m_arity;
@@ -72,6 +82,7 @@ public:
 
 private:
 	std::string m_name;
+	std::string m_resource;
 	size_t m_arity = -1;
 };
 }
@@ -86,7 +97,7 @@ public:
 
 	virtual ~ConsoleCommandManager();
 
-	virtual int Register(const std::string& name, const THandler& handler, size_t arity = -1);
+	virtual int Register(const std::string& name, std::string resource, const THandler& handler, size_t arity = -1);
 
 	virtual void Unregister(int token);
 
@@ -114,12 +125,13 @@ private:
 	{
 		std::string name;
 		THandler function;
+		std::string resource;
 
 		int token;
 		size_t arity;
 
-		inline Entry(const std::string& name, const THandler& function, int token, size_t arity = -1)
-			: name(name), function(function), token(token), arity(arity)
+		inline Entry(const std::string& name, const THandler& function, std::string resource, int token, size_t arity = -1)
+			: name(name), function(function), resource(resource), token(token), arity(arity)
 		{
 		}
 	};
@@ -149,6 +161,7 @@ struct ConsoleArgumentTraits
 	using Greater = std::greater<TArgument>;
 	using Equal   = std::equal_to<TArgument>;
 };
+
 
 template <typename TArgument, typename TConstraint = void>
 struct ConsoleArgumentName
@@ -301,7 +314,7 @@ public:
 	ExternalContext(const std::any& any)
 		: std::any(any)
 	{
-		
+
 	}
 };
 #else
@@ -409,7 +422,6 @@ private:
 	}
 
 public:
-
 	// non-terminator iterator
 	template <size_t Iterator, size_t ArgIterator, typename TupleType>
 	static std::enable_if_t<(Iterator < sizeof...(Args)), bool> CallInternal(TFunc func, ConsoleExecutionContext& context, TupleType tuple)

--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -26,15 +26,15 @@
 struct CommandObject
 {
 	std::string name;
+	std::string resource;
 	int32_t arity;
 
-	CommandObject(const std::string& name, size_t arity)
-		: name(name), arity(arity)
+	CommandObject(const std::string& name, std::string resource, size_t arity)
+		: name(name), resource(resource), arity(arity)
 	{
-
 	}
 
-	MSGPACK_DEFINE_MAP(name, arity);
+	MSGPACK_DEFINE_MAP(name, resource, arity);
 };
 
 static InitFunction initFunction([] ()
@@ -125,6 +125,7 @@ static InitFunction initFunction([] ()
 			{
 				auto resourceManager = resource->GetManager();
 				auto consoleCxt = resourceManager->GetComponent<console::Context>();
+				std::string resourceName = resource->GetName();
 
 				outerRefs[commandName] = commandRef;
 
@@ -139,7 +140,7 @@ static InitFunction initFunction([] ()
 					seGetCurrentContext()->AddAccessControlEntry(se::Principal{ "builtin.everyone" }, se::Object{ "command." + commandName }, se::AccessType::Allow);
 				}
 
-				int commandToken = consoleCxt->GetCommandManager()->Register(commandName, [=](ConsoleExecutionContext& context)
+				int commandToken = consoleCxt->GetCommandManager()->Register(commandName, resourceName, [=](ConsoleExecutionContext& context)
 				{
 					try
 					{
@@ -181,12 +182,36 @@ static InitFunction initFunction([] ()
 
 				consoleCxt->GetCommandManager()->ForAllCommands2([&commandList](const console::CommandMetadata& command)
 				{
-					commandList.emplace_back(command.GetName(), (command.GetArity() == -1) ? -1 : int32_t(command.GetArity()));
+					commandList.emplace_back(command.GetName(), command.GetResourceName(), (command.GetArity() == -1) ? -1 : int32_t(command.GetArity()));
 				});
 
 				context.SetResult(fx::SerializeObject(commandList));
 			}
 		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_RESOURCE_COMMANDS", [](fx::ScriptContext& context)
+	{
+		std::string resourceName = context.CheckArgument<const char*>(0);
+		std::vector<CommandObject> commandList;
+
+		// find the resource
+		fx::ResourceManager* resourceManager = fx::ResourceManager::GetCurrent();
+		fwRefContainer<fx::Resource> resource = resourceManager->GetResource(resourceName);
+		auto consoleCxt = resourceManager->GetComponent<console::Context>();
+
+		if (resource.GetRef())
+		{
+			consoleCxt->GetCommandManager()->ForAllCommands2([&commandList, &resourceName](const console::CommandMetadata& command)
+			{
+				if (command.MatchResourceName(resourceName))
+				{
+					commandList.emplace_back(command.GetName(), command.GetResourceName(), (command.GetArity() == -1) ? -1 : int32_t(command.GetArity()));
+				}
+			});
+		}
+
+		context.SetResult(fx::SerializeObject(commandList));
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_INSTANCE_ID", [](fx::ScriptContext& context)

--- a/ext/native-decls/GetRegisteredCommands.md
+++ b/ext/native-decls/GetRegisteredCommands.md
@@ -13,13 +13,32 @@ The data returned adheres to the following layout:
 ```
 [
 {
-"name": "cmdlist"
+"name": "cmdlist",
+"resource": "resource",
+"arity" = -1,
 },
 {
 "name": "command1"
+"resource": "resource_2",
+"arity" = -1,
 }
 ]
 ```
 
 ## Return value
 An object containing registered commands.
+
+## Example
+
+```lua
+RegisterCommand("showCommands", function()
+    local commands = GetRegisteredCommands()
+    print(("There is currently ^5%s^7 commands registered"):format(#commands))
+
+    local commandList = ""
+    for i=1, #commands do
+        commandlist = commandList + ("%s: %s (arguments: %s)\n"):format(commands[i].resource, commands[i].name, commands[i].arity)
+    end
+
+    print(commandList)
+end)

--- a/ext/native-decls/GetResourceCommands.md
+++ b/ext/native-decls/GetResourceCommands.md
@@ -1,0 +1,45 @@
+---
+ns: CFX
+apiset: shared
+---
+## GET_RESOURCE_COMMANDS
+
+```c
+object GET_RESOURCE_COMMANDS(char* resource);
+```
+
+Returns all commands registered by the specified resource.
+The data returned adheres to the following layout:
+```
+[
+{
+"name": "cmdlist",
+"resource": "example_resource",
+"arity" = -1,
+},
+{
+"name": "command1"
+"resource": "example_resource2",
+"arity" = -1,
+}
+]
+```
+
+## Return value
+An object containing registered commands.
+
+## Example
+
+```lua
+RegisterCommand("getCommands", function(_, args)
+    local commands = GetResourceCommands(args[1])
+    print(("Resource ^5%s^7 Has ^5%s^7 Commands Registered"):format(args[1], #commands))
+
+    local commandList = ""
+    for i=1, #commands do
+        commandlist = commandList + ("%s, "):format(commands[i].name)
+    end
+
+    print(commandList)
+end)
+```


### PR DESCRIPTION
### Goal of this PR
The goal of this PR is quite simple: allow resources to see which resource, registered which command.
This goal, was mainly sparked by a [suggestion in txAdmin](https://discord.com/channels/577993482761928734/1318332458499838055):
> In txAdmin menu, under Resources tab, It would be useful to view all the registered commands under each script in a dropdown

### How is this PR achieving the goal

This PR achieves this by:
- storing the invoking resource from `REGISTER_COMMAND` in the Command Object
- Allowing that data to be accessed from the existing native: `GetRegisteredCommands`
- Adds a Brand new Native: `GET_RESOURCE_COMMANDS`, that allows resources to retrieve the command list, from specific resources, allowing for much cleaner code.
- All internal commands, such as convars, are marked as `internal` for the resource.

### This PR applies to the following area(s)
FiveM, RedM, Server, Natives

### Successfully tested on

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
