### PR TITLE
fix(cfx-ui): allow closing auth modal when authentication failed

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/parts/AuthModal/AuthFormState.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/parts/AuthModal/AuthFormState.tsx
@@ -42,7 +42,7 @@ class AuthFormState {
       return true;
     }
 
-    if (this.isModeExternalAuthProcessing) {
+    if (this.isModeExternalAuthProcessing && !this.errorMessage) {
       return true;
     }
 


### PR DESCRIPTION
### Goal of this PR
Enable closing the login modal when authentication fails.
Currently, the only way to exit the modal is by clicking the `Try again` button. This PR improves the user experience by allowing users to bypass that step when the auth service is unavailable.


### How is this PR achieving the goal
Only returning true in the disabled getter when modal auth is processing and didn't get any error.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3440