### PR TITLE
feat(streaming/rdr3): change entity level cap to `PRI_OPTIONAL_LOW`

### DIFF
--- a/code/components/gta-streaming-rdr3/src/MiscStuff.cpp
+++ b/code/components/gta-streaming-rdr3/src/MiscStuff.cpp
@@ -1,0 +1,17 @@
+#include <StdInc.h>
+#include <Hooking.h>
+
+
+static HookFunction hookFunction([]()
+{
+    // reset? entity level cap to PRI_OPTIONAL_LOW
+    hook::put<uint8_t>(hook::get_pattern("8D 41 ? 89 0D ? ? ? ? 89 05", 2), 3);
+    // init entity level cap to PRI_OPTIONAL_LOW
+    hook::put<uint32_t>(hook::get_pattern("B8 ? ? ? ? 83 25 ? ? ? ? ? 48 8B CB", 1), 3);
+
+    // allow low-priority objects even when LOD distance is <20% (not needed if part below enabled)
+    // hook::nop(hook::get_pattern("0F 97 05 ? ? ? ? 0F 96 05", 7), 7);
+
+    // disable ability to recalculate a level cap
+    hook::nop(hook::get_pattern("89 05 ? ? ? ? 89 05 ? ? ? ? 48 83 C4 ? C3 48 83 EC ? 80 79"), 12);
+});


### PR DESCRIPTION
### Goal of this PR  
<!-- Concise explanation of what this PR meant to achieve -->  
Adjust entity streaming behavior by setting the level cap to `PRI_OPTIONAL_LOW`

### How is this PR achieving the goal  
- Replaces hardcoded level cap values with `PRI_OPTIONAL_LOW` (value `3`) in the entity streaming logic.  
- Disables code responsible for recalculating the level cap at runtime to prevent overrides.  

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


