### PR TITLE
fix(gta-core-five): overriding ladder registers causing bad collision checks

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.Ladder.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.Ladder.cpp
@@ -37,12 +37,21 @@ static HookFunction hookFunction([]()
 		
 		virtual void InternalMain() override
 		{
+			// Restore original rax value
+			mov(al, byte_ptr[rdx+0x0C]);
+			dec(al);
+			cmp(al, 1);
+			setbe(cl);
+			neg(cl);
+			sbb(rax, rax);
+			and(rax, rdx);
+
 			test(rax, rax);
 			jz("fail");
 
 			movss(xmm0, dword_ptr[rax+0x64]);
-			mov(r12, successLocation);
-			jmp(r12);
+			mov(r11, successLocation);
+			jmp(r11);
 
 			L("fail");
 			mov(rax, failLocation);
@@ -54,5 +63,5 @@ static HookFunction hookFunction([]()
 	stub.Init((uintptr_t)location + 5, (uintptr_t)failLocation);
 	
 	hook::nop(location, 5);
-	hook::jump_reg<6>(location, stub.GetCode());
+	hook::jump(location, stub.GetCode());
 });


### PR DESCRIPTION
### Goal of this PR
Fix a issue with ladders that detect that some physical object is colliding in the test made by ladder logic, this only seems to happen in a custom map of NoPixel but very sure that can happen in ladders with same environment(cover above the end of ladder)
Clip: https://streamable.com/52f0it


### How is this PR achieving the goal
I've checked and I was overwriting some registers that was used after, so here I'm restoring original rax value and r11 that is only used at the end for writing.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
Can't test cause is in a custom map, can I get a feature branch to ask people with this issue to test if its working?
**Game builds:** .. 
**Platforms:** Windows


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Not public issue but reported by @d22tny 