### PR TITLE
feat(extra-natives-rdr3): add `GET_PED_BONE_MATRIX` native for RedM

### DIFF
--- a/code/components/extra-natives-rdr3/src/PedNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/PedNatives.cpp
@@ -1,0 +1,57 @@
+#include <StdInc.h>
+#include <ScriptEngine.h>
+#include <Hooking.h>
+#include <EntitySystem.h>
+#include <DirectXMath.h>
+#include <scrEngine.h>
+
+using Matrix4x4 = DirectX::XMFLOAT4X4;
+
+static hook::cdecl_stub<void(void*, uint32_t, Matrix4x4* readMatrix, char)> GetPedBoneTransform([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 0F C2 F7 00 0F 50 C6 83 E0"));
+});
+
+static hook::cdecl_stub<void*(rage::fwEntity*)> GetPedCreatureComponent([]()
+{
+	return hook::get_call(hook::get_pattern("D1 0F 14 FA E8 ? ? ? ? 48 8B C8 4C 8D 44", 4));
+});
+
+static HookFunction hookFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_BONE_MATRIX", [](fx::ScriptContext& context)
+	{
+		rage::fwEntity* ped = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+		uint32_t boneId = context.GetArgument<int>(1);
+
+		if (ped && boneId)
+		{
+
+			void* g_pedCreatureComponent = GetPedCreatureComponent(ped);
+
+			if (g_pedCreatureComponent)
+			{
+
+				Matrix4x4 readMatrix;
+				GetPedBoneTransform(g_pedCreatureComponent, boneId, &readMatrix, (char)0);
+
+				scrVector* forwardVector = context.GetArgument<scrVector*>(2);
+				scrVector* rightVector = context.GetArgument<scrVector*>(3);
+				scrVector* upVector = context.GetArgument<scrVector*>(4);
+				scrVector* atVector = context.GetArgument<scrVector*>(5);
+
+				auto copyVector = [](const float* in, scrVector* out)
+				{
+					out->x = in[0];
+					out->y = in[1];
+					out->z = in[2];
+				};
+
+				copyVector(readMatrix.m[0], forwardVector);
+				copyVector(readMatrix.m[1], rightVector);
+				copyVector(readMatrix.m[2], upVector);
+				copyVector(readMatrix.m[3], atVector);
+			}
+		}
+	});
+});

--- a/ext/native-decls/GetPedBoneMatrix.md
+++ b/ext/native-decls/GetPedBoneMatrix.md
@@ -1,0 +1,30 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+
+## GET_PED_BONE_MATRIX
+
+```c
+void GET_PED_BONE_MATRIX(Ped ped, int boneId, Vector3* forwardVector, Vector3* rightVector, Vector3* upVector, Vector3* position);
+```
+
+Returns the bone matrix of the specified bone id. usefull for entity attachment
+
+## Examples
+```lua
+local fowardVector, rightVector, upVector, position = GetPedBoneMatrix(PlayerPedId(),boneId)
+```
+
+## Parameters
+* **ped**: 
+* **boneId**: 
+
+
+## Return value
+* **forwardVector**: 
+* **rightVector**: 
+* **upVector**: 
+* **position**: 
+


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
this pull request aims to  get  a specified ped bone matrix, this can  be used when attaching entities to ped bone etc
thanks to @Ktos93  

### How is this PR achieving the goal
returns the ped bone matrix of the specified bone id

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491

**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


