### PR TITLE
Optimize ACL for faster deletion on resource stop

### DIFF
--- a/code/client/citicore/se/Security.cpp
+++ b/code/client/citicore/se/Security.cpp
@@ -130,9 +130,10 @@ void Context::AddAccessControlEntry(const Principal& principal, const Object& ob
 
 void Context::RemoveAccessControlEntry(const Principal& principal, const Object& object, AccessType type)
 {
-	for (auto it = m_impl->m_aces.begin(); it != m_impl->m_aces.end(); )
+	auto range = m_impl->m_aces.equal_range(object);
+	for (auto it = range.first; it != range.second; )
 	{
-		if (it->first == object && it->second.principal == principal && it->second.type == type)
+		if (it->second.principal == principal && it->second.type == type)
 		{
 			it = m_impl->m_aces.erase(it);
 		}

--- a/code/client/citicore/se/Security.h
+++ b/code/client/citicore/se/Security.h
@@ -8,6 +8,7 @@ public:
 	inline explicit Principal(const std::string& principal)
 	{
 		m_identifier = principal;
+		std::transform(m_identifier.begin(), m_identifier.end(), m_identifier.begin(), ::tolower);
 	}
 
 	inline const std::string& GetIdentifier() const
@@ -17,12 +18,12 @@ public:
 
 	inline bool operator<(const Principal& right) const
 	{
-		return _stricmp(m_identifier.c_str(), right.m_identifier.c_str()) < 0;
+		return m_identifier < right.m_identifier;
 	}
 
 	inline bool operator==(const Principal& right) const
 	{
-		return _stricmp(m_identifier.c_str(), right.m_identifier.c_str()) == 0;
+		return m_identifier == right.m_identifier;
 	}
 
 private:
@@ -35,6 +36,7 @@ public:
 	inline explicit Object(const std::string& identifier)
 	{
 		m_identifier = identifier;
+		std::transform(m_identifier.begin(), m_identifier.end(), m_identifier.begin(), ::tolower);
 	}
 
 	inline const std::string& GetIdentifier() const
@@ -44,12 +46,12 @@ public:
 
 	inline bool operator<(const Object& right) const
 	{
-		return _stricmp(m_identifier.c_str(), right.m_identifier.c_str()) < 0;
+		return m_identifier < right.m_identifier;
 	}
 
 	inline bool operator==(const Object& right) const
 	{
-		return _stricmp(m_identifier.c_str(), right.m_identifier.c_str()) == 0;
+		return m_identifier == right.m_identifier;
 	}
 
 private:


### PR DESCRIPTION
### How is this PR achieving the goal

Removes the _stricmp that was taking ages by transforming object and principal identifiers to lowercase, uses equal_range in `RemoveAccessControlEntry` to avoid looking through all the aces


### Successfully tested on

**Platforms:** Windows FXServer

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3394


