### PR TITLE
feat(extra-natives-rdr3): add `GET_PED_SCALE` for RedM

### DIFF
--- a/code/components/extra-natives-rdr3/src/PedNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/PedNatives.cpp
@@ -17,6 +17,61 @@ static hook::cdecl_stub<void*(rage::fwEntity*)> GetPedCreatureComponent([]()
 	return hook::get_call(hook::get_pattern("D1 0F 14 FA E8 ? ? ? ? 48 8B C8 4C 8D 44", 4));
 });
 
+static hook::cdecl_stub<float(uintptr_t)> GetPedScale([]()
+{
+	return hook::get_pattern("0F 57 C0 0F 2F 81 ? ? ? ? 0F 82 ? ? ? ? 8B 81");
+});
+
+static hook::cdecl_stub<bool(rage::fwEntity*)> IsMetaPed([]()
+{
+	return hook::get_pattern("40 53 48 83 EC ? 8B 15 ? ? ? ? 48 8B D9 48 83 C1 ? E8 ? ? ? ? 33 D2");
+});
+
+struct PedComponentsContainer
+{
+	void* m_animal;
+	void* m_animalAudio;
+	void* m_animalEars;
+	void* m_animalTail;
+	void* m_animation;
+	void* m_attribute;
+	void* m_audio;
+	void* m_avoidance;
+	void* m_breathe;
+	void* m_cloth;
+	void* m_core;
+	void* m_creature;
+	void* m_distraction;
+	void* m_driving;
+	void* m_dummy;
+	void* m_event;
+	void* m_facial;
+	void* m_footstep;
+	void* m_gameplay;
+	void* m_graphics;
+	void* m_health;
+	void* m_horse;
+	void* m_humanAudio;
+	void* m_intelligence;
+	void* m_inventory;
+	void* m_lookAt;
+	void* m_motion;
+	void* m_motivation;
+	void* m_physics;
+	void* m_projDecal;
+	void* m_player;
+	void* m_ragdoll;
+	void* m_scriptData;
+	void* m_stamina;
+	void* m_targetting;
+	void* m_threatResponse;
+	void* m_transport;
+	void* m_transportUser;
+	void* m_vfxComponent;
+	void* m_visibility;
+	void* m_weapon;
+};
+
 static HookFunction hookFunction([]()
 {
 	fx::ScriptEngine::RegisterNativeHandler("GET_PED_BONE_MATRIX", [](fx::ScriptContext& context)
@@ -54,4 +109,55 @@ static HookFunction hookFunction([]()
 			}
 		}
 	});
+
+	{
+		static PedComponentsContainer** g_pedComponentContainer = hook::get_address<PedComponentsContainer**>(hook::get_pattern("48 8B 05 ? ? ? ? 4C 8B 44 01 ? 48 8B 94 01", 3));
+
+		static int32_t* g_pedComponentIndexOffset = hook::get_address<int32_t*>(hook::get_pattern("2B 0D ? ? ? ? 84 C0 8B C1 74 ? 48 69 C8 ? ? ? ? 0F 28 CE", 2));
+
+
+		fx::ScriptEngine::RegisterNativeHandler("GET_PED_SCALE", [](fx::ScriptContext& context)
+		{
+			rage::fwEntity* ped = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+			if (!ped)
+			{
+				context.SetResult<float>(0.0f);
+				return;
+			}
+
+			uint32_t entityComponents = *reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(ped) + 0x9C);
+			int32_t componentIndex = (entityComponents & 0x1FFFF) - *g_pedComponentIndexOffset;
+
+			if (!g_pedComponentContainer || componentIndex < 0)
+			{
+				context.SetResult<float>(0.0f);
+				return;
+			}
+
+			auto& pedComponent = (*g_pedComponentContainer)[componentIndex];
+
+			float scale = 0.0f;
+			if (!IsMetaPed(ped))
+			{
+				uintptr_t corePtr = reinterpret_cast<uintptr_t>(pedComponent.m_core);
+				corePtr = (corePtr != 0) ? (corePtr & 0xFFFFFFFFFFFFFFFE) : 0;
+				if (corePtr)
+				{
+					scale = *reinterpret_cast<float*>(corePtr + 0x48);
+				}
+			}
+			else
+			{
+				uintptr_t physicsPtr = reinterpret_cast<uintptr_t>(pedComponent.m_physics);
+				physicsPtr = (physicsPtr != 0) ? (physicsPtr & 0xFFFFFFFFFFFFFFFE) : 0;
+				if (physicsPtr)
+				{
+					scale = GetPedScale(physicsPtr);
+				}
+			}
+
+			context.SetResult<float>(scale);
+		});
+	}
+	
 });

--- a/ext/native-decls/GetPedScale.md
+++ b/ext/native-decls/GetPedScale.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_PED_SCALE
+
+```c
+float GET_PED_SCALE(Ped ped);
+```
+
+## Parameters
+* **ped**: The target ped
+
+## Return value
+Returns scale of ped set by [SET_PED_SCALE](#_0x25ACFC650B65C538)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Introduce a new native function `GET_PED_SCALE` that allows retrieving the current scale of a ped, supporting both meta and non-meta peds.


### How is this PR achieving the goal

The PR registers a new native function `GET_PED_SCALE` that retrieves a ped's scale by accessing internal component data. It safely handles both meta and non-meta peds by resolving the correct memory paths and applying necessary type checks.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


