### PR TITLE
Fixes oversights in original RawKeymap PR

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -69,6 +69,17 @@ const EXT_LOCALFUNCREF = 11;
 		return Citizen.canonicalizeRef(ref);
 	};
 
+	/**
+	 * @param {Function} refFunction
+	 * @returns {string|null} the function reference, or null if the refFunction that was passed wasn't a function
+	 */
+	Citizen.getRefFunction = (refFunction) => {
+		if (typeof refFunction !== "function") {
+			return null;
+		}
+		return Citizen.makeRefFunction(refFunction);
+	}
+
 	function refFunctionPacker(refFunction) {
 		const ref = Citizen.makeRefFunction(refFunction);
 

--- a/ext/native-decls/RegisterRawKeymap.md
+++ b/ext/native-decls/RegisterRawKeymap.md
@@ -6,7 +6,7 @@ game: rdr3
 ## REGISTER_RAW_KEYMAP
 
 ```c
-void REGISTER_RAW_KEYMAP(char* keymapName, func onKeyUp, func onKeyDown, int rawKeyIndex, BOOL canBeDisabled);
+void REGISTER_RAW_KEYMAP(char* keymapName, func onKeyDown, func onKeyUp, int rawKeyIndex, BOOL canBeDisabled);
 ```
 
 Registers a keymap that will be triggered whenever `rawKeyIndex` is pressed or released.
@@ -18,8 +18,8 @@ function onStateChange();
 
 ## Parameters
 * **keymapName**: A **unique** name that the keymap will be bound to, duplicates will result in the keymap not being registered.
-* **onKeyUp**: The function to run when the key is no longer being pressed.
-* **onKeyDown**: The function to run when the key is being pressed.
+* **onKeyDown**: The function to run when the key is being pressed, or `nil`.
+* **onKeyUp**: The function to run when the key is no longer being pressed, or `nil`.
 * **rawKeyIndex**: The virtual key to bind this keymap to, see a list [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
 * **canBeDisabled**: If calls to [DISABLE_RAW_KEY_THIS_FRAME](#_0x8BCF0014) will disable this keymap, if a keymap was disabled when the key was pressed down it will still call `onKeyUp` on release.
 

--- a/ext/natives/codegen_out_js.lua
+++ b/ext/natives/codegen_out_js.lua
@@ -121,7 +121,7 @@ print("\treturn (flt === 0.0) ? flt : (flt + 0.0000001);")
 print("}\n")
 
 print("function _mfr(fn) {")
-print("\treturn Citizen.makeRefFunction(fn);")
+print("\treturn Citizen.getRefFunction(fn);")
 print("}\n")
 
 print("const _ENV = null;\n")


### PR DESCRIPTION
### Goal of this PR
This somehow managed to slip through when I originally made this pr, this
just swaps the native declaration and ordering in code to be the right order
since when `RawKeymap` was called the ordering is `keyDown`, `keyUp`.

This fixes another oversight in the initial PR, we should always register
`m_wasTriggered` changes, even if we don't have refs, otherwise we will
have "perma stuck" keymaps if the user decides to not register one part of
the keymap

This also adds a proper error message if you provide an invalid index

This also fixes an issue with `REGISTER_RAW_KEYMAPS` where it would still supply
a ref id even if there was no function (aka when set to null) to make the reference to, and when
calling into the JS ScRT it would error because `callback` would be null.

This copies the [behavior from Lua](https://github.com/citizenfx/fivem/blob/476f550dfb5d35b53ff9db377445be76db7c28bc/data/shared/citizen/scripting/lua/scheduler.lua#L470-L480) where we wrap the call and properly return
null if the `refFunction` is not a function.

![js error because function call is actually null](https://github.com/user-attachments/assets/c64d923d-c832-4c14-a6d7-8afcef104504)



### This PR applies to the following area(s)
RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.