### PR TITLE
tweak(server-impl/sbag): reduce the amount of locking for adding routing targets

### DIFF
--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -1267,6 +1267,7 @@ struct SyncedEntityData
 	sync::SyncEntityPtr entity;
 	bool forceUpdate;
 	bool hasCreated;
+	bool hasRoutedStateBag = false;
 	bool hasNAckedCreate = false;
 };
 

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1800,15 +1800,11 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 
 			ces.syncedEntities[entity->handle] = { entity, baseFrameIndex, syncData.hasCreated };
 
-			if (syncData.hasCreated)
+			if (syncData.hasCreated && !syncData.hasRoutedStateBag)
 			{
-				// Add this player as a routing target to this entity's statebag, if present.
-				// notes:
-				// * this will try to add it every frame, but the statebag will only add it once (std::set).
-				// * will occur on the next update/tick when syncData.hasCreated is true, this'll ensure that it's sent after the client knows about this entity.
-				// TODO: PERF: remove this every-frame call by giving this system a nice and fresh design
 				if (auto stateBag = entity->GetStateBag())
 				{
+					syncData.hasRoutedStateBag = true;
 					stateBag->AddRoutingTarget(slotId);
 				}
 			}


### PR DESCRIPTION
This currently uses a decently amount of the chunk of time in ETW traces because this gets called per frame, this adds another bool to the SyncData and makes sure we only add the routing target once instead of constantly spamming the write lock.

### Goal of this PR
Reduce the locking done for routing targets


### How is this PR achieving the goal
Only adding routing targets once.


### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


