### PR TITLE
fix(cfx-ui): allow modal close button to work properly

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyUiMessageModal/LegacyUiMessageModal.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/parts/LegacyUiMessageModal/LegacyUiMessageModal.tsx
@@ -42,7 +42,7 @@ const UiMessageModal = observer(function UiMessageModal(props: { message: IUiMes
   const renderedMessage = useRenderedFormattedMessage(message);
 
   return (
-    <Modal>
+    <Modal onClose={UiMessageService.closeMessage}>
       <Modal.Header>{title}</Modal.Header>
 
       <Pad size="large">


### PR DESCRIPTION
### Goal of this PR
Fix the issue where the "X" button in the upper right corner of the modal does not close it. Ensures that users can consistently close the modal using either the "X" or the button at the bottom left.

I don't think this behavior is what I expected, many times I have accidentally connected to a server and wanted to close the modal but the X never works.

### How is this PR achieving the goal
By sending the onClose handler (UiMessageService.closeMessage) to the Modal component, the close button (X) now properly calls the close function when clicked :)


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.