### PR TITLE
fix(server/gamestate): memory leak

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3246,19 +3246,24 @@ void ServerGameState::FinalizeClone(const fx::ClientSharedPtr& client, const fx:
 
 auto ServerGameState::CreateEntityFromTree(sync::NetObjEntityType type, const std::shared_ptr<sync::SyncTreeBase>& tree) -> fx::sync::SyncEntityPtr
 {
-	bool hadId = false;
-
 	int id = fx::IsLengthHack() ? (MaxObjectId - 1) : 8191;
 
 	{
+		bool valid = false;
 		std::unique_lock objectIdsLock(m_objectIdsMutex);
 
 		for (; id >= 1; id--)
 		{
 			if (!m_objectIdsSent.test(id) && !m_objectIdsUsed.test(id))
 			{
+				valid = true;
 				break;
 			}
+		}
+
+		if (!valid)
+		{
+			return {};
 		}
 
 		m_objectIdsSent.set(id);

--- a/code/components/citizen-server-impl/src/state/ServerSetters.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerSetters.cpp
@@ -330,7 +330,14 @@ static InitFunction initFunction([]()
 			auto sgs = ref->GetComponent<fx::ServerGameState>();
 			auto entity = sgs->CreateEntityFromTree(sync::NetObjEntityType::Automobile, tree);
 
-			ctx.SetResult(sgs->MakeScriptHandle(entity));
+			uint32_t guid = 0;
+
+			if (entity)
+			{
+				guid = sgs->MakeScriptHandle(entity);
+			}
+
+			ctx.SetResult(guid);
 		});
 
 		fx::ScriptEngine::RegisterNativeHandler("CREATE_VEHICLE_SERVER_SETTER", [ref](fx::ScriptContext& ctx)
@@ -426,7 +433,14 @@ static InitFunction initFunction([]()
 			auto sgs = ref->GetComponent<fx::ServerGameState>();
 			auto entity = sgs->CreateEntityFromTree(typeId, tree);
 
-			ctx.SetResult(sgs->MakeScriptHandle(entity));
+			uint32_t guid = 0;
+
+			if (entity)
+			{
+				guid = sgs->MakeScriptHandle(entity);
+			}
+
+			ctx.SetResult(guid);
 		});
 
 		fx::ScriptEngine::RegisterNativeHandler("CREATE_PED", [=](fx::ScriptContext& ctx)
@@ -450,7 +464,14 @@ static InitFunction initFunction([]()
 			auto sgs = ref->GetComponent<fx::ServerGameState>();
 			auto entity = sgs->CreateEntityFromTree(sync::NetObjEntityType::Ped, tree);
 
-			ctx.SetResult(sgs->MakeScriptHandle(entity));
+			uint32_t guid = 0;
+
+			if (entity)
+			{
+				guid = sgs->MakeScriptHandle(entity);
+			}
+
+			ctx.SetResult(guid);
 		});
 
 		fx::ScriptEngine::RegisterNativeHandler("CREATE_OBJECT_NO_OFFSET", [=](fx::ScriptContext& ctx)
@@ -474,7 +495,14 @@ static InitFunction initFunction([]()
 			auto sgs = ref->GetComponent<fx::ServerGameState>();
 			auto entity = sgs->CreateEntityFromTree(sync::NetObjEntityType::Object, tree);
 
-			ctx.SetResult(sgs->MakeScriptHandle(entity));
+			uint32_t guid = 0;
+
+			if (entity)
+			{
+				guid = sgs->MakeScriptHandle(entity);
+			}
+
+			ctx.SetResult(guid);
 		});
 	});
 });

--- a/ext/native-decls/server/CreateVehicleServerSetter.md
+++ b/ext/native-decls/server/CreateVehicleServerSetter.md
@@ -22,7 +22,7 @@ Unlike CREATE_AUTOMOBILE, this supports other vehicle types as well.
 * **heading**: Heading to face towards, in degrees.
 
 ## Return value
-A script handle for the vehicle.
+A script handle for the vehicle, or 0 if the vehicle failed to be created.
 
 ## Examples
 ```lua


### PR DESCRIPTION
### Goal of this PR
This PR addresses an issue where creating an object, ped, or vehicle via server-setters does not validate the availability of free object IDs. This oversight can lead to memory leaks and undefined behavior, as overwriting an existing entity handle keeps the previous entity pointer alive in the sync pool, resulting in "ghost entities" and inaccessible allocated memory.

### How is this PR achieving the goal
Checking if we got a valid / free object id, and if not, returning a non-valid GUID ('0') indicating failed creation (Client logic parity).

### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Server)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/