### PR TITLE
tweak(game/five): expand support for weapon info entries

### DIFF
--- a/code/components/gta-streaming-five/include/Local.h
+++ b/code/components/gta-streaming-five/include/Local.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr int kNumWeaponInfoBlobs = 512;
+constexpr int kNumWeaponInfoBlobs = 1024;


### PR DESCRIPTION
### Goal of this PR


Prevent server crashes caused by exceeding the default `CWeaponInfoBlob` limit.

### How is this PR achieving the goal


By increasing the `CWeaponInfoBlob` allocation limit from 512 to 1024, this PR ensures stability for servers with a large number of custom or modified weapons. Without this adjustment, servers crash when the default limit is surpassed.

### This PR applies to the following area(s)
This change impacts the FiveM runtime environment.



### Successfully tested on
Wasn't tested on anything 


### Checklist

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ x ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes weapon limits to fix crashing issue once the limit is passed
