### PR TITLE
fix(legitimacy/rdr3): add mojo as a dependency

### DIFF
--- a/code/components/legitimacy/component.json
+++ b/code/components/legitimacy/component.json
@@ -11,6 +11,7 @@
 		"vendor:curl",
 		"vendor:cpr",
 		"vendor:botan",
+		"vendor:mojo",
 		"vendor:zlib",
 		"net:http-server"
 	],


### PR DESCRIPTION
### Goal of this PR

Fixes an issue with building the RedM client. where "conhost-v2" would fail to load because of legitimacy.dll missing its mojo.dll dependency. 

### How is this PR achieving the goal

Add mojo as a dependency for the legitimacy component. Ensuring that mojo project files are built for all games (server, rdr3, ny) rather then just five (where fxdk-main depends on it)

### This PR applies to the following area(s)

FiveM, RedM

### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


