### PR TITLE
feat(nui/resources): add DOES_DUI_EXIST

### DIFF
--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -155,6 +155,14 @@ static InitFunction initFunction([] ()
 
 		context.SetResult(false);
 	});
+	
+	fx::ScriptEngine::RegisterNativeHandler("DOES_DUI_EXIST", [=](fx::ScriptContext& context)
+	{
+		auto duiHandle = context.CheckArgument<uint32_t>(0);
+		
+		auto find = g_ScrBindPool.Handles.find(duiHandle);
+		context.SetResult(find != g_ScrBindPool.Handles.end());
+	});
 
 	class NUIWindowWrapper;
 

--- a/ext/native-decls/DoesDuiExist.md
+++ b/ext/native-decls/DoesDuiExist.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+---
+## DOES_DUI_EXIST
+
+```c
+BOOL DOES_DUI_EXIST(long duiObject);
+```
+
+Returns whether or not the dui exists
+
+## Parameters
+* **duiObject**: The DUI browser handle.
+
+## Return value
+True if the dui exists, false otherwise


### PR DESCRIPTION
### Goal of this PR
I don't know how this PR can be received, but I think it's a good idea to add this native to check if a dui handle is valid, because currently there is no way to do this, and when using the `IS_DUI_AVAILABLE` native with a handle that has been destroyed or invalid it shows an error: `SCRIPT ERROR: invalid handle`.
This native would be equivalent to the `DOES_ENTITY_EXIST` for entities.


### How is this PR achieving the goal
Checking if the DUI handle is valid by verifying its presence in g_ScrBindPool.Handles.


### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
