### PR TITLE
feat(five/streaming): expand train track array

### DIFF
--- a/code/components/extra-natives-five/include/Train.h
+++ b/code/components/extra-natives-five/include/Train.h
@@ -16,9 +16,6 @@ public:
 struct CTrainTrack
 {
 public:
-	// This has never changed.
-	static const int kMaxTracks = 27;
-
 	uint32_t m_hash;
 	bool m_enabled;
 	bool m_isLooped;
@@ -33,7 +30,12 @@ public:
 	uint8_t m_pad[8];
 
 	bool m_disableAmbientTrains;
-	uint8_t m_pad2[0x220];
+
+	uint8_t m_pad2[0x17];
+
+	bool m_isActive;
+
+	uint8_t m_pad3[0x20C];
 
 	// Helper functions
 	static bool AreAllTracksDisabled();

--- a/code/components/gta-streaming-five/src/PatchTrackLimits.cpp
+++ b/code/components/gta-streaming-five/src/PatchTrackLimits.cpp
@@ -1,0 +1,161 @@
+/*
+* This file is part of the CitizenFX project - http://citizen.re/
+*
+* See LICENSE and MENTIONS in the root of the source tree for information
+* regarding licensing.
+*/
+#include "StdInc.h"
+
+#include "CrossBuildRuntime.h"
+#include <Local.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
+struct PatternPair
+{
+	std::string_view pattern;
+	int offset;
+};
+
+struct ClampPatternPair : PatternPair
+{
+	bool clamp;
+};
+
+struct CTrainTrack
+{
+	char pad[0x250];
+};
+
+struct CTrackData
+{
+	char pad[0xA0];
+};
+
+constexpr int kNumTracks = 127;
+
+static CTrackData** trackStore2;
+static CTrainTrack** trackStore;
+
+static HookFunction initFunction([]()
+{
+	if (!xbr::IsGameBuildOrGreater<2545>())
+	{
+		return;
+	}
+	
+	// patching hardcoded max available train tracks
+	{
+		std::initializer_list<ClampPatternPair> list = {
+			{"41 80 FC ? 0F 8D", 3, false},
+			{"83 FF ? 7D ? 44 88 3B", 2, false},
+			{"45 8D 77 ? 88 05", 3, false},
+			{"7D ? 48 8B C8 8B 05", -1, false},
+			{"48 8B C1 48 69 C0 ? ? ? ? 44 88 74 30", -3, false},
+			{"41 83 FE ? 0F 8C ? ? ? ? 44 8B 64 24", 3, false},
+			{"41 80 F9 ? 7C", 3, false},
+			{"83 F8 ? 7D ? 48 8B C8 8B 05", 2, false},
+			{"83 FB ? 0F 8C ? ? ? ? 48 83 C4 ? 41 5F 41 5E 41 5C", 2, false},
+			{"83 F9 ? 7D ? 4C 8D 05", 2, false},
+			{"83 F9 ? 7D ? 42 88 54 00", 2, false},
+			{"83 FA ? 7C ? 83 C8 ? C3 8B C2", 2, false},
+			{"48 3B C2 7C ? F3 C3 ? 48 8B C4", 2, false},
+			{"83 F9 ? 77 ? 48 63 C1 48 8D 0D ? ? ? ? 48 69 C0 ? ? ? ? 48 03 C1 44 39 48", 2, true},
+			{"FF C3 83 FB ? 0F 8C ? ? ? ? 48 83 C4", 4, true},
+			{"83 FA ? 0F 87 ? ? ? ? F3 0F 10 0E", 2, true},
+			{"83 FA ? 0F 87 ? ? ? ? F3 0F 10 35",2, true},
+			{"80 FA ? 77 ? 45 85 C0", 2, true},
+		};
+
+		for (auto& entry : list)
+		{
+			auto location = hook::pattern(entry.pattern).count(1).get(0).get<uint8_t>(entry.offset);
+			hook::put<uint8_t>(location, (entry.clamp ? (kNumTracks - 1) : kNumTracks));
+		}
+	}
+
+	// patching pointers to static track array
+	{
+		trackStore = (CTrainTrack**)hook::AllocateStubMemory(sizeof(CTrainTrack) * kNumTracks);
+
+		std::initializer_list<PatternPair> list = {
+			{"48 8D 0D ? ? ? ? 45 8A C7 48 8B C7", 3},
+			{"4B 8D 14 64", 7},
+			{"48 8D 05 ? ? ? ? 48 69 C9 ? ? ? ? 48 8B 44 01", 3},
+			{"4C 8D 15 ? ? ? ? 33 FF", 3},
+			{"66 0F 6E 4C 08", -4},
+			{"42 38 44 02", -11},
+			{"48 8D 35 ? ? ? ? 44 8B 78", 3},
+			{"49 0F BE CC", 7},
+			{"48 8D 35 ? ? ? ? 41 BB", 3},
+			{"F3 0F 11 4D ? F3 0F 10 54 C8", -14},
+			{"89 44 11 ? 48 83 7C 24", -11},
+			{"8B CB E8 ? ? ? ? 83 25 ? ? ? ? ? E9", -21},
+			{"48 8D 2D ? ? ? ? 49 8B D3", 3},
+			{"48 69 FF ? ? ? ? 44 8B 64 07", -6},
+			{"48 8D 2D ? ? ? ? 48 85 F6 74 ? 85 DB", 3},
+			{"48 89 5C 24 ? 48 0F BE C1", 5 + 4 + 3},
+			{"49 63 C9 48 8D 35", 6},
+			{"84 C9 78 ? 48 0F BE C1 4C 8D 05", 11},
+			{"4C 0F BE C9", 7},
+			{"74 ? F3 43 0F 10 5C 3B", -17},
+			{"41 83 38 ? 74 ? 48 63 C2", 12},
+			{"48 0F BE D2 4C 8D 15", 7},
+			{"48 8D 3D ? ? ? ? 0F 29 74 24 ? 4C 8D 14 40", 3},
+			{"74 ? 48 0F BE 81", 13},
+			{"4C 8D 25 ? ? ? ? 44 0F 28 C6", 3},
+			{"48 8D 05 ? ? ? ? 48 69 FF ? ? ? ? 48 03 F8 0F 84", 3},
+			{"48 85 DB 0F 84 ? ? ? ? 48 8D 3D", 12},
+			{"4C 8D 3D ? ? ? ? 48 8D 15 ? ? ? ? 84 C0", 3},
+			{"48 8D 3D ? ? ? ? 48 8B 5B", 3},
+			{"48 8D 0D ? ? ? ? 83 B8", 3},
+			{"48 8D 0D ? ? ? ? 8A 83 ? ? ? ? 84 C0", 3},
+			{"EB ? 33 C9 84 C9 75 ? 8A 83", -15},
+			{"48 8D 0D ? ? ? ? 48 69 C0 ? ? ? ? 8A 4C 08 ? EB ? 0F 2F F2", 3},
+			{"48 83 EC ? 48 63 F9 48 8D 35", 10},
+			{"4C 8D 05 ? ? ? ? 48 69 C0 ? ? ? ? 42 C6 44 00", 3},
+			{"48 69 C9 ? ? ? ? 42 88 54 01", -7},
+			{"33 F6 45 8B D8 48 8B F9", 11},
+			{"48 03 C1 83 78", -11},
+			{"33 C0 84 C9 78 ? 38 05", 19},
+			{"48 03 C1 44 39 48", -11}
+		};
+
+		void* oldAddress = nullptr;
+		for (auto& entry : list)
+		{
+			auto location = hook::get_pattern<int32_t>(entry.pattern, entry.offset);
+
+			if (!oldAddress)
+			{
+				oldAddress = hook::get_address<void*>(location);
+			}
+
+			auto curTarget = hook::get_address<void*>(location);
+			assert(curTarget == oldAddress);
+
+			hook::put<int32_t>(location, (intptr_t)trackStore - (intptr_t)location - 4);
+		}
+
+		// Patch getTrainTrack function
+		{
+			uint32_t* location = hook::pattern("48 8D 0D ? ? ? ? 48 69 C0 ? ? ? ? 48 03 C1 C3 ?").count(3).get(1).get<uint32_t>(3);
+			auto curTarget = hook::get_address<void*>(location);
+			assert(curTarget == oldAddress);
+			hook::put<int32_t>(location, (intptr_t)trackStore - (intptr_t)location - 4);
+		}
+	}
+	
+	// Patch another static array related to trains
+	{
+		trackStore2 = (CTrackData**)hook::AllocateStubMemory((sizeof(CTrackData) * kNumTracks) * 20);
+		auto location = hook::get_pattern<int32_t>("48 8D 05 ? ? ? ? 49 C1 E0 ? 48 69 F6", 3);
+		hook::put<int32_t>(location, (intptr_t)trackStore2 - (intptr_t)location - 4);
+	}
+
+	// Patch pointer to track array (used for ambient trains)
+	{
+		auto location = hook::get_pattern("48 8D 1D ? ? ? ? F2 48 0F 2A C0", 3);
+		hook::put<int32_t>(location, (intptr_t)trackStore - (intptr_t)location - 4);
+	}
+});


### PR DESCRIPTION
### Goal of this PR

Expands the hardcoded track limit of 27 tracks to 127 (though can be easily expanded in the future by modifying kMaxTracks in extra-natives-five/TrackNatives.cpp and gta-streaming-five/PatchTrackLimits.cpp.

With the introduction of track switching with https://github.com/citizenfx/fivem/pull/3044 There is a bigger need for having more available tracks (Base GTA takes up 12, Leaving 15 for custom tracks that may be taken up by different map resources and track switching)

### How is this PR achieving the goal

By replacing all instances of the original array holding track data and replacing it with a larger allocated array. All checks for trackIndex being less then 27 have also been replaced with kMaxTracks or kMaxTracks - 1. 

This new PR also corrects a crash that occurred on canary with the previous PR.

### This PR applies to the following area(s)
FiveM

### Successfully tested on

For test and resource used for testing see #3191 

All game builds tested were tested on debug, release. With default tracks,  custom tracks and custom tracks exceeding the original 27 track limit.

**Game builds:** 2189, 2372, 2545, 2699, 2802, 2944, 3095, 3258, 3407

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues