### PR TITLE
tweak(font-renderer): force watermark bottom right

### DIFF
--- a/code/components/font-renderer/src/GtaGameInterface.cpp
+++ b/code/components/font-renderer/src/GtaGameInterface.cpp
@@ -476,23 +476,7 @@ static InitFunction initFunction([] ()
 			BottomLeft = 3,
 		};
 
-		static auto anchorPosBase = ([]()
-		{
-			if (launch::IsSDKGuest())
-			{
-				return AnchorPos::BottomRight;
-			}
-			else
-			{
-				std::random_device rd;
-				std::mt19937 gen(rd());
-				std::uniform_int_distribution<> dis(0, 1); // 2/3 (top-left/bottom-left) don't exist anymore
-
-				return static_cast<AnchorPos>(dis(gen));
-			}
-		})();
-
-		auto anchorPos = anchorPosBase;
+		auto anchorPos = AnchorPos::BottomRight;
 
 		// in the menu, we want it to always be on the bottom right
 		if (!inGame)


### PR DESCRIPTION
### Goal of this PR
Watermark currently randomly moves between the top right and bottom right of the player's screen, which is unnecessary. A set position (bottom right was chosen, as it's just a standard/out-of-the-way spot common across the industry) would allow more reliable expectations for the UI.


### How is this PR achieving the goal

Position is hardcoded to bottom right, rather than top and bottom right randomly.


### This PR applies to the following area(s)
FiveM client


### Successfully tested on

**Game builds:** 3258

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Quality of life update, frees up the top right of the screen and sets a position for the watermark going forward.


