### PR TITLE
fix(extra-natives-five): draw rect function offset

### DIFF
--- a/code/components/extra-natives-five/src/Draw2dNatives.cpp
+++ b/code/components/extra-natives-five/src/Draw2dNatives.cpp
@@ -13,7 +13,7 @@ static hook::cdecl_stub<char*(void*)> _allocateDrawRect([]()
 
 static hook::cdecl_stub<void(void*, float a2, float a3, float a4, float a5)> _setDrawRectCoords([]()
 {
-	return hook::get_call(hook::get_pattern("F3 44 0F 59 0D ? ? ? ? E8 ? ? ? ? 33 FF", 0x45));
+	return hook::get_call(hook::get_pattern("F3 44 0F 59 0D ? ? ? ? E8 ? ? ? ? 33 FF", xbr::IsGameBuildOrGreater<3407>() ? 0x4A : 0x45));
 });
 
 static InitFunction initFunction([]()


### PR DESCRIPTION
### Goal of this PR
Fix a crash when running native `DRAW_LINE_2D` due to a shift in the `_setDrawRectCoords` function as of gamebuild 3407.


### How is this PR achieving the goal
Change function offset for version b3407 and later.


### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Game builds:** 3095, 3258, 3407
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3126 