### PR TITLE
feat(server): adds rdr3 research + new server natives

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -763,6 +763,17 @@ struct CPedAINodeData
 	int decisionMaker;
 };
 
+struct CPedVehicleNodeData
+{
+	int curVehicle;
+	int curVehicleSeat;
+	int lastVehiclePedWasIn;
+
+	int curHorse;
+	int curHorseSeat;
+	int lastHorsePedWasOn;
+};
+
 enum ePopType
 {
 	POPTYPE_UNKNOWN = 0,
@@ -868,6 +879,8 @@ public:
 	virtual bool GetScriptHash(uint32_t* scriptHash) = 0;
 
 	virtual bool IsEntityVisible(bool* visible) = 0;
+
+	virtual CPedVehicleNodeData* GetPedVehicleData() = 0;
 };
 
 enum EntityOrphanMode : uint8_t

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -4195,6 +4195,11 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, false>
 
 		return false;
 	}
+
+	virtual CPedVehicleNodeData* GetPedVehicleData() override
+	{
+		return nullptr;
+	}
 };
 
 using CAutomobileSyncTree = SyncTree<

--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -943,7 +943,86 @@ struct CGuardZoneGuardDataNode { };
 struct CGuardZonePointOfInterestFinderDataNode { };
 struct CCombatDirectorCreateUpdateDataNode { };
 struct CPedWeaponDataNode { };
-struct CPedVehicleDataNode { };
+struct CPedVehicleDataNode : GenericSerializeDataNode<CPedVehicleDataNode>
+{
+	CPedVehicleNodeData data;
+
+	bool wasInVehicle;
+	bool inVehicle;
+	bool onHorse;
+	bool wasOnHorse;
+	uint8_t seat = 0;
+
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
+	{
+
+		bool wasInVehicle = data.curVehicle != 0;
+		s.Serialize(wasInVehicle);
+
+		if (wasInVehicle)
+		{
+			s.Serialize(inVehicle);
+			s.Serialize(13, data.curVehicle);
+		}
+		else
+		{
+			data.curVehicle = 0;
+			inVehicle = false;
+		}
+
+		bool wasOnHorse = data.curHorse != 0;
+		s.Serialize(wasOnHorse);
+		if (wasOnHorse)
+		{
+			s.Serialize(onHorse);
+			s.Serialize(13, data.curHorse);
+		}
+		else
+		{
+			data.curHorse = 0;
+			onHorse = false;
+		}
+
+		if (onHorse)
+		{
+			s.Serialize(5, data.curHorseSeat);
+
+			if (data.lastHorsePedWasOn == 0)
+			{
+				data.lastHorsePedWasOn = data.curHorse;
+			}
+		}
+		else
+		{
+			data.curHorseSeat = 0;
+			if (data.lastHorsePedWasOn != data.curHorse)
+			{
+				data.lastHorsePedWasOn = data.curHorse;
+			}
+		}
+
+		if (inVehicle)
+		{
+			s.Serialize(5, data.curVehicleSeat);
+			if (data.lastVehiclePedWasIn == 0)
+			{
+				data.lastVehiclePedWasIn = data.curVehicle;
+			}
+		}
+		else
+		{
+			data.curVehicleSeat = 0;
+
+			if (data.lastVehiclePedWasIn != data.curVehicle)
+			{
+				data.lastVehiclePedWasIn = data.curVehicle;
+			}
+		}
+
+		return true;
+	}
+};
 struct CPlayerCharacterCreatorDataNode { };
 struct CPlayerAmbientModelStreamingDataNode { };
 struct CPlayerVoiceDataNode { };
