### PR TITLE
fix(scripting): RPC natives pointer args for player type

### DIFF
--- a/ext/natives/codegen_out_pointer_args.lua
+++ b/ext/natives/codegen_out_pointer_args.lua
@@ -117,7 +117,7 @@ for _, v in pairs(_natives) do
                 argx = PAS_ARG_POINTER -- These are incorrectly labelled as intPtr
             elseif (a.type.name == 'object') then
                 argx = PAS_ARG_POINTER | PAS_ARG_BUFFER
-            elseif (a.type.name == 'charPtr') or (a.type.name == 'func') then
+            elseif (a.type.name == 'charPtr') or (a.type.name == 'func') or (gApiSet == 'server' and a.type.name == 'Player') then
                 argx = PAS_ARG_POINTER | PAS_ARG_STRING
             elseif a.pointer then
                 argx = PAS_ARG_POINTER


### PR DESCRIPTION
### Goal of this PR
https://github.com/citizenfx/fivem/commit/ec2ba2e99f1891e8e4882aa6bd899f0092cfe51c enabled type checking for server natives but didn't account for arguments of type "Player" being `charPtr` within RPC natives.

### How is this PR achieving the goal
Manual type fix for args of type `Player` in RPC natives.

### This PR applies to the following area(s)
FiveM, Server, Natives

### Successfully tested on
**Game builds:** Not applicable 

**Platforms:** Windows, Linux

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #3023