### PR TITLE
feat(core/five): patch script ptfx limits

### DIFF
--- a/code/components/gta-core-five/PtfxScriptLimit.cpp
+++ b/code/components/gta-core-five/PtfxScriptLimit.cpp
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <StdInc.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
+/*
+ * Override the value (5th parameter) used in the "ptfx manager init" function to create script ptfx array
+ * On b1604 to b3407 default value is 128
+ *
+ * The game keep track of script ptfxs in an atArray defined as :
+ * struct scriptPtfx {
+ *     int a;
+ *     bool b;
+ *     bool c;
+ *     char padding[2];
+ * };
+ *
+ * This was tested with a limit up to 1024 without having any obvious bad side effects, but the game doesn't render some fx above ~384?
+ * This seems related to PtFxSortedEntity pool, but i didn't manage to resolve the rendering issue
+ * I also tried making other parameters of this function to bigger values but it didn't change anything
+ */
+
+static HookFunction hookFunction([]
+{
+  hook::put<int32_t>(hook::get_pattern("C7 44 24 ? ? ? ? ? E8 ? ? ? ? 48 8B CB E8 ? ? ? ? 48 8B CB E8 ? ? ? ? 48 8B CB", 4), 256);
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

While trying to create a spell system in game, i managed to hit the script ptfx very easily with other players.
I tried to cast ~10 spells in 20 seconds with 20 other players around me, making a total of 200 ptfx.
This made a lot of ptfx created with `StartParticleFxLoopedAtCoord` invisible, because the game couldn't attribute script id to all my requests.


### How is this PR achieving the goal

By overriding the init function we have access to multiple limits the game hardcode, the specific "128 ptfx" limit can be changed to 256 very safely, other limits could be changed later but need more research.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604 / 2802 / 3258 / 3407

**Platforms:** Windows

Script used to test :
```
CreateThread(function()
    RequestNamedPtfxAsset('core')
    local coords = vector3(-1050.7, 458.62, 185.3)

    local i = 0
    for x = 1, 32 do
        for y = 1, 32 do
            UseParticleFxAssetNextCall('core')
            local particle = StartParticleFxLoopedAtCoord('fire_wrecked_plane_cockpit', coords.x + x * 2, coords.y + y * 2, coords.z, 0.0, 0.0, 0.0, 1.0, false, false, false, false)
            if particle == 0 then print('BROKE AT', i) break end
            i += 1
        end
    end
end)
```
![image](https://github.com/user-attachments/assets/39aeb196-ec6a-49d8-946f-91a676b1c4e6)


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
None



Special thanks to @Mathu-lmn for the help testing and reversing things around this feature.
Also thanks to @tens0rfl0w for the tip around hook::trampoline