### PR TITLE
fix(five/game): custom station sync from passenger

### DIFF
--- a/code/components/gta-core-five/src/PatchVehicleRadioSync.cpp
+++ b/code/components/gta-core-five/src/PatchVehicleRadioSync.cpp
@@ -31,5 +31,8 @@ static HookFunction hookFunction([]()
 
 		location = hook::get_pattern<char>("E8 ? ? ? ? 83 C0 ? 89 83");
 		hook::call(location, GetRadioStationMetaIndex);
+
+		location = hook::get_pattern<char>("E8 ? ? ? ? 40 8A F8 40 8A D7");
+		hook::call(location, GetRadioStationMetaIndex);
 	}
 });


### PR DESCRIPTION
### Goal of this PR

Fixes an issue in >2944. As behaviour was changed with radio station syncing. This restores the ability for a passenger to change the radio station to a custom station without it being set to 255 (OFF)

### How is this PR achieving the goal

Redirect call to ``GetRadioStationMetaIndex`` which contains all registered radio stations without filtering for stations that are apart of Dat151RelType 124 (RadioStationList2). Restoring previous functionality

### This PR applies to the following area(s)

FiveM

### Successfully tested on

Tested with custom radio stations + vanilla radio stations

**Game builds:** 2944, 3258, 3407

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


