### PR TITLE
fix(nui/core): keep cursor clipping when no cursor is present

### DIFF
--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -353,7 +353,7 @@ static HookFunction initFunction([] ()
 {
 	g_nuiGi->QueryMayLockCursor.Connect([](int& argPtr)
 	{
-		if (HasFocus() && !g_keepInput)
+		if (HasFocus() && g_hasCursor && !g_keepInput)
 		{
 			argPtr = 0;
 		}


### PR DESCRIPTION
### Goal of this PR
This PR addresses an issue where the mouse cursor is not clipped to the game window when a NUI is focused without the cursor being present (i.e., only the keyboard is focused). This behavior causes the cursor to move outside the game frame in non-fullscreen mode or when using a multi-monitor setup, leading to loss of focus while moving the game camera.

### How is this PR achieving the goal
The proposed change introduces a check for the presence of a cursor (`g_hasCursor`). Game frame clipping is now disabled only when a cursor is actively present, ensuring camera movement still works as intended.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable 

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
Reported by myself here: https://forum.cfx.re/t/5172373