### PR TITLE
fix(game/rdr3): forces net peds attachment to draftveh to work

### DIFF
--- a/code/components/gta-core-rdr3/src/GameInitRage.cpp
+++ b/code/components/gta-core-rdr3/src/GameInitRage.cpp
@@ -284,4 +284,10 @@ static HookFunction hookFunctionNet([]()
 
 	// ignore collision-related archetype flag in /CREATE_OBJECT(_NO_OFFSET)?/
 	hook::nop(hook::get_pattern("8B 48 50 48 C1 E9 11 F6 C1 01 0F 84 ? ? 00 00 45", 10), 6);
+
+	// forces networked peds (like horses) attachment to draftveh to work
+	if (xbr::IsGameBuildOrGreater<1491>())
+	{
+		hook::nop(hook::get_pattern("48 83 BE E0 ? ? ? ? ? ? 48 85 C9"), 0xA);
+	}
 });


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Forces networked peds (horses) attachment to networked draft vehicles to work, rdr3 implemented a check to block it to prevent rdr online abuses.

A similar entity attachments check was implemented on gta5 b2545 and it got patched for fivem, restricting this block server owners creativity to have special horses for draft vehicles.


### How is this PR achieving the goal

NOP the instructions blocking the attachment.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


