### PR TITLE
tweak(citizen-server-impl): send clients net id in an entity event

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3608,7 +3608,7 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 
 		// update all clients' lists so the system knows that this entity is valid and should not be deleted anymore
 		// (otherwise embarrassing things happen like a new player's ped having the same object ID as a pending-removed entity, and the game trying to remove it)
-		gscomms_execute_callback_on_main_thread([this, entity]()
+		gscomms_execute_callback_on_main_thread([this, entity, client]()
 		{
 			auto evComponent = m_instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::ResourceEventManagerComponent>();
 
@@ -3622,7 +3622,7 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 			 #/
 			declare function entityCreating(handle: number): void;
 			*/
-			if (!evComponent->TriggerEvent2("entityCreating", { }, MakeScriptHandle(entity)))
+			if (!evComponent->TriggerEvent2("entityCreating", { fmt::sprintf("internal-net:%d", client->GetNetId()) }, MakeScriptHandle(entity)))
 			{
 				if (entity->type != sync::NetObjEntityType::Player)
 				{
@@ -3645,7 +3645,7 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 			 #/
 			declare function entityCreated(handle: number): void;
 			*/
-			evComponent->QueueEvent2("entityCreated", { }, MakeScriptHandle(entity));
+			evComponent->QueueEvent2("entityCreated", { fmt::sprintf("internal-net:%d", client->GetNetId()) }, MakeScriptHandle(entity));
 		});
 	}
 	else


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Send net ID of the client that created the entity to events `entityCreating`, `entityCreated` respectively.
This way, developers don't have the need to call NetworkGetFirstEntityOwner the second time, because the data will be sent as "source".
...


### How is this PR achieving the goal
It is utilizing already provided client data, to send netId to the TriggerEvent2 function which in result allows developers to use the variable "source" (in Lua, can be different in other runtimes).
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Server, Natives
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


