### PR TITLE
tweak(net): generate truly random "GUID"'s

### DIFF
--- a/code/components/citizen-server-impl/include/ClientDropReasons.h
+++ b/code/components/citizen-server-impl/include/ClientDropReasons.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 namespace fx
 {
@@ -10,7 +10,7 @@ enum class ClientDropReason: uint32_t
 	CLIENT,
 	// server initiated a disconnect
 	SERVER,
-	// client with same guid connected and kicks old client
+	// not used, used to drop existing clients with GUID collisions
 	CLIENT_REPLACED,
 	// server -> client connection timed out
 	CLIENT_CONNECTION_TIMED_OUT,

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -758,7 +758,8 @@ static InitFunction initFunction([]()
 
 				if (oldClient)
 				{
-					gameServer->DropClientWithReason(oldClient, fx::serverDropResourceName, fx::ClientDropReason::CLIENT_REPLACED, "Reconnecting");
+					sendError("Something went wrong. Please try reconnecting.");
+					return;
 				}
 			}
 

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -153,7 +153,16 @@ void NetLibrary::AddSendTick()
 	AddTimeoutTick(g_sendDataTicks);
 }
 
-static uint32_t m_tempGuid = GetTickCount();
+static uint64_t GenerateRandomNumber()
+{
+	std::random_device rd;
+	std::mt19937_64 gen(rd());
+	std::uniform_int_distribution<std::uint64_t> dist(0, UINT64_MAX);
+
+	return dist(gen);
+}
+
+static uint64_t s_tempGuid = GenerateRandomNumber();
 
 uint16_t NetLibrary::GetServerNetID()
 {
@@ -579,7 +588,7 @@ static std::mutex g_netFrameMutex;
 
 inline uint64_t GetGUID()
 {
-	return (uint64_t)(0x210000100000000 | m_tempGuid);
+	return s_tempGuid;
 }
 
 uint64_t NetLibrary::GetGUID()
@@ -876,7 +885,7 @@ concurrency::task<void> NetLibrary::ConnectToServer(const std::string& rootUrl)
 	std::string ruRef = rootUrl;
 
 	// increment the GUID so servers won't race to remove us
-	m_tempGuid++;
+	s_tempGuid++;
 
 	auto urlRef = co_await ResolveUrl(ruRef);
 


### PR DESCRIPTION
### Goal of this PR

This is old code that only gets used on initial client connection in cases where the peer doesn't match the same TCP peer (for situations like Cloudflare Warp or other VPN's that don't keep TCP/UDP the same)

This ID previously allowed for someone to get disconnected if they had the unfortunate coincidence of having the same tick time as another player on initial join, and while this happened *rarely*, it still happened.

This makes the GUID a "more random" number, and in situations where the GUID will collide it will drop the connecting client instead of the existing client. Since the GUID gets incremented on every join, there will be no valid collisions anyways.

### This PR applies to the following area(s)
FiveM, RedM, Server


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.