### PR TITLE
feat(gta-streaming-five): try to increase .ymt file limit

### DIFF
--- a/code/components/gta-streaming-five/src/CrashFixes_Clothing.cpp
+++ b/code/components/gta-streaming-five/src/CrashFixes_Clothing.cpp
@@ -1,209 +1,604 @@
 #include <StdInc.h>
 
-#if 0
+#include "Hooking.Patterns.h"
+
 #include <Hooking.h>
-#include <MinHook.h>
+#include <jitasm.h>
 
-#include <CrossBuildRuntime.h>
-#include <ICoreGameInit.h>
+#include "CrossBuildRuntime.h"
+#include "Hooking.Stubs.h"
+#include "ICoreGameInit.h"
 
-#include <Streaming.h>
+const static int MAX_STREAMING_DEPENDENCIES = 120;
 
-// solve 80-dependency limit being hit for clothing by *chaining* dependent .#mt files
-static std::map<uint32_t, uint32_t> g_extraMetadataInheritance;
-
-static int _metadataGetDependencies(streaming::strStreamingModule* self, uint32_t localIdx, uint32_t* indices, int count)
+// Determines the maximum number of streaming dependencies allowed based on the game build version.
+static int GetMaxStreamingDependenciesForBuild()
 {
-	if (auto it = g_extraMetadataInheritance.find(self->baseIdx + localIdx); it != g_extraMetadataInheritance.end())
-	{
-		indices[0] = it->second;
-		return 1;
-	}
+	// Rockstar increased the limit to 100 in build 2612 and later.
+	if (xbr::IsGameBuildOrGreater<2612>()) return 100;
 
-	return 0;
+	return 80; // Default limit for older builds.
 }
 
-static int (*g_origArchetypeGetDependencies)(void* self, uint32_t localIdx, uint32_t* indices, int count);
-
-static int _archetypeGetDependencies(void* self, uint32_t localIdx, uint32_t* indices, int count)
+struct StreamingDependenciesPair
 {
-	static auto strMgr = streaming::Manager::GetInstance();
-	static auto mtStore = strMgr->moduleMgr.GetStreamingModule("ymt");
+	std::string_view pattern;
+	// Locations where the arguments are calculated so we can add the difference of the new limit.
+	// This can also contain the reserving of the stack space.
+	std::initializer_list<int> argsOffsets;
+	std::initializer_list<int> limitOffset; // Locations where the 80(for older builds) or 100(for newer builds) limit is set.
+};
 
-	// get the original, and copy out any metadata dependencies ourselves (except a root entry)
-	uint32_t dependencies[512];
-	int depCount = g_origArchetypeGetDependencies(self, localIdx, dependencies, std::size(dependencies));
-
-	int outCount = 0;
-	auto addOut = [&outCount, indices, count](uint32_t idx)
+namespace rage
+{
+	struct SPedDLCMetaFileQueryData
 	{
-		if (outCount < count)
-		{
-			indices[outCount++] = idx;
-		}
+		int32_t m_storeIndex;
+		uint32_t m_dlcNameHash;
 	};
-
-	std::set<uint32_t> handled;
-
-	uint32_t rootMetadataIndex = 0;
-
-	for (size_t i = 0; i < depCount; i++)
-	{
-		if (handled.find(dependencies[i]) != handled.end())
-		{
-			continue;
-		}
-
-		handled.insert(dependencies[i]);
-
-		auto module = strMgr->moduleMgr.GetStreamingModule(dependencies[i]);
-
-		// if this *isn't* metadata, let's just continue
-		if (module != mtStore)
-		{
-			addOut(dependencies[i]);
-			continue;
-		}
-
-		// if it is, and we don't have a root index yet, set the root index
-		if (!rootMetadataIndex)
-		{
-			rootMetadataIndex = dependencies[i];
-			addOut(dependencies[i]);
-			continue;
-		}
-
-		// and if we do, add a recursive dependency to the (last) root, so we end up with a linked list of dependencies
-		g_extraMetadataInheritance[rootMetadataIndex] = dependencies[i];
-		rootMetadataIndex = dependencies[i];
-	}
-
-	return outCount;
 }
 
