### PR TITLE
fix(server-routing-bucket): change entity argument type

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1665,7 +1665,7 @@ static void Init()
 	{
 		if (context.GetArgumentCount() > 1)
 		{
-			char* ent = context.GetArgument<char*>(0);
+			const auto ent = context.GetArgument<uint32_t>(0);
 			auto bucket = context.GetArgument<int>(1);
 		 	int oldBucket = entity->routingBucket;
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fixes a server crash when using the `onEntityBucketChange` new event.  
Unlike `SET_PLAYER_ROUTING_BUCKET`, `SET_ENTITY_ROUTING_BUCKET` requires a different argument type. 
Was an oversight of mine. 

### How is this PR achieving the goal

we change to the required argument type

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


