### PR TITLE
feat(citizen-devtools): added GET_RESOURCE_MONITOR_DATA

### DIFF
--- a/ext/native-decls/server/GetResourceMonitorData.md
+++ b/ext/native-decls/server/GetResourceMonitorData.md
@@ -1,0 +1,12 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_RESOURCE_MONITOR_DATA
+
+```c
+object GET_RESOURCE_MONITOR_DATA();
+```
+
+## Return value
+An array containing the resource monitor data


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Providing the ability to get data from the resource monitor to visualize it in grafana or something else


### How is this PR achieving the goal

Added the `GET_RESOURCE_MONITOR_DATA` native


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server, Natives


### Successfully tested on

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


