### PR TITLE
fix(scripting/node): load bufferish module in server scripts

### DIFF
--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -64,6 +64,7 @@ static const char* g_platformScripts[] =
 	"citizen:/scripting/v8/natives_server.js",
 	"citizen:/scripting/v8/console.js",
 	"citizen:/scripting/v8/timer.js",
+	"citizen:/scripting/v8/bufferish.js",
 	"citizen:/scripting/v8/msgpack.js",
 	"citizen:/scripting/v8/eventemitter2.js",
 	"citizen:/scripting/v8/main.js"


### PR DESCRIPTION
### Goal of this PR
Resolves an error from #3201.


### How is this PR achieving the goal
The bufferish module was only being loaded in the client runtime.


### This PR applies to the following area(s)
ScRT: JS

### Successfully tested on
n/a


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
n/a


