### PR TITLE
feat(citizen-server-impl): add regex filters for console listener

### DIFF
--- a/code/components/citizen-server-impl/src/ServerBufferReplay.cpp
+++ b/code/components/citizen-server-impl/src/ServerBufferReplay.cpp
@@ -14,37 +14,51 @@
 
 #include <sstream>
 
+#include <regex>
+
 static std::shared_mutex g_consoleBufferMutex;
 static boost::circular_buffer<std::string> g_consoleBuffer(1500);
 
+struct ConsoleListenerEntry
+{
+	std::string handlerRef;
+	std::optional<std::regex> channelFilter;
+	std::optional<std::regex> messageFilter;
+};
+
 static std::shared_mutex g_printListMutex;
-static std::multimap<std::string, std::string> g_resourcePrintListeners;
+static std::unordered_multimap<std::string, ConsoleListenerEntry> g_resourcePrintListeners;
 
 static void LogPrintListener(ConsoleChannel channel, const char* msg)
 {
-	auto msgFmt = fmt::sprintf("%s", msg);
+	const std::string msgFmt = fmt::sprintf("%s", msg);
 
 	{
 		std::unique_lock<std::shared_mutex> lock(g_consoleBufferMutex);
 		g_consoleBuffer.push_back(msgFmt);
 	}
 
-	if (!g_resourcePrintListeners.empty())
+	if (g_resourcePrintListeners.empty())
+		return;
+		
+	gscomms_execute_callback_on_main_thread([channel = std::move(channel), msgFmt = std::move(msgFmt)]()
 	{
-		gscomms_execute_callback_on_main_thread([channel = std::move(channel), msgFmt = std::move(msgFmt)]()
+		std::unique_lock<std::shared_mutex> lock(g_printListMutex);
+		
+		for (auto& [resourceName, entry] : g_resourcePrintListeners)
 		{
-			std::unique_lock<std::shared_mutex> lock(g_printListMutex);
-			
-			for (auto& [resourceName, ref] : g_resourcePrintListeners)
-			{
+			const bool channelMatch = !entry.channelFilter || std::regex_search(channel, *entry.channelFilter);
+			const bool messageMatch = !entry.messageFilter || std::regex_search(msgFmt, *entry.messageFilter);
+
+			if (channelMatch && messageMatch) {
 				lock.unlock();
 
-				fx::ResourceManager::GetCurrent()->CallReference<void>(ref, channel, msgFmt);
+				fx::ResourceManager::GetCurrent()->CallReference<void>(entry.handlerRef, channel, msgFmt);
 
 				lock.lock();
 			}
-		});
-	}
+		}
+	});
 }
 
 static InitFunction initFunction([]()
@@ -53,26 +67,47 @@ static InitFunction initFunction([]()
 	{
 		fx::OMPtr<IScriptRuntime> runtime;
 
-		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
-		{
-			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+		if (!FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime))) 
+			return;
 
-			if (resource)
+		auto* resource = static_cast<fx::Resource*>(runtime->GetParentObject());
+		if (!resource) 
+			return;
+
+		std::string handlerRef = context.CheckArgument<const char*>(0);
+		auto channelFilterRaw = context.GetArgument<const char*>(1);
+		auto messageFilterRaw = context.GetArgument<const char*>(2);
+
+		ConsoleListenerEntry entry;
+		entry.handlerRef = handlerRef;
+
+		auto tryEmplaceRegex = [](std::optional<std::regex>& target, const char* pattern, const char* name) {
+			if (pattern && *pattern)
 			{
-				std::string handlerRef = context.GetArgument<const char*>(0);
-
+				try
 				{
-					std::unique_lock<std::shared_mutex> lock(g_printListMutex);
-					g_resourcePrintListeners.insert({ resource->GetName(), handlerRef });
+					target.emplace(pattern);
 				}
-
-				resource->OnStop.Connect([resource]()
+				catch (const std::regex_error& e)
 				{
-					std::unique_lock<std::shared_mutex> lock(g_printListMutex);
-					g_resourcePrintListeners.erase(resource->GetName());
-				});
+					throw std::runtime_error(va("Invalid %s regex '%s': %s", name, pattern, e.what()));
+				}
 			}
+		};
+
+		tryEmplaceRegex(entry.channelFilter, channelFilterRaw, "channel");
+		tryEmplaceRegex(entry.messageFilter, messageFilterRaw, "message");
+
+		{
+			std::unique_lock<std::shared_mutex> lock(g_printListMutex);
+			g_resourcePrintListeners.emplace(resource->GetName(), std::move(entry));
 		}
+
+		resource->OnStop.Connect([resourceName = resource->GetName()]()
+		{
+			std::unique_lock<std::shared_mutex> lock(g_printListMutex);
+			g_resourcePrintListeners.erase(resourceName);
+		});
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("GET_CONSOLE_BUFFER", [](fx::ScriptContext& context)

--- a/ext/native-decls/RegisterConsoleListener.md
+++ b/ext/native-decls/RegisterConsoleListener.md
@@ -5,11 +5,26 @@ apiset: server
 ## REGISTER_CONSOLE_LISTENER
 
 ```c
-void REGISTER_CONSOLE_LISTENER(func listener);
+void REGISTER_CONSOLE_LISTENER(func listener, char* channelFilter, char* messageFilter);
 ```
 
 Registers a listener for console output messages.
+You can optionally provide filters to only receive messages from specific channels or containing certain text patterns.
 
 ## Parameters
 * **listener**: A function of `(channel: string, message: string) => void`. The message might contain `\n`.
+* **channelFilter**: A regular expression string to filter messages by channel. If `null`, `undefined`, or `""`, all channels are accepted.
+* **messageFilter**: A regular expression string to filter messages by content. If `null`, `undefined`, or `""`, all messages are accepted.
 
+## Examples
+
+```lua
+RegisterConsoleListener(function(channel, message)
+    local cleaned = message:gsub("SCRIPT ERROR:%s*", ""):gsub("ERROR:%s*", "")
+    print(("Error detected in '%s': %s"):format(channel, cleaned))
+end,
+-- Channel filter: accept all channels
+nil,
+-- Message filter: match any message containing "error" (case-insensitive)
+"(SCRIPT ERROR:|ERROR:)")
+```


### PR DESCRIPTION
### Goal of this PR
Add the ability to apply regex filters (channel and message) on the native `REGISTER_CONSOLE_LISTENER`. 

### How is this PR achieving the goal
By retrieving filters (optional) and searching for a match when a new log arrives.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** .. 
**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues