### PR TITLE
feat(graphics/rdr3): add crashometry for vulkan

### DIFF
--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -512,6 +512,10 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureBacking(int width, int h
 
 #pragma comment(lib, "vulkan-1.lib")
 
+#ifdef IS_RDR3
+#include <VulkanHelper.h>
+#endif
+
 fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE shareHandle, int width, int height)
 {
 #ifndef GTA_NY
@@ -666,7 +670,7 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 
 				if (result != VK_SUCCESS)
 				{
-					FatalError("Failed to create a Vulkan image. VkResult: %i", static_cast<int>(result));
+					FatalError("Failed to create a Vulkan image. VkResult: %s", ResultToString(result));
 				}
 
 				VkMemoryRequirements MemoryRequirements;
@@ -693,7 +697,7 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 
 				if (result != VK_SUCCESS)
 				{
-					FatalError("Failed to allocate memory for Vulkan. VkResult: %i", static_cast<int>(result));
+					FatalError("Failed to allocate memory for Vulkan. VkResult: %s", ResultToString(result));
 				}
 
 				VkBindImageMemoryInfo BindImageMemoryInfo = { VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO };
@@ -704,7 +708,7 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 
 				if (result != VK_SUCCESS)
 				{
-					FatalError("Failed to bind Vulkan image memory. VkResult: %i", static_cast<int>(result));
+					FatalError("Failed to bind Vulkan image memory. VkResult: %s", ResultToString(result));
 				}
 
 				auto newImage = new rage::sga::TextureVK::ImageData;

--- a/code/components/rage-graphics-rdr3/include/VulkanHelper.h
+++ b/code/components/rage-graphics-rdr3/include/VulkanHelper.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#if IS_RDR3
+#include <string_view>
+#include <vulkan/vulkan_core.h>
+
+inline std::string_view ResultToString(VkResult result)
+{
+	switch (result)
+	{
+		case VK_ERROR_OUT_OF_HOST_MEMORY:
+			return "VK_ERROR_OUT_OF_HOST_MEMORY A host memory allocation has failed.";
+		case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+			return "VK_ERROR_OUT_OF_DEVICE_MEMORY A device memory allocation has failed.";
+		case VK_ERROR_INITIALIZATION_FAILED:
+			return "VK_ERROR_INITIALIZATION_FAILED Initialization of an object could not be completed for implementation-specific reasons.";
+		case VK_ERROR_DEVICE_LOST:
+			return "VK_ERROR_DEVICE_LOST The logical or physical device has been lost.";
+		case VK_ERROR_MEMORY_MAP_FAILED:
+			return "VK_ERROR_MEMORY_MAP_FAILED Mapping of a memory object has failed.";
+		case VK_ERROR_LAYER_NOT_PRESENT:
+			return "VK_ERROR_LAYER_NOT_PRESENT A requested layer is not present or could not be loaded.";
+		case VK_ERROR_EXTENSION_NOT_PRESENT:
+			return "VK_ERROR_EXTENSION_NOT_PRESENT A requested extension is not supported.";
+		case VK_ERROR_FEATURE_NOT_PRESENT:
+			return "VK_ERROR_FEATURE_NOT_PRESENT A requested feature is not supported.";
+		case VK_ERROR_INCOMPATIBLE_DRIVER:
+			return "VK_ERROR_INCOMPATIBLE_DRIVER The requested version of Vulkan is not supported by the driver or is otherwise incompatible for implementation-specific reasons.";
+		case VK_ERROR_TOO_MANY_OBJECTS:
+			return "VK_ERROR_TOO_MANY_OBJECTS Too many objects of the type have already been created.";
+		case VK_ERROR_FORMAT_NOT_SUPPORTED:
+			return "VK_ERROR_FORMAT_NOT_SUPPORTED A requested format is not supported on this device.";
+		case VK_ERROR_FRAGMENTED_POOL:
+			return "VK_ERROR_FRAGMENTED_POOL A pool allocation has failed due to fragmentation of the pool’s memory. This must only be returned if no attempt to allocate host or device memory was made to accommodate the new allocation. This should be returned in preference to VK_ERROR_OUT_OF_POOL_MEMORY, but only if the implementation is certain that the pool allocation failure was due to fragmentation.";
+		case VK_ERROR_OUT_OF_POOL_MEMORY:
+			return "VK_ERROR_OUT_OF_POOL_MEMORY A pool memory allocation has failed. This must only be returned if no attempt to allocate host or device memory was made to accommodate the new allocation. If the failure was definitely due to fragmentation of the pool, VK_ERROR_FRAGMENTED_POOL should be returned instead.";
+		case VK_ERROR_INVALID_EXTERNAL_HANDLE:
+			return "VK_ERROR_INVALID_EXTERNAL_HANDLE An external handle is not a valid handle of the specified type.";
+		case VK_ERROR_SURFACE_LOST_KHR:
+			return "VK_ERROR_SURFACE_LOST_KHR A surface is no longer available.";
+		case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+			return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR The requested window is already in use by Vulkan or another API in a manner which prevents it from being used again.";
+		case VK_ERROR_OUT_OF_DATE_KHR:
+			return "VK_ERROR_OUT_OF_DATE_KHR A surface has changed in such a way that it is no longer compatible with the swapchain, and further presentation requests using the swapchain will fail. Applications must query the new surface properties and recreate their swapchain if they wish to continue presenting to the surface.";
+		case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
+			return "VK_ERROR_INCOMPATIBLE_DISPLAY_KHR The display used by a swapchain does not use the same presentable image layout, or is incompatible in a way that prevents sharing an image.";
+		case VK_ERROR_VALIDATION_FAILED_EXT:
+			return "VK_ERROR_VALIDATION_FAILED_EXT A command failed because invalid usage was detected by the implementation or a validation-layer.";
+		case VK_ERROR_INVALID_SHADER_NV:
+			return "VK_ERROR_INVALID_SHADER_NV One or more shaders failed to compile or link.";
+		case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
+			return "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT ";
+		case VK_ERROR_FRAGMENTATION_EXT:
+			return "VK_ERROR_FRAGMENTATION A descriptor pool creation has failed due to fragmentation.";
+		case VK_ERROR_NOT_PERMITTED_EXT:
+			return "VK_ERROR_NOT_PERMITTED_EXT";
+		case VK_ERROR_INVALID_DEVICE_ADDRESS_EXT:
+			return "VK_ERROR_INVALID_DEVICE_ADDRESS_EXT A buffer creation failed because the requested address is not available.";
+		default:
+			return "";
+	}
+}
+#endif

--- a/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
@@ -7,7 +7,12 @@
 
 #include <CoreConsole.h>
 
+#include <VulkanHelper.h>
+#include <CrossBuildRuntime.h>
+
 #pragma comment(lib, "vulkan-1.lib")
+
+static bool g_enableVulkanValidation = false;
 
 // Function to print the output of the validation layers
 VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessageCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
@@ -31,11 +36,11 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessageCallback(VkDebugUtilsMessageSeverityF
 		prefix = "ERROR: ";
 	}
 
-	trace("%s [%i][%s]: %s\n", prefix, pCallbackData->messageIdNumber, pCallbackData->pMessageIdName, pCallbackData->pMessage);
+	trace("%s[%i][%s]: %s\n", prefix, pCallbackData->messageIdNumber, pCallbackData->pMessageIdName, pCallbackData->pMessage);
 	return VK_FALSE;
 }
 
