### PR TITLE
fix(extra-natives-five): avoid weapon change with no swap enabled

### DIFF
--- a/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
@@ -366,6 +366,7 @@ static HookFunction hookFunction([]()
 	}
 
 	// CTaskGun::StateDecide
+	if (!xbr::IsGameBuild<1604>())
 	{
 		auto location = hook::get_pattern<char>("83 CE ? 44 8B C6 44 8A CD");
 		auto skipWeaponChange = location + 24;

--- a/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
@@ -6,6 +6,7 @@
 #include <Resource.h>
 #include <fxScripting.h>
 #include <ICoreGameInit.h>
+#include <jitasm.h>
 #include <rageVectors.h>
 #include <MinHook.h>
 #include "Hooking.Stubs.h"
@@ -362,6 +363,46 @@ static HookFunction hookFunction([]()
 		CurrentPitchOffset = *hook::get_pattern<uint32_t>("89 83 ? ? ? ? C7 83 ? ? ? ? ? ? ? ? 0F 28 74 24", 2);
 		NetworkObjectOffset = *hook::get_pattern<uint32_t>("48 8B 81 ? ? ? ? 48 85 C0 74 ? 80 78 ? ? 74 ? 8A 80 ? ? ? ? C0 E8", 3);
 		IsCloneOffset = *hook::get_pattern<uint16_t>("80 78 ? ? 74 ? 8A 80 ? ? ? ? C0 E8", 2);
+	}
+
+	// CTaskGun::StateDecide
+	{
+		auto location = hook::get_pattern<char>("83 CE ? 44 8B C6 44 8A CD");
+		auto skipWeaponChange = location + 24;
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t skipChangeLocation;
+			uintptr_t normalLocation;
+
+			void Init(uintptr_t skip, uintptr_t normal)
+			{
+				skipChangeLocation = skip;
+				normalLocation = normal;
+			}
+
+			virtual void InternalMain() override
+			{
+				or(esi, 0xFFFFFFFF); // Original code
+				mov(r8d, esi); // Original code
+				
+				mov(rax, reinterpret_cast<uintptr_t>(&g_SET_WEAPONS_NO_AUTOSWAP));
+				mov(al, byte_ptr[rax]);
+				test(al, al);
+				jz("normalFlow");
+
+				mov(rax, skipChangeLocation);
+				jmp(rax);
+
+				L("normalFlow");
+				mov(rax, normalLocation);
+				jmp(rax);
+			}
+		} stub;
+
+		stub.Init((uintptr_t)skipWeaponChange, (uintptr_t)location + 0x6);
+		hook::nop(location, 6);
+		hook::jump(location, stub.GetCode());
 	}
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_WEAPON_DAMAGE_MODIFIER", [](fx::ScriptContext& context)


### PR DESCRIPTION
### Goal of this PR
Currently, using `SET_WEAPONS_NO_AUTOSWAP` in combination with enabling ped config flag 48 causes the ped to equip WEAPON_UNARMED when running out of ammo. This behavior should not belong to the purpose of SET_WEAPONS_NO_AUTOSWAP.


### How is this PR achieving the goal
Checking in the stub if `g_SET_WEAPONS_NO_AUTOSWAP` is enabled to skip or continue the flow.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 1604, 3407
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Reported by @n3xuuu not public issue.