### PR TITLE
tweak(five): edit carcols aka sirensettings value to allow for 16bit

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -986,16 +986,23 @@ struct CVehicleDamageStatusDataNode
 
 		bool anySirenBroken = state.buffer.ReadBit();
 
-		if (anySirenBroken)
-		{
-			for (int i = 0; i < 20; i++)
-			{
-				bool sirenBroken = state.buffer.ReadBit();
-			}
-		}
+        if (anySirenBroken)
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                // Read 16 bits for each siren status if you need to check 16 bits at once
+                uint16_t sirenStatus = state.buffer.Read<uint16_t>(16);  // Reading a 16-bit value
 
-		return true;
-	}
+                // Process each bit of the 16-bit value
+                for (int j = 0; j < 16; j++)
+				{
+                    bool sirenBroken = (sirenStatus & (1 << j)) != 0;  // Check if the bit is set
+                }
+            }
+        }
+
+        return true;
+    }
 };
 
 struct CVehicleComponentReservationDataNode { };

--- a/code/components/gta-streaming-five/src/ModKitIdRelocation.cpp
+++ b/code/components/gta-streaming-five/src/ModKitIdRelocation.cpp
@@ -59,22 +59,22 @@ static HookFunction hookFunction([]()
 {
 	_vehicleModKitArray = (uint16_t*)hook::AllocateStubMemory(sizeof(uint16_t) * NUM_MODKIT_INDICES);
 	RelocateRelative(
-	{ { "66 3B F0 73 ? 48 8D", 8 },
-	{ "66 41 3B C0 73 ? 48 8D", 9 },
-	{ "45 33 C0 4C 8D 0D ? ? ? ? B9", 6 },
-	{ "B8 FF FF 00 00 48 8D 3D", 8 },
-	{ "7D ? 41 BC FF FF 00 00 4C 8D 3D", 11 } });
+	{ { "66 3B F0 66 73 ?? 48 8D", 8 },  // Adjusted to 16-bit search: 66 3B F0 66 73 ?? 48 8D
+	{ "66 41 3B C0 66 73 ?? 48 8D", 9 },  // Adjusted to 16-bit search: 66 41 3B C0 66 73 ?? 48 8D
+	{ "45 33 C0 4C 8D 0D ?? ?? ?? ?? B9", 6 },  // Adjusted for 16-bit match (??)
+	{ "66 B8 FF FF 00 00 48 8D 3D", 8 },  // Adjusted to 16-bit search: 66 B8 FF FF 00 00 48 8D 3D
+	{ "7D ?? 41 BC FF FF 00 00 4C 8D 3D", 11 } });  // Adjusted for 16-bit match (??)
 	RelocateAbsolute(
-	{ { "66 3B D1 73 ? 8B C2", 11 },
-	{ "66 39 4B 2A 73 ? 0F", 14 } });
-	hook::nop(hook::get_pattern("66 3B F0 73 ? 48 8D", 0), 5);
-	hook::nop(hook::get_pattern("66 41 3B C0 73 ? 48 8D", 0), 6);
-	hook::nop(hook::get_pattern("66 3B D1 73 ? 8B C2", 0), 5);
-	hook::nop(hook::get_pattern("66 39 4B 2A 73 ? 0F", 0), 6);
+	{ { "66 3B D1 66 73 ?? 8B C2", 11 },  // Adjusted to 16-bit search: 66 3B D1 66 73 ?? 8B C2
+	{ "66 39 4B 2A 66 73 ?? 0F", 14 } });  // Adjusted to 16-bit search: 66 39 4B 2A 66 73 ?? 0F
+	hook::nop(hook::get_pattern("66 3B F0 66 73 ?? 48 8D", 0), 5);
+	hook::nop(hook::get_pattern("66 41 3B C0 66 73 ?? 48 8D", 0), 6);
+	hook::nop(hook::get_pattern("66 3B D1 66 73 ?? 8B C2", 0), 5);
+	hook::nop(hook::get_pattern("66 39 4B 2A 66 73 ?? 0F", 0), 6);
 	hook::nop(hook::get_pattern("41 81 F8 00 04 00 00 7C", 0), 9);
 
 	{
-		auto location = hook::get_pattern("B8 FF FF 00 00 48 8D 3D", 13);
+		auto location = hook::get_pattern("66 B8 FF FF 00 00 48 8D 3D", 13);
 		hook::put<int32_t>(location, NUM_MODKIT_INDICES);
 	}
 });


### PR DESCRIPTION
### Goal of this PR
Adjust from 8-bit to 16-bit carcols/sirensettings values to go beyond 255. Fixing servers that have reached more than 255 emergency vehicles in regards to conflicting carcols ID values.

This value is located in carcols.meta under <siren> <id value="123"> as well as carvariations.meta <sirensettings value="123"> and is currently an 8-bit value thus limiting people to only 255 unique values.

...


### How is this PR achieving the goal
- Attempt to allow reading of not only single bit values but 16-bit values as well.
- Read values properly.
...


### This PR applies to the following area(s)
FiveM, Server, C#
...


### Successfully tested on
Not yet tested.

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Allow for more than 255 emergency vehicles with unique siren - emergency light patterns.

Basic attempt [with little knowledge, apologies] to fix: https://github.com/citizenfx/fivem/issues/2612
