### PR TITLE
fix(client): vulkan load order

### DIFF
--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -604,6 +604,11 @@ int RealMain()
 	// if not, system d3d10.dll etc. may load a d3d11.dll from search path anyway and this may be a 'weird' one
 	loadSystemDll(L"\\d3d11.dll");
 
+#ifdef IS_RDR3
+	// RedM attempts to load vulkan bundled with CEF first which on some systems leads to various issues
+	loadSystemDll(L"\\vulkan-1.dll");
+#endif
+
 	loadSystemDll(L"\\d3d9.dll");
 	loadSystemDll(L"\\d3d10.dll");
 	loadSystemDll(L"\\d3d10_1.dll");


### PR DESCRIPTION
### Goal of this PR

Make RedM load vulkan-1.dll from System32 (if available) over the bundled vulkan-1.dll in CEF. 

CEF's M103's vulkan-1 is several years old and is a dev build versioned "1.0.111.2222" and on some system configurations doesn't play well with it leading to some vulkan assertions or "ERR_GFX_STATE" crashes on start-up.

If in some case the user does not have vulkan-1 installed in System32. The bundled vulkan-1.dll in CEF will be used 

### How is this PR achieving the goal

In launcher we load vulkan-1.dll as a system.dll similar to what is done for dxgi.dll, d3d9.dll, d3d12.dll, d3d10.dll. Most users will have vulkan-1 present here as during the Red Dead Redemption 2 installation Vulkan 1.1.108 installer is ran which places the file in the users C:/Windows/System32/vulkan-1.dll location.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

