### PR TITLE
fix(imgui): various improvements

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -988,25 +988,24 @@ static InitFunction initFunction([]()
 
 				if (assets.GetCount() > 1)
 				{
-					ImGuiListClipper clipper;
-					// -1 because 1st item in Entries always dummy in GTAV and RDR3
-					clipper.Begin(assets.GetCount() - 1);
+					std::vector<uint32_t> filteredIndices;
+					for (uint32_t i = 0; i < assets.GetCount(); i++)
+					{
+						if (assets[i].fileName && strstr(assets[i].fileName, search) != nullptr)
+						{
+							filteredIndices.push_back(i);
+						}
+					}
 
+					ImGuiListClipper clipper;
+
+					// -1 because 1st item in Entries always dummy in GTAV and RDR3
+					clipper.Begin(static_cast<int>(filteredIndices.size()));
 					while (clipper.Step())
 					{
-						for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++)
+						for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
 						{
-							int assetsIndex = row + 1;
-							if (!assets[assetsIndex].fileName)
-							{
-								continue;
-							}
-
-							const std::string name = assets[assetsIndex].fileName;
-							if (!name._Starts_with(search))
-							{
-								continue;
-							}
+							const uint32_t assetsIndex = filteredIndices[i];
 
 							const std::string datetime = PrettyFormatFileTime(assets[assetsIndex].timestamp);
 
@@ -1017,6 +1016,7 @@ static InitFunction initFunction([]()
 							ImGui::Text("%s", datetime.c_str());
 						}
 					}
+					clipper.End();
 				}
 
 				ImGui::EndTable();

--- a/code/components/citizen-server-gui/src/PlayerList.cpp
+++ b/code/components/citizen-server-gui/src/PlayerList.cpp
@@ -326,9 +326,8 @@ static void ShowPopout(std::string guid, PlayerListData* data)
 			}
 		}
 		ImGui::Columns(1);
-
-		ImGui::End();
 	}
+	ImGui::End();
 }
 
 static void SvPlayerList_Render(fx::ServerInstanceBase* instance)
@@ -338,7 +337,8 @@ static void SvPlayerList_Render(fx::ServerInstanceBase* instance)
 	// Lock Mutex Here, it's rarely contested
 	std::shared_lock lock(g_playerListDataMutex);
 
-	ImGui::BeginTable("##svplayerlist", 5 /*Column Num*/, ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable);
+	if (ImGui::BeginTable("##svplayerlist", 5 /*Column Num*/, ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable))
+	{
 		ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_PreferSortDescending);
 		ImGui::TableSetupColumn("Position", ImGuiTableColumnFlags_PreferSortDescending);
 		ImGui::TableSetupColumn("Time Online", ImGuiTableColumnFlags_PreferSortDescending);
@@ -385,5 +385,6 @@ static void SvPlayerList_Render(fx::ServerInstanceBase* instance)
 				ShowPopout(guid, &data);
 			}
 		}
-	ImGui::EndTable();
+		ImGui::EndTable();
+	}
 }

--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -364,7 +364,7 @@ struct CfxBigConsole : FiveMConsoleBase
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 4.0f, 3.0f });
 
-		constexpr ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+		constexpr ImGuiWindowFlags flags = ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
 		return ImGui::Begin(title, nullptr, flags);
 	}
 

--- a/code/components/conhost-v2/src/ConsoleHostImpl.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostImpl.cpp
@@ -480,6 +480,8 @@ void OnConsoleFrameDraw(int width, int height, bool usedSharedD3D11)
 
 	DrawMiniConsole();
 
+	ConHost::OnDrawGui();
+
 	if (g_consoleFlag)
 	{
 		DrawDevGui();
@@ -490,8 +492,6 @@ void OnConsoleFrameDraw(int width, int height, bool usedSharedD3D11)
 	{
 		DrawWinConsole(&g_winConsole);
 	}
-
-	ConHost::OnDrawGui();
 
 	if (wasSmallFont)
 	{

--- a/code/components/conhost-v2/src/DrawPerf.cpp
+++ b/code/components/conhost-v2/src/DrawPerf.cpp
@@ -143,7 +143,7 @@ static InitFunction initFunction([]()
 			}
 		}
 
-		if (!metrics.empty() && ImGui::Begin("DrawPerf", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize))
+		if (!metrics.empty() && ImGui::Begin("DrawPerf", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoFocusOnAppearing))
 		{
 			int i = 0;
 			float spacing = ImGui::GetStyle().ItemSpacing.x;

--- a/code/components/gta-net-five/src/CloneDebug.cpp
+++ b/code/components/gta-net-five/src/CloneDebug.cpp
@@ -1335,7 +1335,7 @@ static InitFunction initFunction([]()
 			ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, window_pos_pivot);
 
 			ImGui::SetNextWindowBgAlpha(0.3f); // Transparent background
-			if (ImGui::Begin("Net Warning", NULL, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav))
+			if (ImGui::Begin("Net Warning", NULL, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs))
 			{
 				ImGui::Text("/!\\ Performance warning");
 				ImGui::Separator();


### PR DESCRIPTION
### Goal of this PR
This PR includes various improvements and bug fixes for ImGui-based UIs, addressing crashes and usability issues encountered in the client and server interfaces.

### How is this PR achieving the goal
- Fixed a client crash when using the search function in the `pgRawStreamer` Debug window. The ImGui clipper does not support modifying the item list during iteration.

- Fixed a server crash that occurred when collapsing a player info window in `svgui`.

- Improved console focus behavior to prevent floating ImGui windows from getting stuck behind the client console.

- Adjusted focus behavior for performance widgets, ensuring that `drawPerf` and the resource time warning widget no longer steal focus when their viewport is clicked.

### This PR applies to the following area(s)
FiveM, Server

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/