### PR TITLE
feat(loading-screens-five): option to hide busy spinner in loading screen

### DIFF
--- a/code/components/loading-screens-five/include/LoadingScreens.h
+++ b/code/components/loading-screens-five/include/LoadingScreens.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern bool showBusySpinner;

--- a/code/components/loading-screens-five/src/HookLoadingScreens.cpp
+++ b/code/components/loading-screens-five/src/HookLoadingScreens.cpp
@@ -8,6 +8,7 @@
 #include <nutsnbolts.h>
 #include <CefOverlay.h>
 #include <DrawCommands.h>
+#include "LoadingScreens.h"
 
 #include <mmsystem.h>
 
@@ -479,7 +480,7 @@ static InitFunction initFunction([] ()
 {
 	OnLookAliveFrame.Connect([]()
 	{
-		if (nui::HasFrame("loadingScreen"))
+		if (nui::HasFrame("loadingScreen") && showBusySpinner)
 		{
 			if (*g_scaleformMgr)
 			{

--- a/code/components/loading-screens-five/src/LoadingScreens.cpp
+++ b/code/components/loading-screens-five/src/LoadingScreens.cpp
@@ -28,10 +28,7 @@
 
 #include <CfxRect.h>
 #include <DrawCommands.h>
-
-#include <CrossBuildRuntime.h>
-
-#include <Error.h>
+#include "LoadingScreens.h"
 
 static std::shared_ptr<ConVar<bool>> g_loadProfileConvar;
 static std::map<uint64_t, std::chrono::milliseconds> g_loadTiming;
@@ -117,6 +114,7 @@ public:
 static LoadsThread loadsThread;
 
 static bool autoShutdownNui = true;
+bool showBusySpinner = true;
 static fx::TNativeHandler g_origShutdown;
 
 #include <nutsnbolts.h>
@@ -195,6 +193,7 @@ static HookFunction hookFunction([]()
 		{
 			endedLoadingScreens = false;
 			autoShutdownNui = true;
+			showBusySpinner = true;
 		});
 
 		{
@@ -555,6 +554,12 @@ static InitFunction initFunction([] ()
 				if (entriesTwo.begin() != entriesTwo.end())
 				{
 					autoShutdownNui = false;
+				}
+
+				entriesTwo = mdComponent->GetEntries("loadscreen_hide_busyspinner");
+				if (entriesTwo.begin() != entriesTwo.end())
+				{
+					showBusySpinner = false;
 				}
 
 				static ConVar<bool> uiLoadingCursor("ui_loadingCursor", ConVar_None, false);


### PR DESCRIPTION
### Goal of this PR
Adding an option to allow hiding the busy spinner in the loading screen:
![image](https://github.com/user-attachments/assets/393449de-6232-4cbb-a855-7c53fb688c5f)

### How is this PR achieving the goal
Added a `fxmanifest` entry called `loadscreen_hide_busyspinner` to allow hiding this.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3407

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/