### PR TITLE
tweak(core/acl): give the creating resource the ability to modify the ACL for its own commands

### DIFF
--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -133,7 +133,12 @@ static InitFunction initFunction([] ()
 					return;
 				}
 
-				// restricted? if not, add the command
+				auto formattedResource = fmt::sprintf("resource.%s", resource->GetName());
+
+				// Always allow the registering resource to do things to its own commands, this allows them to add_ace without needing to do weird wrappers.
+				seGetCurrentContext()->AddAccessControlEntry(se::Principal{ formattedResource }, se::Object{ "command." + commandName }, se::AccessType::Allow);
+
+				// If we're not restricted then allow everyone to use the command
 				if (!context.GetArgument<bool>(2))
 				{
 					seGetCurrentContext()->AddAccessControlEntry(se::Principal{ "builtin.everyone" }, se::Object{ "command." + commandName }, se::AccessType::Allow);
@@ -156,9 +161,13 @@ static InitFunction initFunction([] ()
 					return true;
 				});
 
-				resource->OnStop.Connect([consoleCxt, commandToken]()
+				resource->OnStop.Connect([consoleCxt, commandToken, formattedResource, commandName]()
 				{
 					consoleCxt->GetCommandManager()->Unregister(commandToken);
+
+					// Once we unregister the command make sure we remove the default access
+					seGetCurrentContext()->RemoveAccessControlEntry(se::Principal{ "builtin.everyone" }, se::Object{ "command." + commandName }, se::AccessType::Allow);
+					seGetCurrentContext()->RemoveAccessControlEntry(se::Principal{ formattedResource }, se::Object{ "command." + commandName }, se::AccessType::Allow);
 				}, INT32_MAX);
 			}
 		}


### PR DESCRIPTION
- this allows you to do `ExecuteCommand("add_ace group.moderator command.test allow") as long as the calling resource was the one that created the command

### Goal of this PR
Currently if resources want to do `add_ace` for its own commands it has to do [weird wrappers](https://github.com/overextended/ox_lib/blob/189306d5aac329b39543dd4c7ac93f18361e561f/package/server/resource/acl/index.ts#L4-L5) to [do add_ace](https://github.com/overextended/ox_lib/blob/189306d5aac329b39543dd4c7ac93f18361e561f/resource/acl/server.lua#L6-L21)

Having to use these kinds of wrappers is bad security since it can allow any resource to call them and give itself certain permissions, but there is no way currently to `add_ace` to your own command.

This PR gives the creating resource of a command to have control over it removing the need for resource wrappers and the need to give resources excess permissions.

### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
