### PR TITLE
tweak(core/rdr): add missing `MaxDoorExtensions` to the pool table en…

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -517,6 +517,7 @@ static const char* poolEntriesTable[] = {
 	"MaxTrainScenarioPoints",
 	"MaxUnguardedRequests",
 	"MaxVisibleClothCount",
+	"MaxDoorExtensions"
 	"MetaDataStore",
 	"MotionStore",
 	"mvPageBufferSize",


### PR DESCRIPTION
…tries

### Goal of this PR
Adds the missing pool name to the table entries

### This PR applies to the following area(s)
RedM


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


