### PR TITLE
fix(core/rdr3): revert serialize component changes

### DIFF
--- a/code/components/gta-streaming-rdr3/src/PatchTextureOverride.cpp
+++ b/code/components/gta-streaming-rdr3/src/PatchTextureOverride.cpp
@@ -496,8 +496,8 @@ static HookFunction hookFunction([]()
 	hook::jump(acquireTextureLocation, getTextureIdStub.GetCode());
 
 
-
-
+// remove this when push to produnction !!!
+#if 0
 	auto maxSerializeComponentCountLocation = hook::get_pattern<char>("41 B0 ? B2 ? 48 8B CF E8 ? ? ? ? 48 8B CF 48 89 AF", 2);
 	hook::put<uint8_t>(maxSerializeComponentCountLocation, 3); // set max serialize component count value
 
@@ -505,7 +505,7 @@ static HookFunction hookFunction([]()
 
 	auto serializeBitsCountLocation = hook::get_pattern<char>("41 B8 ? ? ? ? 44 8A 8E ? ? ? ? 49 8B D6 88 5C 24 ? 48 8B CF 48 89 5C 24 ? 48 89 5C 24 ? FF 90 ? ? ? ? 41 38 1E", 2);
 	hook::put<uint32_t>(serializeBitsCountLocation, 3); // 3 bits // extend serialize bits
-
+#endif
 
 	  
 	fx::ScriptEngine::RegisterNativeHandler("REMOVE_TEXTURE", [](fx::ScriptContext& context)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

This PR temporarily reverts the `max serialize` changes due to inconsistencies between the production and canary environments. Once basic functionality is confirmed to work correctly in the canary environment, the change will be reintroduced and pushed to production.

### How is this PR achieving the goal

By disabling the affected part of the code to prevent environment mismatches and ensure stability in production.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


