### PR TITLE
feat(gta-core-rdr3): support for increased networked vehicle pool

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxVehicles.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxVehicles.cpp
@@ -1,0 +1,75 @@
+#include <StdInc.h>
+#include <PoolSizesState.h>
+#include "Hooking.h"
+
+static HookFunction hookFunction([]()
+{
+	constexpr size_t kDefaultMaxVehicles = 40;
+
+	int64_t increaseSize = 0;
+
+	// We use "CNetObjVehicle" as the increase request for vehicles and all other components.
+	auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjVehicle");
+	if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
+	{
+		increaseSize = sizeIncreaseEntry->second;
+	}
+
+	// Set total desired vehicles.
+	uint8_t patch[] = {
+		0xB9,              // mov ecx, imm32
+		0x00, 0x00, 0x00, 0x00, // placholder for the value
+		0x90               // nop
+	};
+
+	uint32_t finalSize = static_cast<uint32_t>(kDefaultMaxVehicles + increaseSize);
+	std::memcpy(&patch[1], &finalSize, sizeof(finalSize));
+	memcpy(hook::get_pattern("8B 0D ? ? ? ? C7 05 ? ? ? ? ? ? ? ? 89 05"), patch, sizeof(patch));
+
+	// Set max amount of vehicles
+	auto address = hook::get_pattern<char>("44 89 0D ? ? ? ? 48 89 15");
+	auto patchValue = [&](uintptr_t addrOffset) {
+		auto currentAddr = address + addrOffset;
+		int32_t relative = *(int32_t*)(currentAddr + 3);
+		auto absolute = currentAddr + 7 + relative; // RIP + relative
+		*absolute = kDefaultMaxVehicles + increaseSize;
+	};
+
+	patchValue(0);
+	patchValue(20);
+	patchValue(27);
+
+	// Mission car limitation, by default is 64
+	{
+		auto location = hook::get_pattern<char>("83 3D ? ? ? ? ? 0F 29 70 ? 0F 28 F1");
+		hook::put<uint8_t>(location, 0x81); // comp with immediate
+		hook::put<uint32_t>(location + 0x6, kDefaultMaxVehicles + increaseSize + 24);
+		hook::nop(location + 0xA, 0x7);
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t returnLocation;
+			
+			virtual void InternalMain() override
+			{
+				// Original Instructions
+				movaps(xmmword_ptr[rax-0x28], xmm6);
+				movaps(xmm6, xmm1);
+				unpcklps(xmm6, xmm0);
+
+				mov(rdi, returnLocation);
+				jmp(rdi);
+			}
+		} stub;
+		stub.returnLocation = (uintptr_t)location + 0x11;
+		hook::jump_reg<7>(location + 0xA, stub.GetCode());
+
+		hook::put<uint16_t>(location + 0x1E, 0x830F); // jae loc_... (unsigned >=)
+	}
+	
+	// Allow registration of script/mission vehicles up to and past the 40 limit.
+	hook::put<uint32_t>(hook::get_pattern("BB ? ? ? ? E9 ? ? ? ? B8 ? ? ? ? 83 FF", 0x1), kDefaultMaxVehicles + increaseSize);
+
+	// Ignore hard coded limit of CVehicle to 128
+	hook::put<char>(hook::get_pattern("76 ? BA ? ? ? ? 41 B8 ? ? ? ? 83 C9 ? E8 ? ? ? ? 33 D2 8B CB"), 0xEB);
+});

--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -226,6 +226,7 @@ static const char* poolEntriesTable[] = {
 	"CNetObjPropSet",
 	"CNetObjStatsTracker",
 	"CNetObjVehicle",
+	"CVehicleSyncData",
 	"CNetObjWorldState",
 	"CNetBlenderPed",
 	"CNetBlenderPhysical",
@@ -596,6 +597,10 @@ static const char* poolEntriesTable[] = {
 	"volSphere",
 	"WorldUpdateEntities",
 	"wptrec",
+	"Wheels",
+	"CMoveVehicle",
+	"Vehicle Intelligence",
+	"fragInstNMGta",
 };
 
 static RageHashList poolEntries(poolEntriesTable);
@@ -647,6 +652,21 @@ static std::unordered_map<uint32_t, std::string_view> objectPoolEntries{
 	{ HashString("atDNetObjectNode"), "atDNetObjectNode" },
 	{ HashString("CObjectCollisionDetectedComponent"), "CObjectCollisionDetectedComponent" },
 	{ HashString("reassignObjectInfo"), "reassignObjectInfo" }
+};
+
+static std::unordered_map<uint32_t, std::string_view> vehiclePoolEntries {
+	{ HashString("Vehicles"), "Vehicles" }, // This already apply default size for CVehicle & 0x4CF5F35A(audVehicleAudioEntity)
+	{ HashString("CVehicleSyncData"), "CVehicleSyncData" },
+	{ HashString("CVehicleAnimationComponent"), "CVehicleAnimationComponent" },
+	{ HashString("CVehicleDrivingComponent"), "CVehicleDrivingComponent" },
+	{ HashString("CVehicleIntelligenceComponent"), "CVehicleIntelligenceComponent" },
+	{ HashString("CVehiclePhysicsComponent"), "CVehiclePhysicsComponent" },
+	{ HashString("CVehicleWeaponsComponent"), "CVehicleWeaponsComponent" },
+	{ HashString("CVehicleCoreComponent"), "CVehicleCoreComponent" },
+	
+	{ HashString("atDNetObjectNode"), "atDNetObjectNode" },
+	{ HashString("reassignObjectInfo"), "reassignObjectInfo" },
+	{ HashString("CNetBlenderPhysical"), "CNetBlenderPhysical" },
 };
 
 atPoolBase* rage::GetPoolBase(uint32_t hash)
@@ -772,6 +792,16 @@ static int64_t GetSizeOfPool(void* configManager, uint32_t poolHash, int default
 	if (auto it = objectPoolEntries.find(poolHash); it != objectPoolEntries.end())
 	{
 		auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjObject");
+		if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
+		{
+			size += sizeIncreaseEntry->second;
+		}
+		return size;
+	}
+
+	if (auto it = vehiclePoolEntries.find(poolHash); it != vehiclePoolEntries.end())
+	{
+		auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find("CNetObjVehicle");
 		if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
 		{
 			size += sizeIncreaseEntry->second;


### PR DESCRIPTION
### Goal of this PR
Allow to increase non and networked vehicles in RedM, the current limit is 40, this aims to allow more boat, trains and all vehicles except draft vehicles for now cause it's need more research.
With this should be good to have the `CNetObjVehicle` in the allowed pool list up to 40.


### How is this PR achieving the goal
Patches several hardcoded vehicle limits in the game(total desired vehicles, mission/script limits, and CVehicle cap)


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.