### PR TITLE
feat(gta-core-rdr3): support for increased networked object pool

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxObjects.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxObjects.cpp
@@ -1,0 +1,31 @@
+#include <StdInc.h>
+
+#include <Pool.h>
+#include <PoolSizesState.h>
+#include "Hooking.h"
+#include "Hooking.Stubs.h"
+
+static HookFunction hookFunction([]()
+{
+	constexpr size_t kDefaultMaxObjects = 60;
+
+	int64_t increaseSize = 0;
+
+	// We use "CNetObjObject" as the increase request for objects and all other components.
+	auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjObject");
+	if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
+	{
+		increaseSize = sizeIncreaseEntry->second;
+	}
+
+	// Set total desired objects.
+	hook::put<uint32_t>(hook::get_pattern("C7 05 ? ? ? ? ? ? ? ? 89 05 ? ? ? ? 89 0D", 0x6), kDefaultMaxObjects + increaseSize);
+
+	// Set max amount of objects
+	*hook::get_address<uint32_t*>(hook::get_pattern("89 0D ? ? ? ? 8D 41 ? 44 89 05", 2)) = kDefaultMaxObjects + increaseSize;
+	*hook::get_address<uint32_t*>(hook::get_pattern("89 0D ? ? ? ? 89 0D ? ? ? ? 8D 41 ? 44 89 05", 2)) = kDefaultMaxObjects + increaseSize;
+	*hook::get_address<uint32_t*>(hook::get_pattern("89 0D ? ? ? ? 89 0D ? ? ? ? 89 0D ? ? ? ? 8D 41", 2)) = kDefaultMaxObjects + increaseSize;
+	
+	// Allow registration of script/mission objects up to and past the 60 limit.
+	hook::put<uint32_t>(hook::get_pattern("BB ? ? ? ? EB ? BB ? ? ? ? EB ? BB ? ? ? ? EB ? 8B CF", 1), kDefaultMaxObjects + increaseSize);
+});

--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -61,6 +61,7 @@ static const char* poolEntriesTable[] = {
 	"atDGameServerTransactionNode",
 	"atDNetEventNode",
 	"atDScriptObjectNode",
+	"atDNetObjectNode",
 	"AttachmentExtension",
 	"audDynMixPatch",
 	"audDynMixPatchSettings",
@@ -227,6 +228,7 @@ static const char* poolEntriesTable[] = {
 	"CNetObjVehicle",
 	"CNetObjWorldState",
 	"CNetBlenderPed",
+	"CNetBlenderPhysical",
 	"CPedSyncData",
 	"CNetworkTrainTrackJunctionSwitchWorldStateData",
 	"CObjectAnimationComponent",
@@ -245,6 +247,8 @@ static const char* poolEntriesTable[] = {
 	"CObjectRiverProbeSubmissionComponent",
 	"CObjectVehicleParentDeletedComponent",
 	"CObjectWeaponsComponent",
+	"CObjectSyncData",
+	"reassignObjectInfo",
 	"CombatMeleeManager_Groups",
 	"CombatMountedManager_Attacks",
 	"CompEntity",
@@ -637,6 +641,14 @@ static std::unordered_map<uint32_t, std::string_view> pedPoolEntries{
 	{ HashString("CPedBreatheComponent"), "CPedBreatheComponent" }
 };
 
+static std::unordered_map<uint32_t, std::string_view> objectPoolEntries{
+	{ HashString("CObjectSyncData"), "CObjectSyncData" },
+	{ HashString("CNetBlenderPhysical"), "CNetBlenderPhysical" },
+	{ HashString("atDNetObjectNode"), "atDNetObjectNode" },
+	{ HashString("CObjectCollisionDetectedComponent"), "CObjectCollisionDetectedComponent" },
+	{ HashString("reassignObjectInfo"), "reassignObjectInfo" }
+};
+
 atPoolBase* rage::GetPoolBase(uint32_t hash)
 {
 	auto it = g_pools.find(hash);
@@ -749,6 +761,17 @@ static int64_t GetSizeOfPool(void* configManager, uint32_t poolHash, int default
 	if (auto it = pedPoolEntries.find(poolHash); it != pedPoolEntries.end())
 	{
 		auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjPedBase");
+		if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
+		{
+			size += sizeIncreaseEntry->second;
+		}
+		return size;
+	}
+
+	// There are several pools that are tied to Objects/CNetObjObject. We want to ensure that the increased value is applied to all of these components.
+	if (auto it = objectPoolEntries.find(poolHash); it != objectPoolEntries.end())
+	{
+		auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjObject");
 		if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
 		{
 			size += sizeIncreaseEntry->second;


### PR DESCRIPTION
### Goal of this PR
Allow to increase networked objects pool in RedM, currently there's a limit of 60.
The structure of the code is the same as that of #3542 made by @Ehbw 
I've tested this increasing up to 200 and looks to work well, but should be good to set the limit to 100 in the pool allow list.


### How is this PR achieving the goal
Adding object pool entries that contains a list of pools that are going to be increased alongside `CNetObjObject`.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.