### PR TITLE
fix(server/gamestate): typo in freecam natives

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1713,7 +1713,7 @@ static void Init()
 				break;
 			case 1:
 				resultVec.x = camData->freeCamPosX;
-				resultVec.y = camData->freeCamPosX;
+				resultVec.y = camData->freeCamPosY;
 				resultVec.z = camData->freeCamPosZ;
 				break;
 			case 2:


### PR DESCRIPTION
### Goal of this PR
I need glasses.

### How is this PR achieving the goal
Fixing the typo.👓

### This PR applies to the following area(s)
FiveM, RedM, Natives

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Server)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/