### PR TITLE
fix(citizen-server-impl): avoid crash on empty headers in writeHead

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/ResourceHttpHandler.cpp
@@ -225,7 +225,7 @@ public:
 			{
 				auto state = unpacked.get().as<std::vector<msgpack::object>>();
 
-				if (state.empty())
+				if (state.empty() || state[0].is_nil())
 				{
 					response->End();
 				}


### PR DESCRIPTION
### Goal of this PR
Prevent the server from crashing when res.writeHead is called with an empty header table.


### How is this PR achieving the goal
By adding a type check to ensure that the second argument of the unpacked message is a valid msgpack::type::MAP before attempting to iterate or cast it.


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3464 


