### PR TITLE
tweak(github): change security branch ref to master

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Issue
-    url: https://github.com/citizenfx/fivem/blob/main/SECURITY.md
+    url: https://github.com/citizenfx/fivem/blob/master/SECURITY.md
     about: For security related issues
 
   - name: Public Documentation (docs.fivem.net)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Updates the ref link in issue template to the correct branch


### How is this PR achieving the goal

Changes the branch ref from `main` -> `master`


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

GitHub


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] My commit message explains what the changes do and what they are for.
