### PR TITLE
fix(mumble): match MAX_USERNAME length with FXServers limit

### DIFF
--- a/code/components/voip-server-mumble/src/messagehandler.cpp
+++ b/code/components/voip-server-mumble/src/messagehandler.cpp
@@ -47,7 +47,8 @@
 #include "ChannelListener.h"
 
 #define MAX_TEXT 512
-#define MAX_USERNAME 128
+// fivem usernames can be 200 characters long + 8 for the max prefix size "[65535] "
+#define MAX_USERNAME 208
 
 #define NO_CELT_MESSAGE "<strong>WARNING:</strong> Your client doesn't support the CELT codec, you won't be able to talk to or hear most clients. Please make sure your client was built with CELT support."
 


### PR DESCRIPTION
### Goal of this PR
This fixes cases where clients would be dropped from the mumble server on connecting even if their name was valid

### How is this PR achieving the goal
Making MAX_USERNAME match the fxserver max username


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

