### PR TITLE
feat(kvp-client): add client asynchronous kvp natives

### DIFF
--- a/ext/native-decls/kvp/DeleteResourceKvpNoSync.md
+++ b/ext/native-decls/kvp/DeleteResourceKvpNoSync.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: server
+apiset: shared
 ---
 ## DELETE_RESOURCE_KVP_NO_SYNC
 

--- a/ext/native-decls/kvp/SetResourceKvpFloatNoSync.md
+++ b/ext/native-decls/kvp/SetResourceKvpFloatNoSync.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: server
+apiset: shared
 ---
 ## SET_RESOURCE_KVP_FLOAT_NO_SYNC
 

--- a/ext/native-decls/kvp/SetResourceKvpIntNoSync.md
+++ b/ext/native-decls/kvp/SetResourceKvpIntNoSync.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: server
+apiset: shared
 ---
 ## SET_RESOURCE_KVP_INT_NO_SYNC
 

--- a/ext/native-decls/kvp/SetResourceKvpNoSync.md
+++ b/ext/native-decls/kvp/SetResourceKvpNoSync.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: server
+apiset: shared
 ---
 ## SET_RESOURCE_KVP_NO_SYNC
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
just like the server we add client asynchronous natives.
using async natives reduces the load on the client as it's not always  needed to wait for the operations to finish

### How is this PR achieving the goal
the goal is to have it stream lined with the server natives that already have async natives

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM/RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


