### PR TITLE
feat(gamestate/server): Add IS_OBJECT_A_PICKUP

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1416,6 +1416,11 @@ static void Init()
 		return uint32_t(node ? node->curWeapon : 0);
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("IS_OBJECT_A_PICKUP", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+    {
+        return entity->type == fx::sync::NetObjEntityType::Pickup || entity->type == fx::sync::NetObjEntityType::PickupPlacement;
+    }));
+
 	fx::ScriptEngine::RegisterNativeHandler("IS_PED_A_PLAYER", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		return entity->type == fx::sync::NetObjEntityType::Player;

--- a/ext/native-decls/IsObjectAPickup.md
+++ b/ext/native-decls/IsObjectAPickup.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+---
+## IS_OBJECT_A_PICKUP
+
+```c
+BOOL IS_OBJECT_A_PICKUP(Object obj);
+```
+
+This native checks if the given object is a pickup.
+
+## Parameters
+* **obj**: The object
+
+## Return value
+
+Returns `true` if the object is a pickup, `false` otherwise.


### PR DESCRIPTION
### Goal of this PR

I'm currently dealing with an issue related to pickup creation exploits on my server.
I want to be able to detect and prevent the creation of pickups reliably.

At the moment, many servers work around this by using `GetEntityModel(entity) == 0` during `entityCreating`, but this approach is fragile and likely to break once the CPickupCreationDataNode is parsed properly (as introduced in PR https://github.com/citizenfx/fivem/pull/2940).
Additionally, we still can't access the raw entity type until PR https://github.com/citizenfx/fivem/pull/2945 is merged.

### How is this PR achieving the goal

This PR introduces the `IS_OBJECT_A_PICKUP` native, matching the existing client-side counterpart.
Ideally, I’d prefer the other PR (https://github.com/citizenfx/fivem/pull/2945) to be accepted in order to unify this logic under a single getter, rather than relying on multiple `IS_..._A_...` checks.
However, since that PR has been stalled since November, this solution offers a more straightforward and less controversial path forward.

```lua
AddEventHandler('entityCreating', function(entity)
	if IsObjectAPickup(entity) then
		CancelEvent()
	end
end)
```

### This PR applies to the following area(s)
Server

### Successfully tested on

**Game builds:** All builds

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

Important note:
This PR is useless if https://github.com/citizenfx/fivem/pull/2945 is accepted.
