### PR TITLE
feat(gamestate/server): add blockedEvents system

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -1476,6 +1476,9 @@ private:
 	bool ValidateEntity(EntityLockdownMode entityLockdownMode, const fx::sync::SyncEntityPtr& entity);
 
 public:
+	std::unordered_set<uint32_t> blockedEvents;
+	std::shared_mutex blockedEventsMutex;
+	bool IsNetGameEventBlocked(uint32_t eventNameHash);
 	std::function<bool()> GetGameEventHandler(const fx::ClientSharedPtr& client, const std::vector<uint16_t>& targetPlayers, net::Buffer&& buffer);
 
 private:

--- a/code/components/citizen-server-impl/include/state/ServerGameStatePublic.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameStatePublic.h
@@ -85,6 +85,8 @@ public:
 	virtual bool IsClientRelevantEntity(const fx::ClientSharedPtr& client, uint32_t objectId) = 0;
 
 	virtual bool GetStateBagStrictMode() const = 0;
+
+	virtual bool IsNetGameEventBlocked(uint32_t eventNameHash) = 0;
 };
 }
 

--- a/code/components/citizen-server-impl/src/packethandlers/NetGameEventPacketHandler.cpp
+++ b/code/components/citizen-server-impl/src/packethandlers/NetGameEventPacketHandler.cpp
@@ -1,4 +1,4 @@
-﻿#include "StdInc.h"
+#include "StdInc.h"
 
 #include <ServerInstanceBase.h>
 
@@ -64,6 +64,11 @@ bool NetGameEventPacketHandlerV2::ProcessNetEvent(fx::ServerInstanceBase* instan
 		serverNetEvent.eventId = clientNetEvent.eventId;
 		serverNetEvent.isReply = clientNetEvent.isReply;
 		serverNetEvent.data = clientNetEvent.data;
+
+		if (sgs->IsNetGameEventBlocked(serverNetEvent.eventNameHash))
+		{
+			return;
+		}
 
 		net::Buffer routingBuffer(kServerMaxReplySize);
 		net::ByteWriter routingWriter{ const_cast<uint8_t*>(routingBuffer.GetBuffer()), kServerMaxReplySize };

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4644,6 +4644,24 @@ void ServerGameState::AttachToObject(fx::ServerInstanceBase* instance)
 
 		console::Printf("net", "---------------- END OBJECT ID DUMP ----------------\n");
 	});
+
+	static auto blockNetGameEvent = instance->AddCommand("block_net_game_event", [this](uint32_t eventNameHash)
+	{
+		std::unique_lock lock(this->blockedEventsMutex);
+		this->blockedEvents.insert(eventNameHash);
+	});
+
+	static auto unblockNetGameEvent = instance->AddCommand("unblock_net_game_event", [this](uint32_t eventNameHash)
+	{
+		std::unique_lock lock(this->blockedEventsMutex);
+		this->blockedEvents.erase(eventNameHash);
+	});
+}
+
+bool ServerGameState::IsNetGameEventBlocked(uint32_t eventNameHash)
+{
+	std::shared_lock lock(this->blockedEventsMutex);
+	return blockedEvents.find(eventNameHash) != blockedEvents.end();
 }
 }
 

--- a/code/tests/server/ServerGameStatePublicInstance.cpp
+++ b/code/tests/server/ServerGameStatePublicInstance.cpp
@@ -1,4 +1,4 @@
-﻿#include "StdInc.h"
+#include "StdInc.h"
 
 #include "ServerGameStatePublicInstance.h"
 
@@ -98,6 +98,11 @@ public:
 	}
 
 	bool GetStateBagStrictMode() const override
+	{
+		return false;
+	}
+
+	bool IsNetGameEventBlocked(uint32_t eventNameHash) override
 	{
 		return false;
 	}


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Rather than doing individual convars or event handler for each and every events that could be potentially exploited in the future (See https://github.com/citizenfx/fivem/pull/3461 for the most recent exploit discovered),
it would be best to allow developers to block individual events that correspond best to their usage.

There is currently a 3 convars blocking already in place related to blocking events, but each one of them needed a PR to be properly made and accepted, causing some abuse during this period.
Doing this using a native would allow more fine tuning from servers owners and be future proof (even for RDR2).
Related convar are : sv_enableNetworkedSounds/sv_enableNetworkedPhoneExplosions/sv_enableNetworkedScriptEntityStates

This method also reduce the need for event handlers for some events that are mostly blocked by servers like "clearPedTasksEvent".
For example, in my codebase :
```lua
AddEventHandler('giveWeaponEvent', function(playerId, eventData)
    CancelEvent()
end)
AddEventHandler('removeAllWeaponsEvent', function(playerId, eventData)
    CancelEvent()
end)
AddEventHandler('clearPedTasksEvent', function(playerId, eventData)
    CancelEvent()
end)
AddEventHandler('ptFxEvent', function(playerId, eventData)
    CancelEvent()
end)
```

Would be replaced with

```lua
-- Using msgNetGameEvent (v1)
DisableNetGameEvent(12, true)
DisableNetGameEvent(14, true)
DisableNetGameEvent(43, true)
DisableNetGameEvent(74, true)

-- Using msgNetGameEventV2
DisableNetGameEvent(`GIVE_WEAPON_EVENT`, true)
DisableNetGameEvent(`REMOVE_ALL_WEAPONS_EVENT`, true)
DisableNetGameEvent(`NETWORK_CLEAR_PED_TASKS_EVENT`, true)
DisableNetGameEvent(`NETWORK_PTFX_EVENT`, true)

-- Add new discovered exploit
DisableNetGameEvent(64, true)
DisableNetGameEvent(`GIVE_PICKUP_REWARDS_EVENT`, true)
```

For my personnal use case, I would also block these events on my server:
CLEAR_AREA_EVENT (I'm never using this, don't want this to be exploited)
CLEAR_RECTANGLE_AREA_EVENT (Same)
PLAYER_TAUNT_EVENT
NETWORK_PLAY_AIRDEFENSE_FIRE_EVENT
NETWORK_BANK_REQUEST_EVENT
REQUEST_DOOR_EVENT (My doors are not networked)
BLOCK_WEAPON_SELECTION (Currently exploitable)
NETWORK_SPECIAL_FIRE_EQUIPPED_WEAPON (Currently exploitable)

### Potential issues

 - Servers owners or developers could block events that are absolutely needed for the game to work properl, we could prevent some events from being blocked.

 - msgNetGameEvent being in a weird "v1 still the main thing, but v2 on it's way" state, we are supporting both format in the same native and with the same parameter, this could be handled differently.


### How is this PR achieving the goal

Add a native to allow developers to block individual events, when the server receive one of the specified events, it just deny them.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
Related PR : https://github.com/citizenfx/fivem/pull/3461
Also see Cfx discord or engineering discord for recent discussion related to pickup exploit.


