### PR TITLE
tweak(gamestate/server): sanitize network synchronized scene

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -921,6 +921,9 @@ struct SyncEntityState
 	bool wantsReassign = false;
 	bool firstOwnerDropped = false;
 	EntityOrphanMode orphanMode = EntityOrphanMode::DeleteWhenNotRelevant;
+#ifdef STATE_FIVE
+	bool allowRemoteSyncedScenes = false;
+#endif
 
 	std::list<std::function<void(const fx::ClientSharedPtr& ptr)>> onCreationRPC;
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -305,6 +305,20 @@ static void Init()
 		return entity->orphanMode;
 	}));
 
+#ifdef STATE_FIVE
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		entity->allowRemoteSyncedScenes = context.GetArgument<bool>(1);
+
+		return true;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		return entity->allowRemoteSyncedScenes;
+	}));
+#endif
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_COORDS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		float position[3];

--- a/ext/native-decls/GetEntityRemoteSyncedScenesAllowed.md
+++ b/ext/native-decls/GetEntityRemoteSyncedScenesAllowed.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED
+
+```c
+BOOL GET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED(Entity entity);
+```
+
+## Parameters
+* **entity**: The entity to get the flag for.
+
+## Return value
+Returns if the entity is allowed to participate in network-synchronized scenes initiated by clients that do not own the entity.

--- a/ext/native-decls/SetEntityRemoteSyncedScenesAllowed.md
+++ b/ext/native-decls/SetEntityRemoteSyncedScenesAllowed.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## SET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED
+
+```c
+void SET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED(Entity entity, bool allow);
+```
+
+Enables or disables the owner check for the specified entity in network-synchronized scenes. When set to `false`, the entity cannot participate in synced scenes initiated by clients that do not own the entity.
+
+By default, this is `false` for all entities, meaning only the entity's owner can include it in networked synchronized scenes.
+
+## Parameters
+* **entity**: The entity to set the flag for.
+* **allow**: Whether to allow remote synced scenes for the entity.


### PR DESCRIPTION
### Goal of this PR
The original GTA network code includes sanitization for local player peds, but it still allows malicious actors to permanently desync a player’s ped on all remote clients. Additionally, other remotely owned entities lack any sanitization, making them vulnerable to similar abuse.

### How is this PR achieving the goal
- Introduces a template-based `Sanitize` method for all game events, streamlining future sanitization implementations.
- Blocks all networked synchronized scenes containing entities that are not owned by the requesting client.
- Provides a bypass mechanism for specific entities via `SET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED`.
- Allows retrieval of the current bypass state with `GET_ENTITY_REMOTE_SYNCED_SCENES_ALLOWED`.

**Note:** Once this change reaches general availability, client-side sanitization can be removed entirely.

### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** 3407

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/