### PR TITLE
feat(cfx-ui): allow html in connecting status

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyConnectingModal/ConnectStatus.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyConnectingModal/ConnectStatus.tsx
@@ -5,11 +5,13 @@ import {
   Modal,
   Text,
   noop,
+  linkify
 } from '@cfx-dev/ui-components';
 import { observer } from 'mobx-react-lite';
 
-import { $L, useL10n } from 'cfx/common/services/intl/l10n';
-import { nl2brx } from 'cfx/utils/nl2br';
+import { $L } from 'cfx/common/services/intl/l10n';
+import { nl2br } from 'cfx/utils/nl2br';
+import { html2react } from 'cfx/utils/html2react';
 
 import { ConnectState } from '../../services/servers/connect/state';
 
@@ -17,7 +19,7 @@ type ConnectStatusProps = {
   state: ConnectState.Status;
 
   onCancel?(): void;
-};
+}; 
 export const ConnectStatus = observer(function ConnectStatus(props: ConnectStatusProps) {
   const {
     state,
@@ -25,7 +27,7 @@ export const ConnectStatus = observer(function ConnectStatus(props: ConnectStatu
     onCancel = noop,
   } = props;
 
-  const message = useL10n('#Servers_Message', state);
+  const { message } = state;
 
   return (
     <>
@@ -33,7 +35,7 @@ export const ConnectStatus = observer(function ConnectStatus(props: ConnectStatu
         <Flex vertical gap="large">
           <Text size="xlarge">{$L('#Servers_Connecting')}</Text>
 
-          {nl2brx(message)}
+          {html2react(linkify(nl2br(message)))}
         </Flex>
       </Pad>
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add support for using HTML code in connecting status e.g. `deferral.update()`, like rejection status can do (deferral.done()), allowing server developers to create more customized update statuses than Adaptive Cards can provide. (excluding inputs of course).
...


### How is this PR achieving the goal
PR is replacing current implementation of showing the status message, to one similar to rejection status.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258, 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

### Preview
I'm attaching a PoC of my change.

![image](https://github.com/user-attachments/assets/c3a5709e-1c4f-4d8d-872b-76a10651ba03)
