### PR TITLE
feat(extra-natives-rdr3): add `GET_ASPECT_RATIO` native RedM

### DIFF
--- a/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
@@ -326,17 +326,30 @@ static HookFunction hookFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_CURRENT_SCREEN_RESOLUTION", [](fx::ScriptContext& context)
 	{
-		 int width = 0;
-		 int height = 0;
+		int width = 0;
+		int height = 0;
 
 		if (g_screenWidth && g_screenHeight)
 		{
-			 width = *g_screenWidth;
-			 height = *g_screenHeight;
+			width = *g_screenWidth;
+			height = *g_screenHeight;
 		}
 
 		*context.GetArgument<int*>(0) = width;
 		*context.GetArgument<int*>(1) = height;
+	});
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_ASPECT_RATIO", [](fx::ScriptContext& context)
+	{
+		float aspectRatio = 0.0f;
+
+		if (g_screenWidth && g_screenHeight && *g_screenWidth && *g_screenHeight )
+		{
+			int width = *g_screenWidth;
+			int height = *g_screenHeight;
+			aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+		}
+
+		context.SetResult<float>(aspectRatio);
 	});
 });

--- a/ext/native-decls/GetAspectRatio.md
+++ b/ext/native-decls/GetAspectRatio.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_ASPECT_RATIO
+
+```c
+float GET_ASPECT_RATIO();
+```
+
+Gets the current aspect ratio
+
+```lua
+local ratio = GetAspectRatio()
+print(string.format("%.2f", ratio))
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR adds a dedicated aspect ratio native in RedM to mirror FiveM’s existing functionality. While GET_CURRENT_SCREEN_RESOLUTION can technically yield the aspect ratio (x/y), a specific native clarifies its purpose and makes usage more straightforward for developers

### How is this PR achieving the goal
It introduces a new native  that directly returns the current aspect ratio

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux

windows
### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


