### PR TITLE
tweak(server-impl): optimize the path for statebags

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -2735,9 +2735,10 @@ bool ServerGameState::SetEntityStateBag(uint8_t playerId, uint16_t objectId, std
 {
 	if (auto entity = GetEntity(0, objectId))
 	{
-		if (entity->GetStateBag())
+		if (entity->HasStateBag())
 		{
 			trace("Creating a new state bag while there's already a state bag on this entity, please report this.\n");
+			return false;
 		}
 
 		entity->SetStateBag(createStateBag());


### PR DESCRIPTION
### Goal of this PR
Reduce contention around accessing state bags.

### How is this PR achieving the goal
Removes the `shared_lock`, which in this case isn't really needed, as this should only ever get written to *once* and then only read afterwards.

This should all be safe since the initial creation of a state bag by the ScRT is always guarded with a `HasStateBag` check.

### This PR applies to the following area(s)
Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


