### PR TITLE
fix(citizen-scripting-v8): Crash when formatting an exception stack trace from a callback that's inside an eval() function.

### DIFF
--- a/code/components/citizen-scripting-v8/src/V8ScriptRuntime.cpp
+++ b/code/components/citizen-scripting-v8/src/V8ScriptRuntime.cpp
@@ -2282,7 +2282,7 @@ static void OnMessage(Local<Message> message, Local<Value> error)
 		v8::String::Utf8Value sourceStr(GetV8Isolate(), frame->GetScriptNameOrSourceURL());
 		v8::String::Utf8Value functionStr(GetV8Isolate(), frame->GetFunctionName());
 		
-		stack << *sourceStr << "(" << frame->GetLineNumber() << "," << frame->GetColumn() << "): " << (*functionStr ? *functionStr : "") << "\n";
+		stack << (*sourceStr ? *sourceStr : "(unknown)") << "(" << frame->GetLineNumber() << "," << frame->GetColumn() << "): " << (*functionStr ? *functionStr : "") << "\n";
 	}
 
 	ScriptTrace("%s\n%s\n%s\n", *messageStr, stack.str(), *errorStr);


### PR DESCRIPTION
### Goal of this PR
Prevent the FXServer instance from crashing, due to the script name being null when an exception is thrown inside a callback, from inside an eval() function. Not all callbacks work, it might only happen for ones triggered from C++ code. For example the callback of https.get() causes the crash, while the callback from `setTimeout()` doesn't.

A simple reproduction for the issue:
```js
eval(`
    const https = require('https');
    https.get('https://google.com', res => {
        throw new Error("dfgfgdfgdfg")
    })
`);
```

A few people reported this crash as if it started happening today, without any changes from their side. Due to the weird nature of eval-ing remotely downloaded code, I have high suspicions (but no proof) that they were using leaked resources with backdoors and the payload was causing the crash. Despite that, the server shouldn't crash from scripts, so the issue should be fixed.

### How is this PR achieving the goal
Default the script name to `(unknown)` if the sourceStr value is null

Before the fix:
![image](https://github.com/user-attachments/assets/fde897f6-03e9-4ba3-9841-161ddf471c70)

After the fix: (no crash, just the stack trace is printed)
![image](https://github.com/user-attachments/assets/2c44c7ca-6d03-4fd3-b1db-0dbdef7b0120)


### This PR applies to the following area(s)
FiveM, RedM, Server, ScRT: JS


### Successfully tested on
FXServer with Node 16 and 22. Haven't tested on the client because I don't know how you could trigger this behavior - https.get isn't available.

**Game builds:** Tested on 3258, most likely irrelevant

**Platforms:** Windows 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


