### PR TITLE
feat(extra-natives-five): add `SET_WET_CLOTH_PIN_RADIUS_SCALE` for wet cloth physics control

### DIFF
--- a/ext/native-decls/SetWetClothPinRadiusScale.md
+++ b/ext/native-decls/SetWetClothPinRadiusScale.md
@@ -1,0 +1,22 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_WET_CLOTH_PIN_RADIUS_SCALE
+
+```c
+void SET_WET_CLOTH_PIN_RADIUS_SCALE(float scale);
+```
+
+Modifies the radius scale used in the simulation of wet cloth physics.
+This affects how cloth behaves when wet, changing how it sticks or reacts to movement.
+
+## Examples
+
+```lua
+SetWetClothPinRadiusScale(1.0)
+```
+
+## Parameters
+* **scale**: A value that controls the wet cloth radius scale, default: 0.3, maximum: 1.0(used for dry cloth by default), lower values increase the adhesion effect of wet cloth, making it cling more tightly to the surface.


### PR DESCRIPTION
### Goal of this PR
Add support for controlling wet cloth physics behavior implementing the native `SET_WET_CLOTH_PIN_RADIUS_SCALE`.  
This allows scripts to modify how tightly wet cloth adheres to characters.
Suggestion in [forum](https://forum.cfx.re/t/request-native-toggle-to-set-clothing-to-ignore-wetness/), thanks so much to @alberttheprince


https://github.com/user-attachments/assets/1fb30fd8-79eb-43d1-b639-783407594df3



### How is this PR achieving the goal
Creating a native to change the default value in `SetWetClothingHeight`, `ProcessWetClothingInWater`, `IncWetClothing` functions.


### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Game builds:** 1604, 3258, 3407

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
