### PR TITLE
fix(core-rdr3): fix crash when Blip limit is reached RedM

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchBlipLimitCrash.cpp
+++ b/code/components/gta-core-rdr3/src/PatchBlipLimitCrash.cpp
@@ -1,0 +1,25 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <MinHook.h>
+#include <Pool.h>
+
+static void* (*g_origCreateWaypoint)(void* waypointController, uint32_t* blipHash);
+static void* CreateWaypoint(void* waypointController, uint32_t* blipHash)
+{
+	static auto pool = rage::GetPoolBase("fwuiBlip");
+
+	if (pool->GetCountDirect() >= pool->GetSize())
+	{
+		trace("Prevented crash: Blip pool 'fwuiBlip' is full (%d out of %d slots used)\n", pool->GetCountDirect(), pool->GetSize());
+		return 0;
+	}
+
+	return g_origCreateWaypoint(waypointController, blipHash);
+}
+
+static HookFunction hookFunction([]()
+{
+	MH_Initialize();
+	MH_CreateHook(hook::get_pattern("45 33 C0 44 38 05 ? ? ? ? 41 0F 95 C0"), CreateWaypoint, (void**)&g_origCreateWaypoint);
+	MH_EnableHook(MH_ALL_HOOKS);
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

this pr fixes a crash, when blip limit has been reached `920` and players use the set waipoint in the big map
it causes them to crash.

![image](https://github.com/user-attachments/assets/97f4f261-e2f3-447f-93b1-657c18e69df1)

![image](https://github.com/user-attachments/assets/f6a1298a-3d41-432a-bf08-ff39daca596c)

thanks to @Ktos93

### How is this PR achieving the goal

Logs in the f8 console when blip limit has been reached and blocks the player  from using the waypoint, which prevents the crash
the log will help players report to the developers so they become aware of the issues.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


