### PR TITLE
fix(handling-loader): fix broken physics

### DIFF
--- a/code/components/handling-loader-five/src/HandlingLoader.cpp
+++ b/code/components/handling-loader-five/src/HandlingLoader.cpp
@@ -334,17 +334,17 @@ static void SetHandlingDataInternal(fx::ScriptContext& context, CHandlingData* h
 				switch (member->m_definition->type)
 				{
 					case rage::parMemberType::Float:
-						setFloatField(handlingChar, offset, context.GetArgument<float>(3), handlingField);
+						setFloatField(handlingChar, offset, context.CheckArgument<float>(3), handlingField);
 						break;
 
 					case rage::parMemberType::UInt8:
-						*(uint8_t*)(handlingChar + offset) = uint8_t(context.GetArgument<int>(3));
+						*(uint8_t*)(handlingChar + offset) = uint8_t(context.CheckArgument<int>(3));
 						break;
 
 					case rage::parMemberType::UInt32:
 						// every string field (so far) is parsed to an int in memory
 					case rage::parMemberType::String:
-						setIntField(handlingChar, offset, context.GetArgument<int>(3), handlingField);
+						setIntField(handlingChar, offset, context.CheckArgument<int>(3), handlingField);
 						break;
 
 					case rage::parMemberType::Vector3_Padded:


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Correct broken physics by modifying handling with nils values


### How is this PR achieving the goal

Switch from GetArgument to CheckArgument to be able to create an error if the value is not correct


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

fixes #3097

