### PR TITLE
tweak: add trace logging for missing callback refIdx

### DIFF
--- a/code/components/citizen-scripting-core/src/ResourceCallbackComponent.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceCallbackComponent.cpp
@@ -102,7 +102,7 @@ result_t ResourceCallbackScriptRuntime::CallRef(int32_t refIdx, char* argsSerial
 			packer.pack_array(0);
 			return fx::MemoryScriptBuffer::Make(sb.data(), static_cast<uint32_t>(sb.size()));
 		})();
-		
+
 		rv.CopyTo(retval);
 	}
 
@@ -116,6 +116,7 @@ result_t ResourceCallbackScriptRuntime::CallRef(int32_t refIdx, char* argsSerial
 
 		if (it == m_refs.end())
 		{
+			trace("[ResourceCallbackComponent] ⚠️ refIdx %d not found in CallRef — maybe expired or invalid.", refIdx);
 			return FX_E_INVALIDARG;
 		}
 
@@ -140,6 +141,7 @@ result_t ResourceCallbackScriptRuntime::DuplicateRef(int32_t refIdx, int32_t* ou
 
 	if (it == m_refs.end())
 	{
+		trace("[ResourceCallbackComponent] ⚠️ refIdx %d not found in DuplicateRef — maybe removed or invalid.", refIdx);
 		return FX_E_INVALIDARG;
 	}
 
@@ -163,6 +165,7 @@ result_t ResourceCallbackScriptRuntime::RemoveRef(int32_t refIdx)
 
 		if (it == m_refs.end())
 		{
+			trace("[ResourceCallbackComponent] ⚠️ refIdx %d not found in RemoveRef — possibly already destroyed.", refIdx);
 			return FX_E_INVALIDARG;
 		}
 


### PR DESCRIPTION
### Goal of this PR
Improve developer insight and debugging capability by adding `trace()` log messages when a callback reference index (`refIdx`) is not found in the `ResourceCallbackScriptRuntime`.

This situation can occur if a reference is used after being removed or never registered, and logging it makes it easier to understand what's happening internally during resource execution.

---

### How is this PR achieving the goal
This PR adds detailed `trace()` logs in the following methods:
- `CallRef`
- `DuplicateRef`
- `RemoveRef`

Each log indicates when a `refIdx` is missing from the internal map, along with the method where it occurred. This helps developers quickly diagnose issues related to lost or invalid callback references during runtime.

The behavior of the methods remains unchanged — the logs are non-intrusive and purely for debugging purposes.

---

### This PR applies to the following area(s)
- FiveM
- Server
- ScRT: C++

---

### Successfully tested on

**Game builds:**  
- 3095  
- 3179  
**Platforms:**  
- Windows 11 x64  
**Tested:**  
- On local `fxserver` with default configuration

---

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and is documented via meaningful `trace()` messages.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

---

### Fixes issues

N/A – This is a debugging improvement and does not fix a specific open issue.
