### PR TITLE
tweak(rdr): build rdr as `RedM.exe` instead of `CitiLaunch.exe`

### DIFF
--- a/code/client/launcher/premake5.lua
+++ b/code/client/launcher/premake5.lua
@@ -218,6 +218,9 @@ local function launcherpersonality_inner(name)
 		filter { "options:game=five" }
 			targetname "FiveM"
 			
+		filter { "options:game=rdr3" }
+			targetname "RedM"
+
 		filter { "options:game=launcher" }
 			targetname "CfxLauncher"
 

--- a/code/tools/ci/psm1/cfxBuildContext.psm1
+++ b/code/tools/ci/psm1/cfxBuildContext.psm1
@@ -175,7 +175,7 @@ function Get-CfxBuildContext {
             $ctx.IS_REDM = $true
 
             $ctx.ProductName = "redm"
-            $ctx.ProductExeName = "CitiLaunch.exe"
+            $ctx.ProductExeName = "RedM.exe"
             $ctx.PremakeGameName = "rdr3"
             $ctx.SentryProjectName = Get-EnvOrDefault $env:CFX_SENTRY_PROJECT_NAME_REDM "redm"
 


### PR DESCRIPTION
### Goal of this PR
Build RedM under its normal name for local builds


### This PR applies to the following area(s)
RedM

### Successfully tested on
**Game builds:** b1491


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

