### PR TITLE
tweak(gta-core-five): set game_useSynchronousAudio convar default true

### DIFF
--- a/code/components/gta-core-five/src/GameAudioState.cpp
+++ b/code/components/gta-core-five/src/GameAudioState.cpp
@@ -482,7 +482,7 @@ static HookFunction hookFunction([]()
 			*rage::g_audUseFrameLimiter = editorMode || g_audUseFrameLimiterConVar;
 		});
 
-		static ConVar<bool> audUseFrameLimiter("game_useSynchronousAudio", ConVar_Archive, false, &useSynchronousAudio);
+		static ConVar<bool> audUseFrameLimiter("game_useSynchronousAudio", ConVar_Archive, true, &useSynchronousAudio);
 	}
 
 	static ConVar<bool> audUseFrameLimiter("game_useAudioFrameLimiter", ConVar_Archive, true, &g_audUseFrameLimiterConVar);


### PR DESCRIPTION
### Goal of this PR
This PR changes the default value of the game_useSynchronousAudio setting to true, which removes the hard cap of 188 FPS in FiveM. The goal is to improve the out-of-the-box experience by allowing players to benefit from uncapped frame rates without requiring manual configuration.

EDIT: I've read the https://github.com/citizenfx/fivem/issues/2354 issue ( checking if it's already an issue posted about this ), i can confirm that this change completely removes the stuttering, it was tested on one of my servers, every player with a decent PC was getting that framerate, and after enabling game_useSynchronousAudio, the stuttering was gone, and also they had unlimited FPS.


### How is this PR achieving the goal
This PR updates the default value passed to the game_useSynchronousAudio console variable from false to true.

### This PR applies to the following area(s)
FiveM
...


### Successfully tested on

**Game builds:** 3095

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://github.com/citizenfx/fivem/issues/2354