### PR TITLE
Increase map legend blip limit

### DIFF
--- a/code/components/gta-core-five/src/PatchBlipMapLegend.cpp
+++ b/code/components/gta-core-five/src/PatchBlipMapLegend.cpp
@@ -1,0 +1,24 @@
+#include "StdInc.h"
+#include "Hooking.h"
+#include <CrossBuildRuntime.h>
+
+// This increase the harcoded limit of blip groups from 100 to 255 in pause menu map legend
+static HookFunction hookFunction([]()
+{
+	// The limit no longer exists on game build 3258 and above
+	if (xbr::IsGameBuildOrGreater<3258>())
+	{
+		return;
+	}
+
+	if (xbr::IsGameBuildOrGreater<2372>())
+	{
+		auto location = hook::get_pattern("EB 03 45 33 E4 66 41 83 F8 64 73 29", 9);
+		hook::put<uint8_t>(location, 0xFF);
+	}
+	else
+	{
+		auto location = hook::get_pattern("03 45 33 E4 66 83 3D ? ? ? ? 64 73", 11);
+		hook::put<uint8_t>(location, 0xFF);
+	}
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Increase the 100-blip limit in the pause menu map legend for game builds below 3258.


### How is this PR achieving the goal

Patches the value comparison to raise the hardcoded maximum blip group limit from 100 to 255


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604, 2189, 2372, 2802, 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
https://forum.cfx.re/t/change-maximum-amount-of-blips/1059087/9


