### PR TITLE
fix(natives): Fixed incorrect behavior of the `SET_CURSOR_LOCATION` native function for both game clients.

### DIFF
--- a/code/components/gta-core-five/component.json
+++ b/code/components/gta-core-five/component.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"dependencies": [
 		"fx[2]",
+		"conhost:v2",
 		"pool-sizes-state",
 		"rage:allocator:five",
 		"rage:nutsnbolts:five",

--- a/code/components/gta-core-five/src/SetCursorLocation.cpp
+++ b/code/components/gta-core-five/src/SetCursorLocation.cpp
@@ -2,6 +2,8 @@
 
 #include "scrEngine.h"
 #include "InputHook.h"
+#include <ConsoleHost.h>
+
 
 rage::scrEngine::NativeHandler m_origSetCursorLocation;
 static HookFunction hookFunction([]()
@@ -12,9 +14,15 @@ static HookFunction hookFunction([]()
 		m_origSetCursorLocation = rage::scrEngine::GetNativeHandler(0xFC695459D4D0E219);
 		rage::scrEngine::RegisterNativeHandler(0xFC695459D4D0E219, [](rage::scrNativeCallContext* context)
 		{
-			InputHook::EnableSetCursorPos(true);
-			(*m_origSetCursorLocation)(context);
-			InputHook::EnableSetCursorPos(false);
+			HWND gameWindow = CoreGetGameWindow();
+			bool consoleEnabled = ConHost::IsConsoleOpen();
+			
+			if (GetForegroundWindow() == gameWindow && !consoleEnabled)
+			{
+				InputHook::EnableSetCursorPos(true);
+				(*m_origSetCursorLocation)(context);
+				InputHook::EnableSetCursorPos(false);
+			}
 		});
 	});
 


### PR DESCRIPTION
### Goal of this PR
Fixed incorrect behavior of the built-in function `SET_CURSOR_LOCATION` on both game clients (rdr3, five), which worked in any case, even if the console (F8) was open or the game was minimized, and the mouse was controlled on the desktop.


### How is this PR achieving the goal
This PR adds a check to the native `SET_CURSOR_LOCATION` function to see if the window is currently active and if the game console (F8) is open. If so, it returns false.


### This PR applies to the following area(s)
FiveM, RedM, Natives


### Successfully tested on

**Game builds:** FiveM (3258), RedM(1491)

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3554


