### PR TITLE
feat(gta-streaming-rdr3): allow registration of custom fonts

### DIFF
--- a/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
@@ -15,9 +15,7 @@
 #include <CustomText.h>
 #include <deque>
 
-#if defined(GTA_FIVE)
 #include <sfFontStuff.h>
-#endif
 
 static bool AddTextEntryForResource(fx::Resource* resource, uint32_t hashKey, const char* textValueRaw)
 {
@@ -122,7 +120,6 @@ static InitFunction initFunction([] ()
 		context.SetResult<bool>(false);
 	});
 
-#if defined(GTA_FIVE)
 	fx::ScriptEngine::RegisterNativeHandler("REGISTER_FONT_ID", [](fx::ScriptContext& context)
 	{
 		context.SetResult(sf::RegisterFontIndex(context.CheckArgument<const char*>(0)));
@@ -132,6 +129,8 @@ static InitFunction initFunction([] ()
 	{
 		sf::RegisterFontLib(context.CheckArgument<const char*>(0));
 	});
+	
+#if defined(GTA_FIVE)
 
 	fx::ScriptEngine::RegisterNativeHandler("ADD_MINIMAP_OVERLAY", [](fx::ScriptContext& context)
 	{

--- a/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
+++ b/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
@@ -154,7 +154,7 @@ static int (*g_origGetFileTypeIdFromExtension)(const char*, const char*);
 static int GetFileTypeIdFromExtension(const char* extension, const char* fileName)
 {
 	// set the name for the later hook to use
-	g_lastStreamingName = extension;
+	g_lastStreamingName = fileName;
 
 	return g_origGetFileTypeIdFromExtension(extension, fileName);
 }

--- a/code/components/gta-streaming-rdr3/component.lua
+++ b/code/components/gta-streaming-rdr3/component.lua
@@ -10,5 +10,6 @@ return function()
 		'components/gta-streaming-five/src/LoadStreamingFile.cpp',
 		'components/gta-streaming-five/src/StreamingFreeTests.cpp',
 		'components/gta-streaming-five/src/PopulationCreationHooks.cpp',
+		'components/gta-streaming-five/src/sfFontStuff.cpp'
 	}
 end


### PR DESCRIPTION
### Goal of this PR
Allow to register custom fonts like in fivem.
And also fix a issue in the `GetFileTypeIdFromExtension` function because is using the extension arg as the fileName and it was containing "garbage" which was preventing the use of the GetStreamingIndexForName function.
<img width="1367" height="768" alt="image" src="https://github.com/user-attachments/assets/024c1d78-b256-498d-8237-90a83452e0b4" />


### How is this PR achieving the goal
Defining a constant to store the number of fonts already registered in the game so we can calculate the index in the `g_fontIds` array. Replacing some patterns to make them work in redm.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.