### PR TITLE
feat(server/gamestate): freecam status natives

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1651,6 +1651,62 @@ static void Init()
 		return resultVector;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("IS_PLAYER_IN_FREE_CAM_MODE", MakePlayerEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		if (const auto& syncTree = entity->syncTree)
+		{
+			if (const auto camData = syncTree->GetPlayerCamera(); camData->camMode != 0)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_FOCUS_POS", MakePlayerEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		scrVector resultVec = {};
+		const auto& syncTree = entity->syncTree;
+
+		if (!syncTree)
+		{
+			return resultVec;
+		}
+
+		const auto camData = syncTree->GetPlayerCamera();
+
+		if (!camData)
+		{
+			return resultVec;
+		}
+
+		float playerPos[3];
+		syncTree->GetPosition(playerPos);
+
+		switch (camData->camMode)
+		{
+			case 0:
+			default:
+				resultVec.x = playerPos[0];
+				resultVec.y = playerPos[1];
+				resultVec.z = playerPos[2];
+				break;
+			case 1:
+				resultVec.x = camData->freeCamPosX;
+				resultVec.y = camData->freeCamPosX;
+				resultVec.z = camData->freeCamPosZ;
+				break;
+			case 2:
+				resultVec.x = playerPos[0] + camData->camOffX;
+				resultVec.y = playerPos[1] + camData->camOffY;
+				resultVec.z = playerPos[2] + camData->camOffZ;
+				break;
+		}
+
+		return resultVec;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_CARRIAGE_ENGINE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto train = entity->syncTree->GetTrainState();

--- a/ext/native-decls/GetPlayerFocusPos.md
+++ b/ext/native-decls/GetPlayerFocusPos.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+---
+
+## GET_PLAYER_FOCUS_POS
+
+```c
+Vector3 GET_PLAYER_FOCUS_POS(char* playerSrc);
+```
+
+Gets the focus position (i.e. the position of the active camera in the game world) of a player.
+
+## Parameters
+* **playerSrc**: The player to get the focus position of
+
+## Return value
+Returns a `Vector3` containing the focus position of the player.

--- a/ext/native-decls/IsPlayerInFreeCamMode.md
+++ b/ext/native-decls/IsPlayerInFreeCamMode.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+---
+
+## IS_PLAYER_IN_FREE_CAM_MODE
+
+```c
+bool IS_PLAYER_IN_FREE_CAM_MODE(char* playerSrc);
+```
+
+## Parameters
+* **playerSrc**: The player to get the free camera mode status of
+
+## Return value
+Returns if the player is in free camera mode.


### PR DESCRIPTION
### Goal of this PR
This PR introduces two new server natives:

1. **`IsPlayerInFreeCamMode`**  
   - Allows to check if a player is in free cam mode (i.e. not using the main game camera / having a camera offset from the players ped position).  

2. **`GetPlayerFocusPos`**  
   - Retrieves the current focus position of a player's camera, representing the game state area currently synced with the player's client.  

### How is this PR achieving the goal
Reading data from `CPlayerCameraDataNode` and returning the relevant information.  

### This PR applies to the following area(s)
FiveM, RedM, Server, Natives

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/