### PR TITLE
fix(gta-core-five): validate river entity archetype

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.RiverEntities.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.RiverEntities.cpp
@@ -2,15 +2,15 @@
 #include <Hooking.h>
 #include <Hooking.Stubs.h>
 
-static void* (*g_orig_River__GetRiverEntity)(int RiverEntity);
+static hook::FlexStruct* (*g_orig_River__GetRiverEntity)(int RiverEntity);
 
 static void (*g_orig_GetBoundingBoxZForRiverEntity)(int RiverEntityIndex, float* MinZ, float* MaxZ);
 static void GetBoundingBoxZForRiverEntity(int RiverEntityIndex, float* MinZ, float* MaxZ)
 {
-	void* entity = g_orig_River__GetRiverEntity(RiverEntityIndex);
+	hook::FlexStruct* entity = g_orig_River__GetRiverEntity(RiverEntityIndex);
 	if (!entity)
 		return;
-	if(!*(void**)((uintptr_t)entity + 0x20)) // Entity archetype
+	if(!entity->At<void*>(0x20)) // Entity archetype
 		return;
 
 	g_orig_GetBoundingBoxZForRiverEntity(RiverEntityIndex, MinZ, MaxZ);

--- a/code/components/gta-core-five/src/CrashFixes.RiverEntities.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.RiverEntities.cpp
@@ -10,6 +10,8 @@ static void GetBoundingBoxZForRiverEntity(int RiverEntityIndex, float* MinZ, flo
 	void* entity = g_orig_River__GetRiverEntity(RiverEntityIndex);
 	if (!entity)
 		return;
+	if(!*(void**)((uintptr_t)entity + 0x20)) // Entity archetype
+		return;
 
 	g_orig_GetBoundingBoxZForRiverEntity(RiverEntityIndex, MinZ, MaxZ);
 }


### PR DESCRIPTION
### Goal of this PR
Fix a crash caused by river entities with null archetype.


### How is this PR achieving the goal
Validating the archetype that is located in 0x20 from the river entity(CEntity).


### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Crash reported by @ook3D 