### PR TITLE
feat(citizen-scripting-lua): ClearTimeout function

### DIFF
--- a/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
+++ b/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
@@ -330,6 +330,16 @@ public:
 
 	lua_State* GetRunningThread();
 
+	lua_State* GetState()
+	{
+		return m_state.Get();
+	}
+
+	auto& GetPendingBookmarks()
+	{
+		return m_pendingBookmarks;
+	}
+
 	/// <summary>
 	/// Manage the fx::ProfilerComponent state while the script runtime is active
 	///

--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -135,6 +135,7 @@ end)
 Wait = Citizen.Wait
 CreateThread = Citizen.CreateThread
 SetTimeout = Citizen.SetTimeout
+ClearTimeout = Citizen.ClearTimeout
 
 --[[
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Adds a ClearTimeout function to the Lua runtime so that scripts can cancel a timer that was previously set with SetTimeout.


### How is this PR achieving the goal
Implements ClearTimeout which removes a scheduled timer from the queue.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


