### PR TITLE
tweak(gta-five-net): network synchronised scene id hacks

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5747,12 +5747,11 @@ struct CNetworkPtFXEvent
 
 struct CRequestNetworkSyncedSceneEvent
 {
-	uint16_t sceneId;
+	uint32_t sceneId; // Increased from uint16_t, see "NetworkSynchronisedSceneHacks.cpp"
 
 	void Parse(rl::MessageBufferView& buffer)
 	{
-		// FIXME: Scene ID length-hack workaround, see `CStartNetworkSyncedSceneEvent`.
-		sceneId = buffer.Read<uint16_t>(8) | (buffer.Read<uint16_t>(5) << 8);
+		sceneId = buffer.Read<uint32_t>(32);
 	}
 
 	inline std::string GetName()
@@ -5839,7 +5838,7 @@ private:
 	};
 
 public:
-	uint16_t sceneId;
+	uint32_t sceneId; // Increased from uint16_t, see "NetworkSynchronisedSceneHacks.cpp"
 	uint32_t startTime;
 
 	bool isActive;
@@ -5873,9 +5872,7 @@ public:
 
 	void Parse(rl::MessageBufferView& buffer)
 	{
-		// FIXME: Synced scene IDs are 13 bits in length, but since it's not an object ID, it's conflicting
-		// with our length-hack logic... We're working around this issue by reading these 13 bits in two parts.
-		sceneId = buffer.Read<uint16_t>(8) | (buffer.Read<uint16_t>(5) << 8);
+		sceneId = buffer.Read<uint32_t>(32);
 
 		startTime = buffer.Read<uint32_t>(32);
 
@@ -5958,13 +5955,12 @@ public:
 
 struct CUpdateNetworkSyncedSceneEvent
 {
-	uint16_t sceneId;
+	uint32_t sceneId; // Increased from uint16_t, see "NetworkSynchronisedSceneHacks.cpp"
 	float rate;
 
 	void Parse(rl::MessageBufferView& buffer)
 	{
-		// FIXME: Scene ID length-hack workaround, see `CStartNetworkSyncedSceneEvent`.
-		sceneId = buffer.Read<uint16_t>(8) | (buffer.Read<uint16_t>(5) << 8);
+		sceneId = buffer.Read<uint32_t>(32);
 
 		rate = (buffer.Read<uint8_t>(8) / 255.0f) * 2.0f;
 	}
@@ -5979,12 +5975,11 @@ struct CUpdateNetworkSyncedSceneEvent
 
 struct CStopNetworkSyncedSceneEvent
 {
-	uint16_t sceneId;
+	uint32_t sceneId; // Increased from uint16_t, see "NetworkSynchronisedSceneHacks.cpp"
 
 	void Parse(rl::MessageBufferView& buffer)
 	{
-		// FIXME: Scene ID length-hack workaround, see `CStartNetworkSyncedSceneEvent`.
-		sceneId = buffer.Read<uint16_t>(8) | (buffer.Read<uint16_t>(5) << 8);
+		sceneId = buffer.Read<uint32_t>(32);
 	}
 
 	inline std::string GetName()

--- a/code/components/gta-net-five/src/NetworkSynchronisedSceneHacks.cpp
+++ b/code/components/gta-net-five/src/NetworkSynchronisedSceneHacks.cpp
@@ -1,0 +1,147 @@
+#include "StdInc.h"
+
+#include "CrossBuildRuntime.h"
+#include "Hooking.h"
+#include "NetGameEvent.h"
+
+#include <jitasm.h>
+
+template<int Build>
+static int GetServerId(const rlGamerInfo<Build>& platformData)
+{
+	return (platformData.peerAddress.localAddr().ip.addr & 0xFFFF) ^ 0xFEED;
+}
+
+static int DoGetServerId(CNetGamePlayer* player)
+{
+	if (xbr::IsGameBuildOrGreater<2824>())
+	{
+		return GetServerId(*player->GetGamerInfo<2824>());
+	}
+
+	if (xbr::IsGameBuildOrGreater<2372>())
+	{
+		return GetServerId(*player->GetGamerInfo<2372>());
+	}
+
+	if (xbr::IsGameBuildOrGreater<2060>())
+	{
+		return GetServerId(*player->GetGamerInfo<2060>());
+	}
+
+	return GetServerId(*player->GetGamerInfo<1604>());
+}
+
+static constexpr char pattern[] = "\x41\xB8\x0D\x00\x00\x00";
+static auto FindPattern(const uintptr_t startAddress)
+{
+	auto address = reinterpret_cast<const uint8_t*>(startAddress);
+
+	while (true)
+	{
+		assert(*address != 0xE9);
+
+		if (memcmp(address, pattern, sizeof(pattern) - 1) == 0)
+		{
+			return reinterpret_cast<uintptr_t>(address);
+		}
+
+		++address;
+	}
+}
+
+static uint32_t GetSceneIdOffset(CNetGamePlayer* player)
+{
+	return (DoGetServerId(player) - 1) * 64;
+}
+
+static HookFunction hookFunction([]()
+{
+	// StartScene - Serializer
+	{
+		//Write
+		hook::put<uint32_t>(hook::get_pattern("41 B8 ? ? ? ? 48 8B C8 C6 44 24 ? ? E8 ? ? ? ? 48 8B 7C 24", 2), 32);
+
+		//Read
+		hook::put<uint32_t>(hook::get_pattern("41 B8 ? ? ? ? 48 8B C8 48 8B D6", 2), 32);
+	}
+
+	// Request-/StopScene - Serializer
+	{
+		const auto cCRequestNetworkSyncedSceneEvent_vtable = hook::get_address<uintptr_t*>(hook::get_pattern<unsigned char>("48 8D 05 ? ? ? ? 89 5E ? 48 8B 5C 24 ? 48 89 06 8A 47", 3));
+
+		// Write
+		uintptr_t target = cCRequestNetworkSyncedSceneEvent_vtable[5];
+
+		hook::put<uint32_t>(FindPattern(target) + 2, 32);
+
+		// Read
+		target = cCRequestNetworkSyncedSceneEvent_vtable[6];
+
+		hook::put<uint32_t>(FindPattern(target) + 2, 32);
+	}
+
+	// UpdateScene - Serializer
+	{
+		const auto cCUpdateNetworkSyncedSceneEvent_vtable = hook::get_address<uintptr_t*>(hook::get_pattern("48 8D 05 ? ? ? ? F3 0F 11 77 ? 0F 28 74 24", 3));
+
+		// Write
+		uintptr_t target = cCUpdateNetworkSyncedSceneEvent_vtable[5];
+		target = target + 5 + *reinterpret_cast<int32_t*>(target + 1);
+
+		hook::put<uint32_t>(FindPattern(target) + 2, 32);
+
+		// Read
+		target = cCUpdateNetworkSyncedSceneEvent_vtable[6];
+		target = target + 5 + *reinterpret_cast<int32_t*>(target + 1);
+
+		hook::put<uint32_t>(FindPattern(target) + 2, 32);
+	}
+
+	// CClonedSynchronizedSceneInfo - Serializer
+	{
+		const auto cClonedSynchronizedSceneInfo_vtable = hook::get_address<uintptr_t*>(hook::get_pattern("48 8D 05 ? ? ? ? E9 ? ? ? ? 48 8B 0D ? ? ? ? 45 33 C9 4D 8B C6 BA ? ? ? ? E8 ? ? ? ? 48 85 C0 0F 84 ? ? ? ? 48 8B C8 E8 ? ? ? ? E9 ? ? ? ? 48 8B 0D ? ? ? ? 45 33 C9 4D 8B C6 BA", 3));
+
+		int vtableIdx = 24;
+
+		if (xbr::IsGameBuildOrGreater<2802>())
+		{
+			vtableIdx = 30;
+		}
+
+		hook::put<uint8_t>(cClonedSynchronizedSceneInfo_vtable[vtableIdx] + 0x1F + 3, 32);
+	}
+
+	// CNetworkSynchronizedScenes - Scene Allocator
+	{
+		static struct : jitasm::Frontend
+		{
+			intptr_t retAddress;
+
+			void Init(const intptr_t ret)
+			{
+				this->retAddress = ret;
+			}
+
+			void InternalMain() override
+			{
+				mov(rcx, rax);
+				mov(rax, reinterpret_cast<uintptr_t>(&GetSceneIdOffset));
+				call(rax);
+				mov(ebp, eax);
+
+				mov(rax, retAddress);
+				jmp(rax);
+			}
+		} patchStub;
+
+		auto location = hook::get_pattern("0F B6 68 ? C1 E5");
+
+		const auto ret = reinterpret_cast<intptr_t>(location) + 7;
+
+		patchStub.Init(ret);
+
+		hook::nop(location, 7);
+		hook::jump_rcx(location, patchStub.GetCode());
+	}
+});


### PR DESCRIPTION
### Goal of this PR
The original game code assigns global IDs for synchronized network scenes by using the physical player index as a unique identifier. The ID space is padded to a maximum of 64 concurrent synchronized scenes `(physicalIndex * 64)`. However, in our network implementation, the local player's physical index is always set to `128`, leading to scene ID collisions when multiple machines trigger networked scenes simultaneously and also integer range overflows (`13-bit = 8191 / 64 = 127 < 128`).

### How is this PR achieving the goal
1. Expansion of Scene ID Serialization:
    - The local scene ID variable was already of type `int32_t`, but the serialization process previously limited scene IDs to 13 bits.
    - This patch expands the serialization logic to utilize the full 32-bit space for scene IDs.

2. Replacement of Physical Player Index with Server ID:
    - Instead of using the physical player index (128 for all local players), we now use the player's server-id as an uniquifier.

### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** 1, 1604, 2060, 2189, 2372, 2545, 2612, 2699, 2802, 2944, 3095, 3258, 3407

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #2910