### PR TITLE
feat(extra-natives/five): add support for configurable outline render technique

### DIFF
--- a/code/components/extra-natives-five/src/GamePrimitives_Outlines.cpp
+++ b/code/components/extra-natives-five/src/GamePrimitives_Outlines.cpp
@@ -35,6 +35,10 @@ static int* g_currentDrawBucket;
 
 static CRGBA outlineColor{ 255, 0, 255, 255 };
 
+constexpr const char* DEFAULT_SHADER_TECHNIQUE_GROUP = "unlit";
+static std::string g_shaderTechniqueGroupId = DEFAULT_SHADER_TECHNIQUE_GROUP;
+
+
 class OutlineRenderer
 {
 public:
@@ -432,7 +436,7 @@ static InitFunction initFunctionBuffers([]()
 				SetBlendState(GetStockStateIdentifier(BlendStateDefault));
 
 				last = *currentShader;
-				*currentShader = _getTechniqueDrawName("unlit");
+				*currentShader = _getTechniqueDrawName(g_shaderTechniqueGroupId.c_str());
 
 				// draw bucket 0 pls, not 1
 				// #TODO: set via DC?
@@ -602,6 +606,21 @@ static InitFunction initFunctionScriptBind([]()
 				outlineEntities.erase(it);
 			}
 		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE", [](fx::ScriptContext& context)
+	{
+		std::string techniqueGroupId = context.GetArgument<const char*>(0);
+		if (techniqueGroupId.empty())
+		{
+			return;
+		}
+		g_shaderTechniqueGroupId = techniqueGroupId;
+	});
+	
+	fx::ScriptEngine::RegisterNativeHandler("RESET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE", [](fx::ScriptContext& context)
+	{
+		g_shaderTechniqueGroupId = DEFAULT_SHADER_TECHNIQUE_GROUP;
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_MATRIX", [](fx::ScriptContext& context)

--- a/ext/native-decls/sdk/ResetEntityDrawOutlineRenderTechnique.md
+++ b/ext/native-decls/sdk/ResetEntityDrawOutlineRenderTechnique.md
@@ -1,0 +1,11 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## RESET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE
+
+```c
+void RESET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE();
+```
+This function undoes changes made by [`SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE`](#_0x68DFF2DD), restoring the original outline rendering behavior. The default render technique group is `unlit`.

--- a/ext/native-decls/sdk/SetEntityDrawOutlineRenderTechnique.md
+++ b/ext/native-decls/sdk/SetEntityDrawOutlineRenderTechnique.md
@@ -1,0 +1,64 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE
+
+```c
+void SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE(char* techniqueGroup);
+```
+Sets the render technique for drawing an entity's outline. This function allows you to specify a technique group name to control how the entity's outline is rendered in the game.
+
+List of known technique group's:
+```
+alt0
+alt1
+alt2
+alt3
+alt4
+alt5
+alt6
+alt7
+alt8
+blit
+cube
+default
+geometry
+imposter
+imposterdeferred
+lightweight0
+lightweight0CutOut
+lightweight0CutOutTint
+lightweight0WaterRefractionAlpha
+lightweight4
+lightweight4CutOut
+lightweight4CutOutTint
+lightweight4WaterRefractionAlpha
+lightweight8
+lightweight8CutOut
+lightweight8CutOutTint
+lightweight8WaterRefractionAlpha
+lightweightHighQuality0
+lightweightHighQuality0CutOut
+lightweightHighQuality0WaterRefractionAlpha
+lightweightHighQuality4
+lightweightHighQuality4CutOut
+lightweightHighQuality4WaterRefractionAlpha
+lightweightHighQuality8
+lightweightHighQuality8CutOut
+lightweightHighQuality8WaterRefractionAlpha
+lightweightNoCapsule4
+lightweightNoCapsule8
+multilight
+tessellate
+ui
+unlit
+waterreflection
+waterreflectionalphaclip
+waterreflectionalphacliptint
+wdcascade
+```
+
+## Parameters
+* **techniqueGroup**: Technique group name.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Allow developers to specify a custom shader technique group for entity outlines via a new native (`SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE`). This expands the flexibility of the outline rendering system, which was previously limited to the unlit technique, and addresses use cases beyond the intended FxDK environment, as some developers rely on this functionality in their own codebases.
![image](https://github.com/user-attachments/assets/d00f2cb0-8b65-4977-b486-e806a3c85ef0)

> Note: While not critical to FxDK usage, this native aims to improve flexibility for developers already relying on outline rendering in their projects.
### How is this PR achieving the goal

Introduces the `SET_ENTITY_DRAW_OUTLINE_RENDER_TECHNIQUE` native, allowing scripts to specify a custom shader technique group for entity outlines. The implementation updates the outline rendering system to use the provided technique group, with a fallback to the default "unlit" technique if none is specified. This expands the flexibility of outline rendering for both FxDK and community use cases.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Natives, FxDK

### Successfully tested on

Game builds: 1604, 3095, 3258, 3407

Platforms: Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


