### PR TITLE
fix(input/five): flush raw input mouse buttons on focus loss

### DIFF
--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -149,6 +149,7 @@ void InputHook::SetGameMouseFocus(bool focus)
 
 	if (g_isFocusStolen)
 	{
+		rage::g_input.m_Buttons() = 0;
 		memset(g_gameKeyArray, 0, 256);
 	}
 


### PR DESCRIPTION
### Goal of this PR
This PR addresses an issue where, with the mouse input method set to "Raw Input," the game fails to reset mouse button states when it loses focus (e.g., when a NUI or the client console gains focus). As a result, any mouse buttons pressed at the moment of focus loss remain in a "pressed" state until the game regains focus and the button is physically pressed again. This behavior can lead to unintended actions, such as continuous weapon firing.

### How is this PR achieving the goal
To resolve this issue, the PR introduces a manual flush of the `ioMouse` button array. This ensures that button states are cleared when the game loses focus, preventing them from getting stuck and mitigating unintended user inputs.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable 

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #2508 