### PR TITLE
fix(gta-streaming-five): add missing padding for pgRawStreamer::RawEntry on RDR3

### DIFF
--- a/code/components/gta-streaming-five/include/fiCollectionWrapper.h
+++ b/code/components/gta-streaming-five/include/fiCollectionWrapper.h
@@ -49,6 +49,9 @@ namespace rage
 		struct RawEntry
 		{
 			FileEntry fe;
+#if defined(IS_RDR3)
+			char m_pad[8];
+#endif
 			uint64_t timestamp;
 
 			const char* fileName;


### PR DESCRIPTION
### Goal of this PR
Fix a crash when opening the pgRawStreamer assets list, in RedM the `timestamp` and `fileName` fields were misaligned due to an 8-byte displacement after
<img width="836" height="810" alt="image" src="https://github.com/user-attachments/assets/bdc6609e-a6e2-4c7d-bd43-2e2f42028456" />


### How is this PR achieving the goal
Adding the missing padding.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Reported in [Engineering Group](https://discord.com/channels/779705925577080842/779739477642838036/1388171299242770442) by @outsider31000 