-static hook::cdecl_stub<bool(void*, uint32_t)> _IsObjectInImage([]()
-{
-	return hook::get_pattern("74 20 8B C2 48 8B", -7);
-});
-
-static void strStreamingModule__GetObjectAndDependencies(streaming::strStreamingModule* self, uint32_t globalIdx, atArray<uint32_t>& outArray, uint32_t* ignoreList, int ignoreCount)
-{
-	static auto str = streaming::Manager::GetInstance();
-
-	// should we be ignored?
-	for (int i = 0; i < ignoreCount; i++)
-	{
-		if (ignoreList[i] == globalIdx)
-		{
-			return;
-		}
-	}
-
-	if (!_IsObjectInImage(str, globalIdx))
-	{
-		return;
-	}
-
-	// start relocating the output array
-	if (outArray.GetSize() == 80 && outArray.GetCount() == 0)
-	{
-		static thread_local uint32_t strIdxList[512];
-
-		outArray.m_offset = strIdxList;
-		outArray.m_size = std::size(strIdxList);
-	}
-
-	// are we already in the list?
-	for (uint32_t entry : outArray)
-	{
-		if (entry == globalIdx)
-		{
-			return;
-		}
-	}
-
-	// add ourselves
-	outArray[outArray.m_count++] = globalIdx;
-
-	// add our dependencies
-	uint32_t dependencies[80];
-	int numDeps = self->GetDependencies(globalIdx - self->baseIdx, dependencies, std::size(dependencies));
-
-	for (int i = 0; i < numDeps; i++)
-	{
-		auto module = str->moduleMgr.GetStreamingModule(dependencies[i]);
-		strStreamingModule__GetObjectAndDependencies(module, dependencies[i], outArray, ignoreList, ignoreCount);
-	}
-}
-
-static HookFunction hookFunctionMetadataDep([]
-{
-	// CModelInfoStreamingModule::GetDependencies
-	MH_Initialize();
-	MH_CreateHook(hook::get_pattern("8B 7F 08 8B 9D 78 03 00 00", -0x4B), _archetypeGetDependencies, (void**)&g_origArchetypeGetDependencies);
-	MH_EnableHook(MH_ALL_HOOKS);
-
-	// rage::fwMetaDataStore vtable -> GetDependencies
-	{
-		auto location = hook::get_pattern("45 8D 41 0C 48 8B D9 C7 40 D8 49 02 00 00 E8", 0x16);
-		auto vtbl = hook::get_address<void**>(location);
-		hook::put(&vtbl[21], _metadataGetDependencies);
-	}
-
-	// reset
-	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]()
-	{
-		g_extraMetadataInheritance.clear();
-	});
-
-	// strStreamingModule::GetObjectAndDependencies rewrite-hack to properly cap-resize
-	hook::jump(hook::get_pattern("49 8B D8 8D 48 01 48 85 D2 7E 12", -0x2C), strStreamingModule__GetObjectAndDependencies);
-});
-
-// increase stack frame size for implied atArray in some clothing metadata loader
-static HookFunction hookFunctionStack([]
-{
-	if (xbr::IsGameBuild<1604>())
-	{
-		auto matches = hook::pattern("B8 00 04 00 00 48 2B E0 48 8D 4C 24 50 8B 01").count(2);
-
-		for (size_t i = 0; i < matches.size(); i++)
-		{
-			auto match = matches.get(i);
-			hook::put<uint32_t>(match.get<void>(1), 0xC00);
-			hook::put<uint16_t>(match.get<void>((i == 0) ? 0x22 : 0x28), 0x180);
-		}
-	}
-});
-
-// stack-increasing attempt at exceeding the 80 dependency limit
-// not sufficiently viable: needed 4 more places
-#if 0
 static int (*g_origRequestObject)(void* self, uint32_t idx, int type, void* extraStackFrame);
-
-static int RequestObjectWrap(void* self, uint32_t idx, int type)
+static int RequestObjectWrap(void* self, uint32_t idx, int type, void* extraStackFrame)
 {
-	uint32_t frame[512 /* count */ + 32 /* safe grow offset */];
-	for (uint32_t& idx : frame)
+	uint32_t frame[MAX_STREAMING_DEPENDENCIES /* count */ + 32 /* safe grow offset */];
+	for (uint32_t& id : frame)
 	{
-		idx = -1;
+		id = -1;
 	}
 
 	return g_origRequestObject(self, idx, type, frame);
 }
 
