### PR TITLE
feat(rage-input-five): AMD Radeon Anti-Lag 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -457,3 +457,6 @@
 [submodule "vendor/boost-submodules/boost-static-string"]
 	path = vendor/boost-submodules/boost-static-string
 	url = https://github.com/boostorg/static_string.git
+[submodule "vendor/AntiLag2-SDK"]
+	path = vendor/AntiLag2-SDK
+	url = https://github.com/GPUOpen-LibrariesAndSDKs/AntiLag2-SDK

--- a/code/components/rage-input-five/component.lua
+++ b/code/components/rage-input-five/component.lua
@@ -3,4 +3,6 @@ return function()
 	configurations {}
 
 	add_dependencies { 'vendor:wil', 'vendor:botan' }
+
+	includedirs { "../vendor/AntiLag2-SDK/" }
 end

--- a/code/components/rage-input-five/include/InputHook.h
+++ b/code/components/rage-input-five/include/InputHook.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <SharedInput.h>
-#include <CrossBuildRuntime.h>
+#include <d3d11.h>
 
 #ifndef COMPILING_RAGE_INPUT_FIVE
 #define INPUT_DECL __declspec(dllimport)

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -123,6 +123,8 @@
   "#Settings_FixedSizeNUIDesc": "Force in-server UI to 1920x1080 resolution, scaled/letterboxed to fit (for servers with UI assuming 1920x1080)",
   "#Settings_NoiseSuppression": "Voice chat noise suppression",
   "#Settings_NoiseSuppressionDesc": "Enable background noise suppression (using RNNoise) for the built-in voice chat",
+  "#Settings_AmdAntiLag": "AMD Anti-Lag 2",
+  "#Settings_AmdAntiLagDesc": "AMD Anti-Lag 2 reduces system latency for improved responsiveness.",
   "#Settings_DiscordRichPresence": "Discord activity status",
   "#Settings_DiscordRichPresenceDesc": "Displays the server you're currently connected to and allows servers to display a custom activity status on your Discord profile.",
   "#Settings_ConnectedProfiles": "Linked identities",

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/settings.tsx
@@ -309,6 +309,19 @@ const GAME_GAME_SETTINGS = new Map<string, ISetting.AnySetting>([
     },
   ],
   [
+    'amdAntiLag',
+    {
+      type: 'checkbox',
+
+      label: $L('#Settings_AmdAntiLag'),
+      description: $L('#Settings_AmdAntiLagDesc'),
+
+      ...convarAccessorsBoolean('game_useAmdAntiLag'),
+
+      visible: () => onlyForFiveM() && useService(IConvarService).getBoolean('game_amdAntiLagPresent'),
+    }
+  ],
+  [
     'discordRichPresence',
     {
       type: 'switch',


### PR DESCRIPTION
### Goal of this PR
This PR introduces support for [AMD Radeon Anti-Lag 2](https://github.com/GPUOpen-LibrariesAndSDKs/AntiLag2-SDK) in FiveM, significantly reducing input latency for systems utilizing AMD Radeon RX 5000 GPUs or newer.

In GPU-bound scenarios, the improvement is particularly noticeable. For example, the following results demonstrate the difference in input-to-game latency under highly GPU-bound conditions within FiveM:

- **Anti-Lag 2 enabled:**
![Screenshot 2025-01-20 091108](https://github.com/user-attachments/assets/b53e7367-ccc6-461e-b7e4-42442ee295ee)
- **Anti-Lag 2 disabled:**
![Screenshot 2025-01-20 091251](https://github.com/user-attachments/assets/c96a9d33-5159-4385-b207-ee93f7607aa1)

_(Green text represents the frame delay between physical input and game interaction.)_

### How is this PR achieving the goal
This implementation integrates AMD Radeon Anti-Lag 2 into the main input polling loop of FiveM. This should also roughly match the entry point for signal callbacks of the message pump.

Alternative entry points, such as hooking game functions closer to the msg pump signaling, resulted in either comparable or less performant outcomes, especially when using Raw Mouse Input.

Mentions of Anti-Lag 2 in the UI adhere to [AMD's naming guidelines](https://gpuopen.com/fidelityfx-naming-guidelines/#antilag2).

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3407 

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/