### PR TITLE
feat(extra-natives/five): visual settings getter native

### DIFF
--- a/code/components/extra-natives-five/src/VisualSettingsNatives.cpp
+++ b/code/components/extra-natives-five/src/VisualSettingsNatives.cpp
@@ -114,6 +114,25 @@ static InitFunction initFunction([]()
 		}
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_VISUAL_SETTING_FLOAT", [](fx::ScriptContext& context)
+	{
+		const char* settingName = context.CheckArgument<const char*>(0);
+		auto settingHash = HashString(settingName);
+
+		for (int i = 0; i < g_visualSettings->entries.GetCount(); ++i)
+		{
+			const VisualSettingsEntry& entry = g_visualSettings->entries[i];
+			if (entry.entryHash == settingHash)
+			{
+				context.SetResult<float>(entry.value);
+				return;
+			}
+		}
+
+		std::string error = va("Visual setting '%s' doesn't exist.", settingName);
+		throw std::runtime_error(error);
+	});
+
 	OnMainGameFrame.Connect([=]()
 	{
 		std::function<void()> func;

--- a/ext/native-decls/GetVisualSettingFloat.md
+++ b/ext/native-decls/GetVisualSettingFloat.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_VISUAL_SETTING_FLOAT
+
+```c
+float GET_VISUAL_SETTING_FLOAT(char* name);
+```
+
+A getter for [SET_VISUAL_SETTING_FLOAT](#_0xD1D31681).
+
+## Parameters
+* **name**: The name of the value to get, such as `pedLight.color.red`.
+
+## Return value
+Returns the floating point value of the specified visual setting on success.


### PR DESCRIPTION
### Goal of this PR
This PR introduces a new native function that retrieves values from `visualsettings.dat`. While a setter already exists for modifying these values via script, there was previously no way to read them. This addition provides a convenient method for accessing visual settings.

I had to redo this PR since i messed up the initial PR, as i initially worked on it on the master branch and didn't do a separate branch for it.

old PR : https://github.com/citizenfx/fivem/pull/2951

...


### How is this PR achieving the goal
Create a new native which allows getting the floating point value of a specific visualsettings.dat setting.
...


### This PR applies to the following area(s)
FiveM

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues