### PR TITLE
feat(extra-natives-five): Add health config natives

### DIFF
--- a/code/components/extra-natives-five/src/PedExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/PedExtraNatives.cpp
@@ -13,6 +13,8 @@
 #include <GameInit.h>
 #include <fxScripting.h>
 #include <Resource.h>
+#include <Hooking.Stubs.h>
+#include <unordered_set>
 
 class CPedHeadBlendData
 {
@@ -58,6 +60,9 @@ public:
 static uint64_t* _id_CPedHeadBlendData;
 static uintptr_t _baseClipsetLocation;
 static uint32_t _pedSweatOffset;
+static uint8_t _pedModelInfoOffset;
+static uint32_t _pedPersonalityIndexOffset;
+static uint8_t _pedHealthConfigHashOffset;
 static float* _motionAimingTurnTransitionThresholdMin = nullptr;
 static float* _motionAimingTurnTransitionThresholdMax = nullptr;
 
@@ -83,8 +88,10 @@ static hook::cdecl_stub<bool(void*, int, int)> _doesPedComponentDrawableExist([]
 
 struct PedPersonality
 {
-	uint32_t hash;
-	char pad[180];
+	uint32_t hash; // 0x00
+	char padding[20];
+	uint32_t healthConfigHash; // 0x18
+	char paddingAfter[156];
 };
 
 static atArray<PedPersonality>* g_pedPersonalities;
@@ -130,11 +137,89 @@ static void SetWetClothPinRadiusScale(float scale)
 	}
 }
 
