### PR TITLE
feat(gamestate/server): sv_protectServerEntities

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -104,6 +104,9 @@ static bool g_networkedPhoneExplosionsEnabled;
 static std::shared_ptr<ConVar<bool>> g_networkedScriptEntityStatesEnabledVar;
 static bool g_networkedScriptEntityStatesEnabled;
 
+static std::shared_ptr<ConVar<bool>> g_protectServerEntitiesDeletionVar;
+static bool g_protectServerEntitiesDeletion;
+
 static std::shared_ptr<ConVar<int>> g_requestControlVar;
 static std::shared_ptr<ConVar<int>> g_requestControlSettleVar;
 
@@ -3172,6 +3175,13 @@ void ServerGameState::ProcessCloneRemove(const fx::ClientSharedPtr& client, rl::
 		if (entity->uniqifier != uniqifier)
 		{
 			GS_LOG("%s: wrong uniqifier (%d - %d->%d)\n", __func__, objectId, uniqifier, entity->uniqifier);
+
+			return;
+		}
+
+		if (entity->IsOwnedByServerScript() && g_protectServerEntitiesDeletion)
+		{
+			GS_LOG("%s: entity is owned by server script %d\n", __func__, objectId);
 
 			return;
 		}
@@ -7785,6 +7795,8 @@ static InitFunction initFunction([]()
 		g_networkedSoundsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedSounds", ConVar_None, true, &g_networkedSoundsEnabled);
 
 		g_networkedPhoneExplosionsEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedPhoneExplosions", ConVar_None, false, &g_networkedPhoneExplosionsEnabled);
+
+		g_protectServerEntitiesDeletionVar = instance->AddVariable<bool>("sv_protectServerEntities", ConVar_Replicated, false, &g_protectServerEntitiesDeletion);
 
 		g_networkedScriptEntityStatesEnabledVar = instance->AddVariable<bool>("sv_enableNetworkedScriptEntityStates", ConVar_None, true, &g_networkedScriptEntityStatesEnabled);
 

--- a/code/components/gta-net-five/src/ClientRPC.cpp
+++ b/code/components/gta-net-five/src/ClientRPC.cpp
@@ -201,7 +201,7 @@ int ObjectToEntity(int objectId);
 namespace sync
 {
 std::map<int, int> g_creationTokenToObjectId;
-std::map<int, uint32_t> g_objectIdToCreationToken;
+std::map<int, uint32_t> g_objectIdToCreationTokenRPC;
 
 static hook::cdecl_stub<void*(int handle)> getScriptEntity([]()
 {
@@ -528,7 +528,7 @@ public:
 
 									g_creationTokenToObjectId[creationToken] = (1 << 16) | obj;
 
-									g_objectIdToCreationToken[obj] = creationToken;
+									g_objectIdToCreationTokenRPC[obj] = creationToken;
 								}
 							}
 						}

--- a/code/components/gta-net-five/src/NetServerObject.cpp
+++ b/code/components/gta-net-five/src/NetServerObject.cpp
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <StdInc.h>
+#include <Hooking.h>
+#include <MinHook.h>
+#include <netObject.h>
+#include <ICoreGameInit.h>
+#include <NetLibrary.h>
+#include <EntitySystem.h>
+#include <CoreConsole.h>
+
+static ICoreGameInit* icgi;
+
+static bool g_protectServerEntity = false;
+
+namespace sync
+{
+	extern std::unordered_map<int, uint32_t> g_objectIdToCreationToken;
+}
+
+static bool CanEntityBeDeleted(rage::netObject* netObject)
+{
+	if (!g_protectServerEntity)
+	{
+		return true;
+	}
+
+	uint16_t creationToken = sync::g_objectIdToCreationToken[netObject->GetObjectId()];
+	
+	if (creationToken != 0)
+	{
+		return netObject->syncData.wantsToDelete && !netObject->syncData.shouldNotBeDeleted;
+	}
+
+	return true;
+}
+
+static void (*g_origCVehicleFactoryDestroy)(void*, CVehicle*, bool);
+static void CVehicleFactory_Destroy(void* self, CVehicle* vehicle, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !vehicle->GetNetObject() || CanEntityBeDeleted((rage::netObject*)vehicle->GetNetObject()))
+	{
+		g_origCVehicleFactoryDestroy(self, vehicle, unk);
+	}
+}
+
+static void (*g_origCPedFactoryDestroy)(void*, fwEntity*, bool);
+static void CPedFactory_Destroy(void* self, fwEntity* ped, bool unk)
+{
+	if (!icgi->OneSyncEnabled || !ped->GetNetObject() || CanEntityBeDeleted((rage::netObject*)ped->GetNetObject()))
+	{
+		g_origCPedFactoryDestroy(self, ped, unk);
+	}
+}
+
+static void (*g_destroyObject)(fwEntity*, int);
+static void DestroyObject(fwEntity* object, int unk)
+{
+	if (!icgi->OneSyncEnabled || !object->GetNetObject() || CanEntityBeDeleted((rage::netObject*)object->GetNetObject()))
+	{
+		g_destroyObject(object, unk);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	static ConVar<bool> protectServerEntities("sv_protectServerEntities", ConVar_Replicated, false, &g_protectServerEntity);
+
+	// Block the client from being able to delete server-setter entities if "sv_protectServerEntities" is set. 
+	// This prevents the deleted object from "flickering" as it gets instantly re-created by the server
+	{
+        MH_Initialize();
+		MH_CreateHook(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? FF 05"), CVehicleFactory_Destroy, (void**)&g_origCVehicleFactoryDestroy);
+		MH_CreateHook(hook::get_pattern("48 8B F1 48 85 D2 74 ? 48 8B 8A", -0x15), CPedFactory_Destroy, (void**)&g_origCPedFactoryDestroy);
+		MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 85 FF 74 ? F7 87")), DestroyObject, (void**)&g_destroyObject);
+		MH_EnableHook(MH_ALL_HOOKS);
+	}
+});
+
+static InitFunction initFunctionSv([]()
+{
+	NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary* netLibrary)
+	{
+	   icgi = Instance<ICoreGameInit>::Get();
+	});
+});


### PR DESCRIPTION
### Goal of this PR

Prevent clients from being able to delete server-setter vehicles if ``sv_protectServerEntities`` is enabled. While also minimising the impact on the client that attempts the deletion.

### How is this PR achieving the goal

By blocking clone removal on the server side if the entity the client is attempting to delete is owned by a server-script. Checks on Functions related to delete Peds, Vehicles and Objects are hooked to ensure that these entities cannot be deleted by game code/natives. This prevents desync cases where the entity owner has deleted the entity on their client. 


### This PR applies to the following area(s)

FiveM, Server

### Successfully tested on

A test resources used to ensure the new changes worked and previous behaviour remained the same is provided with more details being found in server.lua: 
[entity-protection.zip](https://github.com/user-attachments/files/19267120/entity-protection.zip)

**Game builds:**  1604, 3258, 3407

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->




- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
resolves #962 

