### PR TITLE
tweak(server/resources): remove legacy rdr3_warning requirement

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -538,19 +538,6 @@ static InitFunction initFunction([]()
 						console::PrintWarning("resources", "Resource %s does not specify an `fx_version` in fxmanifest.lua.\n", resource->GetName());
 						allowed = false;
 					}
-
-					if (isGame && gameNameString == "rdr3")
-					{
-						auto warningEntries = md->GetEntries("rdr3_warning");
-
-						static const std::string warningString = "I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.";
-
-						if (warningEntries.begin() == warningEntries.end() || warningEntries.begin()->second != warningString)
-						{
-							console::PrintWarning("resources", "Resource %s does not contain the RedM pre-release warning in fxmanifest.lua.\nPlease add ^2rdr3_warning '%s'^3 to fxmanifest.lua in this resource.\n", resource->GetName(), warningString);
-							allowed = false;
-						}
-					}
 				}
 				else
 				{

--- a/ext/system-resources/resources/chat/fxmanifest.lua
+++ b/ext/system-resources/resources/chat/fxmanifest.lua
@@ -21,5 +21,4 @@ files {
 
 fx_version 'adamant'
 games { 'rdr3', 'gta5' }
-rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 nui_callback_strict_mode 'true'


### PR DESCRIPTION
### Goal of this PR

Remove the legacy ``rdr3_warning`` manifest requirement when making client and server scripts for RedM.

### How is this PR achieving the goal

Removes logic that checks for and requires ``rdr3_warning`` to be present with a very specific value in the manifest of each resource that supports game 'rdr3'.

### This PR applies to the following area(s)

RedM, Server

### Successfully tested on

**Game builds:** 149i

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

Comment brought up in Engineering Discord
