### PR TITLE
fix(net-event-doc): fix typedoc not recognizing int

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1652,7 +1652,7 @@ static void Init()
 				 * @param oldBucket - The old bucket where the player was previously in.
 				 *
 				 #/
-				  declare function onPlayerBucketChange(player: string, bucket: int, oldBucket: int): void;
+				  declare function onPlayerBucketChange(player: string, bucket: number, oldBucket: number): void;
 				*/
 				eventManager->TriggerEvent2("onPlayerBucketChange", {}, player, bucket, oldBucket);
 			}
@@ -1690,7 +1690,7 @@ static void Init()
 			 * @param oldBucket - The old bucket where the entity was previously in.
 			 *
 			#/
-			  declare function onEntityBucketChange(entity: string, bucket: int, oldBucket: int): void;
+			  declare function onEntityBucketChange(entity: string, bucket: number, oldBucket: number): void;
 			*/
 			eventManager->TriggerEvent2("onEntityBucketChange", {}, ent, bucket, oldBucket);
 		}


### PR DESCRIPTION
Main code changes are just renaming the comments event parameter types, but line endings weren't consistent so this fixes it as well ig 
![image](https://github.com/user-attachments/assets/6f6828f7-b3ba-4916-9475-4029d408e41e)
