### PR TITLE
feat(extra-natives/five): add light natives

### DIFF
--- a/code/components/extra-natives-five/src/LightNatives.cpp
+++ b/code/components/extra-natives-five/src/LightNatives.cpp
@@ -1,0 +1,370 @@
+#include "StdInc.h"
+#include <ScriptEngine.h>
+#include <Hooking.h>
+#include <GameInit.h>
+#include <Hooking.Stubs.h>
+#include <Streaming.h>
+#include <rageVectors.h>
+#include <EntitySystem.h>
+
+#define MATH_PI 3.14159265358979323846f
+#define MATH_DEG2RAD (MATH_PI / 180.0f)
+
+class CLight;
+
+static hook::cdecl_stub<void(CLight*, uint64_t unk1, char unk2)> CLight_drawLight([]()
+{
+    return hook::get_pattern("48 8B C4 48 89 58 08 48 89 70 10 48 89 78 18 4C 89 60 20 55 41 56 41 57 48 8D 68 A1 48 81 EC A0 00 00 00 0F 29 70 D8 45");
+});
+
+class CLight
+{
+public:
+    rage::Vector3 coords;
+    rage::Vector3 color;
+
+    rage::Vector3 direction;
+    rage::Vector3 tanDirection;
+
+    rage::Vector4 volColorIntensityOuter;
+
+    int clipRectX;
+    int clipRectY;
+    int clipRectWidth;
+    int clipRectHeight;
+
+    uint32_t lightType;
+    uint32_t flags;
+    float intensity;
+    uint32_t timeFlags : 24;
+    uint32_t extraFlags : 8;
+
+    int32_t texDictId;
+    uint32_t textureHash;
+
+    float volIntensity;
+    float volSizeScale;
+    float volOuterExponent;
+
+    size_t shadowTrackingID;
+    int32_t shadowIndex;
+
+    rage::fwInteriorLocation interior;
+
+    float radius;
+    float params[13];
+
+    uint8_t fadeDistance;
+    uint8_t shadowFadeDistance;
+    uint8_t specularFadeDistance;
+    uint8_t volumetricFadeDistance;
+
+    float shadowNearClip;
+    float shadowBlur;
+    float shadowDepthBiasScale;
+
+    float alpha;
+
+    void* unk;
+    char unk2[0xC8];
+
+	CLight()
+	{
+		coords = { 0.0f, 0.0f, 0.0f };
+		color = { 1.0f, 1.0f, 1.0f };
+
+		direction = { 0.0f, 0.0f, 1.0f };
+		tanDirection = { 0.0f, 1.0f, 0.0f };
+
+		volColorIntensityOuter = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+		clipRectX = -1;
+		clipRectY = -1;
+		clipRectWidth = -1;
+		clipRectHeight = -1;
+
+		lightType = 1;
+		flags = (1 << 1);
+		intensity = 1.0f;
+		timeFlags = (1 << 24) - 1;
+		extraFlags = 0;
+
+		texDictId = -1;
+		textureHash = 0;
+
+		volIntensity = 1.0f;
+		volSizeScale = 1.0f;
+		volOuterExponent = 1.0f;
+
+		shadowTrackingID = 0;
+		shadowIndex = -1;
+
+		radius = 1.0f;
+
+		for (int i = 0; i < 13; ++i)
+			params[i] = 0.0f;
+
+		params[0] = 8.0f;
+
+		fadeDistance = 0U;
+		shadowFadeDistance = 0U;
+		specularFadeDistance = 0U;
+		volumetricFadeDistance = 0U;
+
+		shadowNearClip = 0.01f;
+		shadowBlur = 0.0f;
+		shadowDepthBiasScale = 1.0f;
+
+		alpha = 1.0f;
+
+		unk = nullptr;
+		memset(unk2, 0, sizeof(unk2));
+	}
+};
+
+static CLight g_light;
+
+static InitFunction initFunction([]()
+{
+
+    fx::ScriptEngine::RegisterNativeHandler("PREPARE_LIGHT", [](fx::ScriptContext& ctx)
+    {
+        uint32_t lightType = ctx.GetArgument<uint32_t>(0);
+        uint32_t flags = ctx.GetArgument<uint32_t>(1);
+        float x = ctx.GetArgument<float>(2);
+        float y = ctx.GetArgument<float>(3);
+        float z = ctx.GetArgument<float>(4);
+        uint32_t r = ctx.GetArgument<uint32_t>(5);
+        uint32_t g = ctx.GetArgument<uint32_t>(6);
+        uint32_t b = ctx.GetArgument<uint32_t>(7);
+        float intensity = ctx.GetArgument<float>(8);
+
+		g_light.lightType = lightType;
+		g_light.flags = flags;
+		g_light.coords = { x, y, z };
+		g_light.color = { r / 255.0f, g / 255.0f, b / 255.0f };
+		g_light.intensity = intensity;
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("DRAW_LIGHT", [](fx::ScriptContext& ctx)
+    {
+        CLight_drawLight(&g_light, 0, 0);
+		g_light = CLight();
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_TYPE", [](fx::ScriptContext& ctx)
+    {
+        g_light.lightType = ctx.GetArgument<uint32_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_EXTRAFLAGS", [](fx::ScriptContext& ctx)
+    {
+        g_light.extraFlags = ctx.GetArgument<uint32_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_TEXTURE", [](fx::ScriptContext& ctx)
+    {
+        std::string textureDict = ctx.CheckArgument<const char*>(0);
+        uint32_t textureHash = ctx.GetArgument<uint32_t>(1);
+
+        auto str = streaming::Manager::GetInstance();
+        if (!str)
+        {
+            return;
+        }
+
+        auto txdStore = str->moduleMgr.GetStreamingModule("ytd");
+        uint32_t id = -1;
+        txdStore->FindSlot(&id, textureDict.c_str());
+
+        if (id != 0xFFFFFFFF)
+        {
+            g_light.textureHash = textureHash;
+            g_light.texDictId = id;
+        }
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_COORDS", [](fx::ScriptContext& ctx)
+    {
+        float x = ctx.GetArgument<float>(0);
+        float y = ctx.GetArgument<float>(1);
+        float z = ctx.GetArgument<float>(2);
+        g_light.coords = { x, y, z };
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_COLOR", [](fx::ScriptContext& ctx)
+    {
+        int32_t r = ctx.GetArgument<int32_t>(0);
+        int32_t g = ctx.GetArgument<int32_t>(1);
+        int32_t b = ctx.GetArgument<int32_t>(2);
+        g_light.color = { r / 255.0f, g / 255.0f, b / 255.0f };
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_DIRECTION", [](fx::ScriptContext& ctx)
+    {
+        float xDir = ctx.GetArgument<float>(0);
+        float yDir = ctx.GetArgument<float>(1);
+        float zDir = ctx.GetArgument<float>(2);
+        float xTanDir = ctx.GetArgument<float>(3);
+        float yTanDir = ctx.GetArgument<float>(4);
+        float zTanDir = ctx.GetArgument<float>(5);
+
+        auto dir = DirectX::XMVector3Normalize({ xDir, yDir, zDir });
+        g_light.direction.x = DirectX::XMVectorGetX(dir);
+        g_light.direction.y = DirectX::XMVectorGetY(dir);
+        g_light.direction.z = DirectX::XMVectorGetZ(dir);
+        auto tanDir = DirectX::XMVector3Normalize({ xTanDir, yTanDir, zTanDir });
+        g_light.tanDirection.x = DirectX::XMVectorGetX(tanDir);
+        g_light.tanDirection.y = DirectX::XMVectorGetY(tanDir);
+        g_light.tanDirection.z = DirectX::XMVectorGetZ(tanDir);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_RADIUS", [](fx::ScriptContext& ctx)
+    {
+        g_light.radius = ctx.GetArgument<float>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_INTENSITY", [](fx::ScriptContext& ctx)
+    {
+        g_light.intensity = ctx.GetArgument<float>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_FALLOFF", [](fx::ScriptContext& ctx)
+    {
+        float falloff = ctx.GetArgument<float>(0);
+        g_light.params[0] = falloff <= 0.0f ? 1e-6f : falloff;
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_CONE", [](fx::ScriptContext& ctx)
+    {
+        float innerConeAngle = ctx.GetArgument<float>(0);
+        float outerConeAngle = ctx.GetArgument<float>(1);
+
+        g_light.params[7] = innerConeAngle;
+        g_light.params[8] = outerConeAngle;
+        g_light.params[5] = cosf(g_light.params[7] * MATH_DEG2RAD);
+        g_light.params[6] = cosf(g_light.params[8] * MATH_DEG2RAD);
+
+        const float cosAngle = g_light.params[6];
+        const float tanAngle = sqrtf(1.0f - cosAngle * cosAngle) / cosAngle;
+
+        g_light.params[10] = g_light.radius * cosAngle;
+        g_light.params[9] = g_light.params[10] * tanAngle;
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_HEADLIGHT", [](fx::ScriptContext& ctx)
+    {
+        g_light.params[11] = ctx.GetArgument<float>(0);
+        g_light.params[12] = ctx.GetArgument<float>(1);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_AO", [](fx::ScriptContext& ctx)
+    {
+        g_light.params[5] = ctx.GetArgument<float>(0);
+        g_light.params[6] = ctx.GetArgument<float>(1);
+        g_light.params[7] = ctx.GetArgument<float>(2);
+        g_light.params[8] = ctx.GetArgument<float>(3);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_CAPSULE_SIZE", [](fx::ScriptContext& ctx)
+    {
+        g_light.params[5] = ctx.GetArgument<float>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_VOLUME_DETAILS", [](fx::ScriptContext& ctx)
+    {
+        float volIntensity = ctx.GetArgument<float>(0);
+        float volSizeScale = ctx.GetArgument<float>(1);
+        float r = ctx.GetArgument<float>(2);
+        float g = ctx.GetArgument<float>(3);
+        float b = ctx.GetArgument<float>(4);
+        float i = ctx.GetArgument<float>(5);
+        float outerExponent = ctx.GetArgument<float>(6);
+
+        g_light.volIntensity = volIntensity;
+        g_light.volSizeScale = volSizeScale;
+        g_light.volColorIntensityOuter = { r, b, g, i };
+        g_light.volOuterExponent = outerExponent;
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_PLANE", [](fx::ScriptContext& ctx)
+    {
+        float nx = ctx.GetArgument<float>(0);
+        float ny = ctx.GetArgument<float>(1);
+        float nz = ctx.GetArgument<float>(2);
+        float dist = ctx.GetArgument<float>(3);
+
+        float mtx[16];
+        for (int i = 0; i < 16; ++i)
+        {
+            mtx[i] = ctx.GetArgument<float>(4 + i);
+        }
+
+        DirectX::XMVECTOR normal = DirectX::XMVectorSet(nx, ny, nz, 0.0f);
+        DirectX::XMMATRIX matrix = DirectX::XMLoadFloat4x4(reinterpret_cast<DirectX::XMFLOAT4X4*>(mtx));
+        DirectX::XMVECTOR transformedNormal = DirectX::XMVector3TransformNormal(normal, matrix);
+        DirectX::XMFLOAT3 lightPosFloat3(g_light.coords.x, g_light.coords.y, g_light.coords.z);
+        DirectX::XMVECTOR lightPos = DirectX::XMLoadFloat3(&lightPosFloat3);
+        DirectX::XMVECTOR planeOrigin = DirectX::XMVectorSubtract(lightPos, DirectX::XMVectorScale(transformedNormal, dist));
+
+        g_light.params[1] = DirectX::XMVectorGetX(transformedNormal);
+        g_light.params[2] = DirectX::XMVectorGetY(transformedNormal);
+        g_light.params[3] = DirectX::XMVectorGetZ(transformedNormal);
+        g_light.params[4] = -DirectX::XMVectorGetX(DirectX::XMVector3Dot(planeOrigin, transformedNormal));
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_FLAGS", [](fx::ScriptContext& ctx)
+    {
+        g_light.flags = ctx.GetArgument<uint32_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_SHADOW_DETAILS", [](fx::ScriptContext& ctx)
+    {
+        g_light.shadowTrackingID = ctx.GetArgument<int32_t>(0);
+        g_light.shadowNearClip = ctx.GetArgument<float>(1);
+        g_light.shadowBlur = ctx.GetArgument<float>(2);
+        g_light.shadowDepthBiasScale = ctx.GetArgument<float>(3);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_CLIP_RECT", [](fx::ScriptContext& ctx)
+    {
+        g_light.clipRectX = ctx.GetArgument<int>(0);
+        g_light.clipRectY = ctx.GetArgument<int>(1);
+        g_light.clipRectWidth = ctx.GetArgument<int>(2);
+        g_light.clipRectHeight = ctx.GetArgument<int>(3);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_FADE_DISTANCE", [](fx::ScriptContext& ctx)
+    {
+        g_light.fadeDistance = ctx.GetArgument<uint8_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_SHADOW_FADE_DISTANCE", [](fx::ScriptContext& ctx)
+    {
+        g_light.shadowFadeDistance = ctx.GetArgument<uint8_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_SPECULAR_FADE_DISTANCE", [](fx::ScriptContext& ctx)
+    {
+        g_light.specularFadeDistance = ctx.GetArgument<uint8_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_VOLUMETRIC_FADE_DISTANCE", [](fx::ScriptContext& ctx)
+    {
+        g_light.volumetricFadeDistance = ctx.GetArgument<uint8_t>(0);
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_INTERIOR", [](fx::ScriptContext& ctx)
+    {
+        uint16_t interior = ctx.GetArgument<uint8_t>(0);
+        bool isPortal = ctx.GetArgument<uint8_t>(1);
+        uint16_t roomIndex = ctx.GetArgument<uint8_t>(2);
+
+        g_light.interior = { interior, isPortal, roomIndex };
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("SET_LIGHT_ALPHA", [](fx::ScriptContext& ctx)
+    {
+        g_light.alpha = ctx.GetArgument<float>(0);
+    });
+});

--- a/ext/native-decls/DrawLight.md
+++ b/ext/native-decls/DrawLight.md
@@ -1,0 +1,12 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DRAW_LIGHT
+
+```c
+void DRAW_LIGHT();
+```
+
+Draw the prepared light.

--- a/ext/native-decls/PrepareLight.md
+++ b/ext/native-decls/PrepareLight.md
@@ -1,0 +1,24 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## PREPARE_LIGHT
+
+```c
+void PREPARE_LIGHT(int lightType, int flags, float x, float y, float z, int r, int g, int b, float intensity);
+```
+
+Create a new light with specified type, flags, position, color, and intensity.
+
+## Parameters
+
+* **lightType**: The type of the light
+* **flags**: Light flags
+* **x**: X coordinate of the light position
+* **y**: Y coordinate of the light position
+* **z**: Z coordinate of the light position
+* **r**: Red component of the light color (0-255)
+* **g**: Green component of the light color (0-255)
+* **b**: Blue component of the light color (0-255)
+* **intensity**: Intensity of the light

--- a/ext/native-decls/SetLightAlpha.md
+++ b/ext/native-decls/SetLightAlpha.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_ALPHA
+
+```c
+void SET_LIGHT_ALPHA(float alpha);
+```
+
+Set the alpha transparency of the light.
+
+## Parameters
+
+* **alpha**: The alpha transparency value (0.0 to 1.0)

--- a/ext/native-decls/SetLightAo.md
+++ b/ext/native-decls/SetLightAo.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_AO
+
+```c
+void SET_LIGHT_AO(float intensity, float radius, float bias, float intensity2);
+```
+
+Set ambient occlusion (AO) parameters for a specified light.
+
+## Parameters
+
+* **intensity**: The AO intensity
+* **radius**: The AO radius
+* **bias**: The AO bias
+* **intensity2**: Secondary AO intensity

--- a/ext/native-decls/SetLightCapsuleSize.md
+++ b/ext/native-decls/SetLightCapsuleSize.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_CAPSULE_SIZE
+
+```c
+void SET_LIGHT_CAPSULE_SIZE(float size);
+```
+
+Set the capsule size of a specified light.
+
+## Parameters
+
+* **size**: The capsule size value

--- a/ext/native-decls/SetLightClipRect.md
+++ b/ext/native-decls/SetLightClipRect.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_CLIP_RECT
+
+```c
+void SET_LIGHT_CLIP_RECT(int x, int y, int width, int height);
+```
+
+Set the clip rectangle for a created light.
+
+## Parameters
+
+* **x**: The x-coordinate of the clip rectangle
+* **y**: The y-coordinate of the clip rectangle
+* **width**: The width of the clip rectangle
+* **height**: The height of the clip rectangle

--- a/ext/native-decls/SetLightColor.md
+++ b/ext/native-decls/SetLightColor.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_COLOR
+
+```c
+void SET_LIGHT_COLOR(int r, int g, int b);
+```
+
+Set the color of a specified light.
+
+## Parameters
+
+* **r**: Red color component (0-255)
+* **g**: Green color component (0-255)
+* **b**: Blue color component (0-255)

--- a/ext/native-decls/SetLightCone.md
+++ b/ext/native-decls/SetLightCone.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_CONE
+
+```c
+void SET_LIGHT_CONE(float innerConeAngle, float outerConeAngle);
+```
+
+Set the inner and outer cone angles of a specified light.
+
+## Parameters
+
+* **innerConeAngle**: The inner cone angle in degrees
+* **outerConeAngle**: The outer cone angle in degrees

--- a/ext/native-decls/SetLightCoords.md
+++ b/ext/native-decls/SetLightCoords.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_COORDS
+
+```c
+void SET_LIGHT_COORDS(float x, float y, float z);
+```
+
+Set the world coordinates of a specified light.
+
+## Parameters
+
+* **x**: The X coordinate
+* **y**: The Y coordinate
+* **z**: The Z coordinate

--- a/ext/native-decls/SetLightDirection.md
+++ b/ext/native-decls/SetLightDirection.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_DIRECTION
+
+```c
+void SET_LIGHT_DIRECTION(float xDir, float yDir, float zDir, float xTanDir, float yTanDir, float zTanDir);
+```
+
+Set the forward and tangent direction vectors for an existing light, allowing control over its orientation (useful for spotlights and directional lights).
+
+## Parameters
+
+* **xDir**, **yDir**, **zDir**: Components of the normalized forward (direction) vector
+* **xTanDir**, **yTanDir**, **zTanDir**: Components of the normalized tangent vector (defines rotation around the forward axis)

--- a/ext/native-decls/SetLightExtraflags.md
+++ b/ext/native-decls/SetLightExtraflags.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_EXTRAFLAGS
+
+```c
+void SET_LIGHT_EXTRAFLAGS(int extraFlags);
+```
+
+Set additional configuration flags for an existing light
+
+## Parameters
+* **extraFlags**: Bitmask of extra flags

--- a/ext/native-decls/SetLightFadeDistance.md
+++ b/ext/native-decls/SetLightFadeDistance.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_FADE_DISTANCE
+
+```c
+void SET_LIGHT_FADE_DISTANCE(int fadeDistance);
+```
+
+Set the fade distance.
+
+## Parameters
+
+* **fadeDistance**: Maximum distance

--- a/ext/native-decls/SetLightFalloff.md
+++ b/ext/native-decls/SetLightFalloff.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_FALLOFF
+
+```c
+void SET_LIGHT_FALLOFF(float falloff);
+```
+
+Adjust the falloff parameter for an existing light, affecting how light intensity decreases over distance.
+
+## Parameters
+
+* **falloff**: A floating‑point value determining the rate at which light intensity diminishes with distance (must be > 0; values ≤ 0 will be clamped internally)

--- a/ext/native-decls/SetLightFlags.md
+++ b/ext/native-decls/SetLightFlags.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_FLAGS
+
+```c
+void SET_LIGHT_FLAGS(int flags);
+```
+
+Set or update specific flags for a created light to control its behavior or properties.
+
+## Parameters
+
+* **flags**: Bitmask of flags to apply to the light

--- a/ext/native-decls/SetLightHeadlight.md
+++ b/ext/native-decls/SetLightHeadlight.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_HEADLIGHT
+
+```c
+void SET_LIGHT_HEADLIGHT(float intensity, float range);
+```
+
+Set the headlight properties of a created light, adjusting its intensity and range.
+
+## Parameters
+
+* **intensity**: The intensity level of the headlight
+* **range**: The effective range of the headlight

--- a/ext/native-decls/SetLightIntensity.md
+++ b/ext/native-decls/SetLightIntensity.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_INTENSITY
+
+```c
+void SET_LIGHT_INTENSITY(float intensity);
+```
+
+Set the intensity of an existing light.
+
+## Parameters
+
+* **intensity**: The intensity value to set

--- a/ext/native-decls/SetLightInterior.md
+++ b/ext/native-decls/SetLightInterior.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+
+## SET_LIGHT_INTERIOR
+
+```c
+void SET_LIGHT_INTERIOR(int interiorId, bool isPortal, int roomIndex);
+```
+
+Set the interior and room where the light should be active.
+
+## Parameters
+
+* **interiorId**: The ID of the interior where the light should be active
+* **isPortal**: Attach to a portal or room
+* **roomIndex**: The specific room

--- a/ext/native-decls/SetLightPlane.md
+++ b/ext/native-decls/SetLightPlane.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_PLANE
+
+```c
+void SET_LIGHT_PLANE(float x, float y, float z, float w);
+```
+
+Set the plane parameters for a light.
+
+## Parameters
+
+* **x**: X component of the plane
+* **y**: Y component of the plane
+* **z**: Z component of the plane
+* **w**: W component of the plane

--- a/ext/native-decls/SetLightRadius.md
+++ b/ext/native-decls/SetLightRadius.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_RADIUS
+
+```c
+void SET_LIGHT_RADIUS(float radius);
+```
+
+Set the radius of a created light.
+
+## Parameters
+
+* **radius**: The radius value to set

--- a/ext/native-decls/SetLightShadowDetails.md
+++ b/ext/native-decls/SetLightShadowDetails.md
@@ -1,0 +1,19 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_SHADOW_DETAILS
+
+```c
+void SET_LIGHT_SHADOW_DETAILS(int shadowFlags, float shadowDistance, float shadowFade, float shadowDepthBiasScale);
+```
+
+Set the shadow details for a created light.
+
+## Parameters
+
+* **shadowFlags**: Flags controlling shadow behavior
+* **shadowDistance**: The distance at which shadows are rendered
+* **shadowFade**: The fade distance for shadows
+* **shadowDepthBiasScale**: The depth bias scale

--- a/ext/native-decls/SetLightShadowFadeDistance.md
+++ b/ext/native-decls/SetLightShadowFadeDistance.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_SHADOW_FADE_DISTANCE
+
+```c
+void SET_LIGHT_SHADOW_FADE_DISTANCE(int fadeDistance);
+```
+
+Set the fade distance for the shadows of a created light.
+
+## Parameters
+
+* **fadeDistance**: The distance at which the shadow fades

--- a/ext/native-decls/SetLightSpecularFadeDistance.md
+++ b/ext/native-decls/SetLightSpecularFadeDistance.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_SPECULAR_FADE_DISTANCE
+
+```c
+void SET_LIGHT_SPECULAR_FADE_DISTANCE(int fadeDistance);
+```
+
+Set the specular fade distance for a created light.
+
+## Parameters
+
+* **fadeDistance**: The distance at which specular highlights fade

--- a/ext/native-decls/SetLightTexture.md
+++ b/ext/native-decls/SetLightTexture.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_TEXTURE
+
+```c
+void SET_LIGHT_TEXTURE(char* textureDict, int textureHash);
+```
+
+Assign a texture to an existing light source, allowing custom light shapes or patterns using textures from streaming assets.
+
+## Parameters
+
+* **textureDict**: The name of the texture dictionary (TXD) containing the texture
+* **textureHash**: Hash of the texture

--- a/ext/native-decls/SetLightType.md
+++ b/ext/native-decls/SetLightType.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_TYPE
+
+```c
+void SET_LIGHT_TYPE(int lightType);
+```
+
+Change the light type of a already created light.
+Certain light type needs more configurations to work properly (Like direction, flags or size)
+
+## Parameters
+
+* **lightType**: The type of light
+
+```cpp
+enum eLightType
+{
+    NOTHING = 0,
+    POINT = 1,
+    SPOT = 2,
+    CAPSULE = 4,
+    DIRECTION = 8,
+    AO = 16,
+}
+```

--- a/ext/native-decls/SetLightVolumeDetails.md
+++ b/ext/native-decls/SetLightVolumeDetails.md
@@ -1,0 +1,22 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_VOLUME_DETAILS
+
+```c
+void SET_LIGHT_VOLUME_DETAILS(float volIntensity, float volSizeScale, float r, float g, float b, float i, float outerExponent);
+```
+
+Set volumetric light properties for an existing light, enabling custom volumetric effects such as fog-like glow.
+
+## Parameters
+
+* **volIntensity**: Intensity of the volumetric effect
+* **volSizeScale**: Scale of the volumetric volume
+* **r**: Red channel for volumetric outer color (0–255)
+* **g**: Green channel for volumetric outer color (0–255)
+* **b**: Blue channel for volumetric outer color (0–255)
+* **i**: Intensity (alpha) of the volumetric outer color
+* **outerExponent**: Exponent controlling falloff of the volumetric outer glow

--- a/ext/native-decls/SetLightVolumetricFadeDistance.md
+++ b/ext/native-decls/SetLightVolumetricFadeDistance.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_LIGHT_VOLUMETRIC_FADE_DISTANCE
+
+```c
+void SET_LIGHT_VOLUMETRIC_FADE_DISTANCE(int volumetricFadeDistance);
+```
+
+Set the fade distance for volumetric lightingn.
+
+## Parameters
+
+* **volumetricFadeDistance**: The maximum distance
+


### PR DESCRIPTION
### Goal of this PR
This PR introduces several new natives to create, delete, and manage all properties of scripted lights. This enables more flexible lighting setups and access to features that were not previously available through the traditional `DRAW_LIGHT_...` natives, such as texture projection, capsule shapes, and volumetric flags.

![h9vY2odmrp](https://github.com/user-attachments/assets/a7323944-d3ac-4890-84fb-42babcc95fe9)
![ne9Redg3TE](https://github.com/user-attachments/assets/560c6bb7-9328-4c0c-a49d-d49e37f62145)

### How is this PR achieving the goal

Instead of using a per-frame draw approach, this PR implements a handle-based system to manage lights. With the `CREATE_LIGHT` and `DELETE_LIGHT` natives, users can create lights that persist across frames, improving both performance and usability.

Persisting light objects means they are reused every frame, instead of being recreated, using a draw-based native would have required a large number of arguments to expose all the fields of the `CLight` class.

This PR is a draft because it introduces a significant number of new natives.
I’m looking for feedback on the implementation approach and suggestions for improvement before finalizing the design.

Implementation note:
The everyFrame hook seems weird at first reading, but I didn't find any better way to implement it.
Using fwEvent OnGameFrame doesn't render the lights properly.
We need too add lights just after natives finished executing, but before it's cleaned by the game, this hook was the simpliest way I found.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604 to 3258
**Platforms:** Windows

```lua
CreateThread(function()
	for i = 0, 1024 do DeleteLight(i) end -- This could be replaced with a mission clean-up thing ?

	local color = { r = 255, g = 255, b = 0 }
	local intensity = 1.0
	local radius = 1.0

	local light = CreateLight(1, (1<<12), 0.0, 0.0, 0.0, color.r, color.g, color.b, intensity)
	SetLightRadius(light, radius)

	CreateThread(function()
		while true do
			local camPos = GetFinalRenderedCamCoord()
			local endPoint, normal = GetWorldCoordFromScreenCoord(GetDisabledControlNormal(0, 239), GetDisabledControlNormal(0, 240))
			endPoint = endPoint + normal * 10.0

			local rayHandle = StartExpensiveSynchronousShapeTestLosProbe(camPos.x, camPos.y, camPos.z, endPoint.x, endPoint.y, endPoint.z, -1, PlayerPedId(), 0)
			local _, hit, worldPosition = GetShapeTestResultIncludingMaterial(rayHandle)

			if hit then
				SetLightCoords(light, worldPosition.x, worldPosition.y, worldPosition.z)
			end
			Wait(0)
		end
	end)
end)
```


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Resolve https://forum.cfx.re/t/more-drawblanklight-natives-drawvolumetricspotlight-drawcapsule/5327113


