### PR TITLE
feat(server): add external kvp natives

### DIFF
--- a/ext/native-decls/kvp/external/GetExternalKvpFloat.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpFloat.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 ---
 ## GET_EXTERNAL_KVP_FLOAT
 

--- a/ext/native-decls/kvp/external/GetExternalKvpInt.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpInt.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 ---
 ## GET_EXTERNAL_KVP_INT
 

--- a/ext/native-decls/kvp/external/GetExternalKvpString.md
+++ b/ext/native-decls/kvp/external/GetExternalKvpString.md
@@ -1,6 +1,6 @@
 ---
 ns: CFX
-apiset: client
+apiset: shared
 ---
 ## GET_EXTERNAL_KVP_STRING
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add external KVP natives to the server, matching the client-side implementation. This is useful for enabling communication between resources on the server.

### How is this PR achieving the goal

Aligns the server with client KVP natives by implementing the same functionality server-side.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


