### PR TITLE
tweak(exports): wrap non-table returns in table

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -599,7 +599,7 @@ funcref_mt = msgpack.extend({
 
 			rvs[1].__cfx_async_retval(function(r, e)
 				if r then
-					p:resolve(r)
+                			p:resolve(type(r) == "table" and r or { r })
 				elseif e then
 					p:reject(e)
 				end


### PR DESCRIPTION
### Goal of this PR
If a async C# export (e.g., `async Coroutine<string>) returns a non-table value via __cfx_async_retval, the scheduler would return nil when trying to table.unpack the result. This change wraps the result in a table if it isn't one already, ensuring consistent handling and preventing unexpected behaviors.


This would then allow to have async C# exports that return a value without allocating a new array.


### How is this PR achieving the goal
Check if the result is a table, if not wrap it in one.

### This PR applies to the following area(s)
ScRT: Lua

### Successfully tested on
**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [X] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.

