### PR TITLE
feat(gta-streaming-five): allow to edit scene graph pools

### DIFF
--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -111,13 +111,16 @@ static HookFunction hookFunction([]()
 	hook::put<uint32_t>((char*)clearVisDataLocation + 20, sceneNodeCount * 4);
 
 	// Change pool size of FIRST_ROOM_SCENE_NODE_INDEX
-	
 	std::initializer_list<PatternPair> roomSceneNodeIndexLocations = {
-		{ "41 BC ? ? ? ? 0F BA E0 ? 73 ? 0F BA E0", 2 }, // AddVisibility
-		{ "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC ? 41 BB", 61 } // ProcessEntityContainer
+		{ "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 56 48 83 EC ? 4C 8B 91", 77 }, // AddVisibility
+		{ "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC ? 41 BB", 61 }, // ProcessEntityContainer
+		{ "0F B7 42 ? 41 B8 ? ? ? ? 33 D2", 6 } // GetGbufScreenQuadPair
 	};
 	for(auto& entry : roomSceneNodeIndexLocations)
 	{
-		hook::put<uint32_t>(hook::get_pattern(entry.pattern, entry.offset), 1151);
+		hook::put<uint32_t>(hook::get_pattern(entry.pattern, entry.offset),
+			pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize +
+			pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize +
+			pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize - 1);
 	}
 });

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -83,16 +83,13 @@ static int FIRST_PORTAL_SCENE_NODE_INDEX =
 
 static void AddSkyPortal(rage::fwScanResultsSkyPortals* self, rage::fwPortalSceneGraphNode* skyPortalNode)
 {
-	__int64 v3;
-	__int8 v4;
-	if(self->m_skyPortalCount <= 63)
+	if(self->m_skyPortalCount >= 0 && self->m_skyPortalCount <= 63)
 	{
-		uint16_t portalIndex = skyPortalNode->m_index - FIRST_PORTAL_SCENE_NODE_INDEX;
-		v3 = (unsigned __int64)portalIndex >> 3;
-		v4 = skyPortalFlagArray[v3];
-		if(((unsigned __int8)(1 << (portalIndex & 7)) & v4) == 0)
+		const uint16_t nodeIndex = skyPortalNode->m_index - FIRST_PORTAL_SCENE_NODE_INDEX;
+		const uint8_t bitMask = 1 << (nodeIndex % 8);
+		if((skyPortalFlagArray[nodeIndex/8] & bitMask) == 0)
 		{
-			skyPortalFlagArray[v3] = v4 | (1 << (portalIndex & 7));
+			skyPortalFlagArray[nodeIndex/8] |= bitMask;
 			self->m_skyPortals[self->m_skyPortalCount++] = skyPortalNode;
 		}
 	}

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -1,5 +1,8 @@
 #include "StdInc.h"
 #include <Hooking.h>
+#include <mutex>
+
+struct PatternPair;
 
 enum class eSceneGraphPool
 {
@@ -15,71 +18,106 @@ enum class eSceneGraphPool
 
 struct SceneGraphPoolData
 {
-	eSceneGraphPool poolType;
 	int classSize;
 	int poolSize;
 };
 
-std::vector<SceneGraphPoolData> pools = {
-	{eSceneGraphPool::FW_ENTITY_CONTAINER, 48, 800},
-	{eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER, 48, 2}, // Max pool size is 64
-	{eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER, 40, 1000}, // This pool size will apply to FW_STREAMED_SCENE_GRAPH_NODE
-	{eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE, 80, 1}, // This pool size can't be changed, due to asm inc instruction
-	{eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE, 64, 1000}, // This pool size is going to be overwritten by FW_SO_A_ENTITY_CONTAINER
-	{eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE, 32, 150},
-	{eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE, 48, 256},
-	{eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE, 128, 800}
+std::unordered_map<eSceneGraphPool, SceneGraphPoolData> pools = {
+    {eSceneGraphPool::FW_ENTITY_CONTAINER, {48, 800}},
+    {eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER, {48, 2}}, // Max pool size is 64
+    {eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER, {40, 1000}}, // This pool size will apply to FW_STREAMED_SCENE_GRAPH_NODE
+    {eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE, {80, 1}}, // This pool size can't be changed, due to asm inc instruction
+    {eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE, {64, 1000}}, // This pool size is going to be overwritten by FW_SO_A_ENTITY_CONTAINER
+    {eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE, {32, 150}},
+    {eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE, {48, 256}},
+    {eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE, {128, 800}}
 };
 
 int CalculateTotalSize(bool storage) {
 	int total = 0;
 	for (const auto& pool : pools) {
-		total += storage ? (pool.poolSize * pool.classSize) : pool.poolSize;
+		total += storage ? (pool.second.poolSize * pool.second.classSize) : pool.second.poolSize;
 	}
 	return total;
 }
 
+struct PatternPair
+{
+	std::string_view pattern;
+	int offset;
+};
+
 static HookFunction hookFunction([]()
 {
-	assert(pools[1].poolSize <= 64 && "The pool size of FW_FIXED_ENTITY_CONTAINER can't be greater than 64");
-	auto initPoolsLocation = hook::get_pattern("48 8D B3 ? ? ? ? 48 8B FB");
+	// +85
+	assert(pools[eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER].poolSize <= 64 && "The pool size of FW_FIXED_ENTITY_CONTAINER can't be greater than 64");
+	auto initPoolsLocation = hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC ? BA ? ? ? ? B9"); // 48 8D B3 ? ? ? ? 48 8B FB
 	auto assignStorageLocation = hook::get_pattern("48 8B C1 48 89 0D ? ? ? ? 48 81 C1");
+	auto computeSceneNodeLocation = hook::get_pattern("4C 8B C1 0F B6 49 ? 85 C9");
+	auto assignScratchBufferLocation = hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 48 89 91");
+	auto clearVisDataLocation = hook::get_pattern("40 53 48 83 EC ? 48 8B D9 48 8B 89 ? ? ? ? 33 D2 41 B8");
 
 	// Adjust the memory offsets of the allocated pools
-	hook::put<uint32_t>((char*)initPoolsLocation + 3, pools[0].poolSize); // 800
-	hook::put<uint32_t>((char*)initPoolsLocation + 13, pools[0].poolSize + pools[1].poolSize); // 802
-	hook::put<uint32_t>((char*)initPoolsLocation - 4, pools[2].poolSize); // 1802
-	hook::put<uint32_t>((char*)initPoolsLocation + 38, pools[5].poolSize + pools[6].poolSize); // 406
+	hook::put<uint32_t>((char*)initPoolsLocation + 88, pools[eSceneGraphPool::FW_ENTITY_CONTAINER].poolSize); // 800
+	hook::put<uint32_t>((char*)initPoolsLocation + 98, pools[eSceneGraphPool::FW_ENTITY_CONTAINER].poolSize + pools[eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER].poolSize); // 802
+	hook::put<uint32_t>((char*)initPoolsLocation + 81, pools[eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER].poolSize); // 1802
+	hook::put<uint32_t>((char*)initPoolsLocation + 123, pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].poolSize); // 406
 
 	const int poolStorageSize = CalculateTotalSize(true);
 	const int poolFlagSize = CalculateTotalSize(false);
 
 	// Change the size of poolStorage and poolFlags size
-	hook::put<uint32_t>((char*)initPoolsLocation - 41, poolStorageSize);
-	hook::put<uint32_t>((char*)initPoolsLocation - 51, poolStorageSize + poolFlagSize);
+	hook::put<uint32_t>((char*)initPoolsLocation + 44, poolStorageSize);
+	hook::put<uint32_t>((char*)initPoolsLocation + 34, poolStorageSize + poolFlagSize);
 
 	// Change the pool size of each pool constructor
-	hook::put<uint32_t>((char*)initPoolsLocation + 91, pools[0].poolSize);
+	hook::put<uint32_t>((char*)initPoolsLocation + 176, pools[eSceneGraphPool::FW_ENTITY_CONTAINER].poolSize);
 	/*
 	 * To apply the size in the constructor of FW_FIXED_ENTITY_CONTAINER we have to know that the value is being calculated based on an rdi calculation,
 	 * above you can see the instruction "mov edi, 40h" and the argument is passed as "lea edx, [rdi-X]",
 	 * we calculate this value X based on the pool size we want, by default the poolSize is 2, X is 3Eh because 64 - 2 = 62(3E)
 	 */
-	hook::put((char*)initPoolsLocation + 168, (uint8_t)(64 - pools[1].poolSize));
-	hook::put((char*)initPoolsLocation + 251, pools[2].poolSize);
+	hook::put((char*)initPoolsLocation + 256, (uint8_t)(64 - pools[eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER].poolSize));
+	hook::put((char*)initPoolsLocation + 336, pools[eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER].poolSize);
 	// We skip the pool size of FW_EXTERIOR_SCENE_GRAPH_NODE because it can't be changed due to the limitations in the memory offsets when allocating the pools
-	hook::put((char*)initPoolsLocation + 399, pools[4].poolSize);
-	hook::put((char*)initPoolsLocation + 478, pools[5].poolSize);
-	hook::put((char*)initPoolsLocation + 561, pools[6].poolSize);
-	hook::put((char*)initPoolsLocation + 640, pools[7].poolSize);
+	hook::put((char*)initPoolsLocation + 484, pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize);
+	hook::put((char*)initPoolsLocation + 563, pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize);
+	hook::put((char*)initPoolsLocation + 646, pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].poolSize);
+	hook::put((char*)initPoolsLocation + 725, pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].poolSize);
 
 	// Adjust offsets in AssignStorage function
-	hook::put<uint32_t>((char*)assignStorageLocation + 13, pools[0].poolSize * pools[0].classSize); // 38400
-	hook::put<uint8_t>((char*)assignStorageLocation + 27, static_cast<uint8_t>(pools[1].poolSize * pools[1].classSize)); // 96
-	hook::put<uint32_t>((char*)assignStorageLocation + 45, pools[2].poolSize * pools[2].classSize); // 40000
-	hook::put<uint8_t>((char*)assignStorageLocation + 59, static_cast<uint8_t>(pools[3].poolSize * pools[3].classSize)); // 80
-	hook::put<uint32_t>((char*)assignStorageLocation + 70, pools[4].poolSize * pools[4].classSize); // 64000
-	hook::put<uint32_t>((char*)assignStorageLocation + 84, pools[5].poolSize * pools[5].classSize); // 4800
-	hook::put<uint32_t>((char*)assignStorageLocation + 98, pools[6].poolSize * pools[6].classSize); // 12288
-	hook::put<uint32_t>((char*)assignStorageLocation + 113, pools[7].poolSize * pools[7].classSize); // 102400
+	hook::put<uint32_t>((char*)assignStorageLocation + 13, pools[eSceneGraphPool::FW_ENTITY_CONTAINER].poolSize * pools[eSceneGraphPool::FW_ENTITY_CONTAINER].classSize); // 38400
+	hook::put<uint8_t>((char*)assignStorageLocation + 27, static_cast<uint8_t>(pools[eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER].poolSize * pools[eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER].classSize)); // 96
+	hook::put<uint32_t>((char*)assignStorageLocation + 45, pools[eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER].poolSize * pools[eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER].classSize); // 40000
+	hook::put<uint8_t>((char*)assignStorageLocation + 59, static_cast<uint8_t>(pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize * pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].classSize)); // 80
+	hook::put<uint32_t>((char*)assignStorageLocation + 70, pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize * pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].classSize); // 64000
+	hook::put<uint32_t>((char*)assignStorageLocation + 84, pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize * pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].classSize); // 4800
+	hook::put<uint32_t>((char*)assignStorageLocation + 98, pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].poolSize * pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].classSize); // 12288
+	hook::put<uint32_t>((char*)assignStorageLocation + 113, pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].poolSize * pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].classSize); // 102400
+
+	// Adjust offsets in ComputeSceneNode function
+	hook::put<uint32_t>((char*)computeSceneNodeLocation + 50, pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].poolSize); // 1407
+	hook::put<uint32_t>((char*)computeSceneNodeLocation + 90, pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize); // 1151
+	hook::put<uint32_t>((char*)computeSceneNodeLocation + 113, pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize + pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize); // 1001
+
+	// Adjust offsets in AssignScratchBuffer function
+	int sceneNodeCount =
+		pools[eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE].poolSize +
+		pools[eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE].poolSize +
+		pools[eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE].poolSize +
+		pools[eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE].poolSize +
+		pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].poolSize;
+	hook::put<uint32_t>((char*)assignScratchBufferLocation + 28, sceneNodeCount * 4);
+	hook::put<uint32_t>((char*)clearVisDataLocation + 20, sceneNodeCount * 4);
+
+	// Change pool size of FIRST_ROOM_SCENE_NODE_INDEX
+	
+	std::initializer_list<PatternPair> roomSceneNodeIndexLocations = {
+		{ "41 BC ? ? ? ? 0F BA E0 ? 73 ? 0F BA E0", 2 }, // AddVisibility
+		{ "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC ? 41 BB", 61 } // ProcessEntityContainer
+	};
+	for(auto& entry : roomSceneNodeIndexLocations)
+	{
+		hook::put<uint32_t>(hook::get_pattern(entry.pattern, entry.offset), 1151);
+	}
 });

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -190,11 +190,11 @@ static HookFunction hookFunction([]()
 		
 		void InternalMain() override
 		{
-			mov(rcx, reinterpret_cast<uintptr_t>(skyPortalFlagArray.get()));
+			mov(rcx, qword_ptr[rbx+0xC38]);
 			xor(edx, edx);
 			mov(dword_ptr[rcx+0x378], r9d);
 			mov(r8d, static_cast<size_t>((pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].poolSize + 7) / 8));
-			add(rcx, 0x37C);
+			mov(rcx, reinterpret_cast<uintptr_t>(skyPortalFlagArray.get()));
 			mov(rax, (uintptr_t)memset);
 			call(rax);
 			xor(r9d, r9d);

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -1,0 +1,85 @@
+#include "StdInc.h"
+#include <Hooking.h>
+
+enum class eSceneGraphPool
+{
+	FW_ENTITY_CONTAINER = 0,
+	FW_FIXED_ENTITY_CONTAINER = 1,
+	FW_SO_A_ENTITY_CONTAINER = 2,
+	FW_EXTERIOR_SCENE_GRAPH_NODE = 3,
+	FW_STREAMED_SCENE_GRAPH_NODE = 4,
+	FW_INTERIOR_SCENE_GRAPH_NODE = 5,
+	FW_ROOM_SCENE_GRAPH_NODE = 6,
+	FW_PORTAL_SCENE_GRAPH_NODE = 7,
+};
+
+struct SceneGraphPoolData
+{
+	eSceneGraphPool poolType;
+	int classSize;
+	int poolSize;
+};
+
+std::vector<SceneGraphPoolData> pools = {
+	{eSceneGraphPool::FW_ENTITY_CONTAINER, 48, 800},
+	{eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER, 48, 2}, // Max pool size is 64
+	{eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER, 40, 1000}, // This pool size will apply to FW_STREAMED_SCENE_GRAPH_NODE
+	{eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE, 80, 1}, // This pool size can't be changed, due to asm inc instruction
+	{eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE, 64, 1000}, // This pool size is going to be overwritten by FW_SO_A_ENTITY_CONTAINER
+	{eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE, 32, 150},
+	{eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE, 48, 256},
+	{eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE, 128, 800}
+};
+
+int CalculateTotalSize(bool storage) {
+	int total = 0;
+	for (const auto& pool : pools) {
+		total += storage ? (pool.poolSize * pool.classSize) : pool.poolSize;
+	}
+	return total;
+}
+
+static HookFunction hookFunction([]()
+{
+	assert(pools[1].poolSize <= 64 && "The pool size of FW_FIXED_ENTITY_CONTAINER can't be greater than 64");
+	auto initPoolsLocation = hook::get_pattern("48 8D B3 ? ? ? ? 48 8B FB");
+	auto assignStorageLocation = hook::get_pattern("48 8B C1 48 89 0D ? ? ? ? 48 81 C1");
+
+	// Adjust the memory offsets of the allocated pools
+	hook::put<uint32_t>((char*)initPoolsLocation + 3, pools[0].poolSize); // 800
+	hook::put<uint32_t>((char*)initPoolsLocation + 13, pools[0].poolSize + pools[1].poolSize); // 802
+	hook::put<uint32_t>((char*)initPoolsLocation - 4, pools[2].poolSize); // 1802
+	hook::put<uint32_t>((char*)initPoolsLocation + 38, pools[5].poolSize + pools[6].poolSize); // 406
+
+	const int poolStorageSize = CalculateTotalSize(true);
+	const int poolFlagSize = CalculateTotalSize(false);
+
+	// Change the size of poolStorage and poolFlags size
+	hook::put<uint32_t>((char*)initPoolsLocation - 41, poolStorageSize);
+	hook::put<uint32_t>((char*)initPoolsLocation - 51, poolStorageSize + poolFlagSize);
+
+	// Change the pool size of each pool constructor
+	hook::put<uint32_t>((char*)initPoolsLocation + 91, pools[0].poolSize);
+	/*
+	 * To apply the size in the constructor of FW_FIXED_ENTITY_CONTAINER we have to know that the value is being calculated based on an rdi calculation,
+	 * above you can see the instruction "mov edi, 40h" and the argument is passed as "lea edx, [rdi-X]",
+	 * we calculate this value X based on the pool size we want, by default the poolSize is 2, X is 3Eh because 64 - 2 = 62(3E)
+	 */
+	hook::put((char*)initPoolsLocation + 168, (uint8_t)(64 - pools[1].poolSize));
+	hook::put((char*)initPoolsLocation + 251, pools[2].poolSize);
+	// We skip the pool size of FW_EXTERIOR_SCENE_GRAPH_NODE because it can't be changed due to the limitations in the memory offsets when allocating the pools
+	hook::put((char*)initPoolsLocation + 399, pools[4].poolSize);
+	hook::put((char*)initPoolsLocation + 478, pools[5].poolSize);
+	hook::put((char*)initPoolsLocation + 561, pools[6].poolSize);
+	hook::put((char*)initPoolsLocation + 640, pools[7].poolSize);
+
+	// Adjust offsets in AssignStorage function
+	hook::put<uint32_t>((char*)assignStorageLocation + 13, pools[0].poolSize * pools[0].classSize); // 38400
+	hook::put<uint8_t>((char*)assignStorageLocation + 27, static_cast<uint8_t>(pools[1].poolSize * pools[1].classSize)); // 96
+	hook::put<uint32_t>((char*)assignStorageLocation + 45, pools[2].poolSize * pools[2].classSize); // 40000
+	hook::put<uint8_t>((char*)assignStorageLocation + 59, static_cast<uint8_t>(pools[3].poolSize * pools[3].classSize)); // 80
+	hook::put<uint32_t>((char*)assignStorageLocation + 70, pools[4].poolSize * pools[4].classSize); // 64000
+	hook::put<uint32_t>((char*)assignStorageLocation + 84, pools[5].poolSize * pools[5].classSize); // 4800
+	hook::put<uint32_t>((char*)assignStorageLocation + 98, pools[6].poolSize * pools[6].classSize); // 12288
+	hook::put<uint32_t>((char*)assignStorageLocation + 113, pools[7].poolSize * pools[7].classSize); // 102400
+});

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -192,7 +192,8 @@ static HookFunction hookFunction([]()
 		{
 			mov(rcx, reinterpret_cast<uintptr_t>(skyPortalFlagArray.get()));
 			xor(edx, edx);
-			mov(r8, static_cast<size_t>(FIRST_PORTAL_SCENE_NODE_INDEX));
+			mov(dword_ptr[rcx+0x378], r9d);
+			mov(r8d, static_cast<size_t>((pools[eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE].poolSize + 7) / 8));
 			add(rcx, 0x37C);
 			mov(rax, (uintptr_t)memset);
 			call(rax);


### PR DESCRIPTION
### Goal of this PR
Allow editing of most SceneGraphNodes pools, the increase of `fwPortalSceneGraphNode` was suggested in the [forum](https://forum.cfx.re/t/expansion-of-fwportalscenegraphnode-pool/5302881).
Recently it was attempted to add the pool `fwPortalSceneGraphNode` to the gameconfig(#2695) but as prikolium said they are allocated from another precomputed heap and should be looked for in `fwSceneGraph::InitPools`.
This was already done by blattersturm [here](https://github.com/citizenfx/fivem/commit/ba52c98749a83d901af4dd4f5f415fc71d4611d0) but 2 days later they [reverted](https://github.com/citizenfx/fivem/commit/85be134d37afa561e669a9049c52d162bcf550e8) his change due to `Potential cause for 'missing doors after a while'.` What they did was hook the PortalSceneGraphPool constructor to multiply the size and allocate the memory elsewhere.
I don't know if this is the approach that you want to take in order to increase the sizes of these pools.

### How is this PR achieving the goal
First of all, I have defined a list of pools so that their sizes can be easily edited.
```cpp
v0 = Allocate(214473LL, 16LL);
qword_7FF6B50437F8 = v0;
AssignStorage(v0, 210864LL);
v1 = (unsigned int)dword_7FF6B5043808 + v0;
v2 = v1 + 800;
v3 = v1;
v4 = v1 + 802;
v5 = v1 + 1802;
v6 = v1 + 1803;
v7 = v1 + 2803;
v8 = v7 + 406;
```
As you can see in the code, by default the game allocates 214473 in memory which is the sum of the pool storage sizes and the pool flag sizes and in AssignStorageMemory the pool flag sizes are sent. Both values ​​are calculated with the data from the `pools` table and set in both arguments.
The memory displacement offsets are modified for each pool (v2, v4, v5, v6, etc.)
Later the value of all poolSizes is changed in each pool constructor.
And finally, other memory offsets of the AssignStorage function are changed.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 1604, 2060, 2189, 3095, 3258, 3407(My tests have been to join the server and have a test hook to see the arguments that are sent to the pool constructor and they seemed correct.)

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.