### PR TITLE
fix(server): resMan init race

### DIFF
--- a/code/components/citizen-server-impl/src/GetConfigurationMethod.cpp
+++ b/code/components/citizen-server-impl/src/GetConfigurationMethod.cpp
@@ -43,7 +43,12 @@ static InitFunction initFunction([]()
 			std::unique_lock<std::shared_mutex> lock(fileServerLock);
 			fileServers.push_back(std::move(entry));
 
-			auto resourceManager = fx::ResourceManager::GetCurrent();
+			const auto resourceManager = fx::ResourceManager::GetCurrent();
+			if (!resourceManager)
+			{
+				return;
+			}
+
 			resourceManager->ForAllResources([](const fwRefContainer<fx::Resource>& resource)
 			{
 				auto& configurationCache = resource->GetComponent<fx::ResourceConfigurationCacheComponent>();
@@ -67,7 +72,12 @@ static InitFunction initFunction([]()
 				}
 			}
 
-			auto resourceManager = fx::ResourceManager::GetCurrent();
+			const auto resourceManager = fx::ResourceManager::GetCurrent();
+			if (!resourceManager)
+			{
+				return;
+			}
+
 			resourceManager->ForAllResources([](const fwRefContainer<fx::Resource>& resource)
 			{
 				auto& configurationCache = resource->GetComponent<fx::ResourceConfigurationCacheComponent>();


### PR DESCRIPTION
### Goal of this PR
This code path is affected by a potential race condition during server initialization, as commands may be executed before the resource context is fully initialized.

### How is this PR achieving the goal
Early-out if we are not initialized, as there is no res cache to target yet.

### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** Not applicable 

**Platforms:** Windows (Server)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/