### PR TITLE
fix(native-decls): fix native hyperlinks

### DIFF
--- a/ext/native-decls/GetGlobalPassengerMassMultiplier.md
+++ b/ext/native-decls/GetGlobalPassengerMassMultiplier.md
@@ -9,7 +9,7 @@ game: gta5
 float GET_GLOBAL_PASSENGER_MASS_MULTIPLIER();
 ```
 
-A getter for [SET_GLOBAL_PASSENGER_MASS_MULTIPLIER](#_0x1c47f6ac).
+A getter for [SET_GLOBAL_PASSENGER_MASS_MULTIPLIER](#_0x1C47F6AC).
 
 ## Return value
 Returns the mass of each passenger (not counting the driver) as a percentage of vehicle mass. Default value is 0.05

--- a/ext/native-decls/GetVehicleXmasSnowFactor.md
+++ b/ext/native-decls/GetVehicleXmasSnowFactor.md
@@ -7,6 +7,6 @@ game: gta5
 ```c
 float GET_VEHICLE_XMAS_SNOW_FACTOR();
 ```
-A getter for [SET_VEHICLE_XMAS_SNOW_FACTOR](#_80cc4c9e).
+A getter for [SET_VEHICLE_XMAS_SNOW_FACTOR](#_0x80CC4C9E).
 ## Return value
 Returns the grip factor for the vehicles wheels during xmas weather. default value is 0.2.


### PR DESCRIPTION
it appears the hyperlink does not work on the native docs, i believe this is because it was previously in lowercase.

fix SET_GLOBAL_PASSENGER_MASS_MULTIPLIER and SET_VEHICLE_XMAS_SNOW_FACTOR hyperlinks.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix hyperlinks between natives.
...


### How is this PR achieving the goal
changing the case of the native hashes.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Natives
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


