### PR TITLE
fix(client/mumble): request resync if we fail to decrypt a packet after 1 seconds

### DIFF
--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -86,6 +86,8 @@ public:
 	uint32_t m_localLost;
 	uint32_t m_localResync;
 
+	std::chrono::milliseconds m_lastGoodUdp;
+
 	void Encrypt(const uint8_t* plain, uint8_t* cipher, size_t length);
 	bool Decrypt(const uint8_t* cipher, uint8_t* plain, size_t length);
 	std::string GetClientNonce();

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -766,6 +766,16 @@ void MumbleClient::HandleUDP(const uint8_t* buf, size_t size)
 	if (!m_crypto.Decrypt(buf, outBuf, size))
 	{
 		console::DPrintf("mumble", "Failed to decrypt packet\n");
+		if ((msec() - m_crypto.m_lastGoodUdp) > kPingInterval) // we expect to have a good ping atleast once every ping interval 
+		{
+			// we don't want to spam the server with cryto resets
+			m_crypto.m_lastGoodUdp = msec();
+
+			// send a request to the server to reset our crypt state
+			MumbleProto::CryptSetup crypt;
+			Send(MumbleMessageType::CryptSetup, crypt);
+			console::DPrintf("mumble", "Failed to decrypt after 1 seconds, requesting crypt reset");
+		}
 		return;
 	}
 

--- a/code/components/voip-mumble/src/MumbleCrypto.cpp
+++ b/code/components/voip-mumble/src/MumbleCrypto.cpp
@@ -8,6 +8,10 @@
 
 #include <array>
 
+inline std::chrono::milliseconds msec()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+}
 
 void MumbleCrypto::Encrypt(const uint8_t* plain, uint8_t* cipher, size_t length)
 {
@@ -144,6 +148,8 @@ bool MumbleCrypto::Decrypt(const uint8_t* cipher, uint8_t* plain, size_t length)
 	m_localGood++;
 	m_localLate += late;
 	m_localLost += lost;
+
+	m_lastGoodUdp = msec();
 
 	return true;
 }


### PR DESCRIPTION
### Goal of this PR
Send resync for crypt state in situations where we've failed to decrypt after a certain span of times

### How is this PR achieving the goal
After 1s of not being able to decrypt a packet from the server we sent a resync request, copying behavior [from mumble](https://github.com/mumble-voip/mumble/blob/master/src/mumble/ServerHandler.cpp#L244-L254), notably the time we wait is different here, we send ping packets every 1 second, mumble only does it every 5 seconds.

This should hopefully fix some of the last few edge cases where people have reported "i can talk, but I can't hear anyone"


### This PR applies to the following area(s)
FiveM, RedM


### Successfully tested on
**Game builds:** Agnostic

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
