### PR TITLE
fix(net/five): factory nullptr check

### DIFF
--- a/code/components/gta-net-five/src/NetServerObject.cpp
+++ b/code/components/gta-net-five/src/NetServerObject.cpp
@@ -43,24 +43,41 @@ static bool CanEntityBeDeleted(rage::netObject* netObject)
 static void (*g_origCVehicleFactoryDestroy)(void*, CVehicle*, bool);
 static void CVehicleFactory_Destroy(void* self, CVehicle* vehicle, bool unk)
 {
+	if (!vehicle)
+	{
+		return;
+	}
+
 	if (!icgi->OneSyncEnabled || !vehicle->GetNetObject() || CanEntityBeDeleted((rage::netObject*)vehicle->GetNetObject()))
 	{
 		g_origCVehicleFactoryDestroy(self, vehicle, unk);
 	}
 }
 
-static void (*g_origCPedFactoryDestroy)(void*, fwEntity*, bool);
-static void CPedFactory_Destroy(void* self, fwEntity* ped, bool unk)
+static bool (*g_origCPedFactoryDestroy)(void*, fwEntity*, bool);
+static bool CPedFactory_Destroy(void* self, fwEntity* ped, bool unk)
 {
+	if (!ped)
+	{
+		return false;
+	}
+
 	if (!icgi->OneSyncEnabled || !ped->GetNetObject() || CanEntityBeDeleted((rage::netObject*)ped->GetNetObject()))
 	{
-		g_origCPedFactoryDestroy(self, ped, unk);
+		return g_origCPedFactoryDestroy(self, ped, unk);
 	}
+
+	return false;
 }
 
 static void (*g_destroyObject)(fwEntity*, int);
 static void DestroyObject(fwEntity* object, int unk)
 {
+	if (!object)
+	{
+		return;
+	}
+
 	if (!icgi->OneSyncEnabled || !object->GetNetObject() || CanEntityBeDeleted((rage::netObject*)object->GetNetObject()))
 	{
 		g_destroyObject(object, unk);


### PR DESCRIPTION
### Goal of this PR

Fixes an oversight introduced in #3249 

### How is this PR achieving the goal

Check if ped/vehicle/object is a nullptr before trying to call GetNetObject, matching the behaviour of the original functions.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

