### PR TITLE
feat(extra-natives-five): Add natives to modify fall damage

### DIFF
--- a/code/components/extra-natives-five/include/GameValueStub.h
+++ b/code/components/extra-natives-five/include/GameValueStub.h
@@ -40,4 +40,13 @@ struct GameValueStub
 	{
 		hook::put<int32_t>(location, (intptr_t)m_address - (intptr_t)location - offset);
 	}
+
+	inline void SetLocation(void* location, ptrdiff_t offset, ptrdiff_t instruction_size)
+	{
+		intptr_t rip = (intptr_t)location + instruction_size;
+
+		int32_t relOffset = (int32_t)((intptr_t)m_address - rip);
+
+		hook::put<int32_t>((char*)location + offset, relOffset);
+	}
 };

--- a/code/components/extra-natives-five/src/FallDamageExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/FallDamageExtraNatives.cpp
@@ -1,0 +1,111 @@
+#include "StdInc.h"
+
+#include <ScriptEngine.h>
+#include <atArray.h>
+#include <Local.h>
+#include <Hooking.h>
+#include <GameInit.h>
+#include <GameValueStub.h>
+
+static GameValueStub<float> KillFallHeight;
+static GameValueStub<float> KillFallHeightForPlayers;
+
+static GameValueStub<float> FallDamageMultiplier;
+static GameValueStub<float> FallDamageMultiplierLandOnFoot;
+
+static HookFunction initFunction([]()
+{
+	{
+		auto location = hook::get_pattern("F3 44 0F 10 2D ? ? ? ? 48 39 BE");
+		KillFallHeight.Init(*hook::get_address<float*>(location, 5, 9));
+		KillFallHeight.SetLocation(location, 5, 9);
+	}
+
+	{
+		auto location = hook::get_pattern("F3 44 0F 10 2D ? ? ? ? 48 39 BE", 0x12);
+		KillFallHeightForPlayers.Init(*hook::get_address<float*>(location, 5, 9));
+		KillFallHeightForPlayers.SetLocation(location, 5, 9);
+	}
+
+
+	if (xbr::IsGameBuildOrGreater<2802>())
+	{
+		{
+			auto location = hook::get_pattern("F3 44 0F 59 25 ? ? ? ? EB");
+			FallDamageMultiplierLandOnFoot.Init(*hook::get_address<float*>(location, 5, 9));
+			FallDamageMultiplierLandOnFoot.SetLocation(location, 5, 9);
+		}
+
+		{
+			auto location = hook::get_pattern("F3 44 0F 59 25 ? ? ? ? 45 0F 28 CC");
+			FallDamageMultiplier.Init(*hook::get_address<float*>(location, 5, 9));
+			FallDamageMultiplier.SetLocation(location, 5, 9);
+		}
+	}
+	else // 1604-2699
+	{
+		{
+			auto location = hook::get_pattern("F3 44 0F 59 1D ? ? ? ? EB ? F3 44 0F 59");
+			FallDamageMultiplierLandOnFoot.Init(*hook::get_address<float*>(location, 5, 9));
+			FallDamageMultiplierLandOnFoot.SetLocation(location, 5, 9);
+		}
+
+		{
+			auto location = hook::get_pattern("F3 44 0F 59 1D ? ? ? ? 45 0F 28 CB");
+			FallDamageMultiplier.Init(*hook::get_address<float*>(location, 5, 9));
+			FallDamageMultiplier.SetLocation(location, 5, 9);
+		}
+	}
+
+	OnKillNetworkDone.Connect([]()
+	{
+		KillFallHeight.Reset();
+		KillFallHeightForPlayers.Reset();
+		FallDamageMultiplierLandOnFoot.Reset();
+		FallDamageMultiplier.Reset();
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_KILL_FALL_HEIGHT", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(KillFallHeight.Get());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_KILL_FALL_HEIGHT", [=](fx::ScriptContext& context)
+	{
+		const float newValue = context.GetArgument<float>(0);
+		KillFallHeight.Set(std::isnan(newValue) ? 0.0f : std::max(0.0f, newValue));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_KILL_FALL_HEIGHT", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(KillFallHeightForPlayers.Get());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_KILL_FALL_HEIGHT", [=](fx::ScriptContext& context)
+	{
+		const float newValue = context.GetArgument<float>(0);
+		KillFallHeightForPlayers.Set(std::isnan(newValue) ? 0.0f : std::max(0.0f, newValue));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_FALL_DAMAGE_MULTIPLIER", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(FallDamageMultiplier.Get());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_FALL_DAMAGE_MULTIPLIER", [=](fx::ScriptContext& context)
+	{
+		const float newValue = context.GetArgument<float>(0);
+		FallDamageMultiplier.Set(std::isnan(newValue) ? 0.0f : std::max(0.0f, newValue));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(FallDamageMultiplierLandOnFoot.Get());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER", [=](fx::ScriptContext& context)
+	{
+		const float newValue = context.GetArgument<float>(0);
+		FallDamageMultiplierLandOnFoot.Set(std::isnan(newValue) ? 0.0f : std::max(0.0f, newValue));
+	});
+});

--- a/ext/native-decls/GetFallDamageLandOnFootMultiplier.md
+++ b/ext/native-decls/GetFallDamageLandOnFootMultiplier.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER
+
+```c
+float GET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER();
+```
+
+A getter for [SET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER](#_0x164A08C9).
+
+## Return value
+Returns the fall damage multiplier applied when a ped lands **on foot** from a fall below the kill fall height threshold (i.e., when the fall does not cause instant death).
+The default value is `3.0`.

--- a/ext/native-decls/GetFallDamageMultiplier.md
+++ b/ext/native-decls/GetFallDamageMultiplier.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_FALL_DAMAGE_MULTIPLIER
+
+```c
+float GET_FALL_DAMAGE_MULTIPLIER();
+```
+
+A getter for [SET_FALL_DAMAGE_MULTIPLIER](#_0xF2E1A531).
+
+## Return value
+Returns the fall damage multiplier applied to all peds when calculating fall damage from falls **below the kill fall height threshold** (i.e., when the fall does not cause instant death).
+The default value is `7.0`.

--- a/ext/native-decls/GetKillFallHeight.md
+++ b/ext/native-decls/GetKillFallHeight.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_KILL_FALL_HEIGHT
+
+```c
+float GET_KILL_FALL_HEIGHT();
+```
+
+A getter for [SET_KILL_FALL_HEIGHT](#_0x7E8D83E4).
+
+## Return value
+Returns the height from which non-player peds will instantly die due to fall damage.  
+The default value is `10.0`.

--- a/ext/native-decls/GetPlayerKillFallHeight.md
+++ b/ext/native-decls/GetPlayerKillFallHeight.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_KILL_FALL_HEIGHT
+
+```c
+float GET_PLAYER_KILL_FALL_HEIGHT();
+```
+
+A getter for [SET_PLAYER_KILL_FALL_HEIGHT](#_0xAEF2C6A4).
+
+## Return value
+Returns the height from which the player will instantly die due to fall damage.  
+The default value is `15.0`.

--- a/ext/native-decls/SetFallDamageLandOnFootMultiplier.md
+++ b/ext/native-decls/SetFallDamageLandOnFootMultiplier.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER
+
+```c
+void SET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER(float multiplier);
+```
+
+A setter for [GET_FALL_DAMAGE_LAND_ON_FOOT_MULTIPLIER](#_0x3C8A1C92).
+
+## Parameters
+* **multiplier**: fall damage multiplier to apply when a ped lands on foot from a fall below the kill fall height threshold (i.e., when the fall does not cause instant death). Default value is `3.0`.

--- a/ext/native-decls/SetFallDamageMultiplier.md
+++ b/ext/native-decls/SetFallDamageMultiplier.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_FALL_DAMAGE_MULTIPLIER
+
+```c
+void SET_FALL_DAMAGE_MULTIPLIER(float multiplier);
+```
+
+A setter for [GET_FALL_DAMAGE_MULTIPLIER](#_0x2D6A0A83).
+
+## Parameters
+* **multiplier**: fall damage multiplier applied to all peds when calculating fall damage from falls below the kill fall height threshold (i.e., when the fall does not cause instant death). Default value is `7.0`.

--- a/ext/native-decls/SetKillFallHeight.md
+++ b/ext/native-decls/SetKillFallHeight.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_KILL_FALL_HEIGHT
+
+```c
+void SET_KILL_FALL_HEIGHT(float height);
+```
+
+A setter for [GET_KILL_FALL_HEIGHT](#_0x884C8B5A).
+
+## Parameters
+* **height**: height from which the non-player peds will instantly die from fall damage. Default value is `10.0`.

--- a/ext/native-decls/SetPlayerKillFallHeight.md
+++ b/ext/native-decls/SetPlayerKillFallHeight.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_KILL_FALL_HEIGHT
+
+```c
+void SET_PLAYER_KILL_FALL_HEIGHT(float height);
+```
+
+A setter for [GET_PLAYER_KILL_FALL_HEIGHT](#_0x13BC2C63).
+
+## Parameters
+* **height**: height from which the player peds will instantly die from fall damage. Default value is `15.0`.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add getters and setters to modify fall damage. There is value for fatal height from which peds will always die and multiplier of damage if ped is falling from lower, both need to be modifiable.


### How is this PR achieving the goal

I had to add overload method for SetLocation in GameValueStub, the original method assumed the relative offset was always at the instruction start and did not account for instruction size, causing crashes in some cases.

Other than that its just basic hooking to global float values, had to use GameValueStub because complier optimization makes that they were used in other places as well.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Fivem client natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** ..  3258 tested, 2699 checked if patterns exist

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



