### PR TITLE
fix(gta-core-five): validate archetype in manifold contact points

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.SelfCollision.cpp
@@ -3,6 +3,7 @@
 #include "Hooking.Patterns.h"
 #include "Hooking.Stubs.h"
 #include <DirectXMath.h>
+#include <jitasm.h>
 
 namespace rage {
 	struct alignas(16) Vec3V
@@ -89,4 +90,58 @@ static HookFunction hookFunction([]()
 {
 	g_origProcessSelfCollision = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 4C 89 48 ? 4C 89 40 ? 48 89 50 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? B8"), ProcessSelfCollision);
 	g_origCalcClosestLeafDistance = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 48 89 50 ? 55 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? B8 ? ? ? ? E8 ? ? ? ? 48 2B E0 49 8B 38"), CalcClosestLeafDistance);
+
+	// phManifold::RefreshContactPoints
+	// 
+	// This function is responsible for updating the contact points (manifold) between two physics instances (A and B) 
+	// based on their current and previous transformation matrices. These contact points are essential for maintaining 
+	// stable and accurate collision resolution over time.
+	//
+	// In some edge cases, instanceB can return a valid pointer with a null archetype (0x00000000), which would cause 
+	// a crash when accessing the bound of instanceB. To avoid this, we patch the function to insert 
+	// a conditional check: if instanceB or instanceB->archetype is null, we jump early to the failure handler.
+	//
+	// The original `jz` instruction is replaced with an unconditional `jmp`, and the logic is moved to a stub where 
+	// both conditions are properly evaluated before jumping to success or fail locations.
+	{
+		auto location = hook::get_pattern<char>("48 8B 8B ? ? ? ? 48 85 C9 0F 84 ? ? ? ? 48 8B 41 ? F3 0F 10 41");
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t successLocation;
+			uintptr_t failLocation;
+
+			void Init(uintptr_t success, uintptr_t fail)
+			{
+				successLocation = success;
+				failLocation = fail;
+			}
+			
+			virtual void InternalMain() override
+			{
+				mov(rcx, qword_ptr[rbx+0xA8]); // rcx = instanceB
+				test(rcx, rcx);                // if (instanceB == nullptr)
+				jz("fail");
+
+				mov(rax, qword_ptr[rcx+0x10]); // rax = instanceB->archetype
+				test(rax, rax);                // if (instanceB->archetype == nullptr)
+				jz("fail");
+
+				mov(rdi, successLocation);
+				jmp(rdi);
+
+				L("fail");
+				mov(rax, failLocation);
+				jmp(rax);
+			}
+		} stub;
+		stub.Init((uintptr_t)location + 16, (uintptr_t)location + 11);
+
+		// Replace the conditional jump with an unconditional jmp to allow the stub to handle logic
+		hook::nop(location + 10, 2);
+		hook::put<char>(location + 11, 0xE9);
+
+		hook::nop(location, 10);
+		hook::jump(location, stub.GetCode());
+	}
 });


### PR DESCRIPTION
### Goal of this PR
Prevent a potential crash in phManifold::RefreshContactPoints caused by instanceB having a valid pointer but a null m_Archetype.


### How is this PR achieving the goal
Replaces the original conditional jump (jz) with an unconditional jump (jmp) and redirects execution to a stub that performs both required null checks: one for instanceB itself, and another for instanceB->archetype. If either is null, execution is redirected to the failure handler (RemoveAllContacts); otherwise, normal execution continues.


### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 1604, 3407

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3466 


