### PR TITLE
fix(scripting/node-v22): isolate data deallocation sequencing

### DIFF
--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -254,8 +254,8 @@ result_t NodeScriptRuntime::Destroy()
 	node::EmitProcessBeforeExit(m_nodeEnvironment);
 	node::EmitProcessExit(m_nodeEnvironment);
 	node::Stop(m_nodeEnvironment);
-	node::FreeIsolateData(m_isolateData);
 	node::FreeEnvironment(m_nodeEnvironment);
+	node::FreeIsolateData(m_isolateData);
 
 	//uv_loop_close(m_uvLoop);
 	//delete m_uvLoop;


### PR DESCRIPTION
### Goal of this PR
Came up while running with PageHeap enabled.
`FreeIsolateData` deallocates `m_isolate_data`, but `m_nodeEnvironment` still holds a reference to this object in `isolate_data_`. When `FreeEnvironment` is called, it passes this invalid pointer to the `CallbackQueue` via `std::forward`, potentially causing a read access violation on already freed memory.

### How is this PR achieving the goal
We now call `FreeIsolateData` after `FreeEnvironment`, deallocating `m_isolate_data` only after no more object access is guaranteed.

### This PR applies to the following area(s)
Node.js v22 ScRT

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/