### PR TITLE
feat(gamestate/server): ped AI node getter

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -757,6 +757,12 @@ struct CPedMovementGroupNodeData
 	bool isRagdolling;
 };
 
+struct CPedAINodeData
+{
+	int relationShip;
+	int decisionMaker;
+};
+
 enum ePopType
 {
 	POPTYPE_UNKNOWN = 0,
@@ -850,6 +856,8 @@ public:
 	virtual CBoatGameStateNodeData* GetBoatGameState() = 0;
 
 	virtual CPedMovementGroupNodeData* GetPedMovementGroup() = 0;
+
+	virtual CPedAINodeData* GetPedAI() = 0;
 
 	virtual void CalculatePosition() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2468,7 +2468,18 @@ struct CPedMovementGroupDataNode
 	}
 };
 
-struct CPedAIDataNode { };
+struct CPedAIDataNode : GenericSerializeDataNode<CPedAIDataNode>
+{
+	CPedAINodeData data;
+
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
+	{
+		s.Serialize(32, data.relationShip);
+		s.Serialize(32, data.decisionMaker);
+		return true;
+	}
+};
 
 struct CPedAppearanceDataNode
 {
@@ -4067,6 +4078,13 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, false>
 	virtual CPedMovementGroupNodeData* GetPedMovementGroup() override
 	{
 		auto [hasNode, node] = this->template GetData<CPedMovementGroupDataNode>();
+
+		return hasNode ? &node->data : nullptr;
+	}
+
+	virtual CPedAINodeData* GetPedAI() override
+	{
+		auto [hasNode, node] = this->template GetData<CPedAIDataNode>();
 
 		return hasNode ? &node->data : nullptr;
 	}

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -1311,6 +1311,11 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 		return nullptr;
 	}
 
+	virtual CPedAINodeData* GetPedAI() override
+	{
+		return nullptr;
+	}
+
 	virtual void CalculatePosition() override
 	{
 		// TODO: cache it?

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1862,6 +1862,12 @@ static void Init()
 		return 0;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_RELATIONSHIP_GROUP_HASH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto ped = entity->syncTree->GetPedAI();
+		return ped ? ped->relationShip : 0;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_SPEED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto v = entity->syncTree->GetVelocity();

--- a/ext/native-decls/GetPedRelationshipGroupHash.md
+++ b/ext/native-decls/GetPedRelationshipGroupHash.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_PED_RELATIONSHIP_GROUP_HASH
+
+```c
+Hash GET_PED_RELATIONSHIP_GROUP_HASH(Ped ped);
+```
+
+Gets the current relationship group hash of a ped.
+
+## Parameters
+* **ped**: The target ped
+
+## Return value
+The relationship group hash.


### PR DESCRIPTION
### Goal of this PR
Add a new getter to be able to obtain the relationship group from server side.


### How is this PR achieving the goal
Completing the CPedAIDataNode.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, Server, Natives


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
