### PR TITLE
tweak(citizen-resources-client): have a default value with GET_RESOUR…

### DIFF
--- a/code/components/citizen-resources-client/src/KVScriptFunctions.cpp
+++ b/code/components/citizen-resources-client/src/KVScriptFunctions.cpp
@@ -188,14 +188,14 @@ struct SerializeValue<RawType>
 };
 
 template<typename T>
-static void GetResourceKvp_Impl(const std::string& key, fx::ScriptContext& context)
+static void GetResourceKvp_Impl(const std::string& key, bool external, fx::ScriptContext& context)
 {
 	auto db = EnsureDatabase();
 
 	std::string value;
 	if (db->Get(leveldb::ReadOptions{}, key, &value).IsNotFound())
 	{
-		context.SetResult<const char*>(nullptr);
+		context.SetResult<T>(context.GetArgument<T>(external ? 2 : 1));
 		return;
 	}
 
@@ -207,7 +207,7 @@ static void GetResourceKvp(fx::ScriptContext& context)
 {
 	auto key = FormatKey(context.CheckArgument<const char*>(0));
 
-	return GetResourceKvp_Impl<T>(key, context);
+	return GetResourceKvp_Impl<T>(key, false, context);
 }
 
 template<typename T>
@@ -215,7 +215,7 @@ static void GetExternalKvp(fx::ScriptContext& context)
 {
 	auto key = FormatKey(context.CheckArgument<const char*>(1), context.CheckArgument<const char*>(0));
 
-	return GetResourceKvp_Impl<T>(key, context);
+	return GetResourceKvp_Impl<T>(key, true, context);
 }
 
 #include <memory>

--- a/code/components/citizen-server-impl/src/ServerKVScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/ServerKVScriptFunctions.cpp
@@ -212,7 +212,7 @@ static void GetResourceKvp(fx::ScriptContext& context)
 	std::string value;
 	if (db->Get(rocksdb::ReadOptions{}, key, &value).IsNotFound())
 	{
-		context.SetResult<const char*>(nullptr);
+		context.SetResult<T>(context.GetArgument<T>(1));
 		return;
 	}
 

--- a/ext/native-decls/kvp/GetResourceKvpFloat.md
+++ b/ext/native-decls/kvp/GetResourceKvpFloat.md
@@ -5,16 +5,17 @@ apiset: shared
 ## GET_RESOURCE_KVP_FLOAT
 
 ```c
-float GET_RESOURCE_KVP_FLOAT(char* key);
+float GET_RESOURCE_KVP_FLOAT(char* key, float default);
 ```
 
 A getter for [SET_RESOURCE_KVP_FLOAT](#_0x9ADD2938).
 
 ## Parameters
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-The floating-point value stored under the specified key, or 0.0 if not found.
+The floating-point value stored under the specified key, or 0.0/default if not found.
 
 ## Examples
 

--- a/ext/native-decls/kvp/GetResourceKvpInt.md
+++ b/ext/native-decls/kvp/GetResourceKvpInt.md
@@ -5,16 +5,17 @@ apiset: shared
 ## GET_RESOURCE_KVP_INT
 
 ```c
-int GET_RESOURCE_KVP_INT(char* key);
+int GET_RESOURCE_KVP_INT(char* key, int default); 
 ```
 
 A getter for [SET_RESOURCE_KVP_INT](#_0x6A2B1E8).
 
 ## Parameters
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-The integer value stored under the specified key, or 0 if not found.
+The integer value stored under the specified key, or 0/default if not found.
 
 ## Examples
 

--- a/ext/native-decls/kvp/GetResourceKvpString.md
+++ b/ext/native-decls/kvp/GetResourceKvpString.md
@@ -5,16 +5,17 @@ apiset: shared
 ## GET_RESOURCE_KVP_STRING
 
 ```c
-char* GET_RESOURCE_KVP_STRING(char* key);
+char* GET_RESOURCE_KVP_STRING(char* key, char* default);
 ```
 
 A getter for [SET_RESOURCE_KVP](#_0x21C7A35B).
 
 ## Parameters
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-The string value stored under the specified key, or nil/null if not found.
+The string value stored under the specified key, or nil/null/default if not found.
 
 ## Examples
 

--- a/ext/native-decls/kvp/external/GetExternalKvpFloat.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpFloat.md
@@ -5,7 +5,7 @@ apiset: client
 ## GET_EXTERNAL_KVP_FLOAT
 
 ```c
-float GET_EXTERNAL_KVP_FLOAT(char* resource, char* key);
+float GET_EXTERNAL_KVP_FLOAT(char* resource, char* key, float default);
 ```
 
 A getter for [SET_RESOURCE_KVP_FLOAT](#_0x9ADD2938), but for a specified resource.
@@ -13,9 +13,10 @@ A getter for [SET_RESOURCE_KVP_FLOAT](#_0x9ADD2938), but for a specified resourc
 ## Parameters
 * **resource**: The resource to fetch from.
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-A float that contains the value stored in the Kvp or nil/null if none.
+A float that contains the value stored in the Kvp or nil/null/default if none.
 
 ## Examples
 

--- a/ext/native-decls/kvp/external/GetExternalKvpInt.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpInt.md
@@ -5,7 +5,7 @@ apiset: client
 ## GET_EXTERNAL_KVP_INT
 
 ```c
-int GET_EXTERNAL_KVP_INT(char* resource, char* key);
+int GET_EXTERNAL_KVP_INT(char* resource, char* key, int default);
 ```
 
 A getter for [SET_RESOURCE_KVP_INT](#_0x6A2B1E8), but for a specified resource.
@@ -13,9 +13,10 @@ A getter for [SET_RESOURCE_KVP_INT](#_0x6A2B1E8), but for a specified resource.
 ## Parameters
 * **resource**: The resource to fetch from.
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-A int that contains the value stored in the Kvp or nil/null if none.
+A int that contains the value stored in the Kvp or nil/null/default if none.
 
 ## Examples
 

--- a/ext/native-decls/kvp/external/GetExternalKvpString.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpString.md
@@ -5,7 +5,7 @@ apiset: client
 ## GET_EXTERNAL_KVP_STRING
 
 ```c
-char* GET_EXTERNAL_KVP_STRING(char* resource, char* key);
+char* GET_EXTERNAL_KVP_STRING(char* resource, char* key, char* default);
 ```
 
 A getter for [SET_RESOURCE_KVP](#_0x21C7A35B), but for a specified resource.
@@ -13,9 +13,10 @@ A getter for [SET_RESOURCE_KVP](#_0x21C7A35B), but for a specified resource.
 ## Parameters
 * **resource**: The resource to fetch from.
 * **key**: The key to fetch
+* **default**: The default value to set if none is found.
 
 ## Return value
-A string that contains the value stored in the Kvp or nil/null if none.
+A string that contains the value stored in the Kvp or nil/null/default if none.
 
 ## Examples
 


### PR DESCRIPTION
### Goal of this PR

Native GET_RESOURCE_KVP_*, GET_EXTERNAL_KVP_* can have a default value


### How is this PR achieving the goal

I now use the second/third argument instead of a nullptr


### This PR applies to the following area(s)

FiveM, Server, Natives


### Successfully tested on

**Game builds:** 3095

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

https://forum.cfx.re/t/let-get-resource-kvp-have-a-default-value/

