### PR TITLE
fix(core-five): tmp disable expanded blip categories on builds <= 2189

### DIFF
--- a/code/components/gta-core-five/src/PatchBlipCategories.cpp
+++ b/code/components/gta-core-five/src/PatchBlipCategories.cpp
@@ -1,5 +1,7 @@
 #include "StdInc.h"
 
+#include "CrossBuildRuntime.h"
+
 #include <Hooking.h>
 #include <jitasm.h>
 
@@ -21,6 +23,11 @@ static const char* GetBlipCategoryName(const uint8_t category)
 
 static HookFunction hookFunction([]()
 {
+	if (!xbr::IsGameBuildOrGreater<2372>())
+	{
+		return;
+	}
+
 	// Game code expects const char*, so we need to allocate static memory for the category labels
 	InitializeCategoryNames();
 


### PR DESCRIPTION
### Goal of this PR
Game builds <= `2189` require a different approach for patching this as the instruction flow differs in some critical sections.

### How is this PR achieving the goal
Temporarily disable this patch on builds <= `2189` to avoid crashes.
(Given the current game build usage, I propose this approach instead of a global revert, as some servers and scripts have already adapted to this feature.)

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 1604, 2060, 2189, 2372 

**Platforms:** Windows (Client)

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/