### PR TITLE
tweak(core/rdr): add missing `CNetObjHorse` to the pool entries table

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -209,6 +209,7 @@ static const char* poolEntriesTable[] = {
 	"CNetObjDoor",
 	"CNetObjGroupScenario",
 	"CNetObjGuardZone",
+	"CNetObjHorse"
 	"CNetObjHerd",
 	"CNetObjIncident",
 	"CNetObjObject",


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Adds missing pool name to the entries pool table , as seen in the NetObjEntityType.h file this name exists there but it's not in the list

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


