### PR TITLE
fix(gta-core-five): ignore ladder patch for game build 3570

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.Ladder.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.Ladder.cpp
@@ -3,8 +3,15 @@
 #include <jitasm.h>
 #include "Hooking.Patterns.h"
 
+#include "CrossBuildRuntime.h"
+
 static HookFunction hookFunction([]()
 {
+	// Game build 3570 includes built-in validation for this logic, so applying this patch is unnecessary.
+	if (xbr::IsGameBuildOrGreater<3570>())
+	{
+		return;
+	}
 	// CTaskClimbLadder::IsMovementBlocked
 	// This function determines wether the ped can continue climbing the ladder
 	// or if its movement should be blocked due some physical obstacle.


### PR DESCRIPTION
### Goal of this PR
Fix the error when starting fivem in 3570 cause it's trying to find a pattern that doesn't exist in the gamebuild cause is already patched.


### How is this PR achieving the goal
Checking if gamebuild is 3570 or greater.


### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 
**Platforms:** Windows


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Can't start fivem canary with 3570