### PR TITLE
fix(net/sbac): don't duplicate the registration of the state bag component

### DIFF
--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -995,11 +995,6 @@ bool CloneManagerLocal::HandleCloneCreate(const msgClone& msg)
 
 	auto& objectData = m_trackedObjects[msg.GetObjectId()];
 
-	if (!objectData.stateBag)
-	{
-		objectData.stateBag = m_sbac->RegisterStateBag(fmt::sprintf("entity:%d", msg.GetObjectId()), true);
-	}
-
 	objectData.uniqifier = msg.GetUniqifier();
 
 	// owner ID (forced to be remote so we can call ChangeOwner later)


### PR DESCRIPTION
### Goal of this PR
`RegisterStateBag` gets called further down in `rage::netObjectMgr::RegisterNetworkObject(obj)` which is hooked to call `CloneManagerLocal::RegisterNetworkObject` which will *then* register the state bag in a queued mode where it will wait for the client to ack a packet from the server for the object before it would apply it.

Calling it here could lead to the client still getting state bag changes for this even if the entity didn't *actually* exist for the client.



### How is this PR achieving the goal
Remove the call and rely on the call later down the call stack.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


