### PR TITLE
feat(extra-natives-five): add `IS_VEHICLE_WHEEL_BROKEN` native

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -1963,9 +1963,9 @@ static HookFunction initFunction([]()
 		}
 	});
 
-	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_WHEEL_BROKEN", [](fx::ScriptContext& context)
+	fx::ScriptEngine::RegisterNativeHandler("IS_VEHICLE_WHEEL_BROKEN_OFF", [](fx::ScriptContext& context)
 	{
-		if (fwEntity* vehicle = getAndCheckVehicle(context, "IS_VEHICLE_WHEEL_BROKEN"))
+		if (fwEntity* vehicle = getAndCheckVehicle(context, "IS_VEHICLE_WHEEL_BROKEN_OFF"))
 		{
 			auto wheelIndex = context.GetArgument<uint32_t>(1);
 			auto numWheels = readValue<unsigned char>(vehicle, NumWheelsOffset);

--- a/ext/native-decls/IsVehicleWheelBrokenOff.md
+++ b/ext/native-decls/IsVehicleWheelBrokenOff.md
@@ -2,10 +2,10 @@
 ns: CFX
 apiset: client
 ---
-## IS_VEHICLE_WHEEL_BROKEN
+## IS_VEHICLE_WHEEL_BROKEN_OFF
 
 ```c
-BOOL IS_VEHICLE_WHEEL_BROKEN(Vehicle vehicle, int wheelIndex);
+BOOL IS_VEHICLE_WHEEL_BROKEN_OFF(Vehicle vehicle, int wheelIndex);
 ```
 
 Getter for [BREAK_OFF_VEHICLE_WHEEL](?_0xA274CADB).
@@ -15,7 +15,7 @@ Getter for [BREAK_OFF_VEHICLE_WHEEL](?_0xA274CADB).
 local vehicle = GetVehiclePedIsIn(PlayerPedId())
 
 if DoesEntityExist(vehicle) then
-  local isWheelBroken = IsVehicleWheelBroken(vehicle, 1)
+  local isWheelBroken = IsVehicleWheelBrokenOff(vehicle, 1)
   print("Is wheel 1 broken? ", isWheelBroken)
 end
 ```


### PR DESCRIPTION
### Goal of this PR
Add a new native to retrieve if a specific wheel of a vehicle is broken.
Suggested in [this forum post](https://forum.cfx.re/t/how-can-i-find-out-if-a-wheel-is-detached-from-vehicle-or-not/).


### How is this PR achieving the goal
Getting the GetWheelBroken function that return a boolean based on the wheel broken state.

### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Game builds:** 3095, 3407
**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.