### PR TITLE
feat(extra-natives/five): Add SET_FOG_VOLUME_RENDER_DISABLED

### DIFF
--- a/ext/native-decls/SetFogVolumeRenderDisabled.md
+++ b/ext/native-decls/SetFogVolumeRenderDisabled.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_FOG_VOLUME_RENDER_DISABLED
+
+```c
+void SET_FOG_VOLUME_RENDER_DISABLED(BOOL state);
+```
+
+This completely disables rendering of fog volumes (vfxfogvolumeinfo.ymt).
+
+## Parameters
+* **state**: Toggle on or off.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
this native can enable and disable rendering of fog volumes, defined in vfxfogvolumeinfo.ymt.
useful if you want to remove the fog around the city at night, i.e. you changed light colours but its still using vanilla fog volumes.
...


### How is this PR achieving the goal
Self explainatory
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
FiveM
**Game builds:** .. 
3258
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