-static inline std::string GetGPUType(VkPhysicalDeviceType type)
+static inline std::string_view GetGPUType(VkPhysicalDeviceType type)
 {
 	switch (type)
 	{
@@ -72,120 +77,132 @@ static inline bool IsDedicatedGPU(VkPhysicalDeviceType type)
 static VkResult __stdcall vkCreateInstanceHook(VkInstanceCreateInfo* pCreateInfo, VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
 {
 	// the validation layers should be disabled when playing, but enabled when encountering a crash
-	// if we disable these now, we fallback to dx12 for some reason
-#if 0
-	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount + 1);
+	// we keep the data here, to ensure the data does not go out of scope
+	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount);
+	std::vector<const char*> originalExtensions(pCreateInfo->enabledExtensionCount);
 
-	for (size_t i = 0; i < originalLayers.size() - 1; i++)
+	if (g_enableVulkanValidation)
 	{
-		originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
-		trace("Vulkan Instance layers: %s\n", originalLayers[i]);
+
+		for (size_t i = 0; i < originalLayers.size(); i++)
+		{
+			originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
+			trace("Vulkan Instance layers: %s\n", originalLayers[i]);
+		}
+
+		originalLayers.push_back("VK_LAYER_KHRONOS_validation");
+
+		pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
+		pCreateInfo->ppEnabledLayerNames = originalLayers.data();
+
+		for (size_t i = 0; i < originalExtensions.size(); i++)
+		{
+			originalExtensions[i] = pCreateInfo->ppEnabledExtensionNames[i];
+			trace("Vulkan Instance Extensions: %s\n", originalExtensions[i]);
+		}
+
+		originalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+		pCreateInfo->enabledExtensionCount = static_cast<uint32_t>(originalExtensions.size());
+		pCreateInfo->ppEnabledExtensionNames = originalExtensions.data();
+
+		VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo = {};
+
+		debugCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+		debugCreateInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+		debugCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+		debugCreateInfo.pfnUserCallback = DebugMessageCallback;
+
+		pCreateInfo->pNext = &debugCreateInfo;
 	}
 
-	originalLayers.push_back("VK_LAYER_KHRONOS_validation");
-
-	pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
-	pCreateInfo->ppEnabledLayerNames = originalLayers.data();
-
-	std::vector<const char*> originalExtensions(pCreateInfo->enabledExtensionCount + 1);
-
-	for (size_t i = 0; i < originalExtensions.size() - 1; i++)
-	{
-		originalExtensions[i] = pCreateInfo->ppEnabledExtensionNames[i];
-		trace("Vulkan Instance Extensions: %s\n", originalExtensions[i]);
-	}
-
-	originalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-
-	pCreateInfo->enabledExtensionCount = static_cast<uint32_t>(originalExtensions.size());
-	pCreateInfo->ppEnabledExtensionNames = originalExtensions.data();
-
-	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo = {};
-
-	debugCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-	debugCreateInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-	debugCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-	debugCreateInfo.pfnUserCallback = DebugMessageCallback;
-
-	pCreateInfo->pNext = &debugCreateInfo;
-#endif
 	VkResult result = vkCreateInstance(pCreateInfo, pAllocator, pInstance);
 
 	if (result != VK_SUCCESS)
 	{
-		trace("Vulkan instance creation returned: %i\nSee the vulkan docs for the error code (VkResult)\n", result);
+		trace("Vulkan instance creation returned: %s\n", ResultToString(result));
 	}
 
 	// we let rage handle the error (probably defaults back to dx12)
 	return result;
 }
 
-static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
+static inline void SetVulkanCrashometry(const VkPhysicalDevice physicalDevice)
 {
-	// Disabled for now
-#if 0
-	// force validation layers for vulkan, but dont replace the original layers
-	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount + 1);
+	static bool isInitialized = false;
 
-	for (size_t i = 0; i < originalLayers.size() - 1; i++)
+	if (isInitialized)
+		return;
+
+	VkPhysicalDeviceProperties props = {};
+
+	vkGetPhysicalDeviceProperties(physicalDevice, &props);
+
+	// version encoding: https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers
+	uint32_t major = static_cast<uint32_t>(props.apiVersion) >> 22U;
+	uint32_t minor = (static_cast<uint32_t>(props.apiVersion) >> 12U) & 0x3FFU;
+	uint32_t patch = static_cast<uint32_t>(props.apiVersion) & 0xFFFU;
+
+	AddCrashometry("gpu_name", "%s", props.deviceName);
+	AddCrashometry("gpu_id", "%04x:%04x", props.vendorID, props.deviceID);
+	AddCrashometry("vulkan_api_version", "v%u.%u.%u", major, minor, patch);
+	AddCrashometry("validation_layers_enabled", "%i", static_cast<int>(g_enableVulkanValidation));
+
+	// driver version encoding: https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/1e6ca6e3c0763daabd6a101b860ab4354a07f5d3/functions.php#L298-L321
+	// vendor ids: https://www.reddit.com/r/vulkan/comments/4ta9nj/is_there_a_comprehensive_list_of_the_names_and/
+	// NVIDIA
+	if (props.vendorID == 0x10DE)
 	{
-		originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
-		trace("Vulkan Device Layer: %s", originalLayers[i]);
+		AddCrashometry("nvidia_driver", "v%u.%u.%u.%u", (props.driverVersion >> 22) & 0x3ff, (props.driverVersion >> 14) & 0x0ff, (props.driverVersion >> 6) & 0x0ff, (props.driverVersion) & 0x003f);
+	}
+	// INTEL
+	else if (props.vendorID == 0x8086)
+	{
+		AddCrashometry("intel_driver", "v%u.%u", (props.driverVersion >> 14), (props.driverVersion) & 0x3fff);
+	}
+	else
+	{
+		AddCrashometry("driver", "v%u.%u.%u", (props.driverVersion >> 22), (props.driverVersion >> 12) & 0x3ff, props.driverVersion & 0xfff);
 	}
 
-	originalLayers.push_back("VK_LAYER_KHRONOS_validation");
+	trace("GPU Name: %s\nGPU type: %s\nDriver version: %u\nAPI version: %u.%u.%u\n", props.deviceName, GetGPUType(props.deviceType), props.driverVersion, major, minor, patch);
 
-	pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
-	pCreateInfo->ppEnabledLayerNames = originalLayers.data();
-#endif
-
-	static auto _ = ([&physicalDevice]
+	if (!IsDedicatedGPU(props.deviceType))
 	{
-		VkPhysicalDeviceProperties props = {};
+		trace("[WARNING] RedM is using a non dedicated GPU. The GPU type that is in use is: %s", GetGPUType(props.deviceType));
+	}
 
-		vkGetPhysicalDeviceProperties(physicalDevice, &props);
+	isInitialized = true;
+}
 
-		// version encoding: https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers
-		uint32_t major = static_cast<uint32_t>(props.apiVersion) >> 22U;
-		uint32_t minor = (static_cast<uint32_t>(props.apiVersion) >> 12U) & 0x3FFU;
-		uint32_t patch = static_cast<uint32_t>(props.apiVersion) & 0xFFFU;
+static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
+{
+	// we keep the data here, to ensure the data does not go out of scope
+	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount);
 
-		AddCrashometry("gpu_name", "%s", props.deviceName);
-		AddCrashometry("gpu_id", "%04x:%04x", props.vendorID, props.deviceID);
-		AddCrashometry("vulkan_api_version", "v%u.%u.%u", major, minor, patch);
+	if (g_enableVulkanValidation)
+	{
+		// force validation layers for vulkan, but dont replace the original layers
 
-		// driver version encoding: https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/1e6ca6e3c0763daabd6a101b860ab4354a07f5d3/functions.php#L298-L321
-		// vendor ids: https://www.reddit.com/r/vulkan/comments/4ta9nj/is_there_a_comprehensive_list_of_the_names_and/
-		// NVIDIA
-		if (props.vendorID == 0x10DE)
+		for (size_t i = 0; i < originalLayers.size(); i++)
 		{
-			AddCrashometry("nvidia_driver", "v%u.%u.%u.%u", (props.driverVersion >> 22) & 0x3ff, (props.driverVersion >> 14) & 0x0ff, (props.driverVersion >> 6) & 0x0ff, (props.driverVersion) & 0x003f);
-		}
-		// INTEL
-		else if (props.vendorID == 0x8086)
-		{
-			AddCrashometry("intel_driver", "v%u.%u", (props.driverVersion >> 14), (props.driverVersion) & 0x3fff);
-		}
-		else
-		{
-			AddCrashometry("driver", "v%u.%u.%u", (props.driverVersion >> 22), (props.driverVersion >> 12) & 0x3ff, props.driverVersion & 0xfff);
+			originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
+			trace("Vulkan Device Layer: %s", originalLayers[i]);
 		}
 
-		trace("GPU Name: %s\nGPU type: %s\nDriver version: %u\nAPI version: %u.%u.%u\n", props.deviceName, GetGPUType(props.deviceType).c_str(), props.driverVersion, major, minor, patch);
+		originalLayers.push_back("VK_LAYER_KHRONOS_validation");
 
-		if (!IsDedicatedGPU(props.deviceType))
-		{
-			console::DPrintf("Vulkan GPU selection", "[WARNING] RedM is using a non dedicated GPU. The GPU type that is in use is: %s", GetGPUType(props.deviceType));
-		}
+		pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
+		pCreateInfo->ppEnabledLayerNames = originalLayers.data();
+	}
 
-		return true;
-	})();
+	SetVulkanCrashometry(physicalDevice);
 
 	VkResult result = vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
 
 	if (result != VK_SUCCESS)
 	{
-		trace("Vulkan device creation returned: %i\nSee the vulkan docs for the error code (VkResult)", result);
+		trace("Vulkan device creation returned: %s\n", ResultToString(result));
 	}
 
 	return result;
