### PR TITLE
fix(core/rdr3): CWeaponInfo crash mitigation

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchWeaponInfoCrash.cpp
+++ b/code/components/gta-core-rdr3/src/PatchWeaponInfoCrash.cpp
@@ -1,0 +1,79 @@
+#include <StdInc.h>
+
+#include "atArray.h"
+#include "Hooking.h"
+#include "Hooking.Stubs.h"
+
+static hook::cdecl_stub<void*(uint32_t*)> getWeaponInfo([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 83 C4 ? C3 48 8B 41 ? 48 8B 40"));
+});
+
+static bool IsWeaponInfoValid(uint32_t weaponHash)
+{
+	// this function checks if weaponHash returns a valid CItemInfo and that it is a CWeaponInfo instance.
+	void* weaponInfo = getWeaponInfo(&weaponHash);
+	return weaponInfo ? true : false;
+}
+
+static HookFunction hookFunction([]
+{
+	// Check if CWeaponInfo from CWeaponDamageEvent is valid before continuing  
+	{
+		auto location = hook::get_pattern<char>("4C 8D 6F ? 45 8B 45");
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t retnSuccess;
+			uintptr_t retnFail;
+
+			void Init(uintptr_t success, uintptr_t fail)
+			{
+				retnSuccess = success;
+				retnFail = fail;
+			}
+
+			virtual void InternalMain() override
+			{
+				// Original Code
+				lea(r13, qword_ptr[rdi + 0x58]);
+				mov(r8d, dword_ptr[r13]);
+
+				test(r8d, r8d);
+				jz("Fail");
+
+				mov(ecx, r8d);
+
+				push(rcx);
+				push(rdx);
+				push(r8);
+				push(r9);
+
+				mov(rax, reinterpret_cast<uintptr_t>(&IsWeaponInfoValid));
+				call(rax);
+
+				pop(r9);
+				pop(r8);
+				pop(rdx);
+				pop(rcx);
+
+				test(al, al);
+				jz("Fail");
+
+				mov(rcx, retnSuccess);
+				jmp(rcx);
+
+				L("Fail");
+				mov(rcx, retnFail);
+				jmp(rcx);
+			}
+		} patchStub;
+
+		const uintptr_t retnSuccess = (uintptr_t)location + 8;
+		const uintptr_t retnFailure = (uintptr_t)hook::get_pattern("32 C0 E9 ? ? ? ? 44 38 35");
+
+		hook::nop(location, 8);
+		patchStub.Init(retnSuccess, retnFailure);
+		hook::jump_rcx(location, patchStub.GetCode());
+	}
+});


### PR DESCRIPTION
### Goal of this PR

Mitigates crashes caused by accessing a nullptr ``CWeaponInfo`` object. Mitigation for this issue was also possible through server-side scripts listening to ``weaponDamageEvent`` like so

```lua
AddEventHandler("weaponDamageEvent", function(sender, data)
    if data.weaponType == 2416459067 then
        CancelEvent()
    end
end)
```

### How is this PR achieving the goal

Before running any logic in CWeaponDamageEvent, we check if the weaponHash provided by the event is valid (does it return a ``CItemInfo`` and is the sub-type ``CWeaponInfo``), if the check fails, the function returns early with zero, preventing crashes.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

fixes #3335
