### PR TITLE
tweak(github): allow feature requests again & improve template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: |
         Thank you for taking the time to fill out this feature request.
-        Only feature requests are accepted, so please refrain from submitting any other requests (including support requests).
+        Only feature requests are accepted, so please refrain from submitting any other requests (including support requests or security issues).
         
         \* Requests that fail to deliver the proper information may be closed without any feedback.
   
@@ -30,12 +30,12 @@ body:
       description: |
         To your knowledge how would you describe the importancy of this feature?
       options:
-        - Unknown
-        - Nice extra
         - Quality of Life (QoL)
         - Overall quality to the platform
         - Prerequisite for my project
         - Fatal (we can't use the platform without)
+        - Nice extra
+        - Unknown
   
   - type: textarea
     id: implementation
@@ -54,15 +54,17 @@ body:
       description: |
         Which of the following areas does this request apply to? Please mark all that apply.
       options:
+        - FiveM (Legacy)
         - FiveM
         - RedM
         - FXServer
-        - FxDK
         - 'OneSync'
         - 'Natives'
         - 'ScRT: Lua'
         - 'ScRT: C#'
+        - 'ScRT: C# (Mono v2)'
         - 'ScRT: JS'
+        - FxDK
     validations:
       required: true
   


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Enable feature Requests to Make FiveM Great Again.


### How is this PR achieving the goal

Enables the feature request template.
Reorder some stuff kinda based on the "importance" of the project.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

GitHub


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** GitHub


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] My commit message explains what the changes do and what they are for.