@@ -193,6 +210,9 @@ static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreat
 
 static HookFunction hookFunction([]()
 {
+	std::wstring fpath = MakeRelativeCitPath(L"CitizenFX.ini");
+	g_enableVulkanValidation = static_cast<bool>(GetPrivateProfileInt(L"Game", L"EnableVulkanValidation", 0, fpath.c_str()));
+
 	// Vulkan create instance hook
 	{
 		auto location = hook::get_pattern("FF D0 8B F0 89 84 24", -7);

--- a/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
@@ -1,0 +1,209 @@
+#include "StdInc.h"
+
+#include <vulkan/vulkan.h>
+
+#include <Hooking.h>
+#include <Error.h>
+
+#include <CoreConsole.h>
+
+#pragma comment(lib, "vulkan-1.lib")
+
+// Function to print the output of the validation layers
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessageCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
+{
+	std::string prefix;
+
+	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT)
+	{
+		prefix = "VERBOSE: ";
+	}
+	else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
+	{
+		prefix = "INFO: ";
+	}
+	else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+	{
+		prefix = "WARNING: ";
+	}
+	else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+	{
+		prefix = "ERROR: ";
+	}
+
+	trace("%s [%i][%s]: %s\n", prefix, pCallbackData->messageIdNumber, pCallbackData->pMessageIdName, pCallbackData->pMessage);
+	return VK_FALSE;
+}
+
+static inline std::string GetGPUType(VkPhysicalDeviceType type)
+{
+	switch (type)
+	{
+		case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+			return "Other";
+		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+			return "Integrated GPU";
+		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+			return "Discrete GPU";
+		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+			return "Virtual GPU";
+		case VK_PHYSICAL_DEVICE_TYPE_CPU:
+			return "CPU";
+		default:
+			return "Unknown";
+	}
+}
+
+static inline bool IsDedicatedGPU(VkPhysicalDeviceType type)
+{
+	switch (type)
+	{
+		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+			return true;
+		case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+		case VK_PHYSICAL_DEVICE_TYPE_CPU:
+		default:
+			return false;
+	}
+}
+
+static VkResult __stdcall vkCreateInstanceHook(VkInstanceCreateInfo* pCreateInfo, VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
+{
+	// the validation layers should be disabled when playing, but enabled when encountering a crash
+	// if we disable these now, we fallback to dx12 for some reason
+#if 0
+	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount + 1);
+
+	for (size_t i = 0; i < originalLayers.size() - 1; i++)
+	{
+		originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
+		trace("Vulkan Instance layers: %s\n", originalLayers[i]);
+	}
+
+	originalLayers.push_back("VK_LAYER_KHRONOS_validation");
+
+	pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
+	pCreateInfo->ppEnabledLayerNames = originalLayers.data();
+
+	std::vector<const char*> originalExtensions(pCreateInfo->enabledExtensionCount + 1);
+
+	for (size_t i = 0; i < originalExtensions.size() - 1; i++)
+	{
+		originalExtensions[i] = pCreateInfo->ppEnabledExtensionNames[i];
+		trace("Vulkan Instance Extensions: %s\n", originalExtensions[i]);
+	}
+
+	originalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+	pCreateInfo->enabledExtensionCount = static_cast<uint32_t>(originalExtensions.size());
+	pCreateInfo->ppEnabledExtensionNames = originalExtensions.data();
+
+	VkDebugUtilsMessengerCreateInfoEXT debugCreateInfo = {};
+
+	debugCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+	debugCreateInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+	debugCreateInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+	debugCreateInfo.pfnUserCallback = DebugMessageCallback;
+
+	pCreateInfo->pNext = &debugCreateInfo;
+#endif
+	VkResult result = vkCreateInstance(pCreateInfo, pAllocator, pInstance);
+
+	if (result != VK_SUCCESS)
+	{
+		trace("Vulkan instance creation returned: %i\nSee the vulkan docs for the error code (VkResult)\n", result);
+	}
+
+	// we let rage handle the error (probably defaults back to dx12)
+	return result;
+}
+
+static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
+{
+	// Disabled for now
+#if 0
+	// force validation layers for vulkan, but dont replace the original layers
+	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount + 1);
+
+	for (size_t i = 0; i < originalLayers.size() - 1; i++)
+	{
+		originalLayers[i] = pCreateInfo->ppEnabledLayerNames[i];
+		trace("Vulkan Device Layer: %s", originalLayers[i]);
+	}
+
+	originalLayers.push_back("VK_LAYER_KHRONOS_validation");
+
+	pCreateInfo->enabledLayerCount = static_cast<uint32_t>(originalLayers.size());
+	pCreateInfo->ppEnabledLayerNames = originalLayers.data();
+#endif
+
+	static auto _ = ([&physicalDevice]
+	{
+		VkPhysicalDeviceProperties props = {};
+
+		vkGetPhysicalDeviceProperties(physicalDevice, &props);
+
+		// version encoding: https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#extendingvulkan-coreversions-versionnumbers
+		uint32_t major = static_cast<uint32_t>(props.apiVersion) >> 22U;
+		uint32_t minor = (static_cast<uint32_t>(props.apiVersion) >> 12U) & 0x3FFU;
+		uint32_t patch = static_cast<uint32_t>(props.apiVersion) & 0xFFFU;
+
+		AddCrashometry("gpu_name", "%s", props.deviceName);
+		AddCrashometry("gpu_id", "%04x:%04x", props.vendorID, props.deviceID);
+		AddCrashometry("vulkan_api_version", "v%u.%u.%u", major, minor, patch);
+
+		// driver version encoding: https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/1e6ca6e3c0763daabd6a101b860ab4354a07f5d3/functions.php#L298-L321
+		// vendor ids: https://www.reddit.com/r/vulkan/comments/4ta9nj/is_there_a_comprehensive_list_of_the_names_and/
+		// NVIDIA
+		if (props.vendorID == 0x10DE)
+		{
+			AddCrashometry("nvidia_driver", "v%u.%u.%u.%u", (props.driverVersion >> 22) & 0x3ff, (props.driverVersion >> 14) & 0x0ff, (props.driverVersion >> 6) & 0x0ff, (props.driverVersion) & 0x003f);
+		}
+		// INTEL
+		else if (props.vendorID == 0x8086)
+		{
+			AddCrashometry("intel_driver", "v%u.%u", (props.driverVersion >> 14), (props.driverVersion) & 0x3fff);
+		}
+		else
+		{
+			AddCrashometry("driver", "v%u.%u.%u", (props.driverVersion >> 22), (props.driverVersion >> 12) & 0x3ff, props.driverVersion & 0xfff);
+		}
+
+		trace("GPU Name: %s\nGPU type: %s\nDriver version: %u\nAPI version: %u.%u.%u\n", props.deviceName, GetGPUType(props.deviceType).c_str(), props.driverVersion, major, minor, patch);
+
+		if (!IsDedicatedGPU(props.deviceType))
+		{
+			console::DPrintf("Vulkan GPU selection", "[WARNING] RedM is using a non dedicated GPU. The GPU type that is in use is: %s", GetGPUType(props.deviceType));
+		}
+
+		return true;
+	})();
+
+	VkResult result = vkCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
+
+	if (result != VK_SUCCESS)
+	{
+		trace("Vulkan device creation returned: %i\nSee the vulkan docs for the error code (VkResult)", result);
+	}
+
+	return result;
+}
+
+static HookFunction hookFunction([]()
+{
+	// Vulkan create instance hook
+	{
+		auto location = hook::get_pattern("FF D0 8B F0 89 84 24", -7);
+		hook::nop(location, 9);
+		hook::call(location, vkCreateInstanceHook);
+	}
+
+	// Vulkan CreateDevice hook
+	{
+		auto location = hook::get_pattern<char>("FF 15 ? ? ? ? 8B C8 E8 ? ? ? ? 85 C0 0F 85 ? ? ? ? 48 8B 0D");
+		hook::nop(location, 6);
+		hook::call(location, vkCreateDeviceHook);
+	}
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This pr will add crashometry of the resources that are used by the Vulkan API. The data that I added are the following: GPU name, Vulkan APIversion, and driver version. We want to have this data, to diagnose the Vulkan crashes more precisely. To add to that, I also expanded the error handling in glue. Now, instead of having an assert and not having no data, we display the VkResult, so we know what went wrong. 
The validation layers could also be enabled, but it when it is enabled in the instance, it fails and falls back to d3d12. Matter of fact, you need the Vulkan SDK installed, hence the removal for now.

### How is this PR achieving the goal
This pr adds more information to try diagnose crashes, and hopefully guide to a faster solution.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1491  

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
NA

Thanks @Ehbw for the patterns.