### PR TITLE
feat(cfx-ui): refactors the changelog page.

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/pages/ChangelogPage/ChangelogPage.module.scss
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/pages/ChangelogPage/ChangelogPage.module.scss
@@ -1,9 +1,79 @@
 .sticky {
   position: sticky;
-
   top: 0;
   left: 0;
   right: 0;
-
   z-index: 1;
+}
+
+.versionContainer {
+  margin-bottom: 24px;
+  scroll-margin-top: 20px;
+}
+
+.headerContainer {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.buildBadge {
+  display: flex;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+}
+
+.buildNumber {
+  color: white;
+  padding: 4px 10px;
+  font-weight: bold;
+}
+
+.buildDate {
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #333;
+  padding: 4px 10px;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+}
+
+.dateIcon {
+  margin-right: 4px;
+}
+
+.divider {
+  height: 1px;
+  flex: 1;
+  margin-left: 10px;
+}
+
+.loadingContainer {
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loadingText {
+  display: inline-block;
+}
+
+.loadingDots {
+  display: inline-block;
+  animation: loadingPulse 1.5s infinite;
+}
+
+@keyframes loadingPulse {
+  0% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.3;
+  }
 }

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/pages/ChangelogPage/ChangelogPage.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/pages/ChangelogPage/ChangelogPage.tsx
@@ -1,5 +1,4 @@
 import {
-  Indicator,
   Island,
   Flex,
   Pad,
@@ -11,26 +10,26 @@ import {
 } from '@cfx-dev/ui-components';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
-
 import { InsideNavBar } from 'cfx/apps/mpMenu/parts/NavBar/InsideNavBar';
 import { useService } from 'cfx/base/servicesContainer';
 import { $L } from 'cfx/common/services/intl/l10n';
-
 import { IChangelogService } from '../../services/changelog/changelog.service';
+import s from './ChangelogPage.module.scss';
 
 type SelectOptions = React.ComponentProps<typeof Select>['options'];
 
 export const ChangelogPage = observer(function ChangelogPage() {
   const ChangelogService = useService(IChangelogService);
-
+  const scrollableRef = React.useRef<HTMLDivElement>(null);
+  const versionRefs = React.useRef<Record<string, HTMLDivElement | null>>({});
+  
   // Zeroing unseen versions counter
   React.useEffect(() => {
     ChangelogService.maybeMarkNewAsSeen();
   }, []);
 
-  const {
-    versions,
-  } = ChangelogService;
+  const { versions } = ChangelogService;
+
   const versionItemsSelect: SelectOptions = React.useMemo(
     () => versions.map((version) => ({
       value: version,
@@ -38,13 +37,71 @@ export const ChangelogPage = observer(function ChangelogPage() {
     })),
     [versions],
   );
+  
+  React.useEffect(() => {
+    if (ChangelogService.selectedVersion && versionRefs.current[ChangelogService.selectedVersion]) {
+      const element = versionRefs.current[ChangelogService.selectedVersion];
+      if (element && scrollableRef.current) {
+        setTimeout(() => {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+      }
+    }
+  }, [ChangelogService.selectedVersion]);
+  
+  const generateDistinctiveColor = (str: string, index: number): string => {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    
+    const ColorRatio = 0.618033988749895;
+    let h = ((hash % 360) / 360 + index * ColorRatio) % 1.0;
+    
+    h = Math.floor(h * 360);
+    
+    const s = 65 + (index % 3) * 10;
+    const l = 40 + (index % 4) * 5;
+    
+    return `hsl(${h}, ${s}%, ${l}%)`;
+  };
+
+  React.useEffect(() => {
+    if (!versions.length) return;
+    
+    const observerOptions = {
+      root: scrollableRef.current,
+      rootMargin: '100px 0px 100px 0px',
+      threshold: 0.1
+    };
+    
+    const observerCallback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const element = entry.target as HTMLElement;
+          const version = element.dataset.version;
+          if (version) {
+            ChangelogService.getVersionContent(version);
+            observer.unobserve(element);
+          }
+        }
+      });
+    };
+    
+    const observer = new IntersectionObserver(observerCallback, observerOptions);
+    
+    Object.values(versionRefs.current).forEach((ref: HTMLElement | null) => {
+      if (ref) observer.observe(ref);
+    });
+    
+    return () => observer.disconnect();
+  }, [versions.length]);
 
   return (
     <Page>
       <InsideNavBar>
         <Flex centered="axis">
           <Text size="large">{$L('#Changelogs')}</Text>
-
           <Select
             value={ChangelogService.selectedVersion}
             options={versionItemsSelect}
@@ -52,13 +109,92 @@ export const ChangelogPage = observer(function ChangelogPage() {
           />
         </Flex>
       </InsideNavBar>
-
       <Island grow>
-        <Scrollable>
+        <Scrollable ref={scrollableRef}>
           <Pad size="large">
             <Prose>
-              {ChangelogService.selectedVersionContent || (
-                <Indicator />
+              {ChangelogService.hasAnyVersions ? (
+                versions.slice(0, 100).map((version, index) => {
+                  const color = generateDistinctiveColor(version, index);
+                  const versionContent = ChangelogService.getVersionContent(version);
+                  
+                  return (
+                    <div 
+                      key={version} 
+                      className={s.versionContainer}
+                      ref={el => {
+                        versionRefs.current[version] = el;
+                      }}
+                      data-version={version}
+                      id={`changelog-version-${version}`}
+                    >
+                      {/* version indicator with date */}
+                      <div className={s.headerContainer}>
+                        <div 
+                          className={s.buildBadge}
+                          onClick={() => ChangelogService.selectVersion(version)}
+                        >
+                          <div 
+                            className={s.buildNumber}
+                            style={{ backgroundColor: color }}
+                          >
+                            Build {version}
+                          </div>
+                          
+                          {ChangelogService.getBuildDate(version) && (
+                            <div className={s.buildDate}>
+                              <svg 
+                                xmlns="http://www.w3.org/2000/svg" 
+                                width="14" 
+                                height="14" 
+                                viewBox="0 0 24 24" 
+                                fill="none" 
+                                stroke="currentColor" 
+                                strokeWidth="2" 
+                                strokeLinecap="round" 
+                                strokeLinejoin="round" 
+                                className={s.dateIcon}
+                              >
+                                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                                <line x1="16" y1="2" x2="16" y2="6"></line>
+                                <line x1="8" y1="2" x2="8" y2="6"></line>
+                                <line x1="3" y1="10" x2="21" y2="10"></line>
+                              </svg>
+                              {ChangelogService.getBuildDate(version)}
+                            </div>
+                          )}
+                        </div>
+                        <div 
+                          className={s.divider}
+                          style={{ backgroundColor: color }}
+                        />
+                      </div>
+                      
+                      {/* changelog content */}
+                      <div>
+                        {versionContent !== undefined ? (
+                          versionContent
+                        ) : (
+                          <div className={s.loadingContainer}>
+                            <Text size="small" opacity="75">
+                              <span className={s.loadingText}>Loading changelog...</span>
+                            </Text>
+                            <div 
+                              className={s.loadingSpinner} 
+                              style={{ 
+                                borderColor: `${color} transparent ${color} transparent` 
+                              }} 
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })
+              ) : (
+                <div>
+                  <span>🐌 Nothing to display right now check back later!</span>
+                </div>
               )}
             </Prose>
           </Pad>

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/changelog/changelog.service.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/changelog/changelog.service.ts
@@ -223,43 +223,38 @@ class ChangelogService implements AppContribution {
     if (this._versionsContent[version] !== undefined || this._versionsContentLoading[version]) {
       return;
     }
-
-    this._versionsContentLoading[version] = true;
-
-    try {
-      let content;
-      if (priority && 'fetch' in window) {
-        content = await fetcher.text(`${endpoint}/versions/${version}`);
-      } else {
-        content = await fetcher.text(`${endpoint}/versions/${version}`);
-      }
-      
-      const dateMatch = content.match(/<h2>Build \d+ \(created on (.*?)\)<\/h2>/i);
-      const buildDate = dateMatch ? dateMatch[1] : null;
-      
-      if (buildDate) {
-        this._buildDates = this._buildDates || {};
-        this._buildDates[version] = buildDate;
-      }
-      
-      let processedContent = content.replace(/<h2>Build \d+ \(created on .*?\)<\/h2>/i, '').trim();
-      processedContent = processedContent.replace(/<h3>Detailed change list<\/h3>/i, '').trim();
-      const contentTextOnly = processedContent.replace(/<[^>]*>/g, '').trim();
-      
-      if (contentTextOnly.length < 10) {
-        const customMessage = '<div style="font-style: italic; padding: 4px 0;"><p style="font-size: 0.9em; margin: 0; color: #666;">Psst... this build has some changes, but they\'re our little secret! 🤫</p></div>';
-        this.setVersionContent(version, html2react(customMessage));
-      } else {
-        this.setVersionContent(version, html2react(processedContent));
-      }
-    } catch (e) {
-      console.error('Error fetching version content:', e);
-      const errorMessage = '<div style="color: #d64646; padding: 10px;"><p>Failed to load changelog for this build.</p></div>';
-      this.setVersionContent(version, html2react(errorMessage));
-    } finally {
-      this._versionsContentLoading[version] = false;
+  
+  this._versionsContentLoading[version] = true;
+  
+  try {
+    const content = await fetcher.text(`${endpoint}/versions/${version}`);
+    
+    const dateMatch = content.match(/<h2>Build \d+ \(created on (.*?)\)<\/h2>/i);
+    const buildDate = dateMatch ? dateMatch[1] : null;
+    
+    if (buildDate) {
+      this._buildDates = this._buildDates || {};
+      this._buildDates[version] = buildDate;
     }
+    
+    let processedContent = content.replace(/<h2>Build \d+ \(created on .*?\)<\/h2>/i, '').trim();
+    processedContent = processedContent.replace(/<h3>Detailed change list<\/h3>/i, '').trim();
+    const contentTextOnly = processedContent.replace(/<[^>]*>/g, '').trim();
+    
+    if (contentTextOnly.length < 10) {
+      const customMessage = '<div style="font-style: italic; padding: 4px 0;"><p style="font-size: 0.9em; margin: 0; color: #666;">Psst... this build has some changes, but they\'re our little secret! 🤫</p></div>';
+      this.setVersionContent(version, html2react(customMessage));
+    } else {
+      this.setVersionContent(version, html2react(processedContent));
+    }
+  } catch (e) {
+    console.error('Error fetching version content:', e);
+    const errorMessage = '<div style="color: #d64646; padding: 10px;"><p>Failed to load changelog for this build.</p></div>';
+    this.setVersionContent(version, html2react(errorMessage));
+  } finally {
+    this._versionsContentLoading[version] = false;
   }
+}
   
   private _buildDates: Record<string, string> = {};
   


### PR DESCRIPTION
### Goal of this PR
Enhances the view for the changelog page giving a more eye pleasing view of the page with more information in a prettier way.
adds lazy-loading and multiple build version view, enhancing the overall experience of the changelog page.
Where the user is able to just scroll to a different gamebuild/version, or select it at the top which will autojump/scroll to that specific version in a pretty way.

![image](https://github.com/user-attachments/assets/91e3d24d-a177-49a7-b029-803cec4fe2a6)


https://github.com/user-attachments/assets/97b2b95f-9337-4262-a5cc-07c07ee84ae6



...


### How is this PR achieving the goal
PR is adjusting the current implementation of the changelog page to where the above described functionality is implemented.
...


### This PR applies to the following area(s)
FiveM, RedM

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258, 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


