### PR TITLE
fix(core/rdr3): followup for combat crash

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchWeaponTargetCrash.cpp
+++ b/code/components/gta-core-rdr3/src/PatchWeaponTargetCrash.cpp
@@ -9,46 +9,97 @@
 
 static HookFunction hookFunction([]
 {
-	auto location = hook::get_pattern<char>("49 8B 0F 48 8B 01 FF 90 ? ? ? ? 48 85 C0");
-
-	static struct : jitasm::Frontend
+	// Check if the netObject is a nullptr
 	{
-		uintptr_t retnSuccess;
-		uintptr_t retnFail;
+		auto location = hook::get_pattern<char>("49 8B 0F 48 8B 01 FF 90 ? ? ? ? 48 85 C0");
 
-		void Init(uintptr_t success, uintptr_t fail)
+		static struct : jitasm::Frontend
 		{
-			retnSuccess = success;
-			retnFail = fail;
-		}
+			uintptr_t retnSuccess;
+			uintptr_t retnFail;
 
-		virtual void InternalMain() override
+			void Init(uintptr_t success, uintptr_t fail)
+			{
+				retnSuccess = success;
+				retnFail = fail;
+			}
+
+			virtual void InternalMain() override
+			{
+				// Original code
+				test(r15, r15);
+				jz("fail");
+
+				mov(rcx, qword_ptr[r15]);
+				test(rcx, rcx);
+				jz("fail");
+
+				mov(rax, qword_ptr[rcx]);
+				test(rax, rax);
+				jz("fail");
+
+				// Original code, gets the gameObject and checks if thats a null
+				mov(r11, retnSuccess);
+				jmp(r11);
+
+				L("fail");
+				mov(r11, retnFail);
+				jmp(r11);
+			}
+		} patchStub;
+
+		const uintptr_t retnSuccess = (uintptr_t)location + 6;
+		const uintptr_t retnFail = (uintptr_t)hook::get_pattern("33 C0 E9 ? ? ? ? 48 8B 00 FF 90");
+
+		hook::nop(location, 6);
+		patchStub.Init(retnSuccess, retnFail);
+		hook::jump_reg<5>(location, patchStub.GetCode());	
+	}
+
+	// In some situations, usually when a ped is actively being created/destroyed on the client. ped components can be invalid
+	{
+		auto location = hook::get_pattern("48 23 C1 8B 88 ? ? ? ? C1 E1 ? 85 C9 0F 8E ? ? ? ? B8");
+
+		static struct : jitasm::Frontend
 		{
-			// Original code
-			test(r15, r15); 
-			jz("fail");
+			uintptr_t retnSuccess;
+			uintptr_t retnFail;
+			uint32_t compOffset;
 
-			mov(rcx, qword_ptr[r15]);
-			test(rcx, rcx);
+			void Init(uintptr_t success, uintptr_t fail, uint32_t componentOffset)
+			{
+				retnSuccess = success;
+				retnFail = fail;
+				compOffset = componentOffset;
+			}
 
-			jz("fail");
+			virtual void InternalMain() override
+			{
+				// Original code
+				test(rcx, rcx);
+				jz("fail");
 
-			mov(rax, qword_ptr[rcx]);
-			test(rax, rax);
+				and(rax, rcx);
+				test(rax, rax);
+				jz("fail");
 
-			mov(r11, retnSuccess);
-			jmp(r11);
+				mov(ecx, dword_ptr[rax + compOffset]);
 
-			L("fail");
-			mov(r11, retnFail);
-			jmp(r11);
-		}
-	} patchStub;
+				mov(r11, retnSuccess);
+				jmp(r11);
 
-	const uintptr_t retnSuccess = (uintptr_t)location + 6;
-	const uintptr_t retnFail = (uintptr_t)hook::get_pattern("33 C0 E9 ? ? ? ? 48 8B 00 FF 90");
+				L("fail");
+				mov(r11, retnFail);
+				jmp(r11);
+			}
+		} patchStubPedComponents;
 
-	hook::nop(location, 6);
-	patchStub.Init(retnSuccess, retnFail);
-	hook::jump_reg<5>(location, patchStub.GetCode());
+		const uintptr_t retnSuccess = (uintptr_t)location + 9;
+		const uintptr_t retnFail = (uintptr_t)hook::get_pattern("33 C0 E9 ? ? ? ? 48 8B 00 FF 90");
+		uint32_t pedComponentOffset = *hook::get_pattern<uint32_t>("8B 88 ? ? ? ? C1 E1 ? 85 C9 0F 8E ? ? ? ? B8", 2);
+
+		hook::nop(location, 9);
+		patchStubPedComponents.Init(retnSuccess, retnFail, pedComponentOffset);
+		hook::jump_reg<5>(location, patchStubPedComponents.GetCode());	
+	}
 });


### PR DESCRIPTION
### Goal of this PR

Follow up patch for #3547, resolving another crash related to this in cases where an entity is being actively created/destroyed and lacks pedComponents leading to a crash in weaponDamageEvent.

### How is this PR achieving the goal

Implementing a nullptr check in the function where ped components are accessed.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

wyoming-washington-thirteen / RDR2_b1491.exe!sub_1423F081C (0x3d6)