### PR TITLE
feat(scripting/lua): add getnparams to client debug sandbox

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaDebug.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaDebug.cpp
@@ -268,6 +268,42 @@ int db_traceback(lua_State* L)
 	return 1;
 }
 
+int db_getparametersnames(lua_State* L)
+{
+	int arg;
+	lua_Debug ar;
+	lua_State* L1 = getthread(L, &arg);
+	luaL_checktype(L, arg + 1, LUA_TFUNCTION);
+	lua_pushvalue(L, arg + 1);
+	if (!lua_getinfo(L1, ">u", &ar)) /* Retrieve debug info */
+	{
+		lua_pushnil(L); /* Return nil if lua_getinfo fails */
+		return 1;
+	}
+	lua_pop(L, 1); /* Remove the function from the stack */
+	lua_newtable(L); /* Create a table to store parameter names */
+	int args = ar.nparams;
+	lua_pushvalue(L, arg + 1); /* Push the function onto the stack for lua_getlocal */
+	for (int i = 1; i <= args; ++i)
+	{
+		const char* name = lua_getlocal(L1, NULL, i); /* Get the parameter name */
+		if (name)
+		{
+			lua_pushstring(L, name);
+			lua_rawseti(L, -3, i);
+		}
+		else
+		{
+			lua_pushnil(L);
+			lua_rawseti(L, -3, i);
+		}
+	}
+
+	lua_pop(L1, 1); /* Remove the function from the stack */
+
+	return 1;
+}
+
 /*static int db_setcstacklimit (lua_State *L) {
   int limit = (int)luaL_checkinteger(L, 1);
   int res = lua_setcstacklimit(L, limit);
@@ -281,6 +317,7 @@ const luaL_Reg dblib[] = {
 	{"getupvalue", db_getupvalue},
 	{"setmetatable", db_setmetatable},
 	{"traceback", db_traceback},
+	{"getnparams", db_getparametersnames},
 	//{"setcstacklimit", db_setcstacklimit},
 	{nullptr, nullptr}
 };


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Add additional functionality to the new client sandboxed lua debug lib as much of its functionality was removed. 

### How is this PR achieving the goal

Added the `debug.getnparams()` function to be used on the client. This is a bypass for the unsafe debug.getlocal(), so devs can still get the parameter names of a function passed as the argument to the new function.

New lua docs for the debug function
```
---
--- Returns a table with the function parameter names from 1 to `nparams`, or **nil** if `nparms` 
--- is not available. Variable arguments are ignored but will still return parameters before it.
--- `self` is included as the first parameter if the function is a method.
---@param f function
---@return table
function debug.getnparams(f) end
```

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

Unable to build fivem on my laptop but did test it on Windows 10, using a simple C++ script and lua script and the code compiled and ran as expected. Used the functions in the file `LuaDebug.cpp` as reference to ensure consistency.

**Game builds:** 

**Platforms:** 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Addresses #3010

