### PR TITLE
fix(gta-core-five): validate bounds collisions

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
@@ -1,0 +1,59 @@
+#include "StdInc.h"
+
+#include "Hooking.Patterns.h"
+#include "Hooking.Stubs.h"
+#include <DirectXMath.h>
+
+namespace rage {
+	struct alignas(16) Vec3V
+	{
+		float x;
+		float y;
+		float z;
+		float pad;
+
+		Vec3V()
+			: x(0), y(0), z(0), pad(NAN)
+		{
+		}
+
+		Vec3V(float x, float y, float z)
+			: x(x), y(y), z(z), pad(NAN)
+		{
+		}
+	};
+	struct phBound
+	{
+		uint8_t m_Type;
+		uint8_t m_Flags;
+		uint8_t m_PartIndex;
+		float m_RadiusAroundCentroid;
+	};
+	using Mat34V = DirectX::XMMATRIX;
+
+	struct phBoundComposite : phBound {
+		phBound** m_Bounds;
+		rage::Mat34V* m_CurrentMatrices;
+		rage::Mat34V* m_LastMatrices;
+		rage::Vec3V* m_LocalBoxMinMaxs;
+		uint32_t* m_TypeAndIncludeFlags;
+		uint32_t* m_OwnedTypeAndIncludeFlags;
+		uint16_t m_MaxNumBounds;
+		uint16_t m_NumBounds;
+	};
+}
+
+static void (*g_origProcessSelfCollision)(void* self, rage::phBoundComposite* boundComposite, rage::Mat34V* a3, rage::Mat34V a4, void* phManifold, unsigned __int8* a6, unsigned __int8* a7, int a8, bool a9);
+static void ProcessSelfCollision(void* self, rage::phBoundComposite* boundComposite, rage::Mat34V* a3, rage::Mat34V a4, void* phManifold, unsigned __int8* a6, unsigned __int8* a7, int a8, bool a9)
+{
+	if (!boundComposite || !boundComposite->m_Bounds)
+	{
+		return;
+	}
+	g_origProcessSelfCollision(self, boundComposite, a3, a4, phManifold, a6, a7, a8, a9);
+}
+
+static HookFunction hookFunction([]()
+{
+	g_origProcessSelfCollision = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 4C 89 48 ? 4C 89 40 ? 48 89 50 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? B8"), ProcessSelfCollision);
+});


### PR DESCRIPTION
### Goal of this PR
Fix a game crash when two collisions collide with each other without having a valid m_Bounds. This is happening for specific objects, mostly testing objects that are not used in the map but are spawned by malicious players to make people nearby crash. By default when spawning the prop there is no problem, but if the player or something external hits a sub-object that makes it move and collide with another sub-object of the same object it will reproduce this crash.


### How is this PR achieving the goal
Hooking the `ProcessSelfCollision` function and validating that the `boundComposite` and `boundComposite->m_Bounds` are valid

### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 1, 1604, 2060, 2189, 2372, 2545, 3095, 3258, 3407

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3173 