### PR TITLE
feat(scripting/lua): expose CGivePickupRewardsEvent to detect pickup exploits

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5413,6 +5413,25 @@ struct CGiveWeaponEvent
     MSGPACK_DEFINE_MAP(pedId, weaponType, unk1, ammo, givenAsPickup);
 };
 
+struct CGivePickupRewardsEvent
+{
+	void Parse(rl::MessageBufferView& buffer)
+	{
+		receivingPlayers = buffer.Read<uint16_t>(13);
+		pickupHash = buffer.Read<uint32_t>(32);
+	}
+
+	inline std::string GetName()
+	{
+		return "givePickupRewardsEvent";
+	}
+
+	int receivingPlayers; // player net ID
+	int pickupHash; // pickup hash
+
+	MSGPACK_DEFINE_MAP(receivingPlayers, pickupHash);
+};
+
 struct CRemoveWeaponEvent
 {
     void Parse(rl::MessageBufferView& buffer)
@@ -6992,6 +7011,7 @@ enum GTA_EVENT_IDS
 	NETWORK_START_SYNCED_SCENE_EVENT,
 	NETWORK_STOP_SYNCED_SCENE_EVENT,
 	NETWORK_UPDATE_SYNCED_SCENE_EVENT,
+	NETWORK_GIVE_PICKUP_REWARDS_EVENT,
 	INCIDENT_ENTITY_EVENT,
 	GIVE_PED_SCRIPTED_TASK_EVENT,
 	GIVE_PED_SEQUENCE_TASK_EVENT,
@@ -7592,6 +7612,7 @@ std::function<bool()> fx::ServerGameState::GetGameEventHandler(const fx::ClientS
 		case NETWORK_REQUEST_SYNCED_SCENE_EVENT: return GetHandler<CRequestNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
 		case NETWORK_START_SYNCED_SCENE_EVENT: return GetHandler<CStartNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
 		case NETWORK_UPDATE_SYNCED_SCENE_EVENT: return GetHandler<CUpdateNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
+		case NETWORK_GIVE_PICKUP_REWARDS_EVENT: return GetHandler<CGivePickupRewardsEvent>(instance, client, std::move(buffer));
 		case NETWORK_STOP_SYNCED_SCENE_EVENT: return GetHandler<CStopNetworkSyncedSceneEvent>(instance, client, std::move(buffer));
 		case GIVE_PED_SCRIPTED_TASK_EVENT: return GetHandler<CGivePedScriptedTaskEvent>(instance, client, std::move(buffer));
 		default:


### PR DESCRIPTION
### Goal of this PR
This PR enables server developers to detect abuse of `NETWORK_GIVE_PICKUP_REWARDS_EVENT`, which is used by some cheats to grant weapons, armor, or money to other players through vehicle reward spoofing. 

Currently, this event is not exposed to Server Scripts and cannot be tracked like `weaponDamageEvent` or `giveWeaponEvent`, which limits the ability to build effective anticheat systems.


### How is this PR achieving the goal
- Exposes it to Lua as `givePickupRewardsEvent`
- Follows the established pattern for events like `weaponDamageEvent`, ensuring consistency
- Allows developers to detect and handle this event:
```lua
AddEventHandler('givePickupRewardsEvent', function(sender, data)
    print("Detected pickup reward event:", sender, json.encode(data))
end)
```

### This PR applies to the following area(s)
- Server


### Successfully tested on
**Game builds:** All Builds

**Platforms:** Windows, Linux


### Checklist

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these 
