### PR TITLE
feat(server): add command to reload resource client file

### DIFF
--- a/code/components/citizen-resources-core/include/Resource.h
+++ b/code/components/citizen-resources-core/include/Resource.h
@@ -93,6 +93,11 @@ public:
 	virtual bool Start() = 0;
 
 	//
+	// Reloads client files for the resource.
+	//
+	virtual bool ClientReloadFile() = 0;
+
+	//
 	// Stops the resource.
 	//
 	virtual bool Stop() = 0;
@@ -127,6 +132,11 @@ public:
 	// An event to handle tasks to be performed when starting a resource.
 	//
 	fwEvent<> OnStart;
+
+	//
+	// An event to handle tasks to be performed when reloading client files for a resource.
+	//
+	fwEvent<> OnClientReloadFile;
 
 	//
 	// An event to handle tasks to be performed when stopping a resource.

--- a/code/components/citizen-resources-core/include/ResourceImpl.h
+++ b/code/components/citizen-resources-core/include/ResourceImpl.h
@@ -39,6 +39,8 @@ public:
 
 	virtual bool Start() override;
 
+	virtual bool ClientReloadFile() override;
+
 	virtual bool Stop() override;
 
 	virtual void Run(std::function<void()>&& fn) override;

--- a/code/components/citizen-resources-core/src/Resource.cpp
+++ b/code/components/citizen-resources-core/src/Resource.cpp
@@ -116,6 +116,21 @@ bool ResourceImpl::Start()
 	return true;
 }
 
+bool ResourceImpl::ClientReloadFile()
+{
+	m_manager->MakeCurrent();
+
+	if (m_state != ResourceState::Stopped)
+	{
+		if (!OnClientReloadFile())
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 bool ResourceImpl::Stop()
 {
 	m_manager->MakeCurrent();

--- a/code/components/citizen-scripting-core/src/ResourceCallbackComponent.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceCallbackComponent.cpp
@@ -36,6 +36,11 @@ public:
 		return false;
 	}
 
+	virtual bool ClientReloadFile() override
+	{
+		return false;
+	}
+
 	virtual bool Stop() override
 	{
 		return false;

--- a/code/components/citizen-server-impl/src/ResourceConfigurationCacheComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceConfigurationCacheComponent.cpp
@@ -102,6 +102,12 @@ void ResourceConfigurationCacheComponent::AttachToObject(Resource* object)
 	},
 	501);
 
+	object->OnClientReloadFile.Connect([=]()
+	{
+		Invalidate();
+	},
+	501);
+
 	object->OnStop.Connect([=]()
 	{
 		Invalidate();

--- a/code/components/citizen-server-impl/src/ResourceFilesComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceFilesComponent.cpp
@@ -640,7 +640,7 @@ namespace fx
 	{
 		m_resource = object;
 
-		object->OnStart.Connect([this]()
+		auto buildAndHashSets = [this]()
 		{
 			std::set<std::string> sets = { GetDefaultSetName() };
 			ParseFileSets();
@@ -682,7 +682,10 @@ namespace fx
 						hash[10], hash[11], hash[12], hash[13], hash[14], hash[15], hash[16], hash[17], hash[18], hash[19]);
 				}
 			}
-		}, 500);
+		};
+
+		object->OnStart.Connect(buildAndHashSets, 500);
+		object->OnClientReloadFile.Connect(buildAndHashSets, 500);
 	}
 
 	std::string ResourceFilesComponent::GetSetFileName(const std::string& setName)

--- a/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
@@ -484,7 +484,7 @@ namespace fx
 	{
 		m_resource = object;
 
-		object->OnStart.Connect([=]()
+		auto loadStreamFiles = [=]()
 		{
 			if (ShouldUpdateSet())
 			{
@@ -518,7 +518,18 @@ namespace fx
 					}
 				}
 			}
-		}, 500);
+		};
+
+		object->OnStart.Connect(loadStreamFiles, 500);
+
+		object->OnClientReloadFile.Connect([=]()
+		{
+			m_resourcePairs.clear();
+			m_hashPairs.clear();
+
+			loadStreamFiles();
+		},
+		500);
 
 		object->OnStop.Connect([=]()
 		{

--- a/code/components/citizen-server-impl/src/TerminalInput.cpp
+++ b/code/components/citizen-server-impl/src/TerminalInput.cpp
@@ -157,7 +157,7 @@ static InitFunction initFunction([]()
 						// do we need a resource completion list?
 						bool isResourceCommand = false;
 
-						for (auto test : { "ensure", "start", "stop", "restart" })
+						for (auto test : { "ensure", "start", "stop", "restart", "reloadclientfile" })
 						{
 							if (cmd == test)
 							{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This PR adds a command to reload a specific resource’s client files from the file server. Using this command ensures that subsequent players (or for streamed assets, when fetched later) will load the updated files.

The key difference from `ensure/restart` is that it applies to players who join afterwards rather than affecting current players immediately.

### How is this PR achieving the goal
Adds the `reloadclientfile` command to reload a specific resource’s client files from the file server.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
N/A
