### PR TITLE
fix(game/five): hotfix for disappearing hair on mask switch

### DIFF
--- a/code/components/gta-core-five/src/PedAlternateVariationCache.cpp
+++ b/code/components/gta-core-five/src/PedAlternateVariationCache.cpp
@@ -92,8 +92,6 @@ static void AddAlternateVariationsCacheEntry(TAlternateVariationsCache* cacheMap
 
 static void LoadAlternateVariationSwitches(TAlternateVariationsSwitchSet* switchSet, atArray<AlternateVariationsSwitchAsset>* outArray)
 {
-	outArray->m_count = 0;
-
 	for (auto cacheEntry : *switchSet)
 	{
 		// outArray is stored on stack so we want
@@ -107,7 +105,6 @@ static void LoadAlternateVariationSwitches(TAlternateVariationsSwitchSet* switch
 		
 		// rough but will work
 		auto switchAsset = *(AlternateVariationsSwitchAsset*)&cacheEntry->data;
-		assert(outArray->m_count < outArray->GetSize());
 		outArray->Set(outArray->m_count++, std::move(switchAsset));
 	}
 }
@@ -147,6 +144,8 @@ static bool GetAlternateVariationSwitchesByIndex(AlternateVariationsPed* pedEntr
 		return g_origGetAlternateVariationSwitchesByIndex(pedEntry, component, index, dlcNameHash, outArray);
 	}
 
+	outArray->m_count = 0;
+
 	if (auto cachedSwitches = GetAlternateVariationsCacheEntry(&g_cachedAlternatesByIndex, pedEntry->name, dlcNameHash, component, index))
 	{
 		LoadAlternateVariationSwitches(cachedSwitches, outArray);
@@ -163,6 +162,8 @@ static bool GetAlternateVariationSwitchesByAnchor(AlternateVariationsPed* pedEnt
 	{
 		return g_origGetAlternateVariationSwitchesByAnchor(pedEntry, component, anchor, dlcNameHash, outArray);
 	}
+
+	outArray->m_count = 0;
 
 	if (auto cachedSwitches = GetAlternateVariationsCacheEntry(&g_cachedAlternatesByAnchor, pedEntry->name, dlcNameHash, component, anchor))
 	{


### PR DESCRIPTION
### Goal of this PR
This PR fixes an oversight introduced in https://github.com/citizenfx/fivem/pull/3195 that causes hairstyles to reset when equipping or removing a mask.

### How is this PR achieving the goal
Previously, `outArray->m_count = 0;` was only called when the condition in `GetAlternateVariationsCacheEntry` was met. This PR ensures that it is always called, preventing unintended hairstyle resets.

Additionally, the assert statement has been removed. While not directly related to the fix, it was unnecessary.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #3236 