### PR TITLE
fix(component/mumble): return a proper value when user doesn't exist

### DIFF
--- a/code/components/voip-server-mumble/src/client.cpp
+++ b/code/components/voip-server-mumble/src/client.cpp
@@ -112,6 +112,8 @@ bool Client_is_player_muted(const char *namePrefix, size_t len)
 			return c->mute;
 		}
 	}
+
+	return false;
 }
 
 void Client_set_player_muted(const char *namePrefix, size_t len, bool muted)


### PR DESCRIPTION

### Goal of this PR
This fixes the undefined behavior when calling this function, which will hopefully fix this native crashing on Linux, and also fixes returning invalid data on Windows.




### This PR applies to the following area(s)
Server


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
#2115 

