### PR TITLE
tweak(server): shortened players.json privacy announcement link

### DIFF
--- a/code/components/citizen-server-main/src/ServerInstance.cpp
+++ b/code/components/citizen-server-main/src/ServerInstance.cpp
@@ -253,7 +253,7 @@ namespace fx
 				console::PrintWarning(
 					_CFX_NAME_STRING(_CFX_COMPONENT_NAME),
 					"The players.json endpoint has been modified to no longer return the player identifiers without authentication.\n"
-					"To learn more about this change read our announcement at https://forum.cfx.re/t/celebrating-one-year-with-rockstar-games/5269938#fivem-and-redm-6\n"
+					"To learn more about this change read our announcement at https://aka.cfx.re/players-json-privacy\n"
 				);
 			});
 		}


### PR DESCRIPTION
### Goal of this PR
The server players.json IDs privacy announcement link was **big**, now link is _smol_.

### How is this PR achieving the goal
Used the cfx.re link shortener: https://aka.cfx.re/players-json-privacy

### This PR applies to the following area(s)
FXServer, exclusively.

### Successfully tested on
Didn't test it at all (except the link itself).

### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.

### Fixes issues
None, nobody even complained, but I needed to test the shortener and this particular link has been on my head recently.