### PR TITLE
tweak(conhost-v2): clamp CPU usage to 100%

### DIFF
--- a/code/components/conhost-v2/src/DrawPerf.cpp
+++ b/code/components/conhost-v2/src/DrawPerf.cpp
@@ -221,7 +221,7 @@ static InitFunction initFunction([]()
 			lastCpuQuery = timeGetTime();
 		}
 
-		return fmt::sprintf("CPU: %.0f%%", counterValCpu.doubleValue);
+		return fmt::sprintf("CPU: %.0f%%", std::min(counterValCpu.doubleValue, 100.0));
 	});
 
 	addDrawPerfModule("cl_drawGpuUsage", "GPU Usage", []() -> std::string


### PR DESCRIPTION
### Goal of this PR
Following support threads in the Discord guild, this change (#2953) still confuses users as Microsoft clamps CPU utilization values to 100% in task manager.

### How is this PR achieving the goal
Clamp the CPU utilization value to a maximum of 100% to make sure the value matches the one displayed in task manager.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** Not applicable

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/