### PR TITLE
fix(citizen-script-lua): Fix crash with nil value as name in CreateTh…

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -1139,7 +1139,11 @@ static int Lua_CreateThreadNow(lua_State* L)
 
 	if (lua_gettop(L) >= 2)
 	{
-		name = lua_tostring(L, 2);
+		auto luaName = lua_tostring(L, 2);
+		if (luaName != nullptr)
+		{
+			name = luaName;
+		}
 	}
 
 	return Lua_CreateThreadInternal(L, true, 0, 1, name);


### PR DESCRIPTION
…readNow

### Goal of this PR
Fix a crash that happens when a nil value is passed to Citizen.CreateThreadNow as the name.

...


### How is this PR achieving the goal
It checks to see if lua_tostring returns a null pointer and if it does leaves the name empty.
...


### This PR applies to the following area(s)
ScRT: LUA

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 12206

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


