### PR TITLE
feat(mumble): add local player mutes, self deafen, and self mute

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -1269,6 +1269,54 @@ static HookFunction hookFunction([]()
 			}
 		}));
 
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_SELF_MUTED", MakeMumbleNative([](fx::ScriptContext& context)
+		{
+			auto muted = context.GetArgument<bool>(0);
+
+			g_mumbleClient->SetSelfMuted(muted);
+		}));
+		
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_SELF_DEAFENED", MakeMumbleNative([](fx::ScriptContext& context)
+		{
+			auto muted = context.GetArgument<bool>(0);
+
+			g_mumbleClient->SetSelfDeafened(muted);
+		}));
+
+		
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_PLAYER_MUTED_LOCALLY", MakeMumbleNative([](fx::ScriptContext& context)
+		{
+			auto playerId = context.GetArgument<int>(0);
+			auto muted = context.GetArgument<bool>(1);
+
+			if (auto playerName = getMumbleName(playerId))
+			{
+				const auto session = g_mumbleClient->GetPlayerSessionFromName(*playerName);
+				if (session != 0)
+				{
+					g_mumbleClient->MutePlayerLocally(session, muted);
+				}
+			}
+		}));
+		
+		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_PLAYER_MUTED_LOCALLY_BY_SERVER_ID", MakeMumbleNative([](fx::ScriptContext& context)
+		{
+			auto serverId = context.GetArgument<int>(0);
+			auto muted = context.GetArgument<bool>(1);
+
+			auto playerName = g_mumbleClient->GetPlayerNameFromServerId(serverId);
+			if (playerName.empty())
+			{
+				return;
+			}
+			
+			const auto session = g_mumbleClient->GetPlayerSessionFromName(playerName);
+			if (session != 0)
+			{
+				g_mumbleClient->MutePlayerLocally(session, muted);
+			}
+		}));
+
 		fx::ScriptEngine::RegisterNativeHandler("MUMBLE_SET_VOICE_TARGET", MakeMumbleNative([](fx::ScriptContext& context)
 		{
 			auto id = context.GetArgument<int>(0);

--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -82,6 +82,8 @@ public:
 	virtual std::string GetPlayerNameFromServerId(uint32_t serverId) = 0;
 
 	virtual std::string GetVoiceChannelFromServerId(uint32_t serverId) = 0;
+	
+	virtual uint32_t GetPlayerSessionFromName(std::string& playerName) = 0;
 
 	virtual void GetTalkers(std::vector<std::string>* names) = 0;
 
@@ -110,6 +112,12 @@ public:
 	virtual bool DoesChannelExist(const std::string& channelName) = 0;
 
 	virtual std::shared_ptr<lab::AudioContext> GetAudioContext(const std::string& name) = 0;
+	
+	virtual void SetSelfMuted(bool muted) = 0;
+	
+	virtual void SetSelfDeafened(bool selfDeafened) = 0;
+	
+	virtual void MutePlayerLocally(uint32_t sessionId, bool muted) = 0;
 
 	// settings
 	virtual void SetActivationMode(MumbleActivationMode mode) = 0;

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -158,6 +158,8 @@ public:
 
 	virtual std::string GetVoiceChannelFromServerId(uint32_t serverId) override;
 
+	virtual uint32_t GetPlayerSessionFromName(std::string& playerName) override;
+
 	virtual void GetTalkers(std::vector<std::string>* referenceIds) override;
 
 	virtual void SetPositionHook(const TPositionHook& hook) override;
@@ -174,6 +176,12 @@ public:
 
 	virtual void SetListenerMatrix(float position[3], float front[3], float up[3]) override;
 
+	virtual void SetSelfMuted(bool muted) override;
+	
+	virtual void SetSelfDeafened(bool selfDeafened) override;
+	
+	virtual void MutePlayerLocally(uint32_t sessionId, bool muted) override;
+	
 	virtual void SetActivationMode(MumbleActivationMode mode) override;
 
 	virtual void SetPTTButtonState(bool pressed) override;
@@ -196,6 +204,8 @@ private:
 	std::shared_ptr<uvw::TCPHandle> m_tcp;
 
 	std::shared_ptr<uvw::UDPHandle> m_udp;
+
+	std::unordered_set<uint32_t> m_locallyMutedPlayers;
 
 	MumbleConnectionInfo m_connectionInfo;
 
@@ -242,6 +252,14 @@ private:
 	bool m_hasUdp = false;
 
 	bool m_udpTimedOut = false;
+
+	bool m_selfMuted;
+
+	bool m_selfDeafened;
+
+	bool m_lastSelfMuted;
+
+	bool m_lastSelfDeafened;
 
 	// the time in milliseconds since the player joined the mumble server
 	// This is used in for `Ping` packets to determine if we should allow the client to swap from UDP -> TCP


### PR DESCRIPTION
### Goal of this PR
This adds the ability for clients to mute/deafen themselves, which was previously not doable in a nice way.

This comes from a feature request a few months ago from https://github.com/AvarianKnight/pma-voice/issues/521#issue-2864623474

This **has not** been tested (which can be noted from the fact that there is no native documentation), this is more so it doesn't just sit stale on my local branch.

### This PR applies to the following area(s)
FiveM, RedM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
