### PR TITLE
fix(commerce): allow the server to refresh sku's after initial load

### DIFF
--- a/ext/native-decls/LoadPlayerCommerceDataExt.md
+++ b/ext/native-decls/LoadPlayerCommerceDataExt.md
@@ -8,8 +8,36 @@ apiset: server
 void LOAD_PLAYER_COMMERCE_DATA_EXT(char* playerSrc);
 ```
 
-Requests the commerce data from Tebex for the specified player, including the owned SKUs. Use `IS_PLAYER_COMMERCE_INFO_LOADED` to check if it has loaded.
+Requests the commerce data from Tebex for the specified player, including the owned SKUs.
+
+Use [`IS_PLAYER_COMMERCE_INFO_LOADED_EXT`](#_0x1D14F4FE) to check if it has loaded.
+
+This will not automatically update whenever a client purchases a package, if you want to fetch new purchases you will need to call this native again.
+
+This native will temporarily cache the players commerce data for 10 seconds, a call to this native after 10 seconds will re-fetch the players commerce data.
 
 ## Parameters
 * **playerSrc**: The player handle
 
+## Examples
+```lua
+RegisterNetEvent("doesOwnPackage", function(packageIdSku)
+	-- source isn't valid across waits, so we localize it
+	local source = source
+
+	-- input isn't right
+	if type(packageIdSku) ~= "number" then
+		return
+	end
+
+	-- The native will cache the results
+	LoadPlayerCommerceDataExt(source)
+	-- Wait for the players data to load
+	while not IsPlayerCommerceInfoLoadedExt(source) do
+		Wait(0)
+	end
+
+	-- Tell the client if they own the package or not
+	TriggerClientEvent("doesOwnPackage", source, DoesPlayerOwnSkuExt(source, packageIdSku))
+end)
+```


### PR DESCRIPTION
Was talking with @the-neco about the usage of some of the commerce natives but found that their usage was extremely limited because they could not be updated after the first request.

### Goal of this PR
Allow LoadPlayerCommerceDataExt to reload player SKUs while in game, this currently only fetched once and cannot be updated until the player rejoins, this adds unnecessary friction.

This allows `LoadPlayerCommerceDataExt` to fetch the players packages again once every 10 seconds.

### How is this PR achieving the goal
Calls to `LoadPlayerCommerceDataExt` after 10 seconds will refresh the clients SKUs


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
