### PR TITLE
fix(citizen-scripting-core): fixed ClearTimeout after Wait

### DIFF
--- a/code/components/citizen-scripting-core/include/fxScripting.idl
+++ b/code/components/citizen-scripting-core/include/fxScripting.idl
@@ -190,6 +190,8 @@ interface IScriptHostWithBookmarks : fxIBase
 
 	void RemoveBookmarks(in IScriptTickRuntimeWithBookmarks runtime);
 
+	void RemoveBookmark(in IScriptTickRuntimeWithBookmarks runtime, in uint64_t bookmark);
+
 	void CreateBookmarks(in IScriptTickRuntimeWithBookmarks runtime);
 };
 

--- a/code/components/citizen-scripting-core/src/ScriptHost.cpp
+++ b/code/components/citizen-scripting-core/src/ScriptHost.cpp
@@ -112,6 +112,34 @@ static void RemoveBookmarks(IScriptTickRuntimeWithBookmarks* scRT)
 	bookmarkRefs.resourceInsertionIterators.erase(scRT);
 }
 
+static void RemoveBookmark(IScriptTickRuntimeWithBookmarks* scRT, uint64_t bookmark)
+{
+	auto exIt = (bookmarkRefs.executing) ? bookmarkRefs.executingIt : nullptr;
+
+	auto list = &bookmarkRefs.list;
+
+	{
+		for (auto it = list->begin(); it != list->end();)
+		{
+			if (it->bookmark == bookmark)
+			{
+				if (exIt && *exIt == it)
+				{
+					*exIt = it = list->erase(it);
+				}
+				else
+				{
+					it = list->erase(it);
+				}
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+}
+
 static void RunBookmarks()
 {
 	bookmarkRefs.executing = true;
@@ -500,6 +528,13 @@ result_t TestScriptHost::CreateBookmarks(IScriptTickRuntimeWithBookmarks* scRT)
 	::CreateBookmarks(scRT);
 	return FX_S_OK;
 }
+
+result_t TestScriptHost::RemoveBookmark(IScriptTickRuntimeWithBookmarks* scRT, uint64_t bookmark)
+{
+	::RemoveBookmark(scRT, bookmark);
+	return FX_S_OK;
+}
+
 
 result_t TestScriptHost::ScheduleBookmark(IScriptTickRuntimeWithBookmarks* scRT, uint64_t bookmark, int64_t deadline)
 {

--- a/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
+++ b/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
@@ -380,6 +380,8 @@ public:
 
 	void SchedulePendingBookmarks();
 
+	bool RemoveBookmark(uint64_t bookmark);
+
 public:
 	NS_DECL_ISCRIPTRUNTIME;
 

--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -1157,22 +1157,8 @@ static int Lua_ClearTimeout(lua_State* L)
 	int bookmark = luaL_checkinteger(L, 1);
 
 	auto& luaRuntime = fx::LuaScriptRuntime::GetCurrent();
-	lua_State* runtimeState = luaRuntime->GetState();
-
-	bool removed = false;
-
-	auto& pending = luaRuntime->GetPendingBookmarks();
-	for (auto it = pending.begin(); it != pending.end(); ++it)
-	{
-		if (std::get<0>(*it) == static_cast<uint64_t>(bookmark))
-		{
-			pending.erase(it);
-
-			luaL_unref(runtimeState, LUA_REGISTRYINDEX, bookmark);
-			removed = true;
-			break;
-		}
-	}
+	lua_State* runtimeState = luaRuntime->GetRunningThread();
+	bool removed = luaRuntime->RemoveBookmark(bookmark);
 
 	lua_pushboolean(L, removed);
 	return 1;
@@ -1298,6 +1284,13 @@ void LuaScriptRuntime::SchedulePendingBookmarks()
 
 		m_pendingBookmarks.clear();
 	}
+}
+
+bool LuaScriptRuntime::RemoveBookmark(uint64_t bookmark)
+{
+	result_t success = GetScriptHostWithBookmarks()->RemoveBookmark(this, bookmark);
+
+	return success == FX_S_OK;
 }
 
 void LuaScriptRuntime::SetTickRoutine(const std::function<void(uint64_t, bool)>& tickRoutine)


### PR DESCRIPTION
### Goal of this PR

A ClearTimeout() in another thread or after a wait() has no effect, and the SetTimeout continues to execute.


### How is this PR achieving the goal

I basically wrote a function to remove a bookmark directly in the `ScriptHost.cpp` to manage bookmarks between threads, etc.


### This PR applies to the following area(s)

FiveM, RedM, Server, ScRT: Lua

### Successfully tested on

**Game builds:** v3258

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

fixes #3259 

