### PR TITLE
feat(citizen-server-impl): add state bag name in console log drops

### DIFF
--- a/code/components/citizen-server-impl/src/packethandlers/StateBagPacketHandler.cpp
+++ b/code/components/citizen-server-impl/src/packethandlers/StateBagPacketHandler.cpp
@@ -71,15 +71,15 @@ void StateBagPacketHandler::HandleStateBagMessage(fx::ServerInstanceBase* instan
 
 	uint32_t slotId = client->GetSlotId();
 
-	std::string bagNameOnFailure;
-	stateBagComponent->HandlePacket(slotId, clientStateBag.data, &bagNameOnFailure);
-	std::string safeBagName = bagNameOnFailure.empty() ? "unknown" : bagNameOnFailure;
-
 	const bool hitRateLimit = !stateBagRateLimiter->Consume(netId);
 	const bool hitFloodRateLimit = !stateBagRateFloodLimiter->Consume(netId);
 
 	if (hitRateLimit)
 	{
+		std::string tempBagName;
+		stateBagComponent->HandlePacket(slotId, clientStateBag.data, &tempBagName);
+		std::string safeBagName = tempBagName.empty() ? "unknown" : tempBagName;
+		
 		const std::string& clientName = client->GetName();
 		auto printStateWarning = [&clientName, netId, &safeBagName](const std::string& logChannel, const std::string_view logReason,
 		                                              const std::string_view rateLimiter, double rateLimit,
@@ -152,6 +152,10 @@ void StateBagPacketHandler::HandleStateBagMessage(fx::ServerInstanceBase* instan
 	
 	if (slotId != -1)
 	{
+		std::string bagNameOnFailure;
+
+		stateBagComponent->HandlePacket(slotId, clientStateBag.data, &bagNameOnFailure);
+		
 		// state bag isn't present, apply conditions for automatic creation
 		if (!bagNameOnFailure.empty())
 		{


### PR DESCRIPTION
### Goal of this PR
Added the state bag name to the logs when a player is rate limited or kicked due to state bag overflow.


### How is this PR achieving the goal
Extracting the state bag name during early processing of StateBag and StateBagV2 packets.


### This PR applies to the following area(s)
Server


### Successfully tested on
**I only tested this in StateBagV2**
**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3528 


I would like someone to give their opinion on the implementation of this for `StateBag`"v1" because I think I am doing it wrong in that case.