### PR TITLE
fix(extra-natives/five): xmas snow grip factor natives

### DIFF
--- a/ext/native-decls/SetVehicleXmasSnowFactor.md
+++ b/ext/native-decls/SetVehicleXmasSnowFactor.md
@@ -8,4 +8,4 @@ game: gta5
 void SET_VEHICLE_XMAS_SNOW_FACTOR(float gripFactor);
 ```
 ## Parameters
-* **gripFactor**: amount of grip strength vehicle wheels have when xmas weather is active, 1.0 being normal weather grip. 0.2 is the default.
+* **gripFactor**: amount of grip strength vehicle wheels have when xmas weather is active, 0.0 being normal weather grip. 0.2 is the default.


### PR DESCRIPTION
### Goal of this PR
The previous implementation hooked the subtraction instruction (`subss`) instead of the initial multiplication instruction (`mulss`) bypassing the total snow amount multiplier. It also caused game crashes for NPC controlled vehicles when calculating wheel collision vectors and had no impact on player controlled vehicles.

### How is this PR achieving the goal
We now hook the initial multiplication instruction which keeps reference to the total snow amount (which can be overwritten). This calculation occurs in two separate sections, both of which are now patched.

Values are clamped between `0.0` and `2.0` to make sure physics don't get broken.

GameValueStub's used for less code duplication.

### This PR applies to the following area(s)
FiveM, Natives

### Successfully tested on
**Game builds:** 3407

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/