### PR TITLE
Revert "fix(handling-loader): fix broken physics"

### DIFF
--- a/code/components/handling-loader-five/src/HandlingLoader.cpp
+++ b/code/components/handling-loader-five/src/HandlingLoader.cpp
@@ -334,17 +334,17 @@ static void SetHandlingDataInternal(fx::ScriptContext& context, CHandlingData* h
 				switch (member->m_definition->type)
 				{
 					case rage::parMemberType::Float:
-						setFloatField(handlingChar, offset, context.CheckArgument<float>(3), handlingField);
+						setFloatField(handlingChar, offset, context.GetArgument<float>(3), handlingField);
 						break;
 
 					case rage::parMemberType::UInt8:
-						*(uint8_t*)(handlingChar + offset) = uint8_t(context.CheckArgument<int>(3));
+						*(uint8_t*)(handlingChar + offset) = uint8_t(context.GetArgument<int>(3));
 						break;
 
 					case rage::parMemberType::UInt32:
 						// every string field (so far) is parsed to an int in memory
 					case rage::parMemberType::String:
-						setIntField(handlingChar, offset, context.CheckArgument<int>(3), handlingField);
+						setIntField(handlingChar, offset, context.GetArgument<int>(3), handlingField);
 						break;
 
 					case rage::parMemberType::Vector3_Padded:


### PR DESCRIPTION
### Goal of this PR
As outlined in detail in https://github.com/citizenfx/fivem/issues/3130, the [following PR](https://github.com/citizenfx/fivem/pull/3101) attempts to 'validate' against NULL values when using `SetVehicleHandlingFloat` or `SetVehicleHandlingInt` to prevent vehicle physics from breaking. The issue is that NULL values are parsed as 0, meaning that you can also no longer use the value 0 in these natives (which is common).

Furthermore, the issue the PR was intending to fix wasn't actually caused by NULL values; it's isolated to the handling loader setting a high value for `fTractionCurveMax` when 0.0f/NULL is detected ([source](https://github.com/citizenfx/fivem/blob/7bcb23de344a68b53ff0b95e63c49f0a9cb5298a/code/components/handling-loader-five/src/HandlingLoader.cpp#L215-L218)).

Not allowing values of 0 breaks many scripts, including my own. Even if NULL _is_ used, it is parsed as 0 anyway, and therefore the commit doesn't protect against anything & doesn't fix the root issue. You can see this by taking a look at `CheckArgument`; in the case of setting a float, it checks whether the value is equal to an empty constructor of the type, which in the case of a float would be like running `float()`, which returns 0.0f.
https://github.com/citizenfx/fivem/blob/84444fe5a722acb14b3d33bd85f3352871caf0ab/code/components/scripting-gta/include/ScriptEngine.h#L70

Furthermore, the issue the PR was intending to fix wasn't actually caused by NULL values; it's isolated to the handling loader setting a high value for `fTractionCurveMax` when 0.0f/NULL is detected ([source](https://github.com/citizenfx/fivem/blob/7bcb23de344a68b53ff0b95e63c49f0a9cb5298a/code/components/handling-loader-five/src/HandlingLoader.cpp#L215-L218))

### How is this PR achieving the goal

Reverts https://github.com/citizenfx/fivem/pull/3101 to allow 0 (same as NULL) values again.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** 3258

**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #3130