### PR TITLE
fix(citizen-devtools): improve search filter of pool list

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -906,9 +906,24 @@ static InitFunction initFunction([]()
 
 				for (const auto& poolData : poolsInfo)
 				{
-					if (!poolData.name._Starts_with(search))
+					if (search[0] != '\0')
 					{
-						continue;
+						std::string nameLower = poolData.name;
+						std::string itemsStr = std::to_string(poolData.items);
+						std::string maxItemsStr = std::to_string(poolData.maxItems);
+						std::string searchLower = search;
+
+						std::transform(nameLower.begin(), nameLower.end(), nameLower.begin(), ::tolower);
+						std::transform(itemsStr.begin(), itemsStr.end(), itemsStr.begin(), ::tolower);
+						std::transform(maxItemsStr.begin(), maxItemsStr.end(), maxItemsStr.begin(), ::tolower);
+						std::transform(searchLower.begin(), searchLower.end(), searchLower.begin(), ::tolower);
+
+						if (nameLower.find(searchLower) == std::string::npos &&
+							itemsStr.find(searchLower) == std::string::npos &&
+							maxItemsStr.find(searchLower) == std::string::npos)
+						{
+							continue;
+						}
 					}
 
 					std::string humanSize;


### PR DESCRIPTION
### Goal of this PR
Improve QoL of the pool list search feature by making it case-insensitive, allowing partial matches anywhere within the name and allow filter Items & MaxItems.

https://github.com/user-attachments/assets/49e2fbeb-c10a-4ddf-8f3f-4f64b01e7741


### How is this PR achieving the goal
Replaces the strict Starts_with check with a case-insensitive substring search. Now users can type any part of the name, and the filter will match it regardless of case. It also includes Items and MaxItems in the search by converting them to strings and checking if the input matches any part of them.


### This PR applies to the following area(s)
FiveM, RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.