### PR TITLE
fix(server): fix `GET_VEHICLE_PED_IS_IN` for RedM

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1245,33 +1245,51 @@ static void Init()
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_VEHICLE_PED_IS_IN", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
-		auto node = entity->syncTree->GetPedGameState();
-		bool lastVehicleArg = context.GetArgument<bool>(1);
+		 bool lastVehicleArg = context.GetArgument<bool>(1);
 
+		 // get the current resource manager
+		 auto resourceManager = fx::ResourceManager::GetCurrent();
 
-		// get the current resource manager
-		auto resourceManager = fx::ResourceManager::GetCurrent();
+		 // get the owning server instance
+		 auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
 
-		// get the owning server instance
-		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+		 // get the server's game state
+		 auto gameState = instance->GetComponent<fx::ServerGameState>();
 
-		// get the server's game state
-		auto gameState = instance->GetComponent<fx::ServerGameState>();
+		 int lastVeh = 0;
+		 int curVeh = 0;
 
-		if (!node)
-			return (uint32_t)0;
+#ifdef STATE_RDR3
+		 auto pedVehicleData = entity->syncTree->GetPedVehicleData();
+		 if (!pedVehicleData)
+			 return (uint32_t)0;
 
-		// If ped is not in a vehicle, or was not in a previous vehicle (depending on the lastVehicleArg) return 0
-		if ((lastVehicleArg == true && node->lastVehiclePedWasIn == -1) || (lastVehicleArg == false && node->curVehicle == -1))
-			return (uint32_t)0;
+		 if ((lastVehicleArg == true && pedVehicleData->lastVehiclePedWasIn == 0) || (lastVehicleArg == false && pedVehicleData->curVehicle == 0))
+			 return (uint32_t)0;
 
-		auto returnEntity = lastVehicleArg == true ? gameState->GetEntity(0, node->lastVehiclePedWasIn) : gameState->GetEntity(0, node->curVehicle);
+		 lastVeh = pedVehicleData->lastVehiclePedWasIn;
+		 curVeh = pedVehicleData->curVehicle;
 
-		if (!returnEntity)
-			return (uint32_t)0;
+#else
+		 auto node = entity->syncTree->GetPedGameState();
+		 if (!node)
+			 return (uint32_t)0;
 
-		// Return the entity
-		return gameState->MakeScriptHandle(returnEntity);
+		 // If ped is not in a vehicle, or was not in a previous vehicle (depending on the lastVehicleArg) return 0
+		 if ((lastVehicleArg == true && node->lastVehiclePedWasIn == -1) || (lastVehicleArg == false && node->curVehicle == -1))
+			 return (uint32_t)0;
+
+		 lastVeh = node->lastVehiclePedWasIn;
+		 curVeh = node->curVehicle;
+#endif
+
+		 auto returnEntity = lastVehicleArg == true ? gameState->GetEntity(0, lastVeh) : gameState->GetEntity(0, curVeh);
+
+		 if (!returnEntity)
+			 return (uint32_t)0;
+
+		 // Return the entity
+		 return gameState->MakeScriptHandle(returnEntity);
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_PED_IN_VEHICLE_SEAT", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)


### PR DESCRIPTION
### Goal of this PR
The goal is to fix this native for RedM usage where previously was working only for Fivem

this Pr is dependent on this #3495 to be merged

### How is this PR achieving the goal
by fixing the native for RedM developers can use it to get a vehicle and make their own security checks

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1490
**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