+class CHealthConfigInfo
+{
+public:
+	uint32_t hash;
+	float defaultHealth;
+	float defaultArmor;
+	float defaultEndurance;
+	float fatiguedHealthThreshold;
+	float injuredHealthThreshold;
+	float dyingHealthThreshold;
+	float hurtHealthThreshold;
+	float dogTakedownThreshold;
+	float writheFromBulletDamageThreshold;
+	bool meleeCardinalFatalAttackCheck;
+	bool invincible;
+};
+
+
+static std::unordered_map<uint32_t, CHealthConfigInfo> g_healthConfigs;
+static std::unordered_set<uint32_t> g_defaultHealthConfigHashes = {
+	HashString("Strong"),
+	HashString("Average"),
+	HashString("Weak"),
+	HashString("Animal"),
+	HashString("Armour"),
+	HashString("GULL"),
+	HashString("Fish"),
+	HashString("Rat"),
+	HashString("Shark"),
+	HashString("Humpback"),
+};
+
+static CHealthConfigInfo* (*g_origGetHealthInfo)(hook::FlexStruct*);
+static CHealthConfigInfo* GetHealthInfo(hook::FlexStruct* pedPtr)
+{
+	if (!pedPtr)
+		return nullptr;
+
+	// Get model info: CPed + 0x20
+	hook::FlexStruct* modelInfo = pedPtr->Get<hook::FlexStruct*>(_pedModelInfoOffset);
+	if (!modelInfo)
+		return nullptr;
+
+	// Get personality index: modelInfo + 0x14A
+	uint16_t personalityIndex = modelInfo->Get<uint16_t>(_pedPersonalityIndexOffset);
+	if (personalityIndex >= g_pedPersonalities->GetCount())
+		return nullptr;
+
+	const auto& personality = g_pedPersonalities->Get(personalityIndex);
+	hook::FlexStruct* personalityFS = (hook::FlexStruct*)&personality;
+	
+	uint32_t healthHash = personalityFS->Get<uint32_t>(_pedHealthConfigHashOffset);
+
+	auto it = g_healthConfigs.find(healthHash);
+	if (it != g_healthConfigs.end())
+	{
+		return &it->second;
+	}
+
+	const CHealthConfigInfo* info = g_origGetHealthInfo(pedPtr);
+	if (info)
+	{
+		g_healthConfigs[info->hash] = *info;
+		return &g_healthConfigs[info->hash];
+	}
+	else
+	{
+		trace("No health config found for ped personality hash: %08x\n", healthHash);
+		return nullptr;
+	}
+}
+
 static HookFunction initFunction([]()
 {
 	_id_CPedHeadBlendData = hook::get_address<uint64_t*>(hook::get_pattern("48 39 5E 38 74 1B 8B 15 ? ? ? ? 48 8D 4F 10 E8", 8));
 	_baseClipsetLocation = (uintptr_t)hook::get_pattern("48 8B 42 ? 48 85 C0 75 05 E8");
 	_pedSweatOffset = *hook::get_pattern<uint32_t>("72 04 41 0F 28 D0 F3 0F 10 8B", 10);
+
+	_pedModelInfoOffset = *hook::get_pattern<uint8_t>("48 8B 41 ? 33 C9 0F BF 90", 3);
+	_pedPersonalityIndexOffset = *hook::get_pattern<uint32_t>("0F BF 90 ? ? ? ? 48 8B 05 ? ? ? ? 48 69 D2 ? ? ? ? 44 8B 54", 3);
+	_pedHealthConfigHashOffset = *hook::get_pattern<uint8_t>("0F BF 90 ? ? ? ? 48 8B 05 ? ? ? ? 48 69 D2 ? ? ? ? 44 8B 54", 25);
+
+	g_origGetHealthInfo = hook::trampoline(hook::get_pattern("48 8B 41 20 33 C9 0F BF 90 ? ? ? ? 48 8B 05 ? ? ? ? 48 69 D2"), GetHealthInfo);
 
 	g_pedPersonalities = hook::get_address<decltype(g_pedPersonalities)>(hook::get_call(hook::get_pattern<char>("8B 86 B0 00 00 00 BB D5 46 DF E4 85 C0", 0x12)) + 15, 3, 7);
 
@@ -291,7 +376,9 @@ static HookFunction initFunction([]()
 	static std::map<uint32_t, uint16_t> initialPersonalities;
 	static std::list<std::tuple<uint32_t, uint16_t>> undoPersonalities;
 
-	
+	static std::unordered_map<uint32_t, CHealthConfigInfo> initialHealthConfigs;
+	static std::unordered_map<uint32_t, uint32_t> undoHealthConfigs;
+
 	OnKillNetworkDone.Connect([]()
 	{
 		for (auto& [pedModel, personality] : undoPersonalities)
@@ -305,6 +392,27 @@ static HookFunction initFunction([]()
 			}
 		}
 
+		for (auto& [pedModel, savedHealthConfig] : undoHealthConfigs)
+		{
+			auto archetype = GetPedModel(pedModel);
+
+			if (archetype)
+			{
+				auto personalityIndex = reinterpret_cast<hook::FlexStruct*>(archetype)->Get<uint16_t>(_pedPersonalityIndexOffset);
+				if (personalityIndex != 0xFFFF && personalityIndex < g_pedPersonalities->GetCount())
+				{
+					auto& personality = g_pedPersonalities->Get(personalityIndex);
+					if (personality.healthConfigHash != savedHealthConfig)
+					{
+						personality.healthConfigHash = savedHealthConfig;
+					}
+				}
+			}
+		}
+
+		g_healthConfigs.clear();
+
+		undoHealthConfigs.clear();
 		undoPersonalities.clear();
 		SetWetClothPinRadiusScale(0.3f);
 	});
@@ -457,5 +565,259 @@ static HookFunction initFunction([]()
 		float scale = context.GetArgument<float>(0);
 		float newScale = std::isnan(scale) ? 0.3f : std::clamp(scale, 0.0f, 1.0f);
 		SetWetClothPinRadiusScale(newScale);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PED_MODEL_HEALTH_CONFIG", [](fx::ScriptContext& context)
+	{
+		auto pedModel = context.GetArgument<uint32_t>(0);
+		auto archetype = GetPedModel(pedModel);
+		uint32_t healthHash = 0;
+
+		if (archetype)
+		{
+			auto personalityIndex = reinterpret_cast<hook::FlexStruct*>(archetype)->Get<uint16_t>(_pedPersonalityIndexOffset);
+			if (personalityIndex < g_pedPersonalities->GetCount())
+			{
+				healthHash = g_pedPersonalities->Get(personalityIndex).healthConfigHash;
+			}
+		}
+
+		context.SetResult<uint32_t>(healthHash);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PED_MODEL_HEALTH_CONFIG", [](fx::ScriptContext& context)
+	{
+		auto pedModel = context.GetArgument<uint32_t>(0);
+		std::string healthConfigName = context.GetArgument<const char*>(1);
+		uint32_t healthConfigHash = HashString(healthConfigName);
+
+		auto archetype = GetPedModel(pedModel);
+
+		if (archetype)
+		{
+			auto personalityIndex = reinterpret_cast<hook::FlexStruct*>(archetype)->Get<uint16_t>(_pedPersonalityIndexOffset);
+			if (personalityIndex != 0xFFFF)
+			{
+				auto& personality = g_pedPersonalities->Get(personalityIndex);
+				auto oldHash = personality.healthConfigHash;
+
+				personality.healthConfigHash = healthConfigHash;
+
+				// save only first change
+				if (undoHealthConfigs.find(pedModel) == undoHealthConfigs.end())
+				{
+					undoHealthConfigs[pedModel] = oldHash;
+				}
+			}
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("ADD_HEALTH_CONFIG", [](fx::ScriptContext& context)
+	{
+		std::string configName = context.GetArgument<const char*>(0);
+		uint32_t nameHash = HashString(configName);
+
+		// Disallow if this hash belongs to a default config
+		if (g_defaultHealthConfigHashes.find(nameHash) != g_defaultHealthConfigHashes.end())
+		{
+			trace("Cannot create a new health config: '%s' is a reserved default config name.\n", configName.c_str());
+			return;
+		}
+
+		if (g_healthConfigs.find(nameHash) != g_healthConfigs.end())
+		{
+			trace("Cannot create a new health config: '%s' already exists.\n", configName.c_str());
+			return;
+		}
+
+		float defaultHealth = context.GetArgument<float>(1);
+		float defaultArmor = context.GetArgument<float>(2);
+		float defaultEndurance = context.GetArgument<float>(3);
+		float fatiguedHealthThreshold = context.GetArgument<float>(4);
+		float injuredHealthThreshold = context.GetArgument<float>(5);
+		float dyingHealthThreshold = context.GetArgument<float>(6);
+		float hurtHealthThreshold = context.GetArgument<float>(7);
+		float dogTakedownThreshold = context.GetArgument<float>(8);
+		float writheFromBulletDamageThreshold = context.GetArgument<float>(9);
+		bool meleeCardinalFatalAttackCheck = context.GetArgument<bool>(10);
+		bool isInvincible = context.GetArgument<bool>(11);
+
+		CHealthConfigInfo newConfig{};
+		newConfig.hash = nameHash;
+		newConfig.defaultHealth = defaultHealth;
+		newConfig.defaultArmor = defaultArmor;
+		newConfig.defaultEndurance = defaultEndurance;
+		newConfig.fatiguedHealthThreshold = fatiguedHealthThreshold;
+		newConfig.injuredHealthThreshold = injuredHealthThreshold;
+		newConfig.dyingHealthThreshold = dyingHealthThreshold;
+		newConfig.hurtHealthThreshold = hurtHealthThreshold;
+		newConfig.dogTakedownThreshold = dogTakedownThreshold;
+		newConfig.writheFromBulletDamageThreshold = writheFromBulletDamageThreshold;
+		newConfig.meleeCardinalFatalAttackCheck = meleeCardinalFatalAttackCheck;
+		newConfig.invincible = isInvincible;
+
+		g_healthConfigs.emplace(nameHash, newConfig);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("REMOVE_HEALTH_CONFIG", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t nameHash = HashString(name);
+
+		// Disallow if this hash belongs to a default config
+		if (g_defaultHealthConfigHashes.find(nameHash) != g_defaultHealthConfigHashes.end())
+		{
+			trace("Cannot remove health config: '%s' is a reserved default config name.\n", name.c_str());
+			return;
+		}
+
+		auto it = g_healthConfigs.find(nameHash);
+		if (it != g_healthConfigs.end())
+		{
+			g_healthConfigs.erase(it);
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_DEFAULT_HEALTH", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float newValue = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.defaultHealth = newValue;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_DEFAULT_ARMOR", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.defaultArmor = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_DEFAULT_ENDURANCE", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.defaultEndurance = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_FATIGUED_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.fatiguedHealthThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_INJURED_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.injuredHealthThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_DYING_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.dyingHealthThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_HURT_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.hurtHealthThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_DOG_TAKEDOWN_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.dogTakedownThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_WRITHE_FROM_BULLET_THRESHOLD", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		float value = context.GetArgument<float>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.writheFromBulletDamageThreshold = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_MELEE_FATAL_ATTACK", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		bool value = context.GetArgument<bool>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.meleeCardinalFatalAttackCheck = value;
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_HEALTH_CONFIG_INVINCIBLE", [](fx::ScriptContext& context)
+	{
+		std::string name = context.GetArgument<const char*>(0);
+		uint32_t configHash = HashString(name);
+		bool value = context.GetArgument<bool>(1);
+
+		auto it = g_healthConfigs.find(configHash);
+		if (it != g_healthConfigs.end())
+		{
+			it->second.invincible = value;
+		}
 	});
 });

--- a/ext/native-decls/AddHealthConfig.md
+++ b/ext/native-decls/AddHealthConfig.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## ADD_HEALTH_CONFIG
+
+```c
+void ADD_HEALTH_CONFIG(char* configName, float defaultHealth, float defaultArmor, float defaultEndurance, float fatiguedHealthThreshold, float injuredHealthThreshold, float dyingHealthThreshold, float hurtHealthThreshold, float dogTakedownThreshold, float writheFromBulletThreshold, BOOL meleeCardinalFatalAttack, BOOL invincible);
+```
+
+Adds new health config.
+
+## Parameters
+* **configName**: Name of health config. Cannot be default game health config name.
+* **defaultHealth**: Default health value.
+* **defaultArmor**: Default armor value.
+* **fatiguedHealthThreshold**: Fatigued health threshold value.
+* **injuredHealthThreshold**: Injured health threshold value.
+* **dyingHealthThreshold**: Dying health threshold value.
+* **fatiguedHealthThreshold**: Fatigued health threshold value.
+* **hurtHealthThreshold**: Hurt health threshold value.
+* **dogTakedownThreshold**: Dog takedown threshold value.
+* **writheFromBulletThreshold**: Writhe from bulled threshold value.
+* **meleeCardinalFatalAttack**: Melee cardinal fatal attack check value.
+* **invincible**: Invincible value.
+

--- a/ext/native-decls/GetPedModelHealthConfig.md
+++ b/ext/native-decls/GetPedModelHealthConfig.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PED_MODEL_HEALTH_CONFIG
+
+```c
+Hash GET_PED_MODEL_HEALTH_CONFIG(Hash modelHash);
+```
+
+Gets a ped model's health config.
+
+## Examples
+```lua
+GetPedModelHealthConfig(`mp_f_freemode_01`)
+```
+
+## Parameters
+* **modelHash**: Ped's model.
+

--- a/ext/native-decls/RemoveHealthConfig.md
+++ b/ext/native-decls/RemoveHealthConfig.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REMOVE_HEALTH_CONFIG
+
+```c
+void REMOVE_HEALTH_CONFIG(char* configName);
+```
+
+Removes health config.
+
+## Parameters
+* **configName**: Removes config name. Cannot be default game health config name.
+

--- a/ext/native-decls/SetHealthConfigDefaultArmor.md
+++ b/ext/native-decls/SetHealthConfigDefaultArmor.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_DEFAULT_ARMOR
+
+```c
+void SET_HEALTH_CONFIG_DEFAULT_ARMOR(char* configName, float newValue);
+```
+
+Sets default armor value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigDefaultEndurance.md
+++ b/ext/native-decls/SetHealthConfigDefaultEndurance.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_DEFAULT_ENDURANCE
+
+```c
+void SET_HEALTH_CONFIG_DEFAULT_ENDURANCE(char* configName, float newValue);
+```
+
+Sets default endurance value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigDefaultHealth.md
+++ b/ext/native-decls/SetHealthConfigDefaultHealth.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_DEFAULT_HEALTH
+
+```c
+void SET_HEALTH_CONFIG_DEFAULT_HEALTH(char* configName, float newValue);
+```
+
+Sets default health value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigDogTakedownThreshold.md
+++ b/ext/native-decls/SetHealthConfigDogTakedownThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_DOG_TAKEDOWN_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_DOG_TAKEDOWN_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default dog takedown threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigDyingThreshold.md
+++ b/ext/native-decls/SetHealthConfigDyingThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_DYING_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_DYING_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default dying health threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigFatiguedThreshold.md
+++ b/ext/native-decls/SetHealthConfigFatiguedThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_FATIGUED_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_FATIGUED_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default fatigued health threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigHurtThreshold.md
+++ b/ext/native-decls/SetHealthConfigHurtThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_HURT_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_HURT_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default hurt health threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigInjuredThreshold.md
+++ b/ext/native-decls/SetHealthConfigInjuredThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_INJURED_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_INJURED_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default injured health threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigInvincible.md
+++ b/ext/native-decls/SetHealthConfigInvincible.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_INVINCIBLE
+
+```c
+void SET_HEALTH_CONFIG_INVINCIBLE(char* configName, BOOL newValue);
+```
+
+Sets default invincible value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigMeleeFatalAttack.md
+++ b/ext/native-decls/SetHealthConfigMeleeFatalAttack.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_MELEE_FATAL_ATTACK
+
+```c
+void SET_HEALTH_CONFIG_MELEE_FATAL_ATTACK(char* configName, BOOL newValue);
+```
+
+Sets default melee cardinal fatal attack value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetHealthConfigWritheFromBulletThreshold.md
+++ b/ext/native-decls/SetHealthConfigWritheFromBulletThreshold.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_HEALTH_CONFIG_WRITHE_FROM_BULLET_THRESHOLD
+
+```c
+void SET_HEALTH_CONFIG_WRITHE_FROM_BULLET_THRESHOLD(char* configName, float newValue);
+```
+
+Sets default writhe from bullet threshold value for specific health config.
+
+## Parameters
+* **configName**: Name of health config.
+* **newValue**: Value
+

--- a/ext/native-decls/SetPedModelHealthConfig.md
+++ b/ext/native-decls/SetPedModelHealthConfig.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PED_MODEL_HEALTH_CONFIG
+
+```c
+void SET_PED_MODEL_HEALTH_CONFIG(Hash modelHash, char* configName);
+```
+
+Sets a ped model's health config.
+Takes effect only after setting player model with `SET_PLAYER_MODEL`.
+
+## Examples
+```lua
+local pedModel = `mp_f_freemode_01`
+SetPedModelHealthConfig(pedModel, "Strong")
+
+SetPlayerModel(PlayerId(), pedModel)
+SetPedDefaultComponentVariation(PlayerPedId())
+
+```
+
+## Parameters
+* **modelHash**: Ped's model.
+* **configName**: Name of health config.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Unfortunately `pedhealth.meta` cannot be streamed via DATA_FILE entries, so decided to add natives to manipulate those values. It allows to change ped model health config, add new health config, remove health config and modify values of existing health configs.

This will allow to set for example default health value that users spawn with on the server without need to use sethealth/setmaxhealth natives. Didn't test functionality of all fields, but for example dying threshold allows us to change default "100" value that our ped dies to other values.
...


### How is this PR achieving the goal
Hooked directly to function that returns health config from array, if it exists in our map then return modified values instead.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Fivem natives

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:**  3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


