### PR TITLE
feat(extra-natives/five): GET_WEAPON_ACCURACY_SPREAD & SET_WEAPON_ACC…

### DIFF
--- a/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
@@ -13,6 +13,7 @@
 static int WeaponDamageModifierOffset;
 static int WeaponAnimationOverrideOffset;
 static int WeaponRecoilShakeAmplitudeOffset;
+static int WeaponSpreadOffset;
 static int ObjectWeaponOffset;
 
 static int PedOffset = 0x10;
@@ -354,6 +355,7 @@ static HookFunction hookFunction([]()
 		WeaponDamageModifierOffset = *hook::get_pattern<int>("48 8B 0C F8 89 B1", 6);
 		WeaponAnimationOverrideOffset = *hook::get_pattern<int>("8B 9F ? ? ? ? 85 DB 75 3E", 2);
 		WeaponRecoilShakeAmplitudeOffset = *hook::get_pattern<int>("48 8B 47 40 F3 0F 10 B0 ? ? ? ?", 8);
+		WeaponSpreadOffset = *hook::get_pattern<uint8_t>("F3 0F 59 59 ? F3 0F 59 D8", 4);
 
 		ObjectWeaponOffset = *hook::get_pattern<int>("74 5C 48 83 BB ? ? ? ? 00 75 52", 5);
 
@@ -396,6 +398,26 @@ static HookFunction hookFunction([]()
 		}
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_WEAPON_ACCURACY_SPREAD", [](fx::ScriptContext& context)
+	{
+		float accuracySpread = 0;
+
+		if (auto weapon = getWeaponFromHash(context))
+		{
+			accuracySpread = reinterpret_cast<hook::FlexStruct*>(weapon)->Get<float>(WeaponSpreadOffset);
+		}
+
+		context.SetResult<float>(accuracySpread);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_WEAPON_ACCURACY_SPREAD", [](fx::ScriptContext& context)
+	{
+		if (auto weapon = getWeaponFromHash(context))
+		{
+			float weaponSpreadAccuracy = context.GetArgument<float>(1);
+			reinterpret_cast<hook::FlexStruct*>(weapon)->Set<float>(WeaponSpreadOffset, weaponSpreadAccuracy);
+		}
+	});
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_FLASH_LIGHT_KEEP_ON_WHILE_MOVING", [](fx::ScriptContext& context) 
 	{

--- a/ext/native-decls/GetWeaponAccuracySpread.md
+++ b/ext/native-decls/GetWeaponAccuracySpread.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+
+## GET_WEAPON_ACCURACY_SPREAD
+
+```c
+float GET_WEAPON_ACCURACY_SPREAD(Hash weaponHash);
+```
+
+A getter for the accuracy spread of a weapon.
+
+## Parameters
+
+- **weaponHash**: Weapon name hash.
+
+## Return value
+
+The accuracy spread of a weapon.

--- a/ext/native-decls/SetWeaponAccuracySpread.md
+++ b/ext/native-decls/SetWeaponAccuracySpread.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+
+## SET_WEAPON_ACCURACY_SPREAD
+
+```c
+void SET_WEAPON_ACCURACY_SPREAD(Hash weaponHash, float spread);
+```
+
+A setter for the accuracy spread of a weapon.
+
+## Parameters
+
+- **weaponHash**: Weapon name hash.
+- **spread**: Accuracy spread


### PR DESCRIPTION
### Goal of this PR
Introduces a way for client scripts to get & set the accuracy spread value of a weapon via it's hash.


### How is this PR achieving the goal
By introducing `GET_WEAPON_ACCURACY_SPREAD` & `GET_WEAPON_ACCURACY_SPREAD` to allow client scripts to retrieve and set the spread of a weapon.

### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on

**Game builds:** 2062, 3095, 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues