### PR TITLE
feat(core/five): patch PopZone / Zone max limit

### DIFF
--- a/code/components/gta-core-five/src/PatchPopZoneLimits.cpp
+++ b/code/components/gta-core-five/src/PatchPopZoneLimits.cpp
@@ -1,0 +1,26 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include "CrossBuildRuntime.h"
+
+//
+// Increases the max amount of PopCycles / Zones allowed at once.
+// useful for if someone is creating a DLC island or map extension or just modifying the existing zones.
+//
+
+static HookFunction hookFunction([]()
+{
+	{
+		uint8_t* location = hook::get_pattern<uint8_t>("E8 ? ? ? ? 0F BE 40 06 EB 09 E8 ? ? ? ? 0F BE 40 05"); // zone_commands::CommandGetZonePopSchedule
+		hook::put<uint8_t>(location + 6, 182);
+		hook::put<uint8_t>(location + 17, 182);
+
+	}
+	{
+		uint8_t* location = hook::get_pattern<uint8_t>("0F BE 54 88 ? EB 5F 41 B8 ? ? ? ? E8"); // CPopCycle::UpdateCurrZoneFromCoors
+		hook::put<uint8_t>(location + 1, 182);
+	}
+	{
+		uint8_t* location = hook::get_pattern<uint8_t>("0F BE 54 88 ? EB 02 8B D3 89 15"); // CPopCycle::UpdateCurrZoneFromCoors
+		hook::put<uint8_t>(location + 1, 182);
+	}
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Increases the max amount of PopCycles / Zones allowed at once. useful for if someone is creating a DLC island or map extension or just modifying the existing zones.
...


### How is this PR achieving the goal
hooking the necessary locations and increasing the amount
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3407
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


