### PR TITLE
feat(nui): add `IsNuiLoaded` Function

### DIFF
--- a/code/components/nui-resources/src/ResourceUIScripting.cpp
+++ b/code/components/nui-resources/src/ResourceUIScripting.cpp
@@ -425,6 +425,39 @@ static InitFunction initFunction([] ()
 		context.SetResult(nui::HasFocusKeepInput());
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("IS_NUI_LOADED", [](fx::ScriptContext& context)
+	{
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_FAILED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			context.SetResult(false);
+			return;
+		}
+
+		fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+		if (!resource)
+		{
+			context.SetResult(false);
+			return;
+		}
+
+		fwRefContainer<ResourceUI> resourceUI = resource->GetComponent<ResourceUI>();
+		if (!resourceUI.GetRef() || !resourceUI->HasFrame())
+		{
+			context.SetResult(false);
+			return;
+		}
+
+		if (resource->GetName().find('"') != std::string::npos)
+		{
+			context.SetResult(false);
+			return;
+		}
+
+		context.SetResult(true);
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_NUI_ZINDEX", [](fx::ScriptContext& context)
 	{
 		fx::OMPtr<IScriptRuntime> runtime;

--- a/ext/native-decls/IsNuiLoaded.md
+++ b/ext/native-decls/IsNuiLoaded.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+---
+## IS_NUI_LOADED
+
+```c
+BOOL IS_NUI_LOADED();
+```
+
+Returns whether the NUI of the resource is loaded.
+
+## Return value
+True or false.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This PR adds an IsNuiLoaded function that allows you to check if a resource's NUI has been loaded.


### How is this PR achieving the goal
Added a new function IsNuiLoaded to check the loading status of NUI for a resource.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.
