### PR TITLE
fix(state): fix not being able to use any entity native calls in 'entityRemoved'

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -20,8 +20,11 @@ void DisownEntityScript(const fx::sync::SyncEntityPtr& entity);
 static void Init()
 {
 
+
+	// If the entity is in its deleting/finalizing state we should not allow access to them
+	// This should only be used for natives that are not expected to work when an entity is actively being deleted
+	// i.e. setters, getting entity by network id / does exist, or any pool getter natives
 	static auto IsEntityValid = [](const fx::sync::SyncEntityPtr& entity) {
-		// if we're deleting or finalizing our deletion then we don't want to be included in the list
 		return entity && !entity->deleting && !entity->finalizing;
 	};
 
@@ -49,7 +52,7 @@ static void Init()
 
 			auto entity = gameState->GetEntity(id);
 
-			if (!IsEntityValid(entity))
+			if (!entity)
 			{
 				throw std::runtime_error(va("Tried to access invalid entity: %d", id));
 


### PR DESCRIPTION
### Goal of this PR
Fix oversight in 8957209b72626bacd970f07412f3dff6ccac2bf0 which added the `IsEntityValid` to `makeEntityFunction`, this is only needed for checks that an entity is valid (i.e. `DOES_ENTITY_EXIST`, and to a lesser extent, `NETWORK_GET_ENTITY_FROM_NETWORK_ID`) and pool getters.


### How is this PR achieving the goal
Swap back to the old check for `makeEntityFunction`


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes #3042 
