### PR TITLE
tweak(game/five): Use native IsControlKeyDown instead of InputHook::IsKeyDown

### DIFF
--- a/code/components/gta-core-five/src/GameInput.cpp
+++ b/code/components/gta-core-five/src/GameInput.cpp
@@ -8,6 +8,7 @@
 
 #include <gameSkeleton.h>
 #include <ICoreGameInit.h>
+#include <ScriptEngine.h>
 
 #include <atArray.h>
 #include <MinHook.h>
@@ -1133,7 +1134,10 @@ namespace game
 			return InputHook::IsMouseButtonDown(controlData.parameter);
 		}
 
-		return InputHook::IsKeyDown(controlData.parameter);
+		static auto IsRawKeyDown = fx::ScriptEngine::GetNativeHandler(HashString("IS_RAW_KEY_DOWN"));
+		bool isRawKeyDown = FxNativeInvoke::Invoke<bool>(IsRawKeyDown, controlData.parameter);
+
+		return isRawKeyDown;
 	}
 
 	bool IsControlKeyDown(int control)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Prevents key input from being detected when the game window is not focused.


### How is this PR achieving the goal
Replaces InputHook::IsKeyDown with the native IsControlKeyDown in the IsInputSourceDown function.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
