### PR TITLE
fix(net/rdr3): Deadlock in CProcessControlUpdateGraph

### DIFF
--- a/code/components/gta-net-five/src/CloneExperiments.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments.cpp
@@ -1298,6 +1298,7 @@ static void ManageHostMigrationStub(void* a1)
 	}
 }
 
+#ifdef GTA_FIVE
 static void(*g_origUnkBubbleWrap)();
 
 static void UnkBubbleWrap()
@@ -1307,6 +1308,7 @@ static void UnkBubbleWrap()
 		g_origUnkBubbleWrap();
 	}
 }
+#endif
 
 #ifdef GTA_FIVE
 static void* (*g_origNetworkObjectMgrCtor)(void*, void*);
@@ -1733,9 +1735,7 @@ static HookFunction hookFunction([]()
 	// 1604 unused, some bubble stuff
 	//hook::return_function(0x14104D148);
 #ifdef GTA_FIVE
-	MH_CreateHook(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 81 EC ? ? ? ? 48 8D 0D"), UnkBubbleWrap, (void**)&g_origUnkBubbleWrap);
-#elif IS_RDR3
-	MH_CreateHook(hook::get_pattern("48 83 EC ? 8A 05 ? ? ? ? 33 DB 0F 29 74 24 60", -6), UnkBubbleWrap, (void**)&g_origUnkBubbleWrap);
+	MH_CreateHook(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 81 EC ? ? ? ? 48 8D 0D"), UnkBubbleWrap, (void**)&g_origUnkBubbleWrap);;
 #endif
 
 #ifdef GTA_FIVE


### PR DESCRIPTION
### Goal of this PR

Resolves a common Deadlock related to the Cover system for players that navigate around the 0.0, 0.0, 0.0 coordinates in the games world and its surrounding area's.

### How is this PR achieving the goal

By removing a hook in CloneExperiments that accidently made a cover related function no-op in a OneSync environment. Restoring its original behaviour in OneSync and resolving the deadlock

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

Fixes https://github.com/citizenfx/fivem/issues/3203 Fixes #2801 and  https://forum.cfx.re/t/heartlands-world-origin-client-freeze-when-moving-quickly/5182328
