### PR TITLE
fix(extra-natives-rdr3): prevent local entities to be converted to networked objects

### DIFF
--- a/code/components/extra-natives-rdr3/src/NativeFixes.cpp
+++ b/code/components/extra-natives-rdr3/src/NativeFixes.cpp
@@ -155,4 +155,11 @@ static HookFunction hookFunction([]()
 
 		FixPedCombatAttributes();
 	});
+
+	// GET_CLOSEST_OBJECT_OF_TYPE: avoid entities forced to be networked
+	{
+		// By default this native check if the entity is networked, if not it will make the entity networked and we don't want this native to change the network state of the entity to have the same behavior as in fivem
+		auto location = hook::get_pattern("48 85 C0 74 ? 40 38 78 ? 74 ? 8B 15");
+		hook::nop(location, 31);
+	}
 });


### PR DESCRIPTION
### Goal of this PR
Prevent the native `GET_CLOSEST_OBJECT_OF_TYPE` from converting a non-networked object to networked, this causes that when using this native many times it converts unwanted objects to networked and causes the synchronized object pool to fill up quickly.


### How is this PR achieving the goal
Removing instructions that check if the object is already networked.


### This PR applies to the following area(s)
RedM, Natives


### Successfully tested on
**Game builds:** 1491

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2833 


