### PR TITLE
feat(citizen-scripting-lua): Add os.createdir function

### DIFF
--- a/code/components/citizen-scripting-lua/src/LuaOS.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaOS.cpp
@@ -1,5 +1,6 @@
-﻿#include "StdInc.h"
+#include "StdInc.h"
 
+#include <filesystem>
 #include <lua.hpp>
 #include <lua_cmsgpacklib.h>
 
@@ -141,6 +142,55 @@ int LuaOSExecute(lua_State* L)
 	lua_pushstring(L, what);
 	lua_pushinteger(L, stat);
 	return 3; /* return true/nil,what,code */
+}
+
+int LuaOSCreateDir(lua_State* L)
+{
+	const char* directoryPathString = luaL_checkstring(L, 1);
+	std::filesystem::path directoryPath = directoryPathString;
+	// ensure that the path ends with a path separator
+	directoryPath /= "";
+
+	std::string path = directoryPath.generic_string();
+	fwRefContainer<vfs::Device> device = vfs::GetDevice(path);
+	if (!device.GetRef())
+	{
+		std::string directoryAbsolutePath = std::filesystem::absolute(std::filesystem::path(directoryPath)).string();
+		std::string transformedPath;
+		device = vfs::FindDevice(directoryAbsolutePath, transformedPath);
+		if (device.GetRef())
+		{
+			path = transformedPath;
+		}
+	}
+
+	if (!device.GetRef())
+	{
+		return luaL_fileresult(L, 0, directoryPathString);
+	}
+
+	vfs::FindData fd;
+	auto handle = device->FindFirst(path, &fd);
+	if (handle != INVALID_DEVICE_HANDLE)
+	{
+		lua_pushnil(L);
+		lua_pushfstring(L, "%s: %s", directoryPathString, "Directory already exists.");
+		lua_pushinteger(L, 1);
+		return 3;
+	}
+
+	if (!device->CreateDirectory(path))
+	{
+		lua_pushnil(L);
+		lua_pushfstring(L, "%s: %s", directoryPathString, "Failed to create directory");
+		lua_pushinteger(L, 1);
+		device->FindClose(handle);
+		return 3;
+	}
+
+	lua_pushboolean(L, true);
+	device->FindClose(handle);
+	return 1;
 }
 
 int LuaOSRemove(lua_State* L)
@@ -490,6 +540,7 @@ const luaL_Reg systemLibs[] = {
 	{"difftime", LuaOSDiffTime},
 	{"execute", LuaOSExecute},
 	{"getenv", LuaOSGetEnv},
+	{"createdir", LuaOSCreateDir},
 	{"remove", LuaOSRemove},
 	{"rename", LuaOSRename},
 	{"setlocale", LuaOSSetLocale},


### PR DESCRIPTION
### Goal of this PR
With `os.execute` being sandbox disabled, this offers an alternative for creating directories in Lua.


### How is this PR achieving the goal
`LuaOSCreateDir` taps into and works with the VFS system directly to offer a more concise solution for creating directories instead of leaving `os.execute` open for anything and everything.


### This PR applies to the following area(s)
Server, ScRT: Lua


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


