### PR TITLE
tweak(cfx-ui): update error message

### DIFF
--- a/ext/cfx-ui/src/assets/languages/locale-de.json
+++ b/ext/cfx-ui/src/assets/languages/locale-de.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Verbindungsaufbau",
     "#Servers_ConnectingTo": "Verbinde mit {{ serverName }}...",
     "#Servers_ConnectFailed": "Verbindung fehlgeschlagen",
-    "#Servers_Error": "Ошибка (Fehler)",
+    "#Servers_Error": "Fehler",
     "#Servers_Info": "Info",
     "#Servers_CloseOverlay": "Schließen",
     "#Servers_CancelOverlay": "Abbrechen",

--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -68,7 +68,7 @@
   "#Servers_ConnectingTo": "Connecting to {{ serverName }}...",
   "#Servers_ConnectingToServer": "Connecting to server...",
   "#Servers_ConnectFailed": "Connection failed",
-  "#Servers_Error": "Ошибка (Error)",
+  "#Servers_Error": "Error",
   "#Servers_Info": "Info",
   "#Servers_CloseOverlay": "Close",
   "#Servers_CancelOverlay": "Cancel",

--- a/ext/cfx-ui/src/assets/languages/locale-fi.json
+++ b/ext/cfx-ui/src/assets/languages/locale-fi.json
@@ -20,7 +20,7 @@
     "#Servers_Connecting": "Yhdistetään",
     "#Servers_ConnectingTo": "Yhdistetään palvelimelle {{ serverName }}...",
     "#Servers_ConnectFailed": "Yhdistäminen epäonnistui",
-    "#Servers_Error": "Ошибка (Virhe)",
+    "#Servers_Error": "Virhe",
     "#Servers_Info": "Info",
     "#Servers_CloseOverlay": "Sulje",
     "#Servers_CancelOverlay": "Peruuta",

--- a/ext/cfx-ui/src/assets/languages/locale-fr.json
+++ b/ext/cfx-ui/src/assets/languages/locale-fr.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Connexion en cours",
     "#Servers_ConnectingTo": "Connexion en cours sur {{ serverName }}...",
     "#Servers_ConnectFailed": "Connexion échouée",
-    "#Servers_Error": "Ошибка (Erreur)",
+    "#Servers_Error": "Erreur",
     "#Servers_Info": "Info",
     "#Servers_CloseOverlay": "Fermer",
     "#Servers_CancelOverlay": "Retour",

--- a/ext/cfx-ui/src/assets/languages/locale-it.json
+++ b/ext/cfx-ui/src/assets/languages/locale-it.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Connettendo",
     "#Servers_ConnectingTo": "Connettendo a {{ serverName }}...",
     "#Servers_ConnectFailed": "Connessione Fallita",
-    "#Servers_Error": "Ошибка (Errore)",
+    "#Servers_Error": "Errore",
     "#Servers_Info": "Informazioni",
     "#Servers_CloseOverlay": "Chiudi",
     "#Servers_CancelOverlay": "Annulla",

--- a/ext/cfx-ui/src/assets/languages/locale-nb_NO.json
+++ b/ext/cfx-ui/src/assets/languages/locale-nb_NO.json
@@ -62,7 +62,7 @@
     "#Servers_CancelOverlay": "Avbryt",
     "#Servers_CloseOverlay": "Lukk",
     "#Servers_Info": "Info",
-    "#Servers_Error": "Ошибка (Feil)",
+    "#Servers_Error": "Feil",
     "#Servers_ConnectFailed": "Tilkobling mislyktes",
     "#Servers_ConnectingTo": "Kobler til {{ serverName }}...",
     "#Servers_Connecting": "Kobler til",

--- a/ext/cfx-ui/src/assets/languages/locale-nl.json
+++ b/ext/cfx-ui/src/assets/languages/locale-nl.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Verbinden",
     "#Servers_ConnectingTo": "Verbinden met {{ serverName }}...",
     "#Servers_ConnectFailed": "Verbinding mislukt",
