### PR TITLE
feat(extra-natives/five): GET_TRAIN_TRACK_INDEX

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -272,6 +272,7 @@ static int IsAlarmSetOffset;
 static int AlarmTimeLeftOffset;
 static int WheelieStateOffset;
 static int TrainTrackNodeIndexOffset;
+static int TrainTrackIndexOffset;
 static int PreviouslyOwnedByPlayerOffset;
 static int NeedsToBeHotwiredOffset;
 static int IsInteriorLightOnOffset;
@@ -613,6 +614,7 @@ static HookFunction initFunction([]()
 		TrainStateOffset = *hook::get_pattern<uint32_t>("89 91 ? ? ? ? 80 3D ? ? ? ? ? 0F 84", 2);
 		TrainCruiseSpeedOffset = *hook::get_pattern<uint32_t>("C7 87 ? ? ? ? ? ? ? ? E8 ? ? ? ? 4C 89 AF", 2);
 		TrainSpeedOffset = *hook::get_pattern<uint32_t>("4C 89 AF ? ? ? ? 44 89 AF ? ? ? ? 4C 89 AF ? ? ? ? 49 8B 0E", 3);
+		TrainTrackIndexOffset = *hook::get_pattern<uint32_t>("8A 8F ? ? ? ? F3 41 0F 58 CB", 2);
 	}
 
 	{
@@ -1553,6 +1555,8 @@ static HookFunction initFunction([]()
 	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_CRUISE_SPEED", std::bind(readVehicleMemory<float, &TrainCruiseSpeedOffset>, _1, "GET_TRAIN_CRUISE_SPEED"));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_SPEED", std::bind(readVehicleMemory<float, &TrainSpeedOffset>, _1, "GET_TRAIN_SPEED"));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_TRACK_INDEX", std::bind(readVehicleMemory<uint8_t, &TrainTrackIndexOffset>, _1, "GET_TRAIN_TRACK_INDEX"));
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_TRAIN_STATE", makeTrainFunction([](fx::ScriptContext& context, fwEntity* train)
 	{

--- a/ext/native-decls/GetTrainTrackIndex.md
+++ b/ext/native-decls/GetTrainTrackIndex.md
@@ -1,0 +1,14 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_TRAIN_TRACK_INDEX
+
+```c
+int GET_TRAIN_TRACK_INDEX(Vehicle train);
+``` 
+## Parameters
+* **train**: The train handle
+## Return value
+The track index the train is currently on.


### PR DESCRIPTION
### Goal of this PR

Introduces a way for client scripts to know which track a train is currently on. As with track switching a train can change track index from where it was originally created on. Requested by GlitchDetector

### How is this PR achieving the goal

By introducing ``GET_TRAIN_TRACK_INDEX`` to allow client scripts to retrieve the trains current track index.

### This PR applies to the following area(s)

FiveM, Natives

### Successfully tested on

**Game builds:** 1604, 3258

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues