### PR TITLE
fix(extra-natives/five): make track junction ids permanent

### DIFF
--- a/ext/native-decls/GetAllTrackJunctions.md
+++ b/ext/native-decls/GetAllTrackJunctions.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_ALL_TRACK_JUNCTIONS
+
+```c
+object GET_ALL_TRACK_JUNCTIONS();
+```
+
+Returns all track junctions on the client
+The data returned adheres to the following structure:
+```
+[1, 2, 4, 6, 69, 420]
+```
+
+## Return value
+An object containing a list of track junctions ids.
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Make train junction ids permanent, not the relative index of the vector
Currently, the id will "change" if a junction is removed

### How is this PR achieving the goal

Change junction vector to unmmapped_map
Creates a queue of unused ids


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1607, 3407

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.