-    "#Servers_Error": "Ошибка (Fout)",
+    "#Servers_Error": "Fout",
     "#Servers_Info": "Info",
     "#Servers_CloseOverlay": "Sluiten",
     "#Servers_CancelOverlay": "Annuleren",

--- a/ext/cfx-ui/src/assets/languages/locale-pl.json
+++ b/ext/cfx-ui/src/assets/languages/locale-pl.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Łączenie",
     "#Servers_ConnectingTo": "Łączenie z {{ serverName }}...",
     "#Servers_ConnectFailed": "Połączenie nieudane",
-    "#Servers_Error": "Ошибка (Błąd)",
+    "#Servers_Error": "Błąd",
     "#Servers_Info": "Informacja",
     "#Servers_CloseOverlay": "Zamknij",
     "#Servers_CancelOverlay": "Anuluj",

--- a/ext/cfx-ui/src/assets/languages/locale-pt.json
+++ b/ext/cfx-ui/src/assets/languages/locale-pt.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Conectando",
     "#Servers_ConnectingTo": "Conectando-se a {{ serverName }}...",
     "#Servers_ConnectFailed": "Falha na conexão",
-    "#Servers_Error": "Ошибка (Erro)",
+    "#Servers_Error": "Erro",
     "#Servers_Info": "Informação",
     "#Servers_CloseOverlay": "Fechar",
     "#Servers_CancelOverlay": "Cancelar",

--- a/ext/cfx-ui/src/assets/languages/locale-sv.json
+++ b/ext/cfx-ui/src/assets/languages/locale-sv.json
@@ -59,7 +59,7 @@
     "#Servers_CancelOverlay": "Avbryt",
     "#Servers_CloseOverlay": "Stäng",
     "#Servers_Info": "Info",
-    "#Servers_Error": "Ошибка (Fel)",
+    "#Servers_Error": "Fel",
     "#Servers_ConnectFailed": "Anslutning misslyckades",
     "#Servers_ConnectingTo": "Ansluter till {{ serverName }}...",
     "#Servers_Connecting": "Ansluter",

--- a/ext/cfx-ui/src/assets/languages/locale-tr.json
+++ b/ext/cfx-ui/src/assets/languages/locale-tr.json
@@ -59,7 +59,7 @@
     "#Servers_CancelOverlay": "İptal",
     "#Servers_CloseOverlay": "Kapat",
     "#Servers_Info": "Bilgi",
-    "#Servers_Error": "Ошибка (Hata)",
+    "#Servers_Error": "Hata",
     "#Servers_ConnectFailed": "Bağlanılamadı",
     "#Servers_ConnectingTo": "{{ serverName }} bağlanılıyor...",
     "#Servers_Connecting": "Bağlanılıyor",

--- a/ext/cfx-ui/src/assets/languages/locale-zh_Hant.json
+++ b/ext/cfx-ui/src/assets/languages/locale-zh_Hant.json
@@ -59,7 +59,7 @@
     "#Servers_CancelOverlay": "取消",
     "#Servers_CloseOverlay": "關閉",
     "#Servers_Info": "資訊",
-    "#Servers_Error": "Ошибка (錯誤)",
+    "#Servers_Error": "錯誤",
     "#Servers_ConnectFailed": "連線失敗",
     "#Servers_ConnectingTo": "正在連線到 {{ serverName }} ...",
     "#Servers_Connecting": "正在連線中",


### PR DESCRIPTION
### Goal of this PR
This PR removes redundant Russian translations that were mistakenly added before the correct localized error messages. It ensures that error messages display only their intended translations without unnecessary duplicates.

...


### How is this PR achieving the goal
Changing the necessary json files.
...


### This PR applies to the following area(s)
cfx-ui, FiveM Client

...


### Successfully tested on

**Game builds:** 3258

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues