### PR TITLE
feat(extra-native-rdr3): `GET_MINIMAP_TYPE`

### DIFF
--- a/code/components/extra-natives-rdr3/src/HudNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/HudNatives.cpp
@@ -11,6 +11,11 @@ static hook::cdecl_stub<void(void*, char)> g_uiMinimap_SetType([]()
 	return hook::get_pattern("48 81 EC ? ? ? ? 8B F2 48 8B E9 E8", -16);
 });
 
+static hook::cdecl_stub<uint32_t(void*)> g_uiMinimap_GetType([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 83 F8 ? 74 ? 48 8D 15"));
+});
+
 static HookFunction hookFunction([]()
 {
 	{
@@ -27,6 +32,12 @@ static HookFunction hookFunction([]()
 
 		if (g_uiMinimap)
 			g_uiMinimap_SetType(g_uiMinimap, minimapType);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_MINIMAP_TYPE", [](fx::ScriptContext& context)
+	{
+		uint32_t minimapType = g_uiMinimap_GetType(g_uiMinimap);
+		context.SetResult<int>(minimapType);
 	});
 
 	/*

--- a/ext/native-decls/GetMinimapType.md
+++ b/ext/native-decls/GetMinimapType.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_MINIMAP_TYPE
+
+```c
+int GET_MINIMAP_TYPE();
+```
+
+Get the minimap type:
+```
+0 = Off,
+1 = Regular,
+2 = Expanded,
+3 = Simple,
+```


### PR DESCRIPTION
### Goal of this PR
Get the minimap type in RDR3

...


### How is this PR achieving the goal
Return the value 0,1,2 or 3 depending on whether the map is off, standard, expended, or simple. 
...


### This PR applies to the following area(s)
RedM natives

...


### Successfully tested on
Get the minimap type after edit it with SetMinimapType(): ✅
Get the minimap type after edit it in the pause menu: ✅

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixed the missing native to get the minimap type set by SetMinimapType()


