### PR TITLE
feat(core/sbag): allow state bag modifications in strict mode

### DIFF
--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -388,15 +388,13 @@ static InitFunction initFunction([] ()
     	context.SetResult(false);
 	});
 
-	fx::ScriptEngine::RegisterNativeHandler("ALLOW_CLIENT_STATE_BAG", [](fx::ScriptContext& context)
-	{
-    	#ifndef IS_FXSERVER
-        	return;
-    	#endif
-
-    	auto bagName = context.CheckArgument<const char*>(0);
-    	allowedClientStateBags.insert(bagName);
-	});
+	#ifdef IS_FXSERVER
+    	fx::ScriptEngine::RegisterNativeHandler("ALLOW_CLIENT_STATE_BAG", [](fx::ScriptContext& context)
+    	{
+        	auto bagName = context.CheckArgument<const char*>(0);
+        	allowedClientStateBags.insert(bagName);
+    	});
+	#endif
 
 	fx::ScriptEngine::RegisterNativeHandler("ADD_STATE_BAG_CHANGE_HANDLER", [](fx::ScriptContext& context)
 	{

--- a/ext/native-decls/server/AllowClientStateBag
+++ b/ext/native-decls/server/AllowClientStateBag
@@ -1,0 +1,25 @@
+---
+ns: CFX
+apiset: server
+---
+## ALLOW_CLIENT_STATE_BAG
+
+```c
+void ALLOW_CLIENT_STATE_BAG(char* bagName);
+```
+
+Allows a specific state bag to be modified by the client when sv_stateBagStrictMode is enabled.
+
+By default, when sv_stateBagStrictMode is active, clients cannot modify state bags unless explicitly allowed.
+This function adds the specified state bag to the allowlist, enabling client-side modifications.
+
+## Parameters
+* **bagName**: The name of the state bag to allow client modifications on.
+
+## Return value
+This function does not return a value.
+
+## Examples
+```lua
+AllowClientStateBag("jailtime")
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Allow modification of specific state bags in strict mode by introducing a way to 'whitelist' them.


### How is this PR achieving the goal

- Added a new native, `ALLOW_CLIENT_STATE_BAG`, to allow client state bag modifications in `sv_stateBagStrictMode`.
- Updated `SET_STATE_BAG_VALUE` to check `allowedClientStateBags` before allowing modifications.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, Natives, Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** -

**Platforms:** -


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


