### PR TITLE
feat(core/five): patch RadioStation max limit

### DIFF
--- a/code/components/gta-core-five/src/PatchRadioStationLimits.cpp
+++ b/code/components/gta-core-five/src/PatchRadioStationLimits.cpp
@@ -1,0 +1,32 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include "CrossBuildRuntime.h"
+
+//
+// Increases the max amount of possible RadioStations, by default the game is almost at the limit.
+// will be needed if a server adds many new stations.
+//
+
+static HookFunction hookFunction([]()
+{
+	{
+		uint8_t* maxRadioStations = hook::get_pattern<uint8_t>("8D 5E 60 89 35", 2); // audRadioStation::InitClass
+		hook::put<uint8_t>(maxRadioStations, 127);
+		uint32_t* radioStationsMemSize = (uint32_t*)(maxRadioStations + 0x26);
+		hook::put<uint32_t>(radioStationsMemSize, 127 * 8);
+	}
+
+	{
+		uint8_t* maxRadioStations = hook::get_pattern<uint8_t>("BD 60 00 00 00 E9", 1); // audRadioStation::MergeRadioStationList
+		hook::put<uint8_t>(maxRadioStations, 127);
+		uint32_t* radioStationsMemSize = (uint32_t*)(maxRadioStations + 0x43);
+		hook::put<uint32_t>(radioStationsMemSize, 127 * 8);
+	}
+
+	{
+		uint8_t* maxRadioStations = hook::get_pattern<uint8_t>("45 8D 67 ? 8B C6", 3); // audRadioStation::RemoveRadioStationList
+		hook::put<uint8_t>(maxRadioStations, 127);
+		uint32_t* radioStationsMemSize = (uint32_t*)(maxRadioStations + 0x141);
+		hook::put<uint32_t>(radioStationsMemSize, 127 * 8);
+	}
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Increases the max amount of possible RadioStations, by default the game is almost at the limit.
...


### How is this PR achieving the goal
Hooking the necessary locations and increasing the value to 127
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3407
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

closes https://github.com/citizenfx/fivem/issues/2517
