### PR TITLE
tweak(rdr): remove support for older rdr builds

### DIFF
--- a/code/client/launcher/ExecutableLoader.Snapshot.cpp
+++ b/code/client/launcher/ExecutableLoader.Snapshot.cpp
@@ -108,22 +108,7 @@ inline uintptr_t GetTriggerEP()
 		return ep;
 	}
 
-	if (xbr::IsGameBuild<1355>())
-	{
-		return 0x142DE455C; // 1355.18
-	}
-
-	if (xbr::IsGameBuild<1436>())
-	{
-		return 0x142E13DA4; // 1436.31
-	}
-
-	if (xbr::IsGameBuild<1491>())
-	{
-		return 0x142E4FAD0; // 1491.50
-	}
-
-	return 0x142E0F92C; // 1311.20
+	return 0x142E4FAD0; // 1491.50
 }
 
 #define TRIGGER_EP (GetTriggerEP())

--- a/code/client/launcher/GameCache.cpp
+++ b/code/client/launcher/GameCache.cpp
@@ -1968,225 +1968,40 @@ static std::map<int, std::map<std::string, GameCacheEntry>> g_entriesToLoadPerBu
 				"appdata0_update.rpf",
 				{
 					"appdata0_update.rpf", "e68cbb4882db0028ba2701c26ed69152ad992c2e", "https://content.cfx.re/mirrors/patches_redm/1491.50/appdata0_update.rpf", 3164623,
-					{
-						{ "1715741785ce3c28adf9a78633e57f478229bb84", "e68cbb4882db0028ba2701c26ed69152ad992c2e", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1311_to_1491.50.appdata0_update.rpf.hdiff", 1914067 } /* diff sha1: 00d25742c884f95922ecbbae37583cc4d67cc5c1 */,
-						{ "307609c164e78adaf4e50e993328485e6264803f", "e68cbb4882db0028ba2701c26ed69152ad992c2e", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1355_to_1491.50.appdata0_update.rpf.hdiff", 1827754 } /* diff sha1: a9dd1da46bab5bf04ca3835c74497695dec89427 */,
-						{ "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "e68cbb4882db0028ba2701c26ed69152ad992c2e", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.appdata0_update.rpf.hdiff", 1099205 } /* diff sha1: 2486abcb82d0559dbb4ebba1e2cecfd63ef9c97f */,
-						{ "142c6af7a64f2cae06a8f7ac7ad6ee74967afc49", "e68cbb4882db0028ba2701c26ed69152ad992c2e", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.appdata0_update.rpf.hdiff", 859819 } /* diff sha1: de5b59a912f8ec3cdf317acd3f7895fdc30c3bc5 */
-					}
 				}
 			},
 			{
 				"shaders_x64.rpf",
 				{
 					"shaders_x64.rpf", "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "https://content.cfx.re/mirrors/patches_redm/1491.50/shaders_x64.rpf", 233921358,
-					{
-						{ "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1311_to_1491.50.shaders_x64.rpf.hdiff", 18993038 } /* diff sha1: 7e4691a2113c4734a934dccbc88032c070308469 */,
-						{ "a7a45988a6067964214cc4b3af21797249817469", "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1355_to_1491.50.shaders_x64.rpf.hdiff", 17434866 } /* diff sha1: 36371124827afcf6379c35d97602e4503bfc9768 */,
-						{ "f4f06c18701d66958eb6f0ac243c8467033b864b", "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.shaders_x64.rpf.hdiff", 14013870 } /* diff sha1: d0db63b6900d71bbe478ef4e5b1fce52302c5673 */,
-						{ "f456cbaf70ff921f77279db5a901c6a6e5807e2e", "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.shaders_x64.rpf.hdiff", 13734156 } /* diff sha1: d01ea64ced67c5a4746656d4bdcf0e9993a04270 */
-					}
 				}
 			},
 			{
 				"update_1.rpf",
 				{
 					"update_1.rpf", "8c25d7345b7e69ebaee24ccfea97739ace59ba51", "https://content.cfx.re/mirrors/patches_redm/1491.50/update_1.rpf", 2833741450,
-					{
-						{ "9e62163f0383aa4eb30a02fa0f5628bbf4538543", "8c25d7345b7e69ebaee24ccfea97739ace59ba51", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.update_1.rpf.hdiff", 87253125 } /* diff sha1: 83ceb5c113aa6f5be0bc9df8331fc53fdb3835ec */,
-						{ "601a4801f739540bebb2b3e141fda022901a7bd1", "8c25d7345b7e69ebaee24ccfea97739ace59ba51", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.update_1.rpf.hdiff", 17843685 } /* diff sha1: 91edd8683f7872968a71036cef74041579e272f7 */
-					}
 				}
 			},
 			{
 				"update_2.rpf",
 				{
 					"update_2.rpf", "5a77f9b8cb24e1c3e78ee33c7ed218a32e3d2e32", "https://content.cfx.re/mirrors/patches_redm/1491.50/update_2.rpf", 152046254,
-					{
-						{ "87323b6d0e1c790972041a034a6f293eb774c84d", "5a77f9b8cb24e1c3e78ee33c7ed218a32e3d2e32", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.update_2.rpf.hdiff", 24349275 } /* diff sha1: d53cd8b71a3beba9afdb3bd7f76d1e7731be5ec1 */,
-						{ "6b3af948543e7a48013bdec930e8dd586be37266", "5a77f9b8cb24e1c3e78ee33c7ed218a32e3d2e32", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.update_2.rpf.hdiff", 18451453 } /* diff sha1: 4e87e70df5c0d073f8b0790d9ff3440f5cc31878 */
-					}
 				}
 			},
 			{
 				"update_3.rpf",
 				{
 					"update_3.rpf", "be15563d37c1ab0f655eeebb45f4d30527df950d", "https://content.cfx.re/mirrors/patches_redm/1491.50/update_3.rpf", 132374684,
-					{
-						{ "a2708ff55294d70bda198a1ff98c1f4b55b0c0df", "be15563d37c1ab0f655eeebb45f4d30527df950d", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.update_3.rpf.hdiff", 114270024 } /* diff sha1: 9d7af31be4e61cb86a4268c28daae6ce6d40f2bb */,
-						{ "9237da54d2267435fc7d7bf0f3ec054bbeea90a9", "be15563d37c1ab0f655eeebb45f4d30527df950d", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.update_3.rpf.hdiff", 114892075 } /* diff sha1: d98c2b3f2cf3e9049e7b2682aeaf3f9252f47af3 */
-					}
 				}
 			},
 			{
 				"update_4.rpf",
 				{
 					"update_4.rpf", "853a63af1698a970dfb73295faa76a31e56fe4bd", "https://content.cfx.re/mirrors/patches_redm/1491.50/update_4.rpf", 2015028563,
-					{
-						{ "4ec55a211e7cb1d68c8fd471cfb049d7690fc9ee", "853a63af1698a970dfb73295faa76a31e56fe4bd", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1436_to_1491.50.update_4.rpf.hdiff", 19504197 } /* diff sha1: 9c451a6aee4e8a9d4782a2348ff8a569d71b9337 */,
-						{ "503c8de5c16e26afdce502b9aedf1ae16a0e8730", "853a63af1698a970dfb73295faa76a31e56fe4bd", "https://content.cfx.re/mirrors/patches_redm/1491.50/diffs/from_1491_to_1491.50.update_4.rpf.hdiff", 293569 } /* diff sha1: 3f5120c886b76512a5de8843d3e909368a8e64f9 */
-					}
 				}
 			}
 		}
 	},
-	{
-		1436,
-		{
-			{
-				"RDR2.exe",
-				{ "RDR2.exe", "f998b4863b11793547c09c226ab884e1e26931f2", "https://content.cfx.re/mirrors/patches_redm/1436/RDR2.exe", 89104336 }
-			},
-			{
-				"appdata0_update.rpf",
-				{
-					"appdata0_update.rpf", "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "https://content.cfx.re/mirrors/patches_redm/1436/appdata0_update.rpf", 3163551,
-					{
-						{ "1715741785ce3c28adf9a78633e57f478229bb84", "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1311_to_1436.appdata0_update.rpf.hdiff", 1785629 } /* diff sha1: 3dec92f13de7440fed0420ebe12522d9f0bcae9e */,
-						{ "307609c164e78adaf4e50e993328485e6264803f", "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1355_to_1436.appdata0_update.rpf.hdiff", 1726590 } /* diff sha1: e5375671b7270be06fd55052f78e8afc95a8222d */,
-						{ "142c6af7a64f2cae06a8f7ac7ad6ee74967afc49", "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.appdata0_update.rpf.hdiff", 1093833 } /* diff sha1: 1f81d526052eda00d14c1bf601f811c005c8f052 */,
-						{ "e68cbb4882db0028ba2701c26ed69152ad992c2e", "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.appdata0_update.rpf.hdiff", 1093887 } /* diff sha1: f69e79db5ec8b33f4ea4c96d4d96281ecb2feb45 */
-					}
-				}
-			},
-			{
-				"shaders_x64.rpf",
-				{
-					"shaders_x64.rpf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "https://content.cfx.re/mirrors/patches_redm/1436/shaders_x64.rpf", 233898030,
-					{
-						{ "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "f4f06c18701d66958eb6f0ac243c8467033b864b", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1311_to_1436.shaders_x64.rpf.hdiff", 6183735 } /* diff sha1: 22592c1a70552466d8f34c49484bf5475da399ae */,
-						{ "a7a45988a6067964214cc4b3af21797249817469", "f4f06c18701d66958eb6f0ac243c8467033b864b", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1355_to_1436.shaders_x64.rpf.hdiff", 4332901 } /* diff sha1: 5b0ff40e1a76775461903fa9669c950ec0113e46 */,
-						{ "f456cbaf70ff921f77279db5a901c6a6e5807e2e", "f4f06c18701d66958eb6f0ac243c8467033b864b", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.shaders_x64.rpf.hdiff", 265613 } /* diff sha1: 448dad13cdb90971890418041e38db9bc436cf3e */,
-						{ "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "f4f06c18701d66958eb6f0ac243c8467033b864b", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.shaders_x64.rpf.hdiff", 14048549 } /* diff sha1: 026725b8698e25c4d23b0f58fa22543f620e29e1 */
-					}
-				}
-			},
-			{
-				"update_1.rpf",
-				{
-					"update_1.rpf", "9e62163f0383aa4eb30a02fa0f5628bbf4538543", "https://content.cfx.re/mirrors/patches_redm/1436/update_1.rpf", 2836982634,
-					{
-						{ "601a4801f739540bebb2b3e141fda022901a7bd1", "9e62163f0383aa4eb30a02fa0f5628bbf4538543", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.update_1.rpf.hdiff", 89907254 } /* diff sha1: f55dae6db48fd0dda668a3ab7bf45cd8a7601359 */,
-						{ "8c25d7345b7e69ebaee24ccfea97739ace59ba51", "9e62163f0383aa4eb30a02fa0f5628bbf4538543", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.update_1.rpf.hdiff", 89940992 } /* diff sha1: 248a15b3bb1577117e45a7d7fa7cc59342f61236 */
-					}
-				}
-			},
-			{
-				"update_2.rpf",
-				{
-					"update_2.rpf", "87323b6d0e1c790972041a034a6f293eb774c84d", "https://content.cfx.re/mirrors/patches_redm/1436/update_2.rpf", 152008542,
-					{
-						{ "6b3af948543e7a48013bdec930e8dd586be37266", "87323b6d0e1c790972041a034a6f293eb774c84d", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.update_2.rpf.hdiff", 24380905 } /* diff sha1: 0c65b20a6f577d14dd0f9733d03c657542a517c8 */,
-						{ "5a77f9b8cb24e1c3e78ee33c7ed218a32e3d2e32", "87323b6d0e1c790972041a034a6f293eb774c84d", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.update_2.rpf.hdiff", 24361478 } /* diff sha1: febfd15d7614f69ac16715a020b13361b843e30d */
-					}
-				}
-			},
-			{
-				"update_3.rpf",
-				{
-					"update_3.rpf", "a2708ff55294d70bda198a1ff98c1f4b55b0c0df", "https://content.cfx.re/mirrors/patches_redm/1436/update_3.rpf", 132374108,
-					{
-						{ "9237da54d2267435fc7d7bf0f3ec054bbeea90a9", "a2708ff55294d70bda198a1ff98c1f4b55b0c0df", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.update_3.rpf.hdiff", 116090311 } /* diff sha1: 01695c3f9ba37b0c2e3f52aefae433452c3edc2a */,
-						{ "be15563d37c1ab0f655eeebb45f4d30527df950d", "a2708ff55294d70bda198a1ff98c1f4b55b0c0df", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.update_3.rpf.hdiff", 114282726 } /* diff sha1: f985ea07d597bed15b490ab0f99776cb0ac0a643 */
-					}
-				}
-			},
-			{
-				"update_4.rpf",
-				{
-					"update_4.rpf", "4ec55a211e7cb1d68c8fd471cfb049d7690fc9ee", "https://content.cfx.re/mirrors/patches_redm/1436/update_4.rpf", 2014659811,
-					{
-						{ "503c8de5c16e26afdce502b9aedf1ae16a0e8730", "4ec55a211e7cb1d68c8fd471cfb049d7690fc9ee", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491_to_1436.update_4.rpf.hdiff", 18944420 } /* diff sha1: 0f0ea25c6e763c834a0dbeec98773479af6ccaa2 */,
-						{ "853a63af1698a970dfb73295faa76a31e56fe4bd", "4ec55a211e7cb1d68c8fd471cfb049d7690fc9ee", "https://content.cfx.re/mirrors/patches_redm/1436/diffs/from_1491.50_to_1436.update_4.rpf.hdiff", 19046666 } /* diff sha1: 418cd83ffa6c39289784aa99596b840ad40d526b */
-					}
-				}
-			}
-		}
-	},
-	{
-		1355,
-		{
-			{
-				"RDR2.exe",
-				{ "RDR2.exe", "c2fab1d25daef4779aafd2754ec9c593e674e7c3", "https://content.cfx.re/mirrors/patches_redm/1355/RDR2.exe", 84664448 }
-			},
-			{
-				"appdata0_update.rpf",
-				{
-					"appdata0_update.rpf", "307609c164e78adaf4e50e993328485e6264803f", "https://content.cfx.re/mirrors/patches_redm/1355/appdata0_update.rpf", 3069247,
-					{
-						{ "1715741785ce3c28adf9a78633e57f478229bb84", "307609c164e78adaf4e50e993328485e6264803f", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1311_to_1355.appdata0_update.rpf.hdiff", 1703692 } /* diff sha1: dbea61ab2e74c2c9c984a16c17233dcfde014af0 */,
-						{ "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "307609c164e78adaf4e50e993328485e6264803f", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1436_to_1355.appdata0_update.rpf.hdiff", 1644378 } /* diff sha1: 24faaa60d4df3d109410d6b58286a1af0d880bba */,
-						{ "142c6af7a64f2cae06a8f7ac7ad6ee74967afc49", "307609c164e78adaf4e50e993328485e6264803f", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1491_to_1355.appdata0_update.rpf.hdiff", 1740781 } /* diff sha1: e6683ad9aa9bd9ca302b07e324d73d20829ac2f1 */,
-						{ "e68cbb4882db0028ba2701c26ed69152ad992c2e", "307609c164e78adaf4e50e993328485e6264803f", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1491.50_to_1355.appdata0_update.rpf.hdiff", 1740781 } /* diff sha1: 3f83c5e3cf75b833757a7bb3cae39f17b5712986 */
-					}
-				}
-			},
-			{
-				"shaders_x64.rpf",
-				{
-					"shaders_x64.rpf", "a7a45988a6067964214cc4b3af21797249817469", "https://content.cfx.re/mirrors/patches_redm/1355/shaders_x64.rpf", 233585710,
-					{
-						{ "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "a7a45988a6067964214cc4b3af21797249817469", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1311_to_1355.shaders_x64.rpf.hdiff", 1875463 } /* diff sha1: ac5fd94f61158f73719290a79e59bb84050ab5dc */,
-						{ "f4f06c18701d66958eb6f0ac243c8467033b864b", "a7a45988a6067964214cc4b3af21797249817469", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1436_to_1355.shaders_x64.rpf.hdiff", 4184409 } /* diff sha1: 75ccc162577c4366e151b1b373b2d72ba871ae80 */,
-						{ "f456cbaf70ff921f77279db5a901c6a6e5807e2e", "a7a45988a6067964214cc4b3af21797249817469", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1491_to_1355.shaders_x64.rpf.hdiff", 4369953 } /* diff sha1: dc67cb46f136f6b028d5c27872256c3bba5e3788 */,
-						{ "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "a7a45988a6067964214cc4b3af21797249817469", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1491.50_to_1355.shaders_x64.rpf.hdiff", 17310440 } /* diff sha1: 9b08a64a7436dd3983f31a1378757ddc7d6e660e */
-					}
-				}
-			},
-			{
-				"update.rpf",
-				{
-					"update.rpf", "5a087ef32e6b30b4fde8bbeda7babc45f2c1cf4d", "https://content.cfx.re/mirrors/patches_redm/1355/update.rpf", 4685758145,
-					{
-						{ "835a767055cfbf2c2ad86cf4462c7dfb931970fd", "5a087ef32e6b30b4fde8bbeda7babc45f2c1cf4d", "https://content.cfx.re/mirrors/patches_redm/1355/diffs/from_1311_to_1355.update.rpf.hdiff", 1513512317 } /* diff sha1: b528f92872385a37302e367de67d9938de918d33 */
-					}
-				}
-			}
-		}
-	},
-	{
-		1311,
-		{
-			{
-				"RDR2.exe",
-				{ "RDR2.exe", "ac3c2abd80bfa949279d8e1d32105a3d9345c6c8", "https://content.cfx.re/mirrors/patches_redm/1311/RDR2.exe", 91439232 }
-			},
-			{
-				"appdata0_update.rpf",
-				{
-					"appdata0_update.rpf", "1715741785ce3c28adf9a78633e57f478229bb84", "https://content.cfx.re/mirrors/patches_redm/1311/appdata0_update.rpf", 3003087,
-					{
-						{ "307609c164e78adaf4e50e993328485e6264803f", "1715741785ce3c28adf9a78633e57f478229bb84", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1355_to_1311.appdata0_update.rpf.hdiff", 1624654 } /* diff sha1: ebd5f32406de1195d5c02482eb036b78060077f3 */,
-						{ "ba1d727a70fa1c204441c8e3768a1a40b02ef67f", "1715741785ce3c28adf9a78633e57f478229bb84", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1436_to_1311.appdata0_update.rpf.hdiff", 1650802 } /* diff sha1: 35291b0d0e2fa862d4a1c52deb954f7a1a182627 */,
-						{ "142c6af7a64f2cae06a8f7ac7ad6ee74967afc49", "1715741785ce3c28adf9a78633e57f478229bb84", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1491_to_1311.appdata0_update.rpf.hdiff", 1774323 } /* diff sha1: c06f3cc14eb80628aea0baecdcb510ec027bf80e */,
-						{ "e68cbb4882db0028ba2701c26ed69152ad992c2e", "1715741785ce3c28adf9a78633e57f478229bb84", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1491.50_to_1311.appdata0_update.rpf.hdiff", 1775075 } /* diff sha1: 53a91497a26e99a81b47da2e20c484d9032e6eb0 */
-					}
-				}
-			},
-			{
-				"shaders_x64.rpf",
-				{
-					"shaders_x64.rpf", "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "https://content.cfx.re/mirrors/patches_redm/1311/shaders_x64.rpf", 233487310,
-					{
-						{ "a7a45988a6067964214cc4b3af21797249817469", "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1355_to_1311.shaders_x64.rpf.hdiff", 1817785 } /* diff sha1: 4865ba920795b6bcc9724e2e6312beb69fafd4b2 */,
-						{ "f4f06c18701d66958eb6f0ac243c8467033b864b", "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1436_to_1311.shaders_x64.rpf.hdiff", 5981861 } /* diff sha1: bf0116bd17de03b8eac05ac29c74b0a604ce58c6 */,
-						{ "f456cbaf70ff921f77279db5a901c6a6e5807e2e", "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1491_to_1311.shaders_x64.rpf.hdiff", 6142857 } /* diff sha1: 635021d0b676de04b6ebf30fc3ceda54ca58530a */,
-						{ "f8ecee595e74c66c5bd02fd87c2947cf475a2614", "77bad0ab74cd1ef7c646206ea12152449ec56cdf", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1491.50_to_1311.shaders_x64.rpf.hdiff", 18810230 } /* diff sha1: 2c8fa2c0ae76318ba22d683daabf0f83548885aa */
-					}
-				}
-			},
-			{
-				"update.rpf",
-				{
-					"update.rpf", "835a767055cfbf2c2ad86cf4462c7dfb931970fd", "https://content.cfx.re/mirrors/patches_redm/1311/update.rpf", 3515071792,
-					{
-						{ "5a087ef32e6b30b4fde8bbeda7babc45f2c1cf4d", "835a767055cfbf2c2ad86cf4462c7dfb931970fd", "https://content.cfx.re/mirrors/patches_redm/1311/diffs/from_1355_to_1311.update.rpf.hdiff", 354416250 } /* diff sha1: 63abb47155024cffdf6fb86d17162c44880a5b57 */
-					}
-				}
-			}
-		}
-	}
 #endif
 };
 
@@ -2353,12 +2168,7 @@ std::map<std::string, std::string> UpdateGameCache()
 		g_requiredEntries.push_back(entry);
 	}
 
-	if (IsTargetGameBuild<1355>())
-	{
-		g_requiredEntries.push_back({ "x64/dlcpacks/mp008/dlc.rpf", "66a50ed07293b92466423e1db5eed159551d8c25", "nope:https://runtime.fivem.net/patches/dlcpacks/patchday4ng/dlc.rpfmpbiker/dlc.rpf", 487150980 });
-	}
-
-	if (IsTargetGameBuild<1436>() || IsTargetGameBuild<1491>())
+	if (IsTargetGameBuild<1491>())
 	{
 		g_requiredEntries.push_back({ "x64/dlcpacks/mp009/dlc.rpf", "7ae2012968709d6d1079c88ee40369f4359778bf", "nope:https://runtime.fivem.net/patches/dlcpacks/patchday4ng/dlc.rpfmpbiker/dlc.rpf", 494360763 });
 	}

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -174,36 +174,6 @@ inline bool Is3407()
 	return value;
 }
 #elif defined(STATE_RDR3)
-inline bool Is1311()
-{
-	static bool value = ([]()
-	{
-		return fx::GetEnforcedGameBuildNumber() >= 1311;
-	})();
-
-	return value;
-}
-
-inline bool Is1355()
-{
-	static bool value = ([]()
-	{
-		return fx::GetEnforcedGameBuildNumber() >= 1355;
-	})();
-
-	return value;
-}
-
-inline bool Is1436()
-{
-	static bool value = ([]()
-	{
-		return fx::GetEnforcedGameBuildNumber() >= 1436;
-	})();
-
-	return value;
-}
-
 inline bool Is1491()
 {
 	static bool value = ([]()

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -435,10 +435,7 @@ struct CBoatGameStateDataNode
 		bool unk52 = state.buffer.ReadBit();
 		bool forcedBoatLocationWhenAnchored = state.buffer.ReadBit();
 
-		if (Is1355())
-		{
-			bool unk54 = state.buffer.ReadBit();
-		}
+		bool unk54 = state.buffer.ReadBit();
 
 		bool movementResistant = state.buffer.ReadBit(); // resistance >= 0.0
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -6193,7 +6193,7 @@ void CExplosionEvent::Parse(rl::MessageBufferView& buffer)
 	f142 = buffer.ReadBit();
 	f273 = buffer.ReadBit();
 
-	unkHash1436 = Is1436() ? buffer.Read<uint32_t>(32) : 0;
+	unkHash1436 = buffer.Read<uint32_t>(32);
 
 	attachEntityId = buffer.Read<uint16_t>(13);
 	f244 = buffer.Read<uint8_t>(5); // 1311+

--- a/code/components/extra-natives-rdr3/src/NativeFixes.cpp
+++ b/code/components/extra-natives-rdr3/src/NativeFixes.cpp
@@ -159,13 +159,10 @@ static HookFunction hookFunction([]()
 		hook::put<uintptr_t>(&vtable[204], (uintptr_t)CanBlendWhenFixed);
 	}
 
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		auto location = hook::get_pattern<char>("0F 28 05 ? ? ? ? 83 25 ? ? ? ? 00 83 25 ? ? ? ? 00");
+	auto location = hook::get_pattern<char>("0F 28 05 ? ? ? ? 83 25 ? ? ? ? 00 83 25 ? ? ? ? 00");
 
-		g_textCentre = hook::get_address<bool*>(location + 0x33) + 2;
-		g_textDropshadow = hook::get_address<bool*>(location + 0x3B) + 1;
-	}
+	g_textCentre = hook::get_address<bool*>(location + 0x33) + 2;
+	g_textDropshadow = hook::get_address<bool*>(location + 0x3B) + 1;
 
 	rage::scrEngine::OnScriptInit.Connect([]()
 	{
@@ -174,12 +171,8 @@ static HookFunction hookFunction([]()
 		// R* removed some text related natives since RDR3 1436.25 build.
 		// Redirecting original natives to their successors to keep cross build compatibility.
 		// Also re-implementing entirely removed natives.
-		if (xbr::IsGameBuildOrGreater<1436>())
-		{
-			RedirectNoppedTextNatives();
-			ImplementRemovedTextNatives();
-		}
-
+		RedirectNoppedTextNatives();
+		ImplementRemovedTextNatives();
 		FixPedCombatAttributes();
 	});
 

--- a/code/components/gta-core-rdr3/src/GameCrashLogHandler.cpp
+++ b/code/components/gta-core-rdr3/src/GameCrashLogHandler.cpp
@@ -38,11 +38,6 @@ static bool WriteGameLog(const char* path)
 
 static HookFunction hookFunction([]
 {
-	if (!xbr::IsGameBuildOrGreater<1311>())
-	{
-		return;
-	}
-
 	g_gameLogWriter = (decltype(g_gameLogWriter))hook::get_pattern("48 8B D9 E8 ? ? ? ? 48 8B CB E8 ? ? ? ? 48 8D 15", -0xD);
 
 	if (auto func = (void (*)(bool (*)(const char*)))GetProcAddress(GetModuleHandleW(L"CoreRT.dll"), "SetCrashLogHandler"))

--- a/code/components/gta-core-rdr3/src/GameInitRage.cpp
+++ b/code/components/gta-core-rdr3/src/GameInitRage.cpp
@@ -269,14 +269,11 @@ static HookFunction hookFunctionNet([]()
 	hook::jump(hook::get_pattern("84 C0 74 04 32 C0 EB 0E 4C 8B C7 48 8B D6", -0x1D), ReturnTrueAndForcePedMPFlag);
 	hook::jump(hook::get_pattern("40 8A F2 48 8B F9 E8 ? ? ? ? 84 C0 74", -0x12), ReturnTrueAndForcePedMPFlag);
 
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		// nop checks used for not syncing some "unwanted" metaped components
-		hook::nop(hook::get_pattern("8B 40 18 3D CC E2 69 9D"), 0x2F);
+	// nop checks used for not syncing some "unwanted" metaped components
+	hook::nop(hook::get_pattern("8B 40 18 3D CC E2 69 9D"), 0x2F);
 
-		// skip tunable checks for explosion/fire related natives
-		hook::jump(hook::get_pattern("B9 BD C5 AF E3 BA B2 A0 A7 92", -0x14), Return1);
-	}
+	// skip tunable checks for explosion/fire related natives
+	hook::jump(hook::get_pattern("B9 BD C5 AF E3 BA B2 A0 A7 92", -0x14), Return1);
 
 	//hook::jump(0x1406B50E8, LogStubLog1);
 

--- a/code/components/gta-core-rdr3/src/SimpleAllocator.cpp
+++ b/code/components/gta-core-rdr3/src/SimpleAllocator.cpp
@@ -474,21 +474,10 @@ static HookFunction hookFunction([]()
 	hook::call(ptr + 0x21, corrupt_this.GetCode());
 	hook::call(ptr + 0x75, corrupt_next.GetCode());
 #elif IS_RDR3
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		char* ptr = hook::get_pattern<char>("F7 46 ? ? ? ? ? 48 8D 5E");
+	char* ptr = hook::get_pattern<char>("F7 46 ? ? ? ? ? 48 8D 5E");
 
-		hook::call(ptr + 0x18, already_free.GetCode());
-		hook::call(ptr + 0x31, corrupt_this.GetCode());
-		hook::call(ptr + 0xA1, corrupt_next.GetCode());
-	}
-	else
-	{
-		char* ptr = hook::get_pattern<char>("8B 43 ? 48 83 C3 ? 0F BA E0");
-
-		hook::call(ptr + 0x17, already_free.GetCode());
-		hook::call(ptr + 0x34, corrupt_this.GetCode());
-		hook::call(ptr + 0xA4, corrupt_next.GetCode());
-	}
+	hook::call(ptr + 0x18, already_free.GetCode());
+	hook::call(ptr + 0x31, corrupt_this.GetCode());
+	hook::call(ptr + 0xA1, corrupt_next.GetCode());
 #endif
 });

--- a/code/components/gta-game-rdr3/include/NetworkPlayerMgr.h
+++ b/code/components/gta-game-rdr3/include/NetworkPlayerMgr.h
@@ -16,13 +16,13 @@
 #endif
 
 #define DECLARE_ACCESSOR(x) \
-	decltype(impl.m1311.x)& x() \
+	decltype(impl.m1491.x)& x() \
 	{ \
-		return (impl.m1311.x); \
+		return (impl.m1491.x); \
 	} \
-	const decltype(impl.m1311.x)& x() const \
+	const decltype(impl.m1491.x)& x() const \
 	{ \
-		return (impl.m1311.x); \
+		return (impl.m1491.x); \
 	}
 
 namespace rage
@@ -81,13 +81,13 @@ private:
 
 	union
 	{
-		Impl m1311;
+		Impl m1491;
 	} impl;
 
 public:
 	void* GetPlayerInfo()
 	{
-		if (auto pedPlayerComponent = (void*)(impl.m1311.pedPlayerComponent))
+		if (auto pedPlayerComponent = (void*)(impl.m1491.pedPlayerComponent))
 		{
 			return (void*)((char*)pedPlayerComponent + 0x130);
 		}

--- a/code/components/gta-net-five/src/CloneExperiments_ArrayHandler.cpp
+++ b/code/components/gta-net-five/src/CloneExperiments_ArrayHandler.cpp
@@ -18,7 +18,7 @@ static hook::cdecl_stub<rage::netArrayHandlerBase*(rage::netArrayManager*, int, 
 #ifdef GTA_FIVE
 	return hook::get_call(hook::get_pattern("48 8B 0D ? ? ? ? BA 06 00 00 00 45 33 C0", 0xF));
 #elif IS_RDR3
-	return hook::get_call((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B 0D ? ? ? ? 41 8D 56 06 45 33 C0", 0xE) : hook::get_pattern("48 8B 0D ? ? ? ? BA 06 00 00 00 45 33 C0", 0xF));
+	return hook::get_call(hook::get_pattern("48 8B 0D ? ? ? ? 41 8D 56 06 45 33 C0", 0xE));
 #endif
 });
 
@@ -112,7 +112,7 @@ static HookFunction hookFunctionArray([]()
 #ifdef GTA_FIVE
 	g_arrayManager = hook::get_address<rage::netArrayManager**>(hook::get_pattern("48 8B 0D ? ? ? ? BA 06 00 00 00 45 33 C0", 3));
 #elif IS_RDR3
-	g_arrayManager = hook::get_address<rage::netArrayManager**>((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("48 8B 0D ? ? ? ? 41 8D 56 06 45 33 C0", 3) : hook::get_pattern("48 8B 0D ? ? ? ? BA 06 00 00 00 45 33 C0", 3));
+	g_arrayManager = hook::get_address<rage::netArrayManager**>(hook::get_pattern("48 8B 0D ? ? ? ? 41 8D 56 06 45 33 C0", 3));
 #endif
 });
 

--- a/code/components/gta-net-five/src/CloneObjectManager.cpp
+++ b/code/components/gta-net-five/src/CloneObjectManager.cpp
@@ -202,20 +202,11 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_pattern("44 38 33 75 30 66 44", -0x40), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject); //
 	MH_CreateHook(hook::get_pattern("41 80 78 ? FF 74 2D 41 0F B6 40"), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 #elif IS_RDR3
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		MH_CreateHook(hook::get_pattern("48 8B F2 41 B0 01 0F B7 52", -0x1B), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject);
-		MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 8D 76 08 48 83 EB 01 75 E8")), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject);
-		MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x64), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
-	}
-	else
-	{
-		MH_CreateHook(hook::get_pattern("41 0F B7 55 00 41 B0 01 48 8B E9 E8", xbr::IsGameBuildOrGreater<1355>() ? -0x20 : -0x27), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject);
-		MH_CreateHook(hook::get_pattern("45 33 FF C1 E8 03 48 8B F2 48 8B E9 A8 01", -0x24), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject);
-		MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x3B), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
-	}
+	MH_CreateHook(hook::get_pattern("48 8B F2 41 B0 01 0F B7 52", -0x1B), netObjectMgrBase__RegisterNetworkObject, (void**)&g_orig_netObjectMgrBase__RegisterNetworkObject);
+	MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 8D 76 08 48 83 EB 01 75 E8")), netObjectMgrBase__DestroyNetworkObject, (void**)&g_orig_netObjectMgrBase__DestroyNetworkObject);
+	MH_CreateHook(hook::get_pattern("0F B6 43 ? 48 03 C0 48 8B 4C C7 08 EB", -0x64), netObjectMgrBase__GetNetworkObjectForPlayer, (void**)&g_orig_netObjectMgrBase__GetNetworkObjectForPlayer);
 
-	MH_CreateHook(hook::get_pattern("41 83 F9 04 75 ? 8D 4B 20 E8 ? ? ? ? 48", xbr::IsGameBuildOrGreater<1491>() ? -0x39 : -0x31), netObjectMgrBase__ChangeOwner, (void**)&g_orig_netObjectMgrBase__ChangeOwner);
+	MH_CreateHook(hook::get_pattern("41 83 F9 04 75 ? 8D 4B 20 E8 ? ? ? ? 48", -0x39), netObjectMgrBase__ChangeOwner, (void**)&g_orig_netObjectMgrBase__ChangeOwner);
 	MH_CreateHook(hook::get_pattern("45 8A F0 0F B7 F2 E8 ? ? ? ? 33 DB 38", -0x24), netObjectMgrBase__GetNetworkObject, (void**)&g_orig_netObjectMgrBase__GetNetworkObject);
 #endif
 

--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -60,7 +60,7 @@ static hook::cdecl_stub<void()> _initVoiceChatConfig([]()
 #elif IS_RDR3
 static hook::cdecl_stub<void(void*)> _initVoiceChatConfig([]()
 {
-	return hook::get_pattern("8B 83 ? ? ? ? F2 0F 10 8B ? ? ? ? 48", (xbr::IsGameBuildOrGreater<1436>()) ? -0xDD : -0x81);
+	return hook::get_pattern("8B 83 ? ? ? ? F2 0F 10 8B ? ? ? ? 48", -0xDD);
 });
 
 static hook::cdecl_stub<int(void*, uint64_t, uint32_t)> rage__atDataHash([]()
@@ -902,18 +902,11 @@ static HookFunction hookFunction([]()
 #elif IS_RDR3
 	g_viewportGame = hook::get_address<CViewportGame**>(hook::get_pattern("0F 2F F0 76 ? 4C 8B 35", 8));
 
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		g_actorPos = hook::get_address<float*>(hook::get_pattern("45 33 C9 48 89 5D E0 8D 53 01", 63)) + 16;
-	}
-	else
-	{
-		g_actorPos = hook::get_address<float*>(hook::get_pattern("8B C2 48 03 C0 41 8D 49 FF 48 03 C9", -4)) + 16;
-	}
+	g_actorPos = hook::get_address<float*>(hook::get_pattern("45 33 C9 48 89 5D E0 8D 53 01", 63)) + 16;
 
 	{
 		auto location = hook::get_pattern<char>("75 0D 8B C8 E8 ? ? ? ? 84 C0 B0 01 75 03");
-		auto prefsOffset = *(uint32_t*)(location + (xbr::IsGameBuildOrGreater<1436>() ? 40 : 48));
+		auto prefsOffset = *(uint32_t*)(location +  40);
 
 		g_voiceChatMgr = *hook::get_address<void**>(location - 16);
 		g_voiceChatMgrPrefs = (VoiceChatMgrPrefs*)((uint64_t)g_voiceChatMgr + prefsOffset);

--- a/code/components/gta-net-five/src/netGameEvent.cpp
+++ b/code/components/gta-net-five/src/netGameEvent.cpp
@@ -1289,7 +1289,7 @@ static HookFunction hookFunction([]()
 		});
 #endif
 #elif IS_RDR3
-		auto location = hook::get_pattern<char>("C6 47 50 01 4C 8B C3 49 8B D7", (xbr::IsGameBuildOrGreater<1436>()) ? 0x59 : 0x21);
+		auto location = hook::get_pattern<char>("C6 47 50 01 4C 8B C3 49 8B D7", 0x59);
 
 		g_netEventMgr = hook::get_address<void*>(location);
 		MH_CreateHook(hook::get_call(location + 7), EventMgr_AddEvent, (void**)&g_origAddEvent);
@@ -1367,7 +1367,7 @@ static HookFunction hookFunction([]()
 		hook::call(hook::get_pattern("33 C9 E8 ? ? ? ? E9 FD FE FF FF", 2), NetEventError);
 	}
 #elif IS_RDR3
-	hook::call((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("74 ? 48 8B 01 40 8A D6 FF ? ? BA", 25) : hook::get_pattern("BA 01 00 00 00 FF ? ? BA 5B 52 1C A4", 22), NetEventError);
+	hook::call(hook::get_pattern("74 ? 48 8B 01 40 8A D6 FF ? ? BA", 25), NetEventError);
 #endif
 
 	// func that reads neteventmgr by player idx, crashes page heap

--- a/code/components/gta-net-five/src/netPlayerManager.cpp
+++ b/code/components/gta-net-five/src/netPlayerManager.cpp
@@ -105,7 +105,7 @@ static HookFunction hookFunction([]()
 #ifdef GTA_FIVE
 	MH_CreateHook(hook::get_pattern("48 8B F9 48 39 99 ? ? 00 00 74 ? 48 81 C1 ? ? 00 00 48", -12), rage::AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
 #elif IS_RDR3
-	MH_CreateHook((xbr::IsGameBuildOrGreater<1436>()) ? hook::get_pattern("33 DB 48 8B F9 48 39 99 ? ? ? ? 75 ? 8D 53 01", -10) : hook::get_pattern("48 39 99 ? ? ? ? 74 ? 48 81 C1 ? ? ? ? 48 8B 19 48 85", -15), rage::AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
+	MH_CreateHook(hook::get_pattern("33 DB 48 8B F9 48 39 99 ? ? ? ? 75 ? 8D 53 01", -10), rage::AllocateNetPlayer, (void**)&g_origAllocateNetPlayer);
 #endif
 
 	// CNetGamePlayer size

--- a/code/components/gta-net-five/src/netTimeSync.cpp
+++ b/code/components/gta-net-five/src/netTimeSync.cpp
@@ -211,12 +211,7 @@ bool sync::IsWaitingForTimeSync()
 
 	return !(*g_netTimeSync<1604>)->IsInitialized();
 #elif IS_RDR3
-	if (xbr::IsGameBuildOrGreater<1355>())
-	{
-		return !(*g_netTimeSync<1355>)->IsInitialized();
-	}
-
-	return !(*g_netTimeSync<1311>)->IsInitialized();
+	return !(*g_netTimeSync<1491>)->IsInitialized();
 #endif
 }
 
@@ -236,14 +231,7 @@ static inline void TimeSyncMainGameFrameUpdate()
 		(*g_netTimeSync<1604>)->Update();
 	}
 #elif IS_RDR3
-	if (xbr::IsGameBuildOrGreater<1355>())
-	{
-		(*g_netTimeSync<1355>)->Update();
-	}
-	else
-	{
-		(*g_netTimeSync<1311>)->Update();
-	}
+	(*g_netTimeSync<1491>)->Update();
 #endif
 }
 
@@ -263,14 +251,7 @@ static void rage::HandleTimeSyncUpdatePacket(net::packet::TimeSyncResponse& buf)
 		(*g_netTimeSync<1604>)->HandleTimeSync(buf);
 	}
 #elif IS_RDR3
-	if (xbr::IsGameBuildOrGreater<1355>())
-	{
-		(*g_netTimeSync<1355>)->HandleTimeSync(buf);
-	}
-	else
-	{
-		(*g_netTimeSync<1311>)->HandleTimeSync(buf);
-	}
+	(*g_netTimeSync<1491>)->HandleTimeSync(buf);
 #endif
 }
 
@@ -310,11 +291,9 @@ static HookFunction hookFunction([]()
 
 		auto location = hook::get_pattern("48 8B D9 48 39 79 08 0F 85 ? ? 00 00 41 8B E8", -32);
 #elif IS_RDR3
-		void* func = (xbr::IsGameBuildOrGreater<1355>()) ? (void*)&netTimeSync__InitializeTimeStub<1355> :
-			&netTimeSync__InitializeTimeStub<1311>;
+		void* func = (void*)&netTimeSync__InitializeTimeStub<1491>;
 
-		auto location = xbr::IsGameBuildOrGreater<1436>() ? hook::get_pattern("83 C8 FF 4C 89 77 08 83 FD", -87) :
-			hook::get_pattern("48 89 51 08 41 83 F8 02 44 0F 45 C8", -49);
+		auto location = hook::get_pattern("83 C8 FF 4C 89 77 08 83 FD", -87);
 #endif
 
 		MH_CreateHook(location, func, (void**)&g_origInitializeTime);
@@ -339,14 +318,7 @@ static HookFunction hookFunction([]()
 #elif IS_RDR3
 		auto location = hook::get_pattern("4C 8D 45 50 41 03 C7 44 89 6D 50 89", -4);
 
-		if (xbr::IsGameBuildOrGreater<1355>())
-		{
-			g_netTimeSync<1355> = hook::get_address<rage::netTimeSync<1355>**>(location);
-		}
-		else
-		{
-			g_netTimeSync<1311> = hook::get_address<rage::netTimeSync<1311>**>(location);
-		}
+		g_netTimeSync<1491> = hook::get_address<rage::netTimeSync<1491>**>(location);
 #endif	
 	}
 

--- a/code/components/gta-net-rdr3/include/netObjectMgr.h
+++ b/code/components/gta-net-rdr3/include/netObjectMgr.h
@@ -36,7 +36,7 @@ private:
 #define FORWARD_FUNC(name, offset, ...)    \
 	using TFn = decltype(&netObjectMgr::name); \
 	void** vtbl = *(void***)(this);        \
-	return (this->*(get_member<TFn>(vtbl[(offset / 8) + ((offset > 0x68) ? (xbr::IsGameBuildOrGreater<1436>() ? 1 : 0) : 0)])))(__VA_ARGS__);
+	return (this->*(get_member<TFn>(vtbl[(offset / 8) + ((offset > 0x68) ? 1 : 0)])))(__VA_ARGS__);
 
 public:
 	inline void UnregisterNetworkObject(rage::netObject* object, int reason, bool force1, bool force2)

--- a/code/components/gta-net-rdr3/include/netTimeSync.h
+++ b/code/components/gta-net-rdr3/include/netTimeSync.h
@@ -2,18 +2,10 @@
 
 #include "TimeSync.h"
 
-struct TimeSyncPadding1311
-{
-	char m_pad[4];
-};
-
 struct TimeSyncPadding1355
 {
 	char m_pad[24];
 };
-
-template<bool Enable>
-using TimeSyncPadding = std::conditional_t<Enable, TimeSyncPadding1355, TimeSyncPadding1311>;
 
 namespace sync
 {
@@ -40,7 +32,7 @@ private:
 	uint32_t m_unkTrust; // +16
 	uint32_t m_sessionKey; // +20
 	char m_pad_24[44]; // +24
-	TimeSyncPadding<(Build >= 1355)> m_pad_68;
+	TimeSyncPadding1355 m_pad_68;
 	uint32_t m_nextSync; // +72
 	uint32_t m_configTimeBetweenSyncs; // +76
 	uint32_t m_configMaxBackoff; // +80, usually 60000
@@ -63,5 +55,4 @@ private:
 static void HandleTimeSyncUpdatePacket(net::packet::TimeSyncResponse& buf);
 }
 
-static_assert(sizeof(rage::netTimeSync<1311>) == 152);
-static_assert(sizeof(rage::netTimeSync<1355>) == 176);
+static_assert(sizeof(rage::netTimeSync<1491>) == 176);

--- a/code/components/gta-net-rdr3/src/CoreNetworking.cpp
+++ b/code/components/gta-net-rdr3/src/CoreNetworking.cpp
@@ -867,7 +867,7 @@ static HookFunction hookFunction([]()
 	// exitprocess -> terminateprocess
 	MH_Initialize();
 	MH_CreateHookApi(L"kernel32.dll", "ExitProcess", ExitProcessReplacement, nullptr);
-	MH_CreateHook(hook::get_pattern("45 33 C9 4C 8B 11 49 8B D8 48 8B F9", xbr::IsGameBuildOrGreater<1436>() ? -0x1E : -0x19), HandleInitPlayerResultStub, (void**)&g_origHandleInitPlayerResult);
+	MH_CreateHook(hook::get_pattern("45 33 C9 4C 8B 11 49 8B D8 48 8B F9", -0x1E), HandleInitPlayerResultStub, (void**)&g_origHandleInitPlayerResult);
 	MH_EnableHook(MH_ALL_HOOKS);
 
 	hook::iat("ws2_32.dll", CfxSendTo, 20);
@@ -883,35 +883,15 @@ static HookFunction hookFunction([]()
 		hook::jump(getLocalPeerAddress, GetLocalPeerAddress);
 		hook::jump(hook::get_call(getLocalPeerAddress + 0x28), GetLocalPeerId);
 
-		if (xbr::IsGameBuildOrGreater<1491>())
-		{
-			hook::jump(hook::get_call(getLocalPeerAddress + 0x103), GetGamerHandle);
-			hook::jump(hook::get_call(hook::get_call(getLocalPeerAddress + 0x114) + 0x14), InitP2PCryptKey);
-		}
-		else if (xbr::IsGameBuildOrGreater<1436>())
-		{
-			hook::jump(hook::get_call(getLocalPeerAddress + 0xF1), GetGamerHandle);
-			hook::jump(hook::get_call(hook::get_call(getLocalPeerAddress + 0x102) + 0x14), InitP2PCryptKey);
-		}
-		else
-		{
-			hook::jump(hook::get_call(getLocalPeerAddress + 0xF5), GetGamerHandle);
-			hook::jump(hook::get_call(getLocalPeerAddress + 0x116), InitP2PCryptKey);
-		}
+		hook::jump(hook::get_call(getLocalPeerAddress + 0x103), GetGamerHandle);
+		hook::jump(hook::get_call(hook::get_call(getLocalPeerAddress + 0x114) + 0x14), InitP2PCryptKey);
 	}
 
 	//
 	//hook::call(0x1426E100B, ParseAddGamer);
 
 	// all uwuids be 2
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		hook::call(hook::get_pattern("48 83 A4 24 E0 00 00 00 00 48 8D 8C 24 E0", 17), ZeroUUID);
-	}
-	else
-	{
-		hook::call(hook::get_pattern("B9 03 00 00 00 B8 01 00 00 00 87 83", -85), ZeroUUID);
-	}
+	hook::call(hook::get_pattern("48 83 A4 24 E0 00 00 00 00 48 8D 8C 24 E0", 17), ZeroUUID);
 
 	// get session for find result
 	// 1207.58
@@ -972,24 +952,12 @@ static HookFunction hookFunction([]()
 			}
 		} stub;
 
-		if (xbr::IsGameBuildOrGreater<1436>())
-		{
-			playerCountOffset = *(uint32_t*)(location - 15 + 3);
-			playerListOffset = *(uint32_t*)(location + 3);
-			backwardsOffset = *(uint32_t*)(location + 45 + 3);
+		playerCountOffset = *(uint32_t*)(location - 15 + 3);
+		playerListOffset = *(uint32_t*)(location + 3);
+		backwardsOffset = *(uint32_t*)(location + 45 + 3);
 
-			hook::set_call(&origSendGamer, location + 70);
-			hook::call(location + 70, stub.GetCode());
-		}
-		else
-		{
-			playerCountOffset = *(uint32_t*)(location - 14 + 3);
-			playerListOffset = *(uint32_t*)(location + 3);
-			backwardsOffset = *(uint32_t*)(location + 48 + 3);
-
-			hook::set_call(&origSendGamer, location + 72);
-			hook::call(location + 72, stub.GetCode());
-		}
+		hook::set_call(&origSendGamer, location + 70);
+		hook::call(location + 70, stub.GetCode());
 	}
 
 #if 0
@@ -1036,27 +1004,11 @@ static HookFunction hookFunction([]()
 	hook::jump(hook::get_pattern("33 C0 39 41 18 74 11 F6 81 B4 00 00"), Return<int, 1>); // 1408A1014
 
 	// skip cash/inventory
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		hook::jump(hook::get_pattern("75 42 8D 53 03 C7 44 24 20 F4 D2", -0x21), Return<int, 2>);
-		hook::jump(hook::get_pattern("A9 FD FF FF FF 0F 85 B1 00 00 00 48", -0x3E), Return<int, 2>);
-	}
-	else
-	{
-		hook::jump(hook::get_pattern("75 21 4C 8D 0D ? ? ? ? 41 B8 30 10 00 10", -0x21), Return<int, 2>);
-		hook::jump(hook::get_pattern("A9 FD FF FF FF 75 64 48 8B 0D", -0x3A), Return<int, 2>);
-	}
+	hook::jump(hook::get_pattern("75 42 8D 53 03 C7 44 24 20 F4 D2", -0x21), Return<int, 2>);
+	hook::jump(hook::get_pattern("A9 FD FF FF FF 0F 85 B1 00 00 00 48", -0x3E), Return<int, 2>);
 
 	// skip poker
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		hook::jump(hook::get_pattern("48 83 EC 38 48 8B 0D ? ? ? ? E8 ? ? ? ? 33"), Return<int, 2>);
-	}
-	else
-	{
-		hook::jump(hook::get_pattern("48 83 EC 28 48 8B 0D ? ? ? ? E8 ? ? ? ? F6 D8 1B C0 83 C0 02"), Return<int, 2>);
-		hook::jump(hook::get_pattern("B8 02 00 00 00 EB 1F 38 91", -0x22), Return<int, 2>);
-	}
+	hook::jump(hook::get_pattern("48 83 EC 38 48 8B 0D ? ? ? ? E8 ? ? ? ? 33"), Return<int, 2>);
 
 	// don't stop unsafe network scripts
 	hook::jump(hook::get_pattern("83 7B 10 02 74 21 48 8B CB E8", -0x35), Return<int, 0>); // 0x140E8A58C
@@ -1078,19 +1030,9 @@ static HookFunction hookFunction([]()
 	}
 
 	// unusual script check before allowing session to continue
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		hook::nop(hook::get_pattern("84 C0 0F 85 ? 00 00 00 ? ? ? ? 75 ? BA 02 00 00 00", 2), 6);
-	}
-	else
-	{
-		hook::nop(hook::get_pattern("84 C0 75 6C 44 39 7B 20 75", 2), 2);
-	}
+	hook::nop(hook::get_pattern("84 C0 0F 85 ? 00 00 00 ? ? ? ? 75 ? BA 02 00 00 00", 2), 6);
 
 	// ignore tunable (0xE3AFC5BD/0x7CEC5CDA) which intentionally breaking some certain
 	// ped models appearance from syncing between clients, initially added in 1436.31
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		hook::jump(hook::get_pattern("B9 BD C5 AF E3 BA DA 5C EC 7C E8", -19), Return<bool, false>);
-	}
+	hook::jump(hook::get_pattern("B9 BD C5 AF E3 BA DA 5C EC 7C E8", -19), Return<bool, false>);
 });

--- a/code/components/gta-net-rdr3/src/netObject.cpp
+++ b/code/components/gta-net-rdr3/src/netObject.cpp
@@ -56,108 +56,37 @@ static HookFunction hookFunction([]()
 	},
 	1000);
 
-	if (xbr::IsGameBuildOrGreater<1491>())
-	{
-		auto location = hook::get_pattern<char>("7F 2B 41 B9 B8 0A 00 00 C7", 61);
-		createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
-		createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x98);
-		createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0x135);
-		createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x1CD);
-		createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x265);
-		createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x2FD);
-		createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x395);
-		createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x42D);
-		createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x504);
-		createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x59C);
-		createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x633);
-		createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x6D0);
-		createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x768);
-		createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x800);
-		createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x898);
-		createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x930);
-		createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0xA1B);
-		createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0xAB3);
-		createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0xB50);
-		createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0xBED);
-		createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0xC8A);
-		createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0xD27);
-		createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xDC3);
-		createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xE60);
-		createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xEEE);
-		createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xF4A);
-		createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xFA6);
-		createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0x1043);
-		createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0x10E0);
-		createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0x1179);
-	}
-	else if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		auto location = hook::get_pattern<char>("7F 2B 41 B9 B8 0A 00 00 C7", 61);
-		createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
-		createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x98);
-		createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0x130);
-		createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x1C8);
-		createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x260);
-		createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x2F8);
-		createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x390);
-		createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x428);
-		createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x4FF);
-		createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x597);
-		createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x62E);
-		createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x6C6);
-		createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x75E);
-		createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x7F6);
-		createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x88E);
-		createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x926);
-		createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0xA11);
-		createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0xAA9);
-		createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0xB46);
-		createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0xBE3);
-		createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0xC7B);
-		createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0xD13);
-		createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xDAA);
-		createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xE47);
-		createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xED5);
-		createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xF31);
-		createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xFCE);
-		createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0x106B);
-		createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0x1108);
-		createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0x11A1);
-	}
-	else
-	{
-		auto location = hook::get_pattern<char>("0F 8E ? 0F 00 00 41 8A 55", 20);
-		createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
-		createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x6E);
-		createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0xDD);
-		createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x14B);
-		createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x1B9);
-		createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x227);
-		createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x29B);
-		createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x30F);
-		createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x3B2);
-		createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x420);
-		createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x493);
-		createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x501);
-		createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x56F);
-		createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x5DE);
-		createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x64D);
-		createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x6BB);
-		createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0x76E);
-		createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0x7E2);
-		createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0x850);
-		createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0x8BF);
-		createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0x92D);
-		createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0x99C);
-		createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xA0A);
-		createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xA79);
-		createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xB1A);
-		createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xB8E);
-		createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xC02);
-		createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0xC76);
-		createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0xCEA);
-		createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0xD56);	
-	}
+	auto location = hook::get_pattern<char>("7F 2B 41 B9 B8 0A 00 00 C7", 61);
+	createCloneFuncs[(int)NetObjEntityType::Object] = (TCreateCloneObjFn)hook::get_call(location);
+	createCloneFuncs[(int)NetObjEntityType::Heli] = (TCreateCloneObjFn)hook::get_call(location + 0x98);
+	createCloneFuncs[(int)NetObjEntityType::Door] = (TCreateCloneObjFn)hook::get_call(location + 0x135);
+	createCloneFuncs[(int)NetObjEntityType::Boat] = (TCreateCloneObjFn)hook::get_call(location + 0x1CD);
+	createCloneFuncs[(int)NetObjEntityType::Bike] = (TCreateCloneObjFn)hook::get_call(location + 0x265);
+	createCloneFuncs[(int)NetObjEntityType::Automobile] = (TCreateCloneObjFn)hook::get_call(location + 0x2FD);
+	createCloneFuncs[(int)NetObjEntityType::Animal] = (TCreateCloneObjFn)hook::get_call(location + 0x395);
+	createCloneFuncs[(int)NetObjEntityType::Ped] = (TCreateCloneObjFn)hook::get_call(location + 0x42D);
+	createCloneFuncs[(int)NetObjEntityType::Train] = (TCreateCloneObjFn)hook::get_call(location + 0x504);
+	createCloneFuncs[(int)NetObjEntityType::Trailer] = (TCreateCloneObjFn)hook::get_call(location + 0x59C);
+	createCloneFuncs[(int)NetObjEntityType::Player] = (TCreateCloneObjFn)hook::get_call(location + 0x633);
+	createCloneFuncs[(int)NetObjEntityType::Submarine] = (TCreateCloneObjFn)hook::get_call(location + 0x6D0);
+	createCloneFuncs[(int)NetObjEntityType::Plane] = (TCreateCloneObjFn)hook::get_call(location + 0x768);
+	createCloneFuncs[(int)NetObjEntityType::PickupPlacement] = (TCreateCloneObjFn)hook::get_call(location + 0x800);
+	createCloneFuncs[(int)NetObjEntityType::Pickup] = (TCreateCloneObjFn)hook::get_call(location + 0x898);
+	createCloneFuncs[(int)NetObjEntityType::DraftVeh] = (TCreateCloneObjFn)hook::get_call(location + 0x930);
+	createCloneFuncs[(int)NetObjEntityType::WorldState] = (TCreateCloneObjFn)hook::get_call(location + 0xA1B);
+	createCloneFuncs[(int)NetObjEntityType::Horse] = (TCreateCloneObjFn)hook::get_call(location + 0xAB3);
+	createCloneFuncs[(int)NetObjEntityType::Herd] = (TCreateCloneObjFn)hook::get_call(location + 0xB50);
+	createCloneFuncs[(int)NetObjEntityType::GroupScenario] = (TCreateCloneObjFn)hook::get_call(location + 0xBED);
+	createCloneFuncs[(int)NetObjEntityType::AnimScene] = (TCreateCloneObjFn)hook::get_call(location + 0xC8A);
+	createCloneFuncs[(int)NetObjEntityType::PropSet] = (TCreateCloneObjFn)hook::get_call(location + 0xD27);
+	createCloneFuncs[(int)NetObjEntityType::StatsTracker] = (TCreateCloneObjFn)hook::get_call(location + 0xDC3);
+	createCloneFuncs[(int)NetObjEntityType::WorldProjectile] = (TCreateCloneObjFn)hook::get_call(location + 0xE60);
+	createCloneFuncs[(int)NetObjEntityType::Persistent] = (TCreateCloneObjFn)hook::get_call(location + 0xEEE);
+	createCloneFuncs[(int)NetObjEntityType::PedSharedTargeting] = (TCreateCloneObjFn)hook::get_call(location + 0xF4A);
+	createCloneFuncs[(int)NetObjEntityType::CombatDirector] = (TCreateCloneObjFn)hook::get_call(location + 0xFA6);
+	createCloneFuncs[(int)NetObjEntityType::PedGroup] = (TCreateCloneObjFn)hook::get_call(location + 0x1043);
+	createCloneFuncs[(int)NetObjEntityType::Guardzone] = (TCreateCloneObjFn)hook::get_call(location + 0x10E0);
+	createCloneFuncs[(int)NetObjEntityType::Incident] = (TCreateCloneObjFn)hook::get_call(location + 0x1179);
 
 
 	validatePoolHashes[(int)NetObjEntityType::Animal] = HashString("CNetObjPedBase");

