### PR TITLE
fix(cfx-ui): unmount SettingsFlyout when hidden

### DIFF
--- a/ext/cfx-ui/src/cfx/apps/mpMenu/parts/SettingsFlyout/SettingsFlyout.tsx
+++ b/ext/cfx-ui/src/cfx/apps/mpMenu/parts/SettingsFlyout/SettingsFlyout.tsx
@@ -49,6 +49,10 @@ export const SettingsFlyout = observer(function SettingsFlyout() {
     [eventHandler, SettingsUIService],
   );
 
+  if (!SettingsUIService.visible) {
+    return null;
+  }
+
   return (
     <Flyout disableSoundEffects disabled={!SettingsUIService.visible} onClose={SettingsUIService.close} size="small">
       <Page>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix a focus-leak where closing the Settings panel while typing in Korean leaves the hidden input focused and captures subsequent keystrokes.

https://github.com/user-attachments/assets/8645b043-bdb6-4446-af51-f422482956cf

### How is this PR achieving the goal
This PR unmounts the SettingsFlyout component whenever it is hidden, preventing it from retaining focus.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
cfx-ui


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

fixes #2387

