### PR TITLE
fix(scripting): throw error for function references

### DIFF
--- a/code/client/clrcore-v2/Debug.cs
+++ b/code/client/clrcore-v2/Debug.cs
@@ -61,9 +61,13 @@ namespace CitizenFX.Core
 
 		internal static void PrintError(Exception what, string where = null)
 		{
+			WriteLine(CreateError(what, where));
+		}
+
+		internal static string CreateError(Exception what, string where = null)
+		{
 			where = where != null ? " in " + where : "";
-			WriteLine($"^1SCRIPT ERROR{where}: {what.GetType().FullName}: {what.Message}^7");
-			WriteLine(what.StackTrace.ToString());
+			return $"^1SCRIPT ERROR{where}: {what.GetType().FullName}: {what.Message}^7\n" + what.StackTrace.ToString();
 		}
 
 		/*[SecuritySafeCritical]

--- a/code/client/clrcore-v2/Interop/LocalFunction.cs
+++ b/code/client/clrcore-v2/Interop/LocalFunction.cs
@@ -44,8 +44,21 @@ namespace CitizenFX.Core
 		[SecuritySafeCritical]
 		internal unsafe Coroutine<object> Invoke(object[] args)
 		{
-			object[] returnData = MsgPackDeserializer.DeserializeArray(ScriptInterface.InvokeFunctionReference(m_reference, new InPacket(args).value));
-			if (returnData != null && returnData.Length > 0)
+			object[] values = MsgPackDeserializer.DeserializeArray(ScriptInterface.InvokeFunctionReference(m_reference, new InPacket(args).value));
+
+			if (!(values[0] is bool success))
+			{
+				return null;
+			}
+
+			if (!success)
+			{
+				var errorMessage = values[1] as string;
+
+				throw new Exception(errorMessage);
+			}
+
+			if (values[1] is object[] returnData && returnData.Length > 0)
 			{
 				var result = returnData[0];
 

--- a/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
+++ b/code/client/clrcore-v2/Interop/ReferenceFunctionManager.cs
@@ -126,9 +126,9 @@ namespace CitizenFX.Core
 			}
 			catch (Exception e)
 			{
+				var errorMessage = Debug.CreateError(e.InnerException ?? e, "reference call");
 
-				Debug.PrintError(e.InnerException ?? e, "reference call");
-				retval = null;
+				retval = MsgPackSerializer.Serialize(new object[] { false, errorMessage });
 			}
 		}
 
@@ -148,7 +148,9 @@ namespace CitizenFX.Core
 				}
 				catch (Exception ex)
 				{
-					Debug.WriteException(ex, funcRef.m_method, args, "reference function");
+					var errorMessage = Debug.CreateError(ex, "reference function");
+
+					return MsgPackSerializer.Serialize(new object[] { false, errorMessage });
 				}
 
 				if (result is Coroutine coroutine)
@@ -160,7 +162,7 @@ namespace CitizenFX.Core
 							Debug.Write(coroutine.Exception);
 						}
 
-						return MsgPackSerializer.Serialize(new[] { coroutine.GetResultNonThrowing(), coroutine.Exception?.ToString() });
+						return MsgPackSerializer.Serialize(new object[] { true, new[] { coroutine.GetResultNonThrowing(), coroutine.Exception?.ToString() } });
 					}
 					else
 					{
@@ -179,18 +181,19 @@ namespace CitizenFX.Core
 							}
 						};
 
-						return MsgPackSerializer.Serialize(new object[] { returnDictionary });
+						return MsgPackSerializer.Serialize(new object[] { true, returnDictionary });
 					}
 				}
 
-				return MsgPackSerializer.Serialize(new[] { result });
+				return MsgPackSerializer.Serialize(new[] { true, result });
 			}
 			else
 			{
 				Debug.WriteLine($"No such reference for {reference}.");
 			}
 
-			return new byte[] { 0xC0 }; // return nil
+			// return nil
+			return MsgPackSerializer.Serialize(new object[] { false, null });
 		}
 	}
 }

--- a/code/client/clrcore/FunctionReference.cs
+++ b/code/client/clrcore/FunctionReference.cs
@@ -52,7 +52,7 @@ namespace CitizenFX.Core
                 Debug.WriteLine("No such reference for {0}.", reference);
 
                 // return nil
-                return new byte[] { 0xC0 };
+                return MsgPackSerializer.Serialize(new object[] { false, null });
             }
 
             var method = funcRef.m_method;
@@ -81,7 +81,7 @@ namespace CitizenFX.Core
 				};
 			}
 
-			return MsgPackSerializer.Serialize(new[] { rv });
+			return MsgPackSerializer.Serialize(new object[] { true, new[] { rv } });
         }
 
         public static int Duplicate(int reference)

--- a/code/client/clrcore/MsgPackDeserializer.cs
+++ b/code/client/clrcore/MsgPackDeserializer.cs
@@ -266,9 +266,21 @@ namespace CitizenFX.Core
 
 				var returnByteData = remoteFunctionReference.InvokeNative(byteData);
 
-				var returnData = Deserialize(returnByteData) as List<object>;
+				var result = Deserialize(returnByteData) as List<object>;
 
-				if (returnData == null || returnData.Count == 0)
+				if (!(result[0] is bool success))
+				{
+					return null;
+				}
+
+				if (!success)
+				{
+					var errorMessage = result[1] as string;
+
+					throw new Exception(errorMessage);
+				}
+
+				if (!(result[1] is List<object> returnData) || returnData.Count == 0)
 				{
 					return null;
 				}

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -92,9 +92,10 @@ const EXT_LOCALFUNCREF = 11;
 
 		return function (...args) {
 			return runWithBoundaryEnd(() => {
+				let success = false;
 				let retvals = null;
 				try {
-					retvals = unpack(fnRef(pack(args)));
+					[success, ...retvals] = unpack(fnRef(pack(args)));
 				} catch (e) {
 				}
 
@@ -112,6 +113,12 @@ const EXT_LOCALFUNCREF = 11;
 					}
 
 					throw new Error(errorMessage);
+				}
+
+				if (success === false) {
+					const err = new Error(retvals[0]);
+					err.stack = '';
+					throw err;
 				}
 
 				switch (retvals.length) {
@@ -176,14 +183,15 @@ const EXT_LOCALFUNCREF = 11;
 		if (!refFunctionsMap.has(ref)) {
 			console.error('Invalid ref call attempt:', ref);
 
-			return pack([]);
+			return pack([false]);
 		}
 
 		try {
 			return runWithBoundaryStart(() => {
 				const rv = refFunctionsMap.get(ref).callback(...unpack(argsSerialized));
 				if (rv instanceof Promise) {
-					return pack([{'__cfx_async_retval': (cb) => {
+					return pack([true, {
+						'__cfx_async_retval': (cb) => {
 						rv.then(v => {
 							if (cb != null)
 								cb([v], null);
@@ -200,14 +208,13 @@ const EXT_LOCALFUNCREF = 11;
 								cb(null, msg);
 							}
 						});
-					}}]);
 				}
-				return pack([rv]);
+					}]);
+				}
+				return pack([true, rv]);
 			});
 		} catch (e) {
-			global.printError('call ref', e);
-
-			return pack(null);
+			return pack([false, getError('call ref', e)]);
 		}
 	});
 
@@ -598,6 +605,8 @@ const EXT_LOCALFUNCREF = 11;
 							try {
 								return exportsCallbackCache[resource][k](...args);
 							} catch (e) {
+								console.log(e);
+
 								throw new Error(`An error occurred while calling export ${k} of resource ${resource} - see above for details`);
 							}
 						};


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Return the result error when function references throw them.
This both fixes `pcall` not being able to catch and prevent errors from being printed, but also improves the error message(s) when the function reference isn't wrapped in a `pcall`.

#### Before
With pcall:
![image](https://github.com/user-attachments/assets/f6ec4342-9d37-4567-b502-ed309cb0ea90)
Without pcall:
![image](https://github.com/user-attachments/assets/5d824a02-9bb7-4498-8f82-57e8d7b4084a)

#### After
With pcall:
![image](https://github.com/user-attachments/assets/c8c280b7-8ecb-485e-bf66-e19b5cca37df)
Without pcall:
![image](https://github.com/user-attachments/assets/fdb354b1-c06a-4032-b5ff-732601cf8d8d)


### How is this PR achieving the goal

Error handling for function references is done in the scheduler, so when an error is detected, simply throw it rather than printing it and throwing `nil`.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

Fixes #3501
