### PR TITLE
Add documentation to ExecuteCommand native

### DIFF
--- a/ext/native-decls/ExecuteCommand.md
+++ b/ext/native-decls/ExecuteCommand.md
@@ -8,7 +8,17 @@ apiset: shared
 void EXECUTE_COMMAND(char* commandString);
 ```
 
+Depending on your use case you may need to use `add_acl resource.<your_resource_name> command.<command_name> allow` to use this native in your resource.
 
 ## Parameters
 * **commandString**: 
 
+## Examples
+
+```lua
+Citizen.CreateThread(function()
+  -- stop the server after 1 minute
+  Citizen.Wait(60000)
+  ExecuteCommand("quit Shortlived")
+end)
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

The goal of this PR is to help anyone else that experiences the same issue I did, with being unable to use ExecuteCommand in my resource, without first adding an acl for the resource, and attempting to google the issue only told me how to add ACLs for players.


### How is this PR achieving the goal

This PR is achieving that goal by adding documentation to the ExecuteCommand native, to include a simple pointer towards how to add an acl for a resource.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** N/A


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully. (N/A)
- [ ] Code explains itself well and/or is documented. (N/A)
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

N/A
