### PR TITLE
fix(gta-core-five): invalid bounding volume hierarchy

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
@@ -41,6 +41,25 @@ namespace rage {
 		uint16_t m_MaxNumBounds;
 		uint16_t m_NumBounds;
 	};
+
+	struct phOptimizedBvhNode
+	{
+		__int16 m_AABBMin[3];
+		__int16 m_AABBMax[3];
+		unsigned __int16 m_NodeData;
+		unsigned __int8 m_PolygonCount;
+	};
+
+	struct phOptimizedBvh
+	{
+		phOptimizedBvhNode* bvhNode;
+		char pad[120];
+	};
+
+	struct ScalarV
+	{
+		DirectX::XMVECTOR v;
+	};
 }
 
 static void (*g_origProcessSelfCollision)(void* self, rage::phBoundComposite* boundComposite, rage::Mat34V* a3, rage::Mat34V a4, void* phManifold, unsigned __int8* a6, unsigned __int8* a7, int a8, bool a9);
@@ -53,7 +72,21 @@ static void ProcessSelfCollision(void* self, rage::phBoundComposite* boundCompos
 	g_origProcessSelfCollision(self, boundComposite, a3, a4, phManifold, a6, a7, a8, a9);
 }
 
+static rage::ScalarV* (*g_origCalcClosestLeafDistance)(rage::ScalarV*, rage::Vec3V*, rage::phOptimizedBvh* bvh);
+
+static rage::ScalarV* CalcClosestLeafDistance(rage::ScalarV* out, rage::Vec3V* point, rage::phOptimizedBvh* bvh)
+{
+	if (!bvh || !bvh->bvhNode)
+	{
+		rage::ScalarV* result = new rage::ScalarV();
+		result->v = DirectX::XMVectorSet(100000.0f, 10000.0f, 10000.0f, 1.0f);
+		return result;
+	}
+	return g_origCalcClosestLeafDistance(out, point, bvh);
+}
+
 static HookFunction hookFunction([]()
 {
 	g_origProcessSelfCollision = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 4C 89 48 ? 4C 89 40 ? 48 89 50 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? B8"), ProcessSelfCollision);
+	g_origCalcClosestLeafDistance = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 48 89 50 ? 55 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? B8 ? ? ? ? E8 ? ? ? ? 48 2B E0 49 8B 38"), CalcClosestLeafDistance);
 });


### PR DESCRIPTION
### Goal of this PR
Fix a crash that occurred in the call to the `CalcClosestLeafDistance` function that is responsible for traversing the bvh to find the squared distance to the closest leaf node from the given position.
The function could crash if the bvh or bvhNode pointer was null.

### How is this PR achieving the goal
Adding a check before the original call of the function.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 1604, 3095, 3407

**Platforms:** Windows, Linux

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3155 


