### PR TITLE
feat(extra-natives-rdr3): add `GET_ENTITIES_IN_RADIUS` for RedM

### DIFF
--- a/code/components/citizen-scripting-core/include/ScriptSerialization.h
+++ b/code/components/citizen-scripting-core/include/ScriptSerialization.h
@@ -25,4 +25,25 @@ namespace fx
 
 		return packed;
 	}
+
+	template<typename T>
+	inline T DeserializeObject(const scrObject& obj, bool* outSuccess = nullptr)
+	{
+		T result {};
+		try
+		{
+			msgpack::unpacked unpacked;
+			msgpack::unpack(unpacked, obj.data, obj.length);
+			result = unpacked.get().as<T>();
+			if (outSuccess)
+				*outSuccess = true;
+		}
+		catch (...)
+		{
+			if (outSuccess)
+				*outSuccess = false;
+		}
+		return result;
+	}
+
 }

--- a/code/components/extra-natives-rdr3/src/EntityNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/EntityNatives.cpp
@@ -1,0 +1,87 @@
+#include "StdInc.h"
+#include "Hooking.h"
+#include <EntitySystem.h>
+#include <ScriptEngine.h>
+#include <Pool.h>
+#include <ScriptSerialization.h>
+
+static hook::cdecl_stub<uint32_t(fwEntity*)> getScriptGuidForEntity([]()
+{
+	return hook::get_pattern("32 DB E8 ? ? ? ? 48 85 C0 75 ? 8A 05", -35);
+});
+
+constexpr const char* GetPoolNameForEntityType(int entityType)
+{
+	constexpr std::array<const char*, 4> poolNames = {
+		"Invalid", // 0
+		"Peds", // 1
+		"CVehicle", // 2
+		"Object" // 3
+	};
+	return (entityType >= 1 && entityType <= 3)
+		   ? poolNames[entityType]
+		   : "Object";
+}
+
+static HookFunction hookFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITIES_IN_RADIUS", [](fx::ScriptContext& context)
+	{
+		float checkX = context.GetArgument<float>(0);
+		float checkY = context.GetArgument<float>(1);
+		float checkZ = context.GetArgument<float>(2);
+		float radius = context.GetArgument<float>(3);
+		int entityType = context.GetArgument<int>(4);
+		bool sortOutput = context.GetArgument<bool>(5);
+		fx::scrObject models = context.GetArgument<fx::scrObject>(6);
+
+		std::vector<std::pair<float, int>> entities;
+
+		std::vector<int> modelList = fx::DeserializeObject<std::vector<int>>(models);
+		std::unordered_set<int> modelSet(modelList.begin(), modelList.end());
+
+		float squaredMaxDistance = radius * radius;
+
+		auto objectPool = rage::GetPool<fwEntity>(GetPoolNameForEntityType(entityType));
+		for (int i = 0; i < objectPool->GetSize(); i++)
+		{
+			fwEntity* entity = objectPool->GetAt(i);
+			if (!entity)
+				continue;
+
+			auto position = entity->GetPosition();
+
+			float dx = position.x - checkX;
+			float dy = position.y - checkY;
+			float dz = position.z - checkZ;
+			float distSq = dx * dx + dy * dy + dz * dz;
+
+			if (distSq >= squaredMaxDistance)
+				continue;
+
+			auto modelHash = entity->GetArchetype()->hash;
+
+			if (modelSet.empty() || modelSet.find(modelHash) != modelSet.end())
+			{
+				entities.push_back({ distSq, getScriptGuidForEntity(entity) });
+			}
+		}
+
+		if (sortOutput)
+		{
+			std::sort(entities.begin(), entities.end(), [](const auto& a, const auto& b)
+			{
+				return a.first < b.first;
+			});
+		}
+
+		std::vector<int> entityList;
+		entityList.reserve(entities.size());
+		for (auto& entry : entities)
+		{
+			entityList.push_back(entry.second);
+		}
+
+		context.SetResult(fx::SerializeObject(entityList));
+	});
+});

--- a/code/components/gta-streaming-rdr3/include/EntitySystem.h
+++ b/code/components/gta-streaming-rdr3/include/EntitySystem.h
@@ -161,12 +161,19 @@ public:
 		return m_entityType;
 	}
 
+	inline fwArchetype* GetArchetype()
+	{
+		return m_archetype;
+	}
+
 private:
-	char m_pad[40]; // +8
+	char m_pad[24]; // +8
+	fwArchetype* m_archetype; // +32
+	char m_pad2[8]; // +40
 	uint8_t m_entityType; // +48
-	char m_pad2[15]; // +49
+	char m_pad3[15]; // +49
 	rage::PreciseTransform m_transform; // +64
-	char m_pad3[96]; // +128
+	char m_pad4[96]; // +128
 	void* m_netObject; // +224
 };
 

--- a/ext/native-decls/GetEntitiesInRadius.md
+++ b/ext/native-decls/GetEntitiesInRadius.md
@@ -1,0 +1,49 @@
+---
+ns: CFX
+apiset: shared
+---
+## GET_ENTITIES_IN_RADIUS
+
+```c
+object GET_ENTITIES_IN_RADIUS(float x, float y, float z, float radius, int entityType, BOOL sortByDistance, object models);
+```
+
+### Supported types
+* [1] : Peds (including animals) and players.
+* [2] : Vehicles.
+* [3] : Objects (props), doors, and projectiles.
+
+
+### Coordinates need to be send unpacked (x,y,z)
+```lua
+
+-- Define the allowed model hashes
+local allowedModelHashes = { GetHashKey("p_crate03x"), GetHashKey("p_crate22x") }
+
+-- Get the player's current coordinates
+local playerCoords = GetEntityCoords(PlayerPedId())
+
+-- Retrieve all entities of type Object (type 3) within a radius of 10.0 units
+-- that match the allowed model hashes
+-- and sort output entities by distance
+local entities = GetEntitiesInRadius(playerCoords.x, playerCoords.y, playerCoords.z, 10.0, 3, true, allowedModelHashes)
+
+-- Iterate through the list of entities and print their ids
+for i = 1, #entities do
+    local entity = entities[i]
+    print(entity)
+end
+
+```
+
+## Parameters
+* **x**: The X coordinate.
+* **y**: The Y coordinate.
+* **z**: The Z coordinate.
+* **radius**: Max distance from coordinate to entity
+* **entityType**: Entity types see list below
+* **sortByDistance**: Sort output entites by distance from nearest to farthest
+* **models**: List of allowed models its also optional
+
+## Return value
+An array containing entity handles for each entity.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This PR introduces a new native function that retrieves entities within a specified radius using various parameters. It addresses several key issues:

- **Entity Set Limitations:** Current entity sets are limited to 255 entries, and many servers fail to clear them, leading to pool overflows.

- **Single Object Limitation:** The existing `GET_CLOSEST_OBJECT_OF_TYPE` function returns only one object and one model, which restricts its usability.

- **Performance Improvements:** Although servers can achieve similar results using Lua with the `GET_GAME_POOL` native, running this function every frame with same logic takes approximately 0.45ms in Lua, whereas the new native performs the task in around 0.05ms. [Done just for test performance no one use this every frame]

The new native function provides a more flexible and efficient solution for managing and querying entities.
### How is this PR achieving the goal

This PR registers a new native function, `GET_ENTITIES_IN_RADIUS`, which iterates through the appropriate entity pool to filter entities based on their distance from a given point and an optional list of model hashes, with an option to sort results by proximity. It then serializes and returns a list of entits, providing a more efficient and flexible alternative for entity querying.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



