### PR TITLE
fix(streaming/rdr3): don't attempt to reload collisions

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1116,7 +1116,10 @@ static void ReloadMapStore()
 #endif
 		   )
 		{
+			// currently, Reloading custom collision causes it to break in RDR3
+#ifndef IS_RDR3
 			collisionFiles.push_back(std::make_pair(file, obj));
+#endif
 		}
 		else
 		{


### PR DESCRIPTION
### Goal of this PR

Resolves custom collisions failing to load following #3543.

### How is this PR achieving the goal

By not allowing custom ybns/collision to be reloaded in RDR3, as for a currently unknown reason it causes crashes for some clients and ultimately breaks its collision.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491.50

**Platforms:** Windows

Tested with a custom interior with multiple collision files.

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

Reported in engineering discord and tied to sub_142B89780 (0x63) / september-solar-beer crashes that begun on august 6th.
