### PR TITLE
fix(citizen-scripting-core): strict mode only for the client

### DIFF
--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -41,7 +41,9 @@ struct CommandObject
 
 static InitFunction initFunction([] ()
 {
-	static ConVar<bool> stateBagStrictModeVar("sv_stateBagStrictMode", ConVar_Replicated, false);
+	#ifndef IS_FXSERVER
+		static ConVar<bool> stateBagStrictModeVar("sv_stateBagStrictMode", ConVar_Replicated, false);
+	#endif
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_CURRENT_RESOURCE_NAME", [] (fx::ScriptContext& context)
 	{
@@ -363,11 +365,13 @@ static InitFunction initFunction([] ()
 		auto keySize = context.GetArgument<uint32_t>(3);
 		auto replicated = context.GetArgument<bool>(4);
 
-		if (replicated && stateBagStrictModeVar.GetValue())
-		{
-			fx::scripting::Warningf("natives", "StateBags can't be modified from the client, because the StateBag strict mode is enabled. Disable it using setr sv_stateBagStrictMode false\n");
-			return;
-		}
+		#ifndef IS_FXSERVER
+			if (replicated && stateBagStrictModeVar.GetValue())
+			{
+				fx::scripting::Warningf("natives", "StateBags can't be modified from the client, because the StateBag strict mode is enabled. Disable it using setr sv_stateBagStrictMode false\n");
+				return;
+			}
+		#endif
 
 		auto rm = fx::ResourceManager::GetCurrent();
 		auto sbac = rm->GetComponent<fx::StateBagComponent>();


### PR DESCRIPTION
### Goal of this PR

The strict state bags mode prevents writing by the server. My PR corrects this.


### How is this PR achieving the goal

With a `#ifndef` to check that the execution is done on the client side


### This PR applies to the following area(s)

Server


### Successfully tested on

**Game builds:** Not applicable

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

