### PR TITLE
code/vendor/lua/src: Save stack space while handling errors

### DIFF
--- a/code/vendor/lua/src/ldebug.c
+++ b/code/vendor/lua/src/ldebug.c
@@ -632,8 +632,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, currentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 

--- a/code/vendor/lua/src/lvm.c
+++ b/code/vendor/lua/src/lvm.c
@@ -698,8 +698,10 @@ void luaV_concat (lua_State *L, int total) {
       /* collect total length */
       for (i = 1; i < total && tostring(L, top-i-1); i++) {
         size_t l = vslen(top - i - 1);
-        if (l >= (MAX_SIZE/sizeof(char)) - tl)
+        if (l >= (MAX_SIZE/sizeof(char)) - tl) {
+          L->top = top - total;  /* pop strings to avoid wasting stack */
           luaG_runerror(L, "string length overflow");
+        }
         tl += l;
       }
       buffer = luaZ_openspace(L, &G(L)->buff, tl);
@@ -713,7 +715,7 @@ void luaV_concat (lua_State *L, int total) {
       setsvalue2s(L, top-n, luaS_newlstr(L, buffer, tl));  /* create result */
     }
     total -= n-1;  /* got 'n' strings to create 1 new */
-    L->top -= n-1;  /* popped 'n' strings and pushed one */
+    L->top = top - (n - 1);  /* popped 'n' strings and pushed one */
   } while (total > 1);  /* repeat until only 1 result left */
 }
 


### PR DESCRIPTION
### Goal of this PR
This PR fixes a security vulnerability in luaG_runerror() that was cloned from lua but did not receive the security patch. The original issue was reported and fixed under https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf.

This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2022-33099
https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf

