### PR TITLE
fix(shared): include chrono to fix breakage caused by msvc-170

### DIFF
--- a/code/client/shared/StdInc.h
+++ b/code/client/shared/StdInc.h
@@ -113,6 +113,7 @@
 #include <codecvt>
 #include <thread>
 #include <mutex> // for once_flag on GCC
+#include <chrono>
 
 // our common includes
 #define COMPONENT_EXPORT


### PR DESCRIPTION
Microsoft stopped including chrono automatically internally, so we must now include it in our own standard include

https://learn.microsoft.com/en-us/cpp/overview/what-s-new-for-visual-cpp-in-visual-studio?view=msvc-170

### This PR applies to the following area(s)
FiveM, RedM, Server

### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.