### PR TITLE
fix(fxd): detect problematic characters in working directory path that break the script

### DIFF
--- a/fxd.ps1
+++ b/fxd.ps1
@@ -3,10 +3,20 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-
+$pattern = '[\*\?\[\]`$"&|;()@%,#]'
 
 if (!$Command) {
     $Command = 'help'
+}
+
+if ($PSScriptRoot -match $pattern) {
+    $matches = ([regex]::Matches($PSScriptRoot, $pattern)).Index
+    $markerLine = (0..($PSScriptRoot.Length - 1) | ForEach-Object { if ($matches -contains $_) {'^'} else {' '} }) -join ''
+
+    Write-Host "Current working directory contains unsupported characters. Please move or rename the folder:" -ForegroundColor Red
+    Write-Host $PSScriptRoot -ForegroundColor Red
+    Write-Host $markerLine -ForegroundColor Red
+    exit 1
 }
 
 $CommandScript = "$PSScriptRoot\code\tools\fxd\$Command.ps1"


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Prevent the script from breaking when the working directory contains problematic characters by detecting and warning the user

### How is this PR achieving the goal

Adds a check for special characters in the current working directory path that cause powershell script parsing errors, highlights the characters, and asl the user to move or rename the folder

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

fxd tool

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Cant find related issues

![image](https://github.com/user-attachments/assets/b0146ac3-69b4-467f-9ffe-7bb473daf918)
