### PR TITLE
fix(github): bump Linux runner Ubuntu version

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -16,7 +16,7 @@ jobs:
           - [ Server, server, windows ]
           - [ Server, server, linux   ]
     name: ${{ matrix.builds[0] }}${{ matrix.builds[2] == 'linux' && ' (Linux)' || '' }}
-    runs-on: ${{ matrix.builds[2] == 'windows' && 'windows-latest' || 'ubuntu-20.04' }}
+    runs-on: ${{ matrix.builds[2] == 'windows' && 'windows-latest' || 'ubuntu-24.04' }}
     env:
       PROGRAM: ${{ matrix.builds[1] }}
       PLATFORM: ${{ matrix.builds[2] }}      


### PR DESCRIPTION
### Goal of this PR
https://github.com/actions/runner-images/issues/11101

### How is this PR achieving the goal
Bumping the Ubuntu version of the Linux runners to `24.04`.

### This PR applies to the following area(s)
GitHub CI

### Successfully tested on
**Game builds:** /

**Platforms:** /

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
/