### PR TITLE
feat(server): add `GET_ANIMAL_RARITY` to server RedM

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -763,6 +763,11 @@ struct CPedAINodeData
 	int decisionMaker;
 };
 
+struct DataNode_14359ec40Data
+{
+	int rarityLevel;
+};
+
 enum ePopType
 {
 	POPTYPE_UNKNOWN = 0,
@@ -858,6 +863,8 @@ public:
 	virtual CPedMovementGroupNodeData* GetPedMovementGroup() = 0;
 
 	virtual CPedAINodeData* GetPedAI() = 0;
+
+	virtual DataNode_14359ec40Data* GetDataNode_14359ec40() = 0;
 
 	virtual void CalculatePosition() = 0;
 

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -4089,6 +4089,11 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, false>
 		return hasNode ? &node->data : nullptr;
 	}
 
+	virtual DataNode_14359ec40Data* GetDataNode_14359ec40() override
+	{
+		return nullptr;
+	}
+
 	virtual void CalculatePosition() override
 	{
 		// TODO: cache it?

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Header.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Header.h
@@ -491,6 +491,13 @@ struct ParseSerializer
 		return true;
 	}
 
+	template<typename T>
+	bool SerializeSigned(int size, T& data)
+	{
+		data = state->buffer.ReadSigned<T>(size);
+		return true;
+	}
+
 	bool SerializeSigned(int size, float div, float& data)
 	{
 		data = state->buffer.ReadSignedFloat(size, div);

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -986,7 +986,60 @@ struct DataNode_14359a8b0 { };
 struct DataNode_14359aa40 { };
 struct DataNode_143598c90 { };
 struct DataNode_14359eab0 { };
-struct DataNode_14359ec40 { };
+
+struct DataNode_14359ec40 : GenericSerializeDataNode<DataNode_14359ec40>
+{
+
+	DataNode_14359ec40Data data;
+
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
+	{
+		bool unkBool = false;
+		s.Serialize(unkBool);
+
+		if (unkBool)
+		{
+			// TODO : further investigations, default values and divisors are unknown
+			// Unk booleans
+
+			for (int i = 0; i < 41; i++)
+			{
+				bool unkBool2 = false;
+				s.Serialize(unkBool2);
+			}
+
+			// Some unk floats
+			float unkFloat3 = 0.0f;
+			s.SerializeSigned(16, 1.0f, unkFloat3);
+			float unkFloat4 = 0.0f;
+			s.SerializeSigned(8, 1.0f, unkFloat4);
+			float unkFloat5 = 0.0f;
+			s.SerializeSigned(8, 1.0f, unkFloat5);
+
+			for (int i = 0; i < 20; i++)
+			{
+				float unkFloat6 = 0.0f;
+				s.SerializeSigned(16, 1.0f, unkFloat6);
+			}
+
+			float unkFloat7 = 0.0f;
+			s.SerializeSigned(8, 1.0f, unkFloat7);
+			float unkFloat8 = 0.0f;
+			s.SerializeSigned(16, 1.0f, unkFloat8);
+			float unkFloat9 = 0.0f;
+			s.SerializeSigned(16, 1.0f, unkFloat9);
+			float unkFloat10 = 0.0f;
+			s.SerializeSigned(16, 1.0f, unkFloat10);
+		}
+
+		int32_t unk11 = 0;
+		s.SerializeSigned(2, unk11);
+		s.Serialize(2, data.rarityLevel);
+		return true;
+	};
+};
+
 struct DataNode_14359a590 { };
 struct DataNode_14359abd0 { };
 struct DataNode_14359ad88 { };
@@ -1314,6 +1367,13 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 	virtual CPedAINodeData* GetPedAI() override
 	{
 		return nullptr;
+	}
+
+	virtual DataNode_14359ec40Data* GetDataNode_14359ec40() override
+	{
+		auto [hasNode, node] = this->template GetData<DataNode_14359ec40>();
+
+		return hasNode ? &node->data : nullptr;
 	}
 
 	virtual void CalculatePosition() override

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -2439,6 +2439,14 @@ static void Init()
 
 		context.SetResult(fx::SerializeObject(entityList));
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ANIMAL_RARITY", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto unkDataNode = entity->syncTree->GetDataNode_14359ec40();
+
+		return unkDataNode ? unkDataNode->rarityLevel : 0;
+	}));
+
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/GetAnimalRarity.md
+++ b/ext/native-decls/GetAnimalRarity.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: rdr3
+---
+## GET_ANIMAL_RARITY
+
+```c
+int GET_ANIMAL_RARITY(Ped ped);
+```
+
+gets the animal rarity on the server just like the client side native,
+
+## Parameters
+* **ped**: the ped entity
+


### PR DESCRIPTION
### Goal of this PR
Adds a new native to the server `GET_ANIMAL_RARITY` this is usefull for security checks instead of sending these in client events, these can be used to sometimes to get a price / items based on the rarity of the animals.
thanks to @MRV6 

### How is this PR achieving the goal
researching the node to get the rarity levels of animals for server side checks instead of clients by introducing a server native

### This PR applies to the following area(s)
RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