-constexpr const int kStackFrameSize = 8 /* stack frame return */ + 0x1B0 /* stack start */ + 64 /* redzone and some other stuff */;
-
-static HookFunction hookFunction([]
+static void (*g_origCreateDependentsGraph)(void* self, __int64 a2, void* extraStackFrame);
+static void CreateDependentsGraphWrap(void* self, __int64 a2, void* extraStackFrame)
 {
-	// request object
+	uint32_t frame[MAX_STREAMING_DEPENDENCIES /* count */ + 32 /* safe grow offset */];
+	for (uint32_t& id : frame)
 	{
-		auto location = hook::get_pattern<char>("41 8B F8 48 8B F1 75 07 32 C0", -0x1C);
-		assert(location[0x1AD] == 0x50);
+		id = -1;
+	}
+	
+	g_origCreateDependentsGraph(self, a2, frame);
+}
 
-		MH_Initialize();
-		MH_CreateHook(location, RequestObjectWrap, (void**)&g_origRequestObject);
-		MH_EnableHook(MH_ALL_HOOKS);
+static int (*g_origGetNextFilesOnCdNew)(void* self, unsigned int a2, unsigned __int8 a3, __int64* a4, int a5, unsigned int a6, int a7, void* extraStackFrame);
+static int GetNextFilesOnCdNewWrap(void* self, unsigned int a2, unsigned __int8 a3, __int64* a4, int a5, unsigned int a6, int a7, void* extraStackFrame)
+{
+	uint32_t frame[MAX_STREAMING_DEPENDENCIES /* count */ + 32 /* safe grow offset */];
+	for (uint32_t& id : frame)
+	{
+		id = -1;
+	}
+
+	return g_origGetNextFilesOnCdNew(self, a2, a3, a4, a5, a6, a7, frame);
+}
+
+static int (*g_origModelInfoStreamingModuleGetDependencies)(void* self, uint32_t localIdx, uint32_t* indices, int count, void* extraStackFrame);
+static int ModelInfoStreamingModuleGetDependenciesWrap(void* self, uint32_t localIdx, uint32_t* indices, int count, void* extraStackFrame)
+{
+	char extra[(MAX_STREAMING_DEPENDENCIES * 8) /* PedDLCMetaFile */ + 4 /* m_count of fixedArray */ + 32 /* safe grow offset */];
+	for(char& id : extra)
+	{
+		id = 99; // Fill with dummy data
+	}
+	
+	return g_origModelInfoStreamingModuleGetDependencies(self, localIdx, indices, count, extra);
+}
+
+static void (*g_origSetupExternallyDrivenDOFs)(void* self, void* extraStackFrame);
+static void SetupExternallyDrivenDOFsWrap(void* self, void* extraStackFrame)
+{
+	char extra[(MAX_STREAMING_DEPENDENCIES * 8) /* PedDLCMetaFile */ + 4 /* m_count of fixedArray */ + 32 /* safe grow offset */];
+	/*for(char& id : extra)
+	{
+		id = 99; // Fill with dummy data
+	}*/
+
+	g_origSetupExternallyDrivenDOFs(self, extra);
+}
+
+static char (*g_origProcessExternallyDrivenDOFs)(void* self, void* a2, void* extraStackFrame);
+static char ProcessExternallyDrivenDOFsWrap(void* self, void* a2, void* extraStackFrame)
+{
+	char extra[(MAX_STREAMING_DEPENDENCIES * 8) /* PedDLCMetaFile */ + 4 /* m_count of fixedArray */ + 32 /* safe grow offset */];
+	for(char& id : extra)
+	{
+		id = 99; // Fill with dummy data
+	}
+
+	return g_origProcessExternallyDrivenDOFs(self, a2, extra);
+}
+
+/*static char (*g_origClearDLCScenarioInfos)(void* self, __int64 file);
+static char ClearDLCScenarioInfos(void* self, __int64 file)
+{
+	trace("ClearDLCScenarioInfos called with file: %lld\n", file);
+	g_origClearDLCScenarioInfos(self, file);
+	return true;
+}*/
+
+template <class T,int C>
+class atFixedArray {
+public:
+	T elements[C];
+	int count;
+};
+
+/*static void (*g_origGetCreatureMetaDataIndices)(void* self, void* a2, atFixedArray<rage::SPedDLCMetaFileQueryData, MAX_STREAMING_DEPENDENCIES >& targetArray);
+static void GetCreatureMetaDataIndicesWrap(void* self, void* a2, atFixedArray<rage::SPedDLCMetaFileQueryData, MAX_STREAMING_DEPENDENCIES >& targetArray)
+{
+	g_origGetCreatureMetaDataIndices(self, a2, targetArray);
+	trace("GetCreatureMetaDataIndices %d\n", targetArray.count);
+}*/
+
+static hook::cdecl_stub<void(void* self, void* modelInfo, void* targetArray)> _getCreatureMetaDataIndices([]()
+{
+	return hook::get_pattern("40 55 53 56 57 41 54 41 56 41 57 48 8B EC 48 83 EC ? 8B 45 ? 45 33 E4");
+});
+
+static hook::cdecl_stub<void(void* self)> _invalidateExternallyDrivenDOFs([]()
+{
+	return hook::get_call(hook::get_pattern("48 8B C4 53 48 81 EC ? ? ? ? 48 8B 51 ? 48 8B D9", 57));
+});
+
+static void* g_extraMetadataManager;
+
+static void UpdatePropExpressions(hook::FlexStruct* self)
+{
+	if(self)
+	{
+		void* pedModelInfo = self->At<void*>(0x20);
+		if(pedModelInfo)
+		{
+			// CAUTION! _getCreatureMetaDataIndices need to be patched to support the new size of the fixed array
+			atFixedArray<rage::SPedDLCMetaFileQueryData, MAX_STREAMING_DEPENDENCIES> targetArray;
+			targetArray.count = 0;
+			_getCreatureMetaDataIndices(g_extraMetadataManager, pedModelInfo, &targetArray);
+			//GetCreatureMetaDataIndicesWrap(g_extraMetadataManager, pedModelInfo, targetArray);
+			if(targetArray.count > 0)
+			{
+				_invalidateExternallyDrivenDOFs(self);
+			}
+		}
+	}
+}
+
+static HookFunction hookFunctionStack2([]()
+{
+	//This patch is very long, and I'm currently working on b1604, if we get it working on this game build we can transform this patch to b3407, or at least try :)
+	if(!xbr::IsGameBuild<1604>())
+	{
+		trace("Game build is not 1604, skipping streaming dependencies patch.\n");
+		return;
+	}
+	const int originalMaxStreamingDependencies = GetMaxStreamingDependenciesForBuild();
+	
+	// The current implementation supports a maximum of 255 dependencies due to instruction limitations,
+	// as some instructions can only store values up to 1 byte.
+	// This limitation could be bypassed with modifications, but for now, 255 should be more than sufficient.
+	assert(MAX_STREAMING_DEPENDENCIES <= 255 && "MaxStreamingDependencies should be less or equal to 255 due to instruction limitations.");
+
+	const int maxStreamingDependenciesDiff = (MAX_STREAMING_DEPENDENCIES - originalMaxStreamingDependencies) * 4;
+
+	std::initializer_list<StreamingDependenciesPair> streamingDependenciesLocations = {
+		{
+			"48 89 5C 24 ? 48 89 6C 24 ? 89 54 24 ? 56 57 41 56 48 81 EC ? ? ? ? 4C 8B F1", // strStreamingInfoManager::AddDependentCounts
+			{ 21, 43, 107, 191 },
+			{ 49 }
+		},
+		{
+			"48 8B C4 48 89 58 ? 48 89 68 ? 48 89 70 ? 89 50 ? 57 48 81 EC ? ? ? ? 48 8B D9", // strStreamingInfoManager::RemoveDependentCountsAndUnrequest
+			{ 22, 44, 234, 260 },
+			{ 50 }
+		},
+		{
+			"48 89 5C 24 ? 44 89 44 24 ? 89 4C 24 ? 57", // rage::FindDependents
+			{ 18, 67, 103, 122, 148, 175, 185, 192 },
+			{ 46, 81 }
+		},
+		{
+			"48 8B C4 48 89 58 ? 48 89 68 ? 48 89 70 ? 48 89 78 ? 41 56 48 81 EC ? ? ? ? 48 8B F1 4D 8B F0", // strStreamingInfoManager::GetObjectAndDependenciesSizes
+			{ 24, 55, 87, 126, 152, 197 },
+			{ 36 }
+		},
+		{
+			"48 8B C4 48 89 58 ? 48 89 68 ? 48 89 70 ? 89 50 ? 57 48 81 EC ? ? ? ? 33 C0", // strStreamingModule::GetObjectAndDependencies
+			{ 22, 34, 149, 236, 273 },
+			{ 158 }
+		},
+		{
+			"48 89 5C 24 ? 89 4C 24 ? 56 57 41 56 48 81 EC", // rage::AreDependenciesMet
+			{ 16, 63, 162, 234, 241 },
+			{ 77 }
+		},
+		{
+			"48 89 5C 24 ? 48 89 54 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ? ? ? ? 4C 8B F1", // rage::strStreamingLoader::RequestStreamFiles
+			{ 24, 57, 164, 479, 492, 518, 525 },
+			{ 358 }
+		},
+		{
+			"40 57 48 81 EC ? ? ? ? 41 B8", // CSceneStreamerMgr::AllDepsSatisfied
+			{ 5, 109 },
+			{ 11 }
+		},
+	};
+
+	for(const auto& entry : streamingDependenciesLocations)
+	{
+		auto location = hook::get_pattern<char>(entry.pattern);
+
+		for(const auto& argsOffsets : entry.argsOffsets)
+		{
+			auto value = *(int32_t*)(location + argsOffsets);
+			hook::put<int32_t>(location + argsOffsets, value + (value < 0 ? -maxStreamingDependenciesDiff : maxStreamingDependenciesDiff));
+		}
+
+		for(const auto& limitOffset : entry.limitOffset)
+		{
+			hook::put<char>(location + limitOffset, MAX_STREAMING_DEPENDENCIES);
+		}
+	}
+
+	// This is to prevent an unknown crash that I think is fixed in latest game builds, I was wrong :(
+	//g_origClearDLCScenarioInfos = hook::trampoline(hook::get_pattern("48 89 5C 24 ? 89 54 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 4C 8B 31"), ClearDLCScenarioInfos);
+	
+	constexpr const int kCountArrayOffset = (MAX_STREAMING_DEPENDENCIES * 8);
+
+	// CExtraMetadataMgr::GetCreatureMetaDataIndices
+	// Here we need to change the offset of m_count because GetCreatureMetaDataIndices except r8(third arg) to be a fixed array of (80 for old builds, 100 for new builds) elements.
+	// So we need to calculate the new offset to m_count based in the new MAX_STREAMING_DEPENDENCIES value.
+	// Also, we need to make sure all functions that call this are also patched to use the new m_count offset.
+	{
+		auto location = hook::get_pattern<char>("40 55 53 56 57 41 54 41 56 41 57 48 8B EC 48 83 EC ? 8B 45 ? 45 33 E4");
+		//g_origGetCreatureMetaDataIndices = hook::trampoline(location, GetCreatureMetaDataIndicesWrap);
+
+		// Location of the m_count offsets 
+		std::initializer_list<int> getCreatureMetaDataIndicesOffsets = {
+			85,  /* mov     [r8+280h], r12d */
+			98,  /* mov     dword ptr [r8+280h], 1 */
+			256, /* movsxd  rax, dword ptr [rdi+280h] */
+			273  /* mov     [rdi+280h], eax */
+		};
+
+		for(const auto& offset : getCreatureMetaDataIndicesOffsets)
+		{
+			hook::put<int32_t>(location + offset, kCountArrayOffset);
+		}
+	}
+	
+	// CPed::ProcessExternallyDrivenDOFs
+	{
+		constexpr const int kStackFrameSize = 8 + 0x3F0 + 64;
+		
+		auto location = hook::get_pattern<char>("48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 83 A1");
+
+		g_origProcessExternallyDrivenDOFs = hook::trampoline(location, ProcessExternallyDrivenDOFsWrap);
+
+		auto location2 = hook::get_pattern<char>("4C 8D 45 ? 49 8B D7 44 89 AD");
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//lea(r8, qword_ptr[rbp-0x50]); // Original instruction
+				lea(r8, qword_ptr[rsp + kStackFrameSize]);
+				mov(rdx, r15);
+				//mov(dword_ptr[rbp+0x230], r13d); // Original instruction
+				mov(dword_ptr[rsp + kStackFrameSize + kCountArrayOffset], r13d);
+				ret();
+			}
+		} stub1;
+		hook::nop(location2, 14);
+		hook::call_reg<2>(location2, stub1.GetCode()); // rdx
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//cmp(dword_ptr[rbp + 0x230], r13d); // Original instruction
+				cmp(dword_ptr[rsp + kStackFrameSize + kCountArrayOffset], r13d);
+				ret();
+			}
+		} stub2;
+		hook::nop(location2 + 33, 7);
+		hook::call_rcx(location2 + 33, stub2.GetCode());
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//lea(r14, qword_ptr[rbp - 0x50]); // Original instruction
+				lea(r14, qword_ptr[rsp + kStackFrameSize]);
+				mov(qword_ptr[rsp + 0x20 + 8 /* Return addr for call */], r14); // Original instruction
+				ret();
+			}
+		} stub3;
+		hook::nop(location2 + 46, 9);
+		hook::call_rcx(location2 + 46, stub3.GetCode());
+
+		auto location3 = hook::get_pattern("3B B5 ? ? ? ? 0F 82 ? ? ? ? 41 83 CC");
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//cmp(esi, dword_ptr[rbp + 0x230]); // Original instruction
+				cmp(esi, dword_ptr[rsp + kStackFrameSize + kCountArrayOffset]);
+				ret();
+			}
+		} stub4;
+		hook::nop(location3, 6);
+		hook::call_rcx(location3, stub4.GetCode());
+	}
+	
+	// CPed::SetupExternallyDrivenDOFs
+    {
+        constexpr const int kStackFrameSize = 8 + 0x420 + 64;
+        
+        auto location = hook::get_pattern<char>("48 8B C4 48 89 48 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 33 F6");
+        
+        g_origSetupExternallyDrivenDOFs = hook::trampoline(location, SetupExternallyDrivenDOFsWrap);
+
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                lea(r8, qword_ptr[rbp + kStackFrameSize]); // Original instruction AQUI CARGA EL ARRAY
+                mov(rdx, rdi); // Original instruction
+                mov(qword_ptr[rbp - 0x40], rax); // Original instruction
+                mov(dword_ptr[rbp + kStackFrameSize + kCountArrayOffset], esi); // Original instruction
+                ret();
+            }
+        } stub1;
+        hook::nop(location + 150, 17);
+        hook::call_reg<2>(location + 150, stub1.GetCode()); // rdx
+
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                cmp(dword_ptr[rbp + kStackFrameSize + kCountArrayOffset], esi); // Original instruction
+                ret();
+            }
+        } stub2;
+        hook::nop(location + 184, 6);
+        hook::call_reg<2>(location + 184, stub2.GetCode()); // rdx
+
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                movsxd(rbx, dword_ptr[rbp + rcx * 8 + kStackFrameSize]); // Original instruction
+                ret();
+            }
+        } stub3;
+        hook::nop(location + 196, 5);
+        hook::call_reg<3>(location + 196, stub3.GetCode()); // rbx
+
+        auto location2 = hook::get_pattern("3B 85 ? ? ? ? 0F 82 ? ? ? ? 0F B7 5C 24");
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                cmp(eax, dword_ptr[rbp + kStackFrameSize + kCountArrayOffset]); // Original instruction
+                ret();
+            }
+        } stub4;
+        hook::nop(location2, 6);
+        hook::call_reg<2>(location2, stub4.GetCode()); // rdx
+
+        auto location4 = hook::get_pattern<char>("8B FE 89 B5 ? ? ? ? 39 B5", 8);
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                cmp(dword_ptr[rbp + kStackFrameSize + kCountArrayOffset], esi); // Original instruction
+                ret();
+            }
+        } stub5;
+        hook::nop(location4, 6);
+        hook::call_rcx(location4, stub5.GetCode());
+
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                lea(rsi, qword_ptr[rbp + kStackFrameSize]); // Original instruction
+                mov(qword_ptr[rbp+0x300], rsi); // Original instruction
+                ret();
+            }
+        } stub6;
+        hook::nop(location4 + 12, 11);
+        hook::call_reg<2>(location4 + 12, stub6.GetCode());
+
+        auto location5 = hook::get_pattern("3B BD ? ? ? ? 0F 82 ? ? ? ? 33 F6");
+        static struct : jitasm::Frontend
+        {
+            virtual void InternalMain() override
+            {
+                cmp(edi, dword_ptr[rbp + kStackFrameSize + kCountArrayOffset]); // Original instruction
+                ret();
+            }
+        } stub7;
+        hook::nop(location5, 6);
+        hook::call_rcx(location5, stub7.GetCode());
+    }
+
+	// CPedPropsMgr::UpdatePropExpressions
+	// This is one of the functions that call GetCreatureMetaDataIndices, so we have patched the m_count and increase the reserve of the stack(sub rsp, add rsp)
+	{
+		auto location = hook::get_pattern<char>("48 85 C9 74 ? 48 8B C4");
+
+		g_extraMetadataManager = hook::get_address<void*>(location + 31);
+
+		hook::trampoline(location, UpdatePropExpressions);
+	}
+	
+	// CModelInfoStreamingModule::GetDependencies
+	// This function has been trampolined to add a new arg(5th arg) to the function with a new stack frame that contains the fixed array of MAX_STREAMING_DEPENDENCIES elements.
+	// This is one of the functions that call GetCreatureMetaDataIndices, so we have patched the m_count here
+	{
+		constexpr const int kStackFrameSize = 8 + 0x5D0;
+
+		auto location = hook::get_pattern<char>("48 8B C4 48 89 58 ? 44 89 48 ? 89 50 ? 48 89 48");
+
+		g_origModelInfoStreamingModuleGetDependencies = hook::trampoline(location, ModelInfoStreamingModuleGetDependenciesWrap);
+
+		auto location2 = hook::get_pattern<char>("4C 8D 85 ? ? ? ? 49 8B D7 44 89 B5");
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//lea(r8, qword_ptr[rbp + 0xA0]); // Original instruction
+				lea(r8, qword_ptr[rsp + kStackFrameSize]); // Option 1
+				ret();
+			}
+		} stub1;
+		hook::nop(location2, 7);
+		hook::call(location2, stub1.GetCode());
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//mov(r8d, dword_ptr[rbp+0x320]); // Original instruction
+				mov(r8d, dword_ptr[rsp + kStackFrameSize + kCountArrayOffset]); // del array
+				ret();
+			}
+		} stub4;
+		hook::nop(location2 + 22, 7);
+		hook::call(location2 + 22, stub4.GetCode());
+		
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//lea(rdx, qword_ptr[rbp + 0xA0]); // Original instruction
+				lea(rdx, qword_ptr[rsp + (kStackFrameSize)]); // Option 1
+				ret();
+			}
+		} stub2;
+		
+		hook::nop(location2 + 37, 7);
+		hook::call(location2 + 37, stub2.GetCode());
+		
+		auto location3 = hook::get_pattern("44 8B 85 ? ? ? ? 89 74 24");
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//mov(r8d, dword_ptr[rbp+0x320]); // Original instruction
+				mov(r8d, dword_ptr[rsp + kStackFrameSize + kCountArrayOffset]);
+				ret();
+			}
+		} stub3;
+		hook::nop(location3, 7);
+		hook::call(location3, stub3.GetCode());
+		
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				//mov(dword_ptr[rbp + 0x320], r14d); // Original instruction
+				mov(dword_ptr[rsp + kStackFrameSize + kCountArrayOffset], r14d);
+				ret();
+			}
+		} stub5;
+		hook::nop(location2 + 10, 7);
+		hook::call(location2 + 10, stub5.GetCode());
+	}
+	
+	// rage::strStreamingInfoManager::GetNextFilesOnCdNew
+	{
+		constexpr const int kStackFrameSize = 8 + 0x228 + 64;
+
+		auto location = hook::get_pattern<char>("48 8B C4 4C 89 48 ? 44 88 40 ? 89 50 ? 53");
+
+		g_origGetNextFilesOnCdNew = hook::trampoline(location, GetNextFilesOnCdNewWrap);
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				lea(rdi, qword_ptr[rsp + kStackFrameSize]);
+				ret();
+			}
+		} stub1;
+		
+		hook::nop(location + 68, 7);
+		hook::call_rcx(location + 68, stub1.GetCode());
+
+		hook::put<uint32_t>(location + 224, kStackFrameSize);
+		hook::put<uint32_t>(location + 236, MAX_STREAMING_DEPENDENCIES);
+
+		hook::put<uint32_t>(location + 284, kStackFrameSize);
+
+		auto location2 = hook::get_pattern<char>("4C 8D 84 24 ? ? ? ? 41 B9 ? ? ? ? 48 8B 08");
+
+		hook::put<uint32_t>(location2 + 4, kStackFrameSize);
+		hook::put<uint32_t>(location2 + 10, MAX_STREAMING_DEPENDENCIES);
+
+		hook::put<uint32_t>(location2 + 53, kStackFrameSize);
+
+		auto location3 = hook::get_pattern<char>("8B 94 9C");
+
+		hook::put<uint32_t>(location3 - 165, kStackFrameSize);
+		hook::put<uint32_t>(location3 - 159, MAX_STREAMING_DEPENDENCIES);
+
+		hook::put<uint32_t>(location3 + 3, kStackFrameSize);
+
+		hook::put<uint32_t>(location3 + 75, kStackFrameSize);
+	}
+
+	// rage::strStreamingInfoManager::CreateDependentsGraph
+	{
+		constexpr const int kStackFrameSize = 8 /* stack frame return */ + 0x1F0 /* stack start */ + 0x40 /* redzone and some other stuff */;
+
+		auto location = hook::get_pattern("48 89 4C 24 ? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 45 33 C0");
+
+		g_origCreateDependentsGraph = hook::trampoline(location, CreateDependentsGraphWrap);
+
+		auto location1 = hook::get_pattern<char>("48 8D 7C 24 ? 41 8B CC 8B D3");
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				lea(rdi, qword_ptr[rsp + kStackFrameSize]);
+				ret();
+			}
+		} stub1;
+		hook::call(location1, stub1.GetCode());
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				lea(r8, qword_ptr[rsp + kStackFrameSize]);
+				mov(r12d, MAX_STREAMING_DEPENDENCIES);
+				ret();
+			}
+		} stub2;
+		hook::call_rcx(location1 + 30, stub2.GetCode());
+
+		static struct : jitasm::Frontend
+		{
+			virtual void InternalMain() override
+			{
+				mov(eax, dword_ptr[rsp + (r14*4) + kStackFrameSize]);
+				ret();
+			}
+		} stub3;
+		hook::call_rcx(location1 + 116, stub3.GetCode());
+	}
+
+	// rage::strStreamingInfoManager::RequestObject
+	{
+		constexpr const int kStackFrameSize = 8 + 0x230 + 64;
+		
+		auto location = hook::get_pattern<char>("41 8B F8 48 8B F1 75 07 32 C0", -0x1C);
+		
+		g_origRequestObject = hook::trampoline(location, RequestObjectWrap);
 
 		static struct : jitasm::Frontend
 		{
@@ -215,13 +610,13 @@ static HookFunction hookFunction([]
 		} stub1;
 
 		hook::call_rcx(location + 0x1A3, stub1.GetCode());
-		hook::put<uint32_t>(location + 0x1AD, 512);
+		hook::put<uint32_t>(location + 0x1AD, MAX_STREAMING_DEPENDENCIES);
 
 		static struct : jitasm::Frontend
 		{
 			virtual void InternalMain() override
 			{
-				mov(eax, dword_ptr[rsp + (rcx * 4) + kStackFrameSize]);
+				mov(eax, dword_ptr[rsp + (rcx * 4) + (kStackFrameSize)]);
 
 				// NOTE: flags straddling ret!
 				cmp(dword_ptr[rdx + rax * 8], 0);
@@ -257,5 +652,3 @@ static HookFunction hookFunction([]
 		hook::call_rcx(location + 0x31C, stub4.GetCode());
 	}
 });
-#endif
-#endif


### PR DESCRIPTION
### Goal of this PR
Increase the YMT dependency limit, currently the main problem with this is the clothing packs that add new YMT files and this causes it to reach the preset limit of the game build, each game build has free YMT slots but this depends on how many are being used by the game itself, this is a major problem especially in version 2545 (although it is used very little) and in 3407 (it is one of the reasons why it is preferred to use others).

This PR is still in the development and testing phase, the only thing I have been able to test is a resource (for b1604) provided by a [forum post](https://forum.cfx.re/t/setplayermodel-crash-when-you-have-too-much-ymts-assigned-to-a-freemode-ped-model/) from 2020, but I've been having a rare crash where switching to a male ped, then a female ped, then back to a male ped would result in a random crash on a function related to clearing DLCs scenarios.
But at least that's a pretty big step because you can change the ped model without getting the default ymt crash.

I would also like to show that I am open to any help with this change (whether it be helping me continue to patch functions I missed, fixing issues related to existing patches, providing resources, etc.), here is my discord: `danielgp`.

The patch is only made to work on 1604 but if everything works well I will adapt it to 3407 or 3258

### How is this PR achieving the goal
I'm going to explain the process I followed from the moment I started making the patch until I finished it.

First, I created a constant called `MAX_STREAMING_DEPENDENCIES` with a default value of 120 so we could increase it when necessary (this value can only reach 255 due to instruction limits that only allow 1 byte).
Next, I defined `streamingDependenciesLocations`, a list containing the function signature for each entry, then a list of offsets to locate arguments related to stack space (whether allocating space on the stack, accessing a variable, etc.), and another list containing offsets to locate the raw limits (80 for older versions, 100 for newer ones).
For the argument offsets what I've done is read the current value and add or subtract a difference to satisfy the `MAX_STREAMING_DEPENDENCIES` in that function, that is (case for b1604) if the offset points to 0x200 and the new `MAX_STREAMING_DEPENDENCIES` is 120 the new value will be 0x200 + ( (120 - 80) * 4). And for the list of limits where it says 0x50(80 decimal) it will be replaced with 0x78(120 decimal) these raw limits are for one of two things, the first is for the loop that initializes the dependency array to -1 and the argument passed to the GetDependencies function.

With this "system" I have been able to patch 8 not very complex functions, but for longer functions this has been very inefficient, so seeing the way NTA did the [RequestObject patch](https://github.com/citizenfx/fivem/commit/8bc08eaad224ac99ff5b45b87a2f83ac51bc79e9) I decided to do it in all the functions that were long or that had another data structure.

For this type of functions what I have done has been a hook::trampoline to send them a new argument that would be the new stackFrame based on `MAX_STREAMING_DEPENDENCIES`. In each part of the function that accessed the fixed structure of size 80 I have made a stub with jitasm to replace it with the same instruction but do it using rsp + kStackFrameSize (previously calculated) and also using kCountArrayOffset to locate the end of the array because the m_count is located at the end of the atFixedArray.

On the other hand, I have completely replaced the `UpdatePropExpressions` function because it was too small and I think it was better to "remake" it with the new size array than to patch it the old way.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 1604(pending testing)
**Platforms:** Windows


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2938 