### PR TITLE
feat(server/gamestate): vehicles natives

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -327,6 +327,8 @@ struct CPedGameStateNodeData
 	bool actionModeEnabled;
 	bool isFlashlightOn;
 
+	int deathState;
+
 	inline CPedGameStateNodeData()
 		: lastVehicle(-1), lastVehicleSeat(-1), lastVehiclePedWasIn(-1)
 	{
@@ -742,6 +744,12 @@ struct CVehicleDamageStatusNodeData
 	bool windowsState[8];
 };
 
+struct CVehicleScriptGameStateNodeData
+{
+	bool isDrowning;
+	bool isVehicleInAir;
+};
+
 struct CBoatGameStateNodeData
 {
 	bool lockedToXY;
@@ -804,6 +812,8 @@ public:
 	virtual uint64_t GetPedGameStateFrameIndex() = 0;
 
 	virtual CVehicleGameStateNodeData* GetVehicleGameState() = 0;
+
+	virtual CVehicleScriptGameStateNodeData* GetVehicleGameScript() = 0;
 
 	virtual CVehicleAppearanceNodeData* GetVehicleAppearance() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -440,6 +440,7 @@ struct CPhysicalScriptGameStateDataNode { };
 
 struct CVehicleScriptGameStateDataNode
 {
+	CVehicleScriptGameStateNodeData data;
 	ePopType m_popType;
 
 	bool Parse(SyncParseState& state)
@@ -447,7 +448,7 @@ struct CVehicleScriptGameStateDataNode
 		// Strings pulled from X360 TU0
 		state.buffer.ReadBit(); // Has Freebies
 		state.buffer.ReadBit(); // Can Be Visibly Damaged
-		state.buffer.ReadBit(); // Is Drowning
+		data.isDrowning = state.buffer.ReadBit(); // Is Drowning
 		state.buffer.ReadBit(); // Part Of Convoy
 		state.buffer.ReadBit(); // Vehicle Can Be Targeted
 		state.buffer.ReadBit(); // Take Less Damage
@@ -491,7 +492,7 @@ struct CVehicleScriptGameStateDataNode
 			state.buffer.ReadBit();
 		}
 
-		state.buffer.ReadBit(); // "Is Vehicle In Air"
+		data.isVehicleInAir = state.buffer.ReadBit(); // "Is Vehicle In Air"
 		bool isParachuting = state.buffer.ReadBit();
 		if (isParachuting)
 		{
@@ -1324,7 +1325,7 @@ struct CPedGameStateDataNode
 		}
 
 		auto arrestState = state.buffer.Read<int>(1);
-		auto deathState = state.buffer.Read<int>(2);
+		data.deathState = state.buffer.Read<int>(2);
 
 		auto hasWeapon = state.buffer.ReadBit();
 		int weapon = 0;

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -1311,6 +1311,11 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 		return nullptr;
 	}
 
+	virtual CVehicleScriptGameStateNodeData* GetVehicleGameScript() override
+	{
+		return nullptr;
+	}
+
 	virtual void CalculatePosition() override
 	{
 		// TODO: cache it?

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -633,6 +633,27 @@ static void Init()
 		return vn ? vn->isEngineStarting : false;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_IN_AIR", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto vn = entity->syncTree->GetVehicleGameScript();
+
+		return vn ? vn->isVehicleInAir : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_DROWNING", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto vn = entity->syncTree->GetVehicleGameScript();
+
+		return vn ? vn->isDrowning : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_DEATH_STATE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto vn = entity->syncTree->GetPedGameState();
+
+		return vn ? vn->deathState : 0; 
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_HANDBRAKE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto vn = entity->syncTree->GetVehicleGameState();

--- a/ext/native-decls/GetPedDeathState.md
+++ b/ext/native-decls/GetPedDeathState.md
@@ -1,0 +1,26 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_PED_DEATH_STATE
+
+```c
+int GET_PED_DEATH_STATE(Ped ped);
+```
+Retrieves the death state of the ped.
+
+```c
+enum eDeathState
+{
+    DeathState_Alive = 0,   // The ped is alive
+    DeathState_Dying = 1,   // The ped is in the process of dying
+    DeathState_Dead = 2,    // The ped is dead
+    DeathState_Max = 3      // Maximum health? maybe
+};
+```
+
+## Parameters
+* **ped**: The target ped.
+
+## Return value
+Returns the current death state of the ped as a value from the `eDeathState` enumeration.

--- a/ext/native-decls/IsVehicleDrowning.md
+++ b/ext/native-decls/IsVehicleDrowning.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## IS_VEHICLE_DROWNING
+
+```c
+bool IS_VEHICLE_DROWNING(Vehicle vehicle);
+```
+
+Getter to check if the current vehicle is drowning.
+
+## Parameters
+* **vehicle**: The target vehicle.
+
+## Return value
+Return `true` if the vehicle is drowning (and the vehicle is underwater), `false` otherwise.

--- a/ext/native-decls/IsVehicleInAir.md
+++ b/ext/native-decls/IsVehicleInAir.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: server
+---
+## IS_VEHICLE_IN_AIR
+
+```c
+bool IS_VEHICLE_IN_AIR(Vehicle vehicle);
+```
+
+Getter to check if the current vehicle is in the air.
+
+## Parameters
+* **vehicle**: The target vehicle.
+
+## Return value
+Return `true` if the vehicle is in the air, `false` otherwise.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
* Added IS_VEHICLE_IN_AIR
* Added IS_VEHICLE_DROWNING
* Added GET_PED_DEATH_STATE to check if a player is alive, dying or dead.


### How is this PR achieving the goal
By exposing fields in datanodes that were already read, (i couldn't find doc about DeathState_Max tho)


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Server, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


