### PR TITLE
tweak(github/ci): registry auth and lowercase image name

### DIFF
--- a/.github/workflows/build_alpine_container.yml
+++ b/.github/workflows/build_alpine_container.yml
@@ -23,6 +23,10 @@ jobs:
             sparse-checkout-cone-mode: true
             fetch-depth: 1
             submodules: false
+      - name: Convert repo name to lowercase
+        id: repo_name
+        run: echo "REPO_NAME_LOWER=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -33,19 +37,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME_LOWER }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           file: code/tools/ci/docker-builder/Dockerfile
           push: true
-          tags:  ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}:latest
+          tags:  ${{ env.REGISTRY }}/${{ env.REPO_NAME_LOWER }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.REPO_NAME_LOWER }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/ci/build_linux.sh
+++ b/.github/workflows/ci/build_linux.sh
@@ -6,7 +6,10 @@ ROOT_REPO=$(pwd)
 IMAGE_NAME="fivem-builder-linux-alpine"
 IMAGE_TAG="latest"
 REGISTRY="ghcr.io"
-IMAGE_PATH="${REGISTRY}/${GITHUB_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+REPO_NAME_LOWER="${GITHUB_REPOSITORY,,}"
+
+IMAGE_PATH="${REGISTRY}/${REPO_NAME_LOWER}/${IMAGE_NAME}:${IMAGE_TAG}"
 
 echo "Pulling Docker image from $IMAGE_PATH..."
 docker pull $IMAGE_PATH

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -3,7 +3,8 @@ name: CI Build all products
 on:
   workflow_call:
 
-permissions: {}
+permissions:
+  packages: read
 
 jobs:
   build_all:
@@ -50,7 +51,15 @@ jobs:
         shell: bash
         run: |
           mkdir -p "$ROOT_DEP" && cd "$_" || exit 1
-        
+      
+      - name: Log in to the Container registry
+        if: ${{ matrix.builds[2] == 'linux' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compile
         shell: bash
         run: |

--- a/.github/workflows/pr_opened.yml
+++ b/.github/workflows/pr_opened.yml
@@ -176,6 +176,8 @@ jobs:
   
   build_all:
     name: Build
+    permissions:
+      packages: read
     needs: input_validation
     if: ${{ needs.input_validation.outputs.requires_compilation == 'true' }}
     uses: ./.github/workflows/ci_build.yml


### PR DESCRIPTION
### Goal of this PR
Addresses two oversights from a previous change (#3212).

### How is this PR achieving the goal
- The repository name and owner name are now converted to lowercase before pushing the builder image to the registry. This ensures compatibility with GHCR, which does not support uppercase characters in image names.
- Authentication with the container registry is now performed prior to pulling the image, addressing issues related to private access settings.

**Note:** While these changes have been tested, enterprise organizations may have different configurations when scoping access to private container images. As such, there is no guarantee that this will behave as intended across all environments.

### This PR applies to the following area(s)
GitHub CI

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Github-hosted Runner

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/