@@ -1398,6 +1477,13 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 	{
 		*visible = true;
 		return true;
+	}
+
+	virtual CPedVehicleNodeData* GetPedVehicleData() override
+	{
+		auto [hasNode, node] = this->template GetData<CPedVehicleDataNode>();
+
+		return hasNode ? &node->data : nullptr;
 	}
 };
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -2439,6 +2439,135 @@ static void Init()
 
 		context.SetResult(fx::SerializeObject(entityList));
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_SEAT_PED_IS_USING", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		 int currentSeat = -3;
+		 auto resourceManager = fx::ResourceManager::GetCurrent();
+		 auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+		 auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+#ifdef STATE_RD3
+
+		 auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		 if (!pedVehicleData)
+			 return -3;
+
+		 const int horseSeat = pedVehicleData->curHorseSeat;
+		 const int vehicleSeat = pedVehicleData->curVehicleSeat;
+
+		 if (horseSeat != 0)
+		 {
+			 currentSeat = horseSeat - 2;
+		 }
+		 else if (vehicleSeat != 0)
+		 {
+			 currentSeat = vehicleSeat - 2;
+		 }
+#else
+		 auto pedGameState = entity->syncTree->GetPedGameState();
+		 if (!pedGameState)
+			 return -3;
+		 currentSeat = pedGameState->curVehicleSeat - 2;
+
+#endif
+
+		 return currentSeat;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_PED_IN_ANY_VEHICLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		 bool inVehicle = false;
+
+#ifdef STATE_RD3
+		 auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		 if (!pedVehicleData)
+			 return false;
+
+		 inVehicle = pedVehicleData->curVehicleSeat != 0;
+#else
+		 auto pedGameState = entity->syncTree->GetPedGameState();
+		 if (!pedGameState)
+			 return false;
+
+		 inVehicle = pedGameState->curVehicleSeat != -1;
+#endif
+
+		 return inVehicle;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_PED_IN_VEHICLE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		 const int vehEntity = context.GetArgument<int>(1);
+		 if (!vehEntity)
+			 return false;
+
+		 int vehicleId = 0;
+		 bool inVehicle = false;
+
+#ifdef STATE_RD3
+
+		 auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		 if (!pedVehicleData)
+			 return false;
+
+		 inVehicle = pedVehicleData->curVehicleSeat != 0;
+		 vehicleId = pedVehicleData->curVehicle;
+#else
+		 auto pedGameState = entity->syncTree->GetPedGameState();
+		 if (!pedGameState)
+			 return false;
+		 inVehicle = pedGameState->curVehicleSeat != -1;
+		 vehicleId = pedGameState->curVehicle != -1 ? pedGameState->curVehicle : 0;
+
+#endif
+
+		 if (!vehicleId || !inVehicle)
+			 return false;
+
+		 auto resourceManager = fx::ResourceManager::GetCurrent();
+		 auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+		 auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+		 auto veh = gameState->GetEntity(vehEntity);
+		 if (!veh)
+			 return false;
+
+		 return vehicleId == veh->handle;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_MOUNT", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		 auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		 if (!pedVehicleData)
+			 return 0;
+
+		 const bool isSeated = pedVehicleData->curHorseSeat != 0;
+		 if (!isSeated)
+			 return 0;
+
+		 auto resourceManager = fx::ResourceManager::GetCurrent();
+		 auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+		 auto gameState = instance->GetComponent<fx::ServerGameState>();
+
+		 auto horseEntity = gameState->GetEntity(0, pedVehicleData->curHorse);
+
+		 if (!IsEntityValid(horseEntity))
+		 {
+			 return 0;
+		 }
+
+		 const int ent = gameState->MakeScriptHandle(horseEntity);
+		 return ent;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_PED_ON_MOUNT", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		   auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		   if (!pedVehicleData)
+			   
+		   return pedVehicleData->curHorseSeat != 0;
+	}));
 }
 
 static InitFunction initFunction([]()

--- a/ext/native-decls/GetMount.md
+++ b/ext/native-decls/GetMount.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+game: rdr3
+---
+## GET_MOUNT
+
+```c
+int GET_MOUNT(Ped ped)
+```
+returns the entity of the mount the ped is on
+
+## Parameters
+* **ped**: the ped id
+

--- a/ext/native-decls/GetSeatPedIsUsing.md
+++ b/ext/native-decls/GetSeatPedIsUsing.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+game: shared
+---
+## GET_SEAT_PED_IS_USING
+
+```c
+int GET_SEAT_PED_IS_USING(Ped ped)
+```
+returns the seat index of the specified ped, if not seated or not in vehicle returns -3 just client natives
+
+## Parameters
+* **ped**: the ped id
+

--- a/ext/native-decls/IsPedInAnyVehicle.md
+++ b/ext/native-decls/IsPedInAnyVehicle.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: shared
+---
+## IS_PED_IN_ANY_VEHICLE
+
+```c
+BOOL IS_PED_IN_ANY_VEHICLE(Ped ped)
+```
+returns true if the specified ped is in any vehicle
+
+## Parameters
+* **ped**: the ped id
+
+

--- a/ext/native-decls/IsPedInVehicle.md
+++ b/ext/native-decls/IsPedInVehicle.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: server
+game: shared
+---
+## IS_PED_IN_VEHICLE
+
+```c
+BOOL IS_PED_IN_VEHICLE(Ped ped, Vehicle vehicle)
+```
+returns true if the specified ped is in the speficied vehicle
+
+## Parameters
+* **ped**: the ped id
+* **vehicle**: the vehicle id
+

--- a/ext/native-decls/IsPedOnMount.md
+++ b/ext/native-decls/IsPedOnMount.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: server
+game: rdr3
+---
+## IS_PED_ON_MOUNT
+
+```c
+BOOL IS_PED_ON_MOUNT(Ped ped)
+```
+returns true if the specified ped is on a mount
+
+## Parameters
+* **ped**: the ped id
+


### PR DESCRIPTION
### Goal of this PR
Add the ability in RedM to better manage networked vehicles and horses on the server side by calling these natives. This enables more secure scripts against cheaters and system abuse.

CPedVehicleDataNode was researched to achieve this goal.

Vehicle natives were made compatible with FiveM and properly Tested.

-  `IS_PED_ON_MOUNT`  just like the client 
-  `GET_MOUNT`   just like the client 
-  `IS_PED_IN_VEHICLE` just like the client FiveM/RedM
-  `IS_PED_IN_ANY_VEHICLE` just like the client FiveM/RedM
-  `GET_SEAT_PED_IS_USING` just like the client RedM, works in FiveM too


thanks to @Korioz  for the help

### How is this PR achieving the goal
By adding these natives and with the rdr3 research we will be able to secure scripts and manage vehicle/horse systems unlike before in RedM

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RedM
FiveM *vehicles native support only*

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


