### PR TITLE
feat(extra-natives-five): add DrawCorona native

### DIFF
--- a/code/components/extra-natives-five/src/VfxNatives.cpp
+++ b/code/components/extra-natives-five/src/VfxNatives.cpp
@@ -24,6 +24,13 @@ namespace rage
 	using Vec4V = DirectX::XMVECTOR;
 }
 
+static hook::cdecl_stub<void(void*, Vector3*, float, uint32_t, float, float, Vector3*, float, float, float, uint16_t)> addLightCorona([]()
+{
+	return hook::get_call(hook::get_pattern("F3 0F 11 44 24 28 F3 0F 11 7C 24 20 E8 ? ? ? ? E8", 12));
+});
+
+static void* g_coronas;
+
 static hook::cdecl_stub<void(CVehicle*, int32_t, rage::Mat34V*, int32_t*)> _getExhaustMatrix([]()
 {
 	return hook::get_pattern("4D 8B E1 49 8B F0 48 8B D9 44 0F 29 48", -0x33);
@@ -92,6 +99,10 @@ static HookFunction hookFunction([]()
 	{
 		g_vfxNitrousOverride.Reset();
 	});
+
+	{
+		g_coronas = hook::get_address<void*>(hook::get_pattern("F3 0F 11 44 24 28 F3 0F 11 7C 24 20 E8 ? ? ? ? E8", -4));
+	}
 });
 
 static InitFunction initFunction([]()
@@ -108,6 +119,36 @@ static InitFunction initFunction([]()
 			float minSqrDist = g_vfxNitrousOverride.GetDefault();
 			g_vfxNitrousOverride.Set(std::clamp(sqrDist, minSqrDist, kMaxPtfxSqrDist));
 		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("DRAW_CORONA", [](fx::ScriptContext& context)
+	{
+		float x = context.GetArgument<float>(0);
+		float y = context.GetArgument<float>(1);
+		float z = context.GetArgument<float>(2);
+		float size = context.GetArgument<float>(3);
+		
+		uint32_t color = (
+		    (std::clamp(context.GetArgument<int>(4), 0, 255) << 24) |
+		    (std::clamp(context.GetArgument<int>(5), 0, 255) << 16) |
+		    (std::clamp(context.GetArgument<int>(6), 0, 255) << 8) |
+		    (std::clamp(context.GetArgument<int>(7), 0, 255) << 0)
+		);
+		
+		float intensity = context.GetArgument<float>(8);
+		float zBias = std::clamp(context.GetArgument<float>(9), 0.0f, 1.0f);
+		float directionX = context.GetArgument<float>(10);
+		float directionY = context.GetArgument<float>(11);
+		float directionZ = context.GetArgument<float>(12);
+		float viewThreshold = context.GetArgument<float>(13);
+		float innerAngle = context.GetArgument<float>(14);
+		float outerAngle = context.GetArgument<float>(15);
+		uint16_t flags = context.GetArgument<uint16_t>(16);
+
+		Vector3 position = { x, y, z };
+		Vector3 direction = { directionX, directionY, directionZ };
+
+		addLightCorona(g_coronas, &position, size, color, intensity, zBias, &direction, viewThreshold, innerAngle, outerAngle, flags);
 	});
 
 	// GH-2003: Backport b3095 vehicle exhaust bone getters to earlier builds

--- a/ext/native-decls/DrawCorona.md
+++ b/ext/native-decls/DrawCorona.md
@@ -1,0 +1,53 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DRAW_CORONA
+
+```c
+void DRAW_CORONA(float posX, float posY, float posZ, float size, int red, int green, int blue, int alpha, float intensity, float zBias, float dirX, float dirY, float dirZ, float viewThreshold, float innerAngle, float outerAngle, int flags);
+```
+
+Allows drawing advanced light effects, known as coronas, which support flares, volumetric lighting, and customizable glow properties.
+
+## Parameters
+* **posX**: The X position of the corona origin.
+* **posY**: The Y position of the corona origin.
+* **posZ**: The Z position of the corona origin.
+* **size**: The size of the corona.
+* **red**: The red component of the marker color, on a scale from 0-255.
+* **green**: The green component of the marker color, on a scale from 0-255.
+* **blue**: The blue component of the marker color, on a scale from 0-255.
+* **alpha**: The alpha component of the marker color, on a scale from 0-255.
+* **intensity**: The intensity of the corona.
+* **zBias**: zBias slightly shifts the depth of surfaces to make sure they don’t overlap or cause visual glitches when they are very close together. The zBias value are usually in the range of 0.0 to 1.0.
+* **dirX**: The X direction of the corona.
+* **dirY**: The Y direction of the corona.
+* **dirZ**: The Z direction of the corona.
+* **viewThreshold**: The view threshold is to determine the fading of the corona based on the distance.
+* **innerAngle**: The inner angle of the corona.
+* **outerAngle**: The outer angle of the corona.
+* **flags**: The corona flags.
+
+```cpp
+enum eCoronaFlags
+{
+    CF_HAS_DIRECTION = 2, // Only render the corona in the direction of dirX, dirY, dirZ
+    CF_NO_RENDER_UNDERWATER = 4, // Disable rendering of the corona underwater
+    CF_NO_RENDER_UNDERGROUND = 8, // This keep drawing the corona in underground zones (like tunnels)
+    CF_NO_RENDER_FLARE = 16, // Disable rendering of the corona flare
+}
+```
+
+## Examples
+
+```lua
+local pedCoords = GetEntityCoords(PlayerPedId())
+Citizen.CreateThread(function()
+    while true do
+        DrawCorona(pedCoords.x, pedCoords.y, pedCoords.z, 5.0, 255, 255, 255, 255, 4.0, 0.2, pedCoords.x, pedCoords.y, pedCoords.z, 1.0, 0.0, 90.0, 2)
+        Wait(0)
+    end
+end)
+```


### PR DESCRIPTION
### Goal of this PR
Added native `DRAW_CORONA` to render more advanced light effects, like volumetric lights.

![image](https://github.com/user-attachments/assets/6b140d7c-2d47-40c3-b01c-914da481c795)

### How is this PR achieving the goal
Creating the `CCoronas` structure that contains the list of coronas, and a method to add new ones.
The patterns have been taken from https://github.com/thorium-cfx/fivem/commit/26f7e2d61251f798b87d5aba0750372993e32d22 and the `CF_NO_RENDER_UNDERGROUND` flag from https://github.com/alexguirre/Spotlight/blob/master/Source/Core/Memory/GameStructs.cs#L296

### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Game builds:** 3095, 3407

**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.