### PR TITLE
fix(citizen-server-impl): add the ability to restart categories for command: restart

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -742,7 +742,7 @@ static InitFunction initFunction([]()
 			}
 		});
 
-		auto restartCommandRef = [=](const std::string& resourceName, const bool isPrintStoppedResource) 
+		static auto restartCommandRef = instance->AddCommand("restart", [=](const std::string& resourceName) 
 		{
 			if (resourceName.empty())
 				return;
@@ -752,7 +752,7 @@ static InitFunction initFunction([]()
 				for (const auto& resource : findByComponent(resourceName))
 				{
 					auto conContext = instance->GetComponent<console::Context>();
-					conContext->ExecuteSingleCommandDirect(ProgramArguments{ "restart", resource, "false" });
+					conContext->ExecuteSingleCommandDirect(ProgramArguments{ "restart", resource });
 				}
 
 				return;
@@ -767,25 +767,14 @@ static InitFunction initFunction([]()
 			}
 
 			if (resource->GetState() != fx::ResourceState::Started)
-			{
-				if (isPrintStoppedResource)
-					trace("Can't restart a stopped resource.\n");
+			{	
+				trace(fmt::sprintf("^3Skipping resource \"%s\" restart as it is not started.^7\n", resourceName));
 				return;
 			}
 
 			auto conCtx = instance->GetComponent<console::Context>();
 			conCtx->ExecuteSingleCommandDirect(ProgramArguments{ "stop", resourceName });
 			conCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", resourceName });
-		};
-
-		static auto restartCommand_0 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName)
-		{
-			restartCommandRef(resourceName, true);
-		});
-
-		static auto restartCommand_1 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName, const bool isPrintStoppedResource)
-		{
-			restartCommandRef(resourceName, isPrintStoppedResource);
 		});
 		
 

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -742,7 +742,7 @@ static InitFunction initFunction([]()
 			}
 		});
 
-		auto restartCommandRef = [=](const std::string& resourceName, const bool isPrintStopedResource) 
+		auto restartCommandRef = [=](const std::string& resourceName, const bool isPrintStoppedResource) 
 		{
 			if (resourceName.empty())
 				return;
@@ -768,7 +768,7 @@ static InitFunction initFunction([]()
 
 			if (resource->GetState() != fx::ResourceState::Started)
 			{
-				if (isPrintStopedResource)
+				if (isPrintStoppedResource)
 					trace("Can't restart a stopped resource.\n");
 				return;
 			}
@@ -783,9 +783,9 @@ static InitFunction initFunction([]()
 			restartCommandRef(resourceName, true);
 		});
 
-		static auto restartCommand_1 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName, const bool isPrintStopedResource)
+		static auto restartCommand_1 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName, const bool isPrintStoppedResource)
 		{
-			restartCommandRef(resourceName, isPrintStopedResource);
+			restartCommandRef(resourceName, isPrintStoppedResource);
 		});
 		
 

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -742,7 +742,7 @@ static InitFunction initFunction([]()
 			}
 		});
 
-		static auto restartCommandRef = instance->AddCommand("restart", [=](const std::string& resourceName)
+		auto restartCommandRef = [=](const std::string& resourceName, const bool isPrintStopedResource) 
 		{
 			if (resourceName.empty())
 				return;
@@ -752,7 +752,7 @@ static InitFunction initFunction([]()
 				for (const auto& resource : findByComponent(resourceName))
 				{
 					auto conContext = instance->GetComponent<console::Context>();
-					conContext->ExecuteSingleCommandDirect(ProgramArguments{ "restart", resource });
+					conContext->ExecuteSingleCommandDirect(ProgramArguments{ "restart", resource, "false" });
 				}
 
 				return;
@@ -766,17 +766,28 @@ static InitFunction initFunction([]()
 				return;
 			}
 
-			
 			if (resource->GetState() != fx::ResourceState::Started)
 			{
-				trace("Can't restart a stopped resource.\n");
+				if (isPrintStopedResource)
+					trace("Can't restart a stopped resource.\n");
 				return;
 			}
 
 			auto conCtx = instance->GetComponent<console::Context>();
 			conCtx->ExecuteSingleCommandDirect(ProgramArguments{ "stop", resourceName });
 			conCtx->ExecuteSingleCommandDirect(ProgramArguments{ "start", resourceName });
+		};
+
+		static auto restartCommand_0 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName)
+		{
+			restartCommandRef(resourceName, true);
 		});
+
+		static auto restartCommand_1 = instance->AddCommand("restart", [restartCommandRef](const std::string& resourceName, const bool isPrintStopedResource)
+		{
+			restartCommandRef(resourceName, isPrintStopedResource);
+		});
+		
 
 #if defined(_DEBUG) && defined(_WIN32)
 		static auto openCommandRef = instance->AddCommand("open", [=](const std::string& resourceName)

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -744,6 +744,20 @@ static InitFunction initFunction([]()
 
 		static auto restartCommandRef = instance->AddCommand("restart", [=](const std::string& resourceName)
 		{
+			if (resourceName.empty())
+				return;
+
+			if (isCategory(resourceName))
+			{
+				for (const auto& resource : findByComponent(resourceName))
+				{
+					auto conContext = instance->GetComponent<console::Context>();
+					conContext->ExecuteSingleCommandDirect(ProgramArguments{ "restart", resource });
+				}
+
+				return;
+			}
+
 			auto resource = resman->GetResource(resourceName);
 
 			if (!resource.GetRef())
@@ -752,6 +766,7 @@ static InitFunction initFunction([]()
 				return;
 			}
 
+			
 			if (resource->GetState() != fx::ResourceState::Started)
 			{
 				trace("Can't restart a stopped resource.\n");


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add the ability to restart categories for command: restart
...


### How is this PR achieving the goal
Added ability to use: “restart [resourceCategory]” like start/stop. Also added a new variation of “restart [resourceCategory] [isPrintStoppedResource]” to avoid the situation where a category may contain a resource that is not running. All other behavioral logic remains the same.

![image](https://github.com/user-attachments/assets/742c3268-a5db-49cf-8a3b-c7cece849f2b)
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM, Server
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


