### PR TITLE
tweak(cfx-ui): Use the language set in Top Servers locale setting

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/pages/HomePage/TopServers/TopServers.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/pages/HomePage/TopServers/TopServers.tsx
@@ -50,7 +50,7 @@ export const TopServersBlock = observer(function TopServersBlock() {
 
   const HomeScreenServerList = useService(HomeScreenServerListService);
 
-  const countryTitle = useServerCountryTitle(IntlService.systemLocale, IntlService.systemLocaleCountry);
+  const countryTitle = useServerCountryTitle(IntlService.locale, IntlService.localeCountry);
 
   if (HomeScreenServerList.topRegionServers.length === 0) {
     return null;
@@ -65,7 +65,7 @@ export const TopServersBlock = observer(function TopServersBlock() {
               {$L('#Home_RegionTopServers')}
             </Text>
 
-            <CountryFlag country={IntlService.systemLocaleCountry} title={countryTitle} />
+            <CountryFlag country={IntlService.localeCountry} title={countryTitle} />
           </Flex>
 
           <Title fixedOn="left" title={$L('#Home_RegionTopServers_Explainer')}>

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/intl/intl.mpMenu.ts
@@ -17,8 +17,59 @@ export function registerMpMenuIntlService(container: ServicesContainer) {
   container.registerImpl(IIntlService, MpMenuIntlService);
 }
 
+const languageToCountryMap: Record<string, string> = {
+  ar: 'SA',
+  bg: 'BG',
+  ca: 'ES',
+  cs: 'CZ',
+  da: 'DK',
+  de: 'DE',
+  en: 'US',
+  es: 'ES',
+  fa: 'IR',
+  fi: 'FI',
+  fr: 'FR',
+  hu: 'HU',
+  it: 'IT',
+  ja: 'JP',
+  ko: 'KR',
+  lt: 'LT',
+  'nb-no': 'NO',
+  nl: 'NL',
+  pl: 'PL',
+  pt: 'PT',
+  ro: 'RO',
+  ru: 'RU',
+  sv: 'SE',
+  th: 'TH',
+  tr: 'TR',
+  vi: 'VN',
+  'zh-hans': 'CN',
+  'zh-hant': 'TW'
+};
+
 @injectable()
 class MpMenuIntlService implements IIntlService {
+  readonly locale = (() => {
+    const locale = window.localStorage.getItem('language');
+    if (locale) {
+      const lcLanguage = locale.split('-')[0];
+      const ucLanguage = languageToCountryMap[locale];
+
+      if (ucLanguage) {
+        return `${lcLanguage}-${ucLanguage}`;
+      }
+    }
+
+    return this.systemLocale;
+  })();
+
+  readonly localeCountry = (() => {
+    const [_, country] = this.locale.split('-');
+
+    return country.toUpperCase();
+  })();
+
   readonly systemLocale = (() => {
     const systemLocale = mpMenu.systemLanguages[0] || 'en-US';
     const [language, country] = systemLocale.split('-');

--- a/ext/cfx-ui/src/cfx/apps/mpMenu/services/servers/list/HomeScreenServerList.service.ts
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/services/servers/list/HomeScreenServerList.service.ts
@@ -88,7 +88,7 @@ export class HomeScreenServerListService implements AppContribution {
       reviveServerListConfig({
         type: ServersListType.RegionalTop,
         locales: {
-          [this.intlService.systemLocale]: true,
+          [this.intlService.locale]: true,
         },
         sortBy: ServersListSortBy.Boosts,
         sortDir: ServerListSortDir.Desc,

--- a/ext/cfx-ui/src/cfx/common/services/intl/intl.service.ts
+++ b/ext/cfx-ui/src/cfx/common/services/intl/intl.service.ts
@@ -9,6 +9,9 @@ export function useIntlService(): IIntlService {
 export const IIntlService = defineService<IIntlService>('IntlService');
 
 export interface IIntlService {
+  readonly locale: string;
+  readonly localeCountry: string;
+
   readonly systemLocale: string;
   readonly systemLocaleCountry: string;
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Use the language set by the user instead of the system language in Top servers.


### How is this PR achieving the goal
This PR makes Top servers use the language defined in the locale setting instead of the system language.  
It retrieves the selected language from localStorage.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
cfx-ui


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


