### PR TITLE
feat(scripting/v8): support unpacking Lua vectors

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -3,6 +3,9 @@
 
 const EXT_FUNCREF = 10;
 const EXT_LOCALFUNCREF = 11;
+const EXT_VECTOR2 = 20;
+const EXT_VECTOR3 = 21;
+const EXT_VECTOR4 = 22;
 
 (function (global) {
 	let boundaryIdx = 1;
@@ -49,6 +52,30 @@ const EXT_LOCALFUNCREF = 11;
 
 	const pack = data => msgpack.encode(data, { codec });
 	const unpack = data => msgpack.decode(data, { codec });
+	
+	const vectorUnpacker = (data) => {
+	  const buffer = Buffer.from(data);
+	
+	  return Array.from(
+	    new Float32Array(buffer.buffer, buffer.byteOffset, buffer.length / 4),
+	    (value) => Number(value.toPrecision(7))
+	  );
+	};
+	
+	addExtension({
+	  type: EXT_VECTOR2,
+	  unpack: vectorUnpacker,
+	});
+	
+	addExtension({
+	  type: EXT_VECTOR3,
+	  unpack: vectorUnpacker,
+	});
+	
+	addExtension({
+	  type: EXT_VECTOR4,
+	  unpack: vectorUnpacker,
+	});
 
 	// store for use by natives.js
 	global.msgpack_pack = pack;


### PR DESCRIPTION
### Goal of this PR

Allows the JS runtime to unpack vectors received from Lua as arrays, rather than requiring manual handling of buffers.

**However**, I would like to add default Vector classes instead of using arrays if acceptable.


### How is this PR achieving the goal

Adds a msgpackr extension for the vector types (20, 21, 22), dependant on #3018.


### This PR applies to the following area(s)

ScRT: JS


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

Supercedes #2946


