### PR TITLE
feat(game/five): add ped prop collection natives

### DIFF
--- a/code/components/extra-natives-five/src/PedCollectionsNatives.cpp
+++ b/code/components/extra-natives-five/src/PedCollectionsNatives.cpp
@@ -403,6 +403,12 @@ static HookFunction hookFunction([]()
 		// Call GET_PED_DRAWABLE_VARIATION to get global drawable index.
 		fx::ScriptEngine::CallNativeHandler(0x67F3780DD425D4FC, newContext);
 		int globalDrawableIndex = newContext.GetResult<int>();
+		if(globalDrawableIndex < 0)
+		{
+			context.SetResult<int>(-1);
+			return;
+		}
+
 		context.SetResult<int>(g_GetDlcDrawableIdx(variationInfoCollection, componentId, globalDrawableIndex));
 	});
 	fx::ScriptEngine::RegisterNativeHandler("GET_PED_DRAWABLE_VARIATION_COLLECTION_NAME", [](fx::ScriptContext& context)
@@ -422,7 +428,70 @@ static HookFunction hookFunction([]()
 		// Call GET_PED_DRAWABLE_VARIATION to get global drawable index.
 		fx::ScriptEngine::CallNativeHandler(0x67F3780DD425D4FC, newContext);
 		int globalDrawableIndex = newContext.GetResult<int>();
+		if(globalDrawableIndex < 0)
+		{
+			context.SetResult<const char*>(nullptr);
+			return;
+		}
+
 		auto variationInfo = g_GetVariationInfoFromDrawableIdx(variationInfoCollection, componentId, globalDrawableIndex);
+		if (!variationInfo)
+		{
+			context.SetResult<const char*>(nullptr);
+			return;
+		}
+
+		context.SetResult<const char*>(GetCollectionName(variationInfo));
+	});
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_PROP_COLLECTION_LOCAL_INDEX", [](fx::ScriptContext& context)
+	{
+		uint32_t pedId = context.GetArgument<uint32_t>(0);
+		int anchorPoint = context.GetArgument<int>(1);
+		auto variationInfoCollection = GetPedVariationInfoCollection(pedId);
+		if (!variationInfoCollection)
+		{
+			context.SetResult<int>(-1);
+			return;
+		}
+
+		fx::ScriptContextBuffer newContext;
+		newContext.Push(pedId);
+		newContext.Push(anchorPoint);
+		// Call GET_PED_PROP_INDEX to get global prop index.
+		fx::ScriptEngine::CallNativeHandler(0x898CC20EA75BACD8, newContext);
+		int globalPropIndex = newContext.GetResult<int>();
+		if(globalPropIndex < 0)
+		{
+			context.SetResult<int>(-1);
+			return;
+		}
+		
+		context.SetResult<int>(g_GetDlcPropIdx(variationInfoCollection, anchorPoint, globalPropIndex));
+	});
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_PROP_COLLECTION_NAME", [](fx::ScriptContext& context)
+	{
+		uint32_t pedId = context.GetArgument<uint32_t>(0);
+		int anchorPoint = context.GetArgument<int>(1);
+		auto variationInfoCollection = GetPedVariationInfoCollection(pedId);
+		if (!variationInfoCollection)
+		{
+			context.SetResult<const char*>(nullptr);
+			return;
+		}
+
+		fx::ScriptContextBuffer newContext;
+		newContext.Push(pedId);
+		newContext.Push(anchorPoint);
+		// Call GET_PED_PROP_INDEX to get global prop index.
+		fx::ScriptEngine::CallNativeHandler(0x898CC20EA75BACD8, newContext);
+		int globalPropIndex = newContext.GetResult<int>();
+		if(globalPropIndex < 0)
+		{
+			context.SetResult<const char*>(nullptr);
+			return;
+		}
+		
+		auto variationInfo = g_GetVariationInfoFromPropIdx(variationInfoCollection, anchorPoint, globalPropIndex);
 		if (!variationInfo)
 		{
 			context.SetResult<const char*>(nullptr);

--- a/ext/native-decls/GetPedPropCollectionLocalIndex.md
+++ b/ext/native-decls/GetPedPropCollectionLocalIndex.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PED_PROP_COLLECTION_LOCAL_INDEX
+
+```c
+int GET_PED_PROP_COLLECTION_LOCAL_INDEX(Ped ped, int anchorPoint);
+```
+
+An analogue to [GET_PED_PROP_INDEX](#_0x898CC20EA75BACD8) that returns collection local prop index (inside [GET_PED_PROP_COLLECTION_NAME](#_0x6B5653E4) collection) instead of the global prop index.
+
+## Parameters
+* **ped**: The target ped
+* **anchorPoint**: One of the anchor points from [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F)
+
+## Return value
+Local drawable index of the drawable that is currently used in the given ped and component, or -1 if the ped does not have a prop at the specified anchor point

--- a/ext/native-decls/GetPedPropCollectionName.md
+++ b/ext/native-decls/GetPedPropCollectionName.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PED_PROP_COLLECTION_NAME
+
+```c
+char* GET_PED_PROP_COLLECTION_NAME(Ped ped, int anchorPoint);
+```
+
+An analogue to [GET_PED_PROP_INDEX](#_0x898CC20EA75BACD8) that returns collection name instead of the global drawable index.
+
+Should be used together with [GET_PED_PROP_COLLECTION_LOCAL_INDEX](#_0xCD420AD1).
+
+## Parameters
+* **ped**: The target ped
+* **anchorPoint**: One of the anchor points from [SET_PED_PROP_INDEX](#_0x93376B65A266EB5F)
+
+## Return value
+Collection name to which the current prop used in the given ped and anchor point belongs to. Returns null if Ped is not found, does not have a prop at the specified anchor point, or if the index is out of bounds.


### PR DESCRIPTION
### Goal of this PR
Add two new FiveM client natives for prop collections to provide parity with existing drawable variation natives. The new natives allow retrieving collection-local indices and collection names for ped props, similar to [GetPedDrawableVariationCollectionLocalIndex](https://docs.fivem.net/natives/?_0x9970386F=) and [GetPedDrawableVariationCollectionName](https://docs.fivem.net/natives/?_0xBCE0AB63=).

### How is this PR achieving the goal

Added two new native functions
1. `GET_PED_PROP_COLLECTION_LOCAL_INDEX`: Returns the collection-local index for a prop at a given anchor point
2. `GET_PED_PROP_COLLECTION_NAME`: Returns the collection name for a prop at a given anchor point

### This PR applies to the following area(s)
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


