### PR TITLE
tweak(component/mumble): Allow clients to connect to mumble, if they …

### DIFF
--- a/code/components/voip-server-mumble/src/server.cpp
+++ b/code/components/voip-server-mumble/src/server.cpp
@@ -570,26 +570,23 @@ static InitFunction initFunction([]()
 				return;
 			}
 
-			if (mumble_allowExternalConnections->GetValue())
+
+			// is this a Mumble ping?
+			if (len == 12 && *(uint32_t*)data == 0)
 			{
-				// is this a Mumble ping?
-				if (len == 12 && *(uint32_t*)data == 0)
-				{
-					uint32_t ping[6];
-					memcpy(ping, data, len);
-
-					ping[0] = htonl((uint32_t)((PROTVER_MAJOR << 16) | (PROTVER_MINOR << 8) | (PROTVER_PATCH)));
-					ping[3] = htonl((uint32_t)Client_count());
-					ping[4] = htonl((uint32_t)getIntConf(MUMBLE_MAX_CLIENTS));
-					ping[5] = htonl((uint32_t)getIntConf(MAX_BANDWIDTH));
-
-					*intercepted = true;
-
-					interceptor->Send(address, ping, sizeof(ping));
-
-					return;
-				}
+				uint32_t ping[6];
+				memcpy(ping, data, len);
+				
+				ping[0] = htonl((uint32_t)((PROTVER_MAJOR << 16) | (PROTVER_MINOR << 8) | (PROTVER_PATCH)));
+				ping[3] = htonl((uint32_t)Client_count());
+				ping[4] = htonl((uint32_t)getIntConf(MUMBLE_MAX_CLIENTS));
+				ping[5] = htonl((uint32_t)getIntConf(MAX_BANDWIDTH));
+				
+				*intercepted = true;
+				interceptor->Send(address, ping, sizeof(ping));
+				return;
 			}
+			
 
 			auto fromAddress = address.GetHostBytes();
 


### PR DESCRIPTION
…present the right ADMIN_PASSPHRASE even if mumble_allowExternalConnections isn't enabled.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Allow external clients to connect to the ingame Mumble server if they pressent the right ADMIN_PASSPHRASE, wich can be set with a convar. This allows the community to create external voice chat moderation tools without exposing themselves to the risk of the voice chat being hijacked.


### How is this PR achieving the goal

It allows external clients to join if they present the ADMIN_PASSPHRASE among their tokens


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...

Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

This PR was made as a reply to these changes: https://github.com/citizenfx/fivem/pull/3415#issuecomment-3083204266

