### PR TITLE
feat(extra-natives/five): track switching

### DIFF
--- a/ext/native-decls/GetClosestTrackNodes.md
+++ b/ext/native-decls/GetClosestTrackNodes.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_CLOSEST_TRACK_NODES
+
+```c
+object GET_CLOSEST_TRACK_NODES(Vector3 position, float radius);
+```
+
+Get all track nodes and their track ids within the radius of the specified coordinates.
+
+## Parameters
+* **position**: Get track nodes at position
+* **radius**: Get track nodes within radius
+
+## Return value
+Returns a list of tracks and node entries: a trackNode and a trackId
+
+The data returned adheres to the following layout:
+```
+[{trackNode1, trackId1}, ..., {trackNodeN, trackIdN}]
+```
+
+## Return value
+An object containing a list of track ids and track nodes that are within the specified radius.

--- a/ext/native-decls/GetTrackNodeCoords.md
+++ b/ext/native-decls/GetTrackNodeCoords.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRACK_NODE_COORDS
+
+```c
+bool GET_TRACK_NODE_COORDS(int trackIndex, uint32_t trackNode, Vector3* coords);
+```
+
+Gets the coordinates of a specific track node.
+
+## Parameters
+* **trackIndex**: The track index
+* **trackNode**: The track node
+* **coords**: The resulting track node coords
+
+## Return value
+Returns if it succeeds in getting coords or not

--- a/ext/native-decls/GetTrackNodeCount.md
+++ b/ext/native-decls/GetTrackNodeCount.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRACK_NODE_COUNT
+
+```c
+int GET_TRACK_NODE_COUNT(int trackIndex);
+```
+
+Gets the specified tracks node count.
+
+## Parameters
+* **trackIndex**: The track index
+
+## Return value
+The amount of track nodes on the specified track

--- a/ext/native-decls/RegisterTrackJunction.md
+++ b/ext/native-decls/RegisterTrackJunction.md
@@ -1,0 +1,22 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REGISTER_TRACK_JUNCTION
+
+```c
+int REGISTER_TRACK_JUNCTION(int trackIndex, int trackNode, int newIndex, int newNode, bool direction);
+```
+
+Registers a track junction that when enabled will cause a train on the defined trackIndex, node and direction to change its current track index and begin traveling on the new node
+
+## Parameters
+* **trackIndex**: The track index a train should be on
+* **trackNode**: The node a train should be on
+* **newIndex**: The new track index for a train to be placed on
+* **newNode**: The new track node for a train to be placed on
+* **direction**: The direction a train should be traveling for this junction
+
+## Return value
+The track junction's handle or -1 if invalid.

--- a/ext/native-decls/RemoveTrackJunction.md
+++ b/ext/native-decls/RemoveTrackJunction.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REMOVE_TRACK_JUNCTION
+
+```c
+bool REMOVE_TRACK_JUNCTION(int junctionIndex);
+```
+
+Removes the specified track junction.
+
+## Parameters
+* **junctionIndex**: The junctions index
+
+## Return value
+Returns if it succeeds in removing a junction or not

--- a/ext/native-decls/SetTrackJunctionActive.md
+++ b/ext/native-decls/SetTrackJunctionActive.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_TRACK_JUNCTION_ACTIVE
+
+```c
+bool SET_TRACK_JUNCTION_ACTIVE(int junctionIndex, bool state);
+```
+Sets the state of a track junction.
+
+## Parameters
+* **junctionIndex**: The junctions index
+* **state**: Toggles the state of the junction
+
+## Return value
+Returns if it succeeds setting the junctions state or not


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Introduce a way to register track switching. Track switching allows for a train to change the track index it is currently navigating along. Suggested by @glitchdetector 


### How is this PR achieving the goal

introduces ``REGISTER_TRACK_SWITCH`` and ``SET_TRACK_SWITCH_ACTIVE`` to allow for registration of a train switch and ability to enable/disable the track switch

### This PR applies to the following area(s)

FiveM, Natives

### Successfully tested on

A test resource showing the functionality of all new natives and test cases are provided  https://github.com/citizenfx/fivem/pull/3044#issuecomment-2671891066


**Game builds:** 1604, 2060, 3258, 3407

**Platforms:** Windows

### Checklist

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.

### Fixes issues


