### PR TITLE
fix(server): fix `GET` heading & rotation natives for objects RedM

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -520,6 +520,7 @@ struct CVehicleGameStateNodeData
 struct CEntityOrientationNodeData
 {
 	compressed_quaternion<11> quat;
+	float rotX, rotY, rotZ;
 };
 
 struct CDummyObjectCreationNodeData

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -296,20 +296,12 @@ struct CEntityOrientationDataNode : GenericSerializeDataNode<CEntityOrientationD
 	template<typename Serializer>
 	bool Serialize(Serializer& s)
 	{
-#if 0
-		auto rotX = state.buffer.ReadSigned<int>(9) * 0.015625f;
-		auto rotY = state.buffer.ReadSigned<int>(9) * 0.015625f;
-		auto rotZ = state.buffer.ReadSigned<int>(9) * 0.015625f;
 
-		data.rotX = rotX;
-		data.rotY = rotY;
-		data.rotZ = rotZ;
-#else
+		s.SerializeRotation(data.rotX, data.rotY, data.rotZ);
 		s.Serialize(2, data.quat.largest);
 		s.Serialize(11, data.quat.integer_a);
 		s.Serialize(11, data.quat.integer_b);
 		s.Serialize(11, data.quat.integer_c);
-#endif
 
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -383,6 +383,7 @@ static void Init()
 		}
 		else
 		{
+#ifdef STATE_FIVE
 			auto en = entity->syncTree->GetEntityOrientation();
 			auto on = entity->syncTree->GetObjectOrientation();
 
@@ -426,6 +427,16 @@ static void Init()
 					resultVec.z = glm::degrees(resultVec.z);
 				}
 			}
+#elif STATE_RDR3
+
+			auto en = entity->syncTree->GetEntityOrientation();
+			if (en)
+			{
+				resultVec.x = en->rotX * 180.0f / pi;
+				resultVec.y = en->rotY * 180.0f / pi;
+				resultVec.z = en->rotZ * 180.0f / pi;
+			}
+#endif
 		}
 	};
 


### PR DESCRIPTION
### Goal of this PR
Fixes `GET_ENTITY_HEADING` & `GET_ENTITY_ROTATION` for obejcts in RedM server side

### How is this PR achieving the goal
Adds a fix for the  natives `GET_ENTITY_HEADING` & `GET_ENTITY_ROTATION` for RedM server side, which didn't work for objects

thanks to @Korioz  for the help

### This PR applies to the following area(s)
RedM

### Successfully tested on


**Game builds:** .. 
1491
**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


