### PR TITLE
fix(v8/scripting): don't encode int64 to BigInt

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -54,6 +54,10 @@ const EXT_LOCALFUNCREF = 11;
 		copyBuffers: true, 
 		// don't throw an error when an invalid date is provided (msgpack-lite compatibility)
 		onInvalidDate: true,
+		// keep int64s as numbers rather then a BigInt (msgpack-lite compatibility)
+		int64AsType: 'number',
+		// Encode BigInt as a number. (msgpack-lite compatibility)
+		largeBigIntToFloat: true
 	};
 
 	/** @type {import("./msgpack").Packr} */


### PR DESCRIPTION
### Goal of this PR

Fixes an oversight where int64s were encoded to BigInt. Breaking compatibility as msgpack-lite didn't do the same

### How is this PR achieving the goal

Force int64s to be encoded as a number same as msgpack-lite

### This PR applies to the following area(s)

FiveM, RedM, Server, ScRT: JS


### Successfully tested on
**Game builds:** N/A

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

#3234 #3232 