### PR TITLE
tweak(input/five): usabillity improvements

### DIFF
--- a/code/components/citizen-game-main/src/FrontendNui.cpp
+++ b/code/components/citizen-game-main/src/FrontendNui.cpp
@@ -305,7 +305,7 @@ public:
 	{
 	}
 
-	virtual void SetGameMouseFocus(bool val) override
+	virtual void SetGameMouseFocus(bool val, bool flushMouse = true) override
 	{
 	}
 

--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -39,6 +39,8 @@ private:
 
 	bool m_lastTargetMouseFocus = true;
 
+	bool m_flushMouse = true;
+
 public:
 	virtual void GetGameResolution(int* width, int* height) override;
 
@@ -61,17 +63,19 @@ public:
 
 	virtual void UnsetTexture() override;
 
-	virtual void SetGameMouseFocus(bool val) override
+	virtual void SetGameMouseFocus(bool val, bool flushMouse = true) override
 	{
 		m_targetMouseFocus = val;
+		m_flushMouse = flushMouse;
 	}
 
 	void UpdateMouseFocus()
 	{
 		if (m_targetMouseFocus != m_lastTargetMouseFocus)
 		{
-			InputHook::SetGameMouseFocus(m_targetMouseFocus);
+			InputHook::SetGameMouseFocus(m_targetMouseFocus, m_flushMouse);
 			m_lastTargetMouseFocus = m_targetMouseFocus;
+			m_flushMouse = true;
 		}
 	}
 

--- a/code/components/nui-core/include/CefOverlay.h
+++ b/code/components/nui-core/include/CefOverlay.h
@@ -171,7 +171,7 @@ namespace nui
 
 		virtual void UnsetTexture() = 0;
 
-		virtual void SetGameMouseFocus(bool val) = 0;
+		virtual void SetGameMouseFocus(bool val, bool flushMouse = true) = 0;
 
 		virtual HWND GetHWND() = 0;
 

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -144,7 +144,7 @@ namespace nui
 	{
 		if (!HasFocus() && hasFocus)
 		{
-			g_nuiGi->SetGameMouseFocus(false);
+			g_nuiGi->SetGameMouseFocus(false, hasCursor);
 		}
 		else if (!hasFocus && HasFocus())
 		{

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -660,7 +660,12 @@ static HookFunction initFunction([] ()
 						browser->GoForward();
 					}
 				}
+				suppressInput();
 			} break;
+			case WM_XBUTTONDOWN:
+			case WM_XBUTTONDBLCLK:
+				suppressInput();
+				break;
 			case WM_LBUTTONDOWN:
 			case WM_RBUTTONDOWN:
 			case WM_MBUTTONDOWN:

--- a/code/components/nui-core/src/CefInput.cpp
+++ b/code/components/nui-core/src/CefInput.cpp
@@ -20,6 +20,7 @@
 #include <console/Console.VariableHelpers.h>
 
 using nui::HasFocus;
+using nui::HasCursor;
 
 extern nui::GameInterface* g_nuiGi;
 
@@ -353,7 +354,7 @@ static HookFunction initFunction([] ()
 {
 	g_nuiGi->QueryMayLockCursor.Connect([](int& argPtr)
 	{
-		if (HasFocus() && g_hasCursor && !g_keepInput)
+		if (HasFocus() && HasCursor() && !g_keepInput)
 		{
 			argPtr = 0;
 		}

--- a/code/components/rage-input-five/include/InputHook.h
+++ b/code/components/rage-input-five/include/InputHook.h
@@ -68,7 +68,7 @@ extern INPUT_DECL fwEvent<HWND, UINT, WPARAM, LPARAM, bool&, LRESULT&> Deprecate
 
 extern INPUT_DECL fwEvent<int&> QueryMayLockCursor;
 
-INPUT_DECL void SetGameMouseFocus(bool focus);
+INPUT_DECL void SetGameMouseFocus(bool focus, bool flushMouse = true);
 
 INPUT_DECL void EnableSetCursorPos(bool enabled);
 

--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -150,7 +150,9 @@ static char* g_gameKeyArray;
 
 static std::atomic<int> g_isFocusStolenCount;
 
-void InputHook::SetGameMouseFocus(bool focus)
+static std::map<int, std::vector<InputHook::ControlBypass>> g_controlBypasses;
+
+void InputHook::SetGameMouseFocus(bool focus, bool flushMouse)
 {
 	if (focus)
 	{
@@ -165,11 +167,27 @@ void InputHook::SetGameMouseFocus(bool focus)
 
 	if (g_isFocusStolen)
 	{
-		rage::g_input.m_Buttons() = 0;
 		if (*g_diMouseDevice)
 		{
 			(*g_diMouseDevice)->Unacquire();
 		}
+
+		if (flushMouse)
+		{
+			int32_t persistingButtons = 0;
+			for (const auto& [subsystem, bypasses] : g_controlBypasses)
+			{
+				for (const auto [isMouse, ctrlIdx] : bypasses)
+				{
+					if (isMouse)
+					{
+						persistingButtons |= ctrlIdx & 0xFF;
+					}
+				}
+			}
+			rage::g_input.m_Buttons() &= persistingButtons;
+		}
+
 		memset(g_gameKeyArray, 0, 256);
 	}
 
@@ -180,8 +198,6 @@ void InputHook::EnableSetCursorPos(bool enabled)
 {
 	g_enableSetCursorPos = enabled;
 }
-
-static std::map<int, std::vector<InputHook::ControlBypass>> g_controlBypasses;
 
 void InputHook::SetControlBypasses(int subsystem, std::initializer_list<ControlBypass> bypasses)
 {

--- a/code/components/rage-input-rdr3/include/InputHook.h
+++ b/code/components/rage-input-rdr3/include/InputHook.h
@@ -16,7 +16,7 @@ namespace InputHook
 
 	extern INPUT_DECL fwEvent<int&> QueryMayLockCursor;
 
-	INPUT_DECL void SetGameMouseFocus(bool focus);
+	INPUT_DECL void SetGameMouseFocus(bool focus, bool flushMouse = true);
 
 	INPUT_DECL void EnableSetCursorPos(bool enabled);
 }

--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -34,7 +34,7 @@ static void EnableFocus()
 	}
 }
 
-void InputHook::SetGameMouseFocus(bool focus)
+void InputHook::SetGameMouseFocus(bool focus, bool flushMouse)
 {
 	if (!enableFocus || !disableFocus)
 	{


### PR DESCRIPTION
### Goal of this PR
This fixes regressions introduced by some previous changes and improves inconsistencies across different input methods.

### How is this PR achieving the goal
[tweak(nui/core): disable cursor clipping in main menu](https://github.com/citizenfx/fivem/commit/1cdd2262bb9266129d865a8fdb0a18ad030a05a3) 

Small regression introduced by a previous change done by me (https://github.com/citizenfx/fivem/pull/3083) that enabled cursor clipping in the main menu, which is an unwanted behavior in general.

[tweak(input/five): only flush mouse buttons on full focus loss](https://github.com/citizenfx/fivem/commit/0f9ddca23f842bc1a4a63c42375417b183dfdc9f) 

The current implementation is a bit confusing, when we set 'SetGameMouseFocus' in 'InputHook' to false, there are still cases where inputs get passed through, for example when a NUI has focus but no cursor set. In those cases we don't want to flush the mouse buttons as the game continues to receive input, which would require a button repress to keep the input active.

[tweak(input/five): exclude PTT button from flush on focus loss](https://github.com/citizenfx/fivem/commit/0f9ddca23f842bc1a4a63c42375417b183dfdc9f)

Another small regression introduced by a previous change done by me (https://github.com/citizenfx/fivem/pull/3076) that flushes mouse buttons on focus loss. This successfully fixes stuck mouse button, but also resets the PTT button state on focus loss, which of course isn't intended behavior.

[tweak(nui/core): block X-Buttons on WndProc](https://github.com/citizenfx/fivem/commit/fd6f1d94d0db1a99fcee9ae7972d45d88e26200b) 

This missed case handling for WM_XBUTTONDOWN and similar, causing the game camera to stutter and the PTT state to reset when a NUI had full focus and a user was pressing a X-Button (commonly used for PTT) while the game received other inputs (mouse move, ...). This only affects users that have their input setting set to "Windows".

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #3230 