### PR TITLE
feat(server/gamestate): add a argument to onPlayerDropped

### DIFF
--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -1171,7 +1171,7 @@ namespace fx
 			if (!fx::IsBigMode() && isFinal)
 			{
 				// send every player information about the dropping client
-				events->TriggerClientEvent("onPlayerDropped", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId());
+				events->TriggerClientEvent("onPlayerDropped", std::optional<std::string_view>(), client->GetNetId(), client->GetName(), client->GetSlotId(), true);
 			}
 		}
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1545,7 +1545,7 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 									{
 										int otherSlot = plit->second;
 
-										sec->TriggerClientEvent("onPlayerDropped", fmt::sprintf("%d", client->GetNetId()), ownerNetId, ownerRef->GetName(), otherSlot);
+										sec->TriggerClientEvent("onPlayerDropped", fmt::sprintf("%d", client->GetNetId()), ownerNetId, ownerRef->GetName(), otherSlot, false);
 
 										/*NETEV playerLeftScope SERVER
 								/#*


### PR DESCRIPTION
Add an argument to onPlayerDropped to differentiate when the player really disconnected from the server or just left the onesync range

In my case it's useful, because I want to write a 3D text when someone is disconnecting from the server, but it bothers me to loop through each player server-side and find nearest players to send them a client-side event.

This code wasn't tested yet. I need to build FiveM Client and test

```lua
AddEventHandler('onPlayerDropped', function(playerId, playerName, slotId, isServerDisconnect)
    if (isServerDisconnect) then
        print(playerName .. " dropped from the server")
    else
        print(playerName .. " left your onesync range")
    end
end)
```


