### PR TITLE
tweak(core/rdr): add `CNetObjDraftVehicle` to the pool entries

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -207,6 +207,7 @@ static const char* poolEntriesTable[] = {
 	"CNetObjAnimScene",
 	"CNetObjCombatDirector",
 	"CNetObjDoor",
+	"CNetObjDraftVehicle",
 	"CNetObjGroupScenario",
 	"CNetObjGuardZone",
 	"CNetObjHerd",

--- a/code/shared/net/NetObjEntityType.h
+++ b/code/shared/net/NetObjEntityType.h
@@ -79,7 +79,7 @@ namespace fx::sync
 #endif
 #if defined(STATE_RDR3) || defined(IS_RDR3)
 			case NetObjEntityType::Animal: return "CNetObjAnimal";
-			case NetObjEntityType::DraftVeh: return "CNetObjDraftVeh";
+			case NetObjEntityType::DraftVeh: return "CNetObjDraftVehicle";
 			case NetObjEntityType::StatsTracker: return "CNetObjStatsTracker";
 			case NetObjEntityType::PropSet: return "CNetObjPropSet";
 			case NetObjEntityType::AnimScene: return "CNetObjAnimScene";


### PR DESCRIPTION
### Goal of this PR
Add draft vehicle to the pool entries so it shows on the Pool List

Also shows the proper name for `GetNetObjEntityName`, this is only used by the client to display pretty printed names

### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
