### PR TITLE
fix(client): fix incorrect parameters for `GetVehicleXenonLightsCustomColor`

### DIFF
--- a/ext/native-decls/GetVehicleXenonLightsCustomColor.md
+++ b/ext/native-decls/GetVehicleXenonLightsCustomColor.md
@@ -13,9 +13,6 @@ Returns vehicle xenon lights custom RGB color values. Do note this native doesn'
 
 ## Parameters
 * **vehicle**: The vehicle handle.
-* **red**: Red color (0-255).
-* **green**: Green color (0-255).
-* **blue**: Blue color (0-255).
 
 ## Return value
-A boolean indicating if vehicle have custom xenon lights RGB color.
+A boolean indicating if vehicle have custom xenon lights RGB color and the RGB values.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix `GetVehicleXenonLightsCustomColor` parameters.

...


### How is this PR achieving the goal
Removing the red, green and blue parameters
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Naitves
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 
3407

**Platforms:** 
Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


