### PR TITLE
feat(server/state): add GIVE_PED_SCRIPTED_TASK handler

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5993,6 +5993,44 @@ struct CStopNetworkSyncedSceneEvent
 
 	MSGPACK_DEFINE_MAP(sceneId);
 };
+
+/*NETEV givePedScriptedTaskEvent SERVER
+/#*
+ * Triggered when a client requests to assign a scripted task to a remotely-controlled ped.
+ *
+ * @param sender - The network ID of the player initiating the event.
+ * @param data - The event data.
+ #/
+declare function givePedScriptedTaskEvent(sender: number, data: {
+	/#*
+	 * The network ID of the target ped receiving the task.
+	 #/
+	entityNetId: number,
+	/#*
+	 * The ID of the assigned task. See [GetIsTaskActive](https://docs.fivem.net/natives/?_0xB0760331C7AA4155)
+	 #/
+	taskId: number,
+	
+}): void;
+*/
+struct CGivePedScriptedTaskEvent
+{
+	uint16_t entityNetId;
+	uint16_t taskId;
+
+	void Parse(rl::MessageBufferView& buffer)
+	{
+		entityNetId = buffer.Read<uint16_t>(16);
+		taskId = buffer.Read<uint16_t>(10);
+	}
+
+	inline std::string GetName()
+	{
+		return "givePedScriptedTaskEvent";
+	}
+
+	MSGPACK_DEFINE_MAP(entityNetId, taskId);
+};
 #endif
 
 #ifdef STATE_RDR3
@@ -7443,6 +7481,7 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 		case NETWORK_START_SYNCED_SCENE_EVENT: return GetHandler<CStartNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
 		case NETWORK_UPDATE_SYNCED_SCENE_EVENT: return GetHandler<CUpdateNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
 		case NETWORK_STOP_SYNCED_SCENE_EVENT: return GetHandler<CStopNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
+		case GIVE_PED_SCRIPTED_TASK_EVENT: return GetHandler<CGivePedScriptedTaskEvent>(instance, client, std::move(buffer));
 		default:
 			break;
 	};
@@ -7570,6 +7609,7 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandlerWithEvent(const fx
 		case net::force_consteval<uint32_t, HashRageString("NETWORK_START_SYNCED_SCENE_EVENT")>: return GetHandlerWithEvent<CStartNetworkSyncedSceneEvent>(instance, client, netGameEvent);
 		case net::force_consteval<uint32_t, HashRageString("NETWORK_UPDATE_SYNCED_SCENE_EVENT")>: return GetHandlerWithEvent<CUpdateNetworkSyncedSceneEvent>(instance, client, netGameEvent);
 		case net::force_consteval<uint32_t, HashRageString("NETWORK_STOP_SYNCED_SCENE_EVENT")>: return GetHandlerWithEvent<CStopNetworkSyncedSceneEvent>(instance, client, netGameEvent);
+		case net::force_consteval<uint32_t, HashRageString("GIVE_PED_SCRIPTED_TASK_EVENT")>: return GetHandlerWithEvent<CGivePedScriptedTaskEvent>(instance, client, netGameEvent);
 		default:
 			break;
 	};


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR adds a way to prevent certain manipulations of NPCs. Native functions such as TaskShootAtEntity and TaskGoToEntity are often used by malicious users to manipulate NPC into harming other players without requiring network control over them. 

I believe that a handler is more suitable than a convar in this case, considering the wide variety of tasks.

### How is this PR achieving the goal

Introduce CGivePedScriptedTaskEvent struct and added the corresponding handler in the GetGameEventHandler and GetGameEventHandlerWithEvent functions.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

