### PR TITLE
feat(extra-natives-five): GET/SET_VEHICLE_WHEEL_HEIGHT

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -304,6 +304,7 @@ static int VehicleTransmissionOffset;
 static int WheelYRotOffset = 0x008;
 static int WheelInvYRotOffset = 0x010;
 static int WheelXOffsetOffset = 0x030;
+static int WheelHeightOffset = 0x038;
 static int WheelTyreRadiusOffset = 0x110;
 static int WheelRimRadiusOffset = 0x114;
 static int WheelTyreWidthOffset = 0x118;
@@ -1569,6 +1570,16 @@ static HookFunction initFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_WHEEL_X_OFFSET", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
 	{
 		*reinterpret_cast<float*>(wheelAddr + WheelXOffsetOffset) = context.GetArgument<float>(2);
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_WHEEL_HEIGHT", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	{
+		context.SetResult<float>(*reinterpret_cast<float*>(wheelAddr + WheelHeightOffset));
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_WHEEL_HEIGHT", makeWheelFunction([](fx::ScriptContext& context, fwEntity* vehicle, uintptr_t wheelAddr)
+	{
+		*reinterpret_cast<float*>(wheelAddr + WheelHeightOffset) = context.GetArgument<float>(2);
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_TOP_SPEED_MODIFIER", [](fx::ScriptContext& context)


### PR DESCRIPTION
### Goal of this PR
Add the ability to get and set vehicles' wheels height


### How is this PR achieving the goal
Adding the required natives to be able to modify these values by memory patching.


### This PR applies to the following area(s)
FiveM, Natives.


### Successfully tested on
I didn't test it on FiveM itself, but I tested it using a debugger on single player. Since this is a simple code, this should work without any issues.


**Game builds:** All of them?


**Platforms:** Windows, Linux


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
N/A