--- a/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
+++ b/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
@@ -434,54 +434,27 @@ static HookFunction hookFunction([] ()
 		doStub.addFunc = AddStreamingFileWrap;
 		hook::jump_rcx(location, doStub.GetCode());
 #elif IS_RDR3
-		if (xbr::IsGameBuildOrGreater<1436>()) // starting from 1436.31
+		void* location = hook::pattern("83 0F FF 48 8D 4D C8 E8 3C 93 FE FF").count(1).get(0).get<void>(27);
+
+		static struct : public jitasm::Frontend
 		{
-			void* location = hook::pattern("83 0F FF 48 8D 4D C8 E8 3C 93 FE FF").count(1).get(0).get<void>(27);
+			void* addFunc;
 
-			static struct : public jitasm::Frontend
+			void InternalMain() override
 			{
-				void* addFunc;
+				pop(rdi);
+				pop(rsi);
+				pop(rbx);
+				pop(rbp);
 
-				void InternalMain() override
-				{
-					pop(rdi);
-					pop(rsi);
-					pop(rbx);
-					pop(rbp);
+				mov(rcx, rax);
+				mov(rax, (uint64_t)addFunc);
+				jmp(rax);
+			}
+		} doStub;
 
-					mov(rcx, rax);
-					mov(rax, (uint64_t)addFunc);
-					jmp(rax);
-				}
-			} doStub;
-
-			doStub.addFunc = AddStreamingFileWrap;
-			hook::jump_rcx(location, doStub.GetCode());
-		}
-		else
-		{
-			void* location = hook::pattern("83 CF FF 89 3E 48 8D 4D 58 E8").count(1).get(0).get<void>(35);
-
-			static struct : public jitasm::Frontend
-			{
-				void* addFunc;
-
-				void InternalMain() override
-				{
-					pop(r12);
-					pop(rdi);
-					pop(rsi);
-					pop(rbp);
-
-					mov(rcx, rax);
-					mov(rax, (uint64_t)addFunc);
-					jmp(rax);
-				}
-			} doStub;
-
-			doStub.addFunc = AddStreamingFileWrap;
-			hook::jump_rcx(location, doStub.GetCode());
-		}
+		doStub.addFunc = AddStreamingFileWrap;
+		hook::jump_rcx(location, doStub.GetCode());
 #endif
 	}
 

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -588,12 +588,7 @@ namespace rage::sga
 
 static hook::thiscall_stub<int(rage::sga::ext::DynamicResource*)> _dynamicResource_GetResourceIdx([]()
 {
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		return hook::get_call(hook::get_pattern("0F B7 56 6A 8B C0 4C 8B 04 C3 65", -5));
-	}
-
-	return hook::get_call(hook::get_pattern("48 8B 47 30 48 8B 1C D8 48 8B CB E8", 11));
+	return hook::get_call(hook::get_pattern("0F B7 56 6A 8B C0 4C 8B 04 C3 65", -5));
 });
 
 static hook::thiscall_stub<void(rage::sga::ext::DynamicResource*, rage::sga::GraphicsContext*, const rage::sga::MapData&)> _dynamicResource_UnmapBase([]()
@@ -721,27 +716,9 @@ static HookFunction hookFunction([]()
 
 	g_renderThreadTlsIndex = *hook::get_pattern<uint32_t>("42 09 0C 02 BA 01 00 00 00 3B CA 0F 44 C2 88 05", -15);
 
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		g_d3d12Driver = hook::get_address<void*>(hook::get_pattern("75 04 33 C0 EB 1A E8", 28));
-	}
-	else if (xbr::IsGameBuildOrGreater<1355>())
-	{
-		g_d3d12Driver = hook::get_address<void*>(hook::get_pattern("B9 01 00 00 00 48 83 3D ? ? ? ? 00 0F", 25));
-	}
-	else
-	{
-		g_d3d12Driver = hook::get_address<void*>(hook::get_pattern("83 E9 01 74 ? 83 F9 02 75 ? 48 8B CF E8", -4));
-	}
+	g_d3d12Driver = hook::get_address<void*>(hook::get_pattern("75 04 33 C0 EB 1A E8", 28));
 
-	if (xbr::IsGameBuildOrGreater<1436>())
-	{
-		g_vkDriver = hook::get_address<void*>(hook::get_pattern("33 C0 EB 2F 41 B8 80 00 00 00", 47));
-	}
-	else
-	{
-		g_vkDriver = hook::get_address<void*>(hook::get_pattern("B9 03 00 00 00 48 83 3D ? ? ? ? 00 0F", 25));
-	}
+	g_vkDriver = hook::get_address<void*>(hook::get_pattern("33 C0 EB 2F 41 B8 80 00 00 00", 47));
 
 	g_d3d12Device = hook::get_address<decltype(g_d3d12Device)>(hook::get_pattern("48 8B 01 FF 50 78 48 8B 0B 48 8D", -7));
 	g_vkHandle = hook::get_address<decltype(g_vkHandle)>(hook::get_pattern("8D 50 41 8B CA 44 8B C2 F3 48 AB 48 8B 0D", 14));

--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -409,7 +409,7 @@ static HookFunction hookFunction([]()
 	// disable DInput device creation
 	// two matches, we want the first
 	char* dinputCreate = hook::get_pattern<char>("45 33 C9 48 8D 15 ? ? ? ? 48 8B 01 FF");
-	hook::nop(dinputCreate, (xbr::IsGameBuildOrGreater<1436>() ? 169 : 166));
+	hook::nop(dinputCreate, 169);
 
 	// jump over raw input keyboard handling
 	hook::put<uint8_t>(hook::get_pattern("0F 85 ? ? 00 00 45 39 26 75 ? 41 0F", 9), 0xEB);

--- a/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
+++ b/code/components/rage-nutsnbolts-rdr3/src/FrameHook.cpp
@@ -149,7 +149,7 @@ static HookFunction hookFunction([]()
 	hook::set_call(&g_origLookAlive, lookAliveFrameCall);
 	hook::call(lookAliveFrameCall, OnLookAlive);
 
-	auto runState = hook::pattern("85 F6 78 ? 75 ? 83 FB 01 75").count(1).get(0).get<char>(xbr::IsGameBuildOrGreater<1436>() ? -0x2A : -0x1E);
+	auto runState = hook::pattern("85 F6 78 ? 75 ? 83 FB 01 75").count(1).get(0).get<char>(-0x2A);
 
 	MH_Initialize();
 	MH_CreateHook(runState, DoAppState, (void**)&g_appState);

--- a/code/components/rage-scripting-rdr3/src/ScriptHandlerMgr.cpp
+++ b/code/components/rage-scripting-rdr3/src/ScriptHandlerMgr.cpp
@@ -79,14 +79,11 @@ static HookFunction hookFunction([]()
 	});
 
 	// remove assertion for duplicate scripts (R* prod debug)
-	if (xbr::IsGameBuildOrGreater<1355>())
-	{
-		auto pattern = hook::pattern("FF 50 ? 84 C0 74 ? BA ? ? ? ? 41").count(3);
+	auto pattern = hook::pattern("FF 50 ? 84 C0 74 ? BA ? ? ? ? 41").count(3);
 
-		for (int i = 0; i < pattern.size(); i++)
-		{
-			hook::put<uint8_t>(pattern.get(i).get<void>(5), 0xEB);
-		}
+	for (int i = 0; i < pattern.size(); i++)
+	{
+		hook::put<uint8_t>(pattern.get(i).get<void>(5), 0xEB);
 	}
 });
 

--- a/code/components/rage-scripting-rdr3/src/scrThread.cpp
+++ b/code/components/rage-scripting-rdr3/src/scrThread.cpp
@@ -66,7 +66,7 @@ rage::eThreadState WRAPPER CfxGtaThread::Tick(uint32_t opsToExecute)
 
 static hook::thiscall_stub<void(GtaThread*)> gtaThreadKill([]()
 {
-	return hook::get_pattern("48 8B D7 FF 50 58 0F BE", xbr::IsGameBuildOrGreater<1436>() ? -0x48 : -0x3A);
+	return hook::get_pattern("48 8B D7 FF 50 58 0F BE", -0x48);
 });
 
 void CfxGtaThread::Kill()


### PR DESCRIPTION
### Goal of this PR
Since these are used by almost nobody (latest stats show there was a total of two players on a build older than 1491).

Older game builds (1311 and 1355) were already broken due to legitimacy changes and overlay changes.

This should make it easier for newer community PR's to validate changes since they will only have test against the latest version (which most were already doing anyways).

### How is this PR achieving the goal
Removes version checks and only keeps 1491


### This PR applies to the following area(s)
RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491

**Platforms:** Windows 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


