### PR TITLE
feat(gta-streaming-five): increase fwPortalSceneGraphNode pool size to 800

### DIFF
--- a/code/components/conhost-v2/src/DevGui.cpp
+++ b/code/components/conhost-v2/src/DevGui.cpp
@@ -294,6 +294,7 @@ devgui_convar "Tools/Streaming/Streaming Stats" strdbg
 devgui_convar "Tools/Streaming/Streaming List" strlist
 devgui_convar "Tools/Streaming/Pool Monitor" net_showPools
 devgui_convar "Tools/Streaming/pgRawStreamer assets" net_pgStats
+devgui_convar "Tools/Streaming/Scene Graph Pools" sceneGraphPools
 devgui_convar "Tools/Network/OneSync/Network Object Viewer" netobjviewer
 devgui_convar "Tools/Network/OneSync/Network SyncLog" netobjviewer_syncLog
 devgui_convar "Tools/Network/OneSync/Network Time" net_showTime

--- a/code/components/devtools-five/src/SceneGraphPoolsDebug.cpp
+++ b/code/components/devtools-five/src/SceneGraphPoolsDebug.cpp
@@ -1,0 +1,417 @@
+#include <StdInc.h>
+#include <CoreConsole.h>
+#include <ConsoleHost.h>
+#include <imgui.h>
+#include <Hooking.h>
+#include <jitasm.h>
+
+#include "Hooking.Stubs.h"
+#include "ScriptEngine.h"
+#include "ScriptInvoker.h"
+
+namespace rage
+{
+	struct alignas(16) Vec4V
+	{
+		float x, y, z, w;
+	};
+	struct Vector3
+	{
+		float x, y, z;
+		float __pad;
+	};
+	struct atUserBitSet
+	{
+		unsigned int *bits;
+		unsigned __int16 size;
+		unsigned __int16 bitSize;
+		char m_Pad[4];
+	};
+	struct PortalEntry
+	{
+		void* portal;
+		void* destination;
+	};
+	struct PortalStack
+	{
+		PortalEntry elements[192];
+		int count;
+		char m_Pad[4];
+	};
+	enum eSceneGraphNodeType : uint8_t
+	{
+		EXTERIOR,
+		STREAMED,
+		INTERIOR,
+		ROOM,
+		PORTAL
+	};
+	struct fwSceneGraphNode
+	{
+		fwSceneGraphNode* next;
+		fwSceneGraphNode* child;
+		eSceneGraphNodeType type;
+		uint8_t flags;
+		int16_t index;
+		char m_pad[4];
+	};
+	struct fwScanNodes
+	{
+		Vec4V exteriorScreenQuad;
+		Vector3 cameraPosition;
+		
+		PortalStack postalStack;
+		void* scanBase;
+		fwSceneGraphNode* rootNode;
+		void* scanResults;
+		void* zBuffer[2];
+		unsigned int *visFlags;
+		Vec4V* screenQuadsStorage[2];
+		atUserBitSet beingVisited[2];
+		atUserBitSet visited[2];
+		atUserBitSet lodsOnly;
+		uint8_t* bufferGuard;
+	};
+	struct fwPortalCorners
+	{
+		rage::Vector3 corners[4];
+	};
+	struct fwPortalSceneGraphNode : fwSceneGraphNode
+	{
+		uint8_t unk0[4];
+		char m_pad[4];
+		fwPortalCorners corners;
+		void* container;
+		void* interiorNode;
+		fwSceneGraphNode* negativePortal;
+		fwSceneGraphNode* positivePortal;
+	};
+	struct Color32 {
+		uint32_t m_Color;
+		constexpr Color32(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
+			: m_Color((uint32_t(a) << 24) | (uint32_t(r) << 16) | (uint32_t(g) << 8) | uint32_t(b)) {}
+	};
+	struct Vector2
+	{
+		float x;
+		float y;
+	};
+	struct fwBasePool
+	{
+		uint8_t* storage;
+		uint8_t* flags;
+		int size;
+		int storageSize;
+		int firstFreeIndex;
+		int lastFreeIndex;
+		int slotsUsed : 30;
+		int ownsArray : 2;
+		char pad[0x2C];
+	};
+}
+
+static hook::cdecl_stub<void(rage::Vec4V*, rage::Vec4V*, rage::Vec4V*, rage::Color32 color)> drawPoly([]()
+{
+	return hook::get_call(hook::get_pattern("4C 8D 44 24 ? 0F B6 C1", 0x10));
+});
+
+static rage::fwScanNodes* scanNodes = nullptr;
+static int scanNodesCount = 0;
+
+static rage::fwPortalSceneGraphNode* nearestPortal = nullptr;
+static rage::Vector3 nearestPortalPos = { 0.0f, 0.0f, 0.0f };
+static float nearestPortalDist = 100.0f;
+
+static bool drawPortals = true;
+static float portalColor[4] = { 0.0f, 0.0f, 1.0f, 0.4f };
+
+static void VisibilityBegin(rage::fwScanNodes* scanNodes)
+{
+	scanNodes = scanNodes;
+}
+
+static inline float DistSq(const rage::Vector3& a, const rage::Vector3& b)
+{
+	const float dx = a.x - b.x;
+	const float dy = a.y - b.y;
+	const float dz = a.z - b.z;
+	return dx*dx + dy*dy + dz*dz;
+}
+
+static inline rage::Vector3 PortalCenter(const rage::fwPortalSceneGraphNode* p)
+{
+	const auto& c = p->corners.corners;
+	return { (c[0].x + c[1].x + c[2].x + c[3].x) * 0.25f,
+			 (c[0].y + c[1].y + c[2].y + c[3].y) * 0.25f,
+			 (c[0].z + c[1].z + c[2].z + c[3].z) * 0.25f,
+			 0.0f };
+}
+
+static void ConsiderPortalNearest(rage::fwPortalSceneGraphNode* portal, const rage::Vector3& refPos)
+{
+	const rage::Vector3 center = PortalCenter(portal);
+	const float d2 = DistSq(center, refPos);
+	if (d2 < nearestPortalDist)
+	{
+		nearestPortalDist = d2;
+		nearestPortal = portal;
+		nearestPortalPos = center;
+	}
+}
+
+static void DrawPortal(rage::fwPortalSceneGraphNode portal, rage::Color32 color)
+{
+	if(!drawPortals)
+		return;
+	
+	const auto& pc = portal.corners.corners;
+	
+	rage::Vec4V v0 = { pc[0].x, pc[0].y, pc[0].z, 1.0f };
+	rage::Vec4V v1 = { pc[1].x, pc[1].y, pc[1].z, 1.0f };
+	rage::Vec4V v2 = { pc[2].x, pc[2].y, pc[2].z, 1.0f };
+	rage::Vec4V v3 = { pc[3].x, pc[3].y, pc[3].z, 1.0f };
+
+	// Front Face
+	drawPoly(&v0, &v1, &v2, color);
+	drawPoly(&v0, &v2, &v3, color);
+
+	// Back Face
+	drawPoly(&v0, &v2, &v1, color);
+    drawPoly(&v0, &v3, &v2, color);
+}
+
+static void TraverseGraphNode(rage::fwSceneGraphNode* node)
+{
+	while (node)
+	{
+		scanNodesCount++;
+		
+		switch (node->type)
+		{
+			case rage::PORTAL:
+			{
+				ConsiderPortalNearest(reinterpret_cast<rage::fwPortalSceneGraphNode*>(node), scanNodes->cameraPosition);
+				rage::Color32 color(
+					static_cast<uint8_t>(portalColor[0] * 255),
+					static_cast<uint8_t>(portalColor[1] * 255),
+					static_cast<uint8_t>(portalColor[2] * 255),
+					static_cast<uint8_t>(portalColor[3] * 255)
+				);
+				DrawPortal(*reinterpret_cast<rage::fwPortalSceneGraphNode*>(node), color);
+				break;
+			}
+			case rage::EXTERIOR:
+			case rage::STREAMED:
+			case rage::INTERIOR:
+			case rage::ROOM:
+				break;
+		}
+
+		if (node->child)
+			TraverseGraphNode(node->child);
+
+		node = node->next;
+	}
+}
+
+static void DebugDrawGraphNode()
+{
+	if(scanNodes == nullptr)
+	{
+		return;
+	}
+	rage::fwSceneGraphNode* root = scanNodes->rootNode;
+	scanNodesCount = 0;
+	nearestPortalDist = 100.0f;
+	
+	TraverseGraphNode(root);
+	if(nearestPortal)
+	{
+		rage::Color32 color(255, 0, 0, static_cast<uint8_t>(portalColor[3] * 255));
+		DrawPortal(*nearestPortal, color);
+	}
+}
+
+static void VisibilityEnd()
+{
+	DebugDrawGraphNode();
+}
+
+// This is to validate that beingVisited, visited, lodsOnly, etc bitsets are not being overflowed
+static void ValidateScratchBufferGuard(rage::fwScanNodes* self)
+{
+	for (int i = 0; i < 16; ++i)
+	{
+		assert((self->bufferGuard[i] == 0xFE) && "Scratch buffer guard corruption detected");
+	}
+}
+
+struct PoolEntry
+{
+	const char* name;
+	rage::fwBasePool* pool;
+};
+
+static std::vector<PoolEntry> poolList;
+
+static void (*g_origFwBasePool)(rage::fwBasePool*, int, uint8_t*, uint8_t*, const char*, int, int);
+static void FwBasePool(rage::fwBasePool* pool, int poolSize, uint8_t* storage, uint8_t* scratchBuffer, const char* name, int classSize, int flags)
+{
+	poolList.push_back({ name, pool });
+	g_origFwBasePool(pool, poolSize, storage, scratchBuffer, name, classSize, flags);
+}
+
+static int16_t (*g_origComputeSceneNodeIndex)(const void* sceneNode);
+static int16_t ComputeSceneNodeIndex(const void* sceneNode)
+{
+	auto result = g_origComputeSceneNodeIndex(sceneNode);
+	trace("Scene Node Index: %d\n", result);
+	return result;
+}
+
+static HookFunction hookFunction([]()
+{
+	g_origComputeSceneNodeIndex = hook::trampoline(hook::get_pattern("4C 8B C1 0F B6 49 ? 85 C9"), ComputeSceneNodeIndex);
+	g_origFwBasePool = hook::trampoline(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 89 1D ? ? ? ? EB ? 48 89 35 ? ? ? ? 48 8B 0D")), FwBasePool);
+	// Visibility Being
+	{
+		auto location = hook::get_pattern<char>("44 88 8B ? ? ? ? 66 45 3B 88");
+		
+		static struct : jitasm::Frontend
+		{
+			uintptr_t continueLocation;
+
+			virtual void InternalMain() override
+			{
+				mov(byte_ptr[rbx+0xCE1], r9b);
+
+				mov(rcx, rbx);
+				mov(r15, (uintptr_t)VisibilityBegin); // VisibilityBeing(this)
+				call(r15);
+				
+				mov(r15, continueLocation);
+				jmp(r15);
+			}
+		} stub;
+		stub.continueLocation = (uintptr_t)location + 7;
+		hook::nop(location, 7);
+		hook::jump(location, stub.GetCode());
+	}
+
+	// Visibility End
+	{
+		auto location = hook::get_pattern<char>("48 8B 93 ? ? ? ? 48 8D 4D ? 48 81 C2 ? ? ? ? E8 ? ? ? ? 4C 8D 4C 24");
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t continueLocation;
+
+			virtual void InternalMain() override
+			{
+				mov(rdx, qword_ptr[rbx+0xC28]);
+				
+				mov(rcx, (uintptr_t)VisibilityEnd);
+				call(rcx);
+				
+				mov(rcx, continueLocation);
+				jmp(rcx);
+			}
+		} stub;
+		stub.continueLocation = (uintptr_t)location + 7;
+		hook::nop(location, 7);
+		hook::jump_rcx(location, stub.GetCode());
+	}
+
+	// Asset scratch buffer guard
+	{
+		auto location = hook::get_pattern<char>("48 8D 4C 24 ? E8 ? ? ? ? B0 ? 48 81 C4 ? ? ? ? 5D");
+
+		static struct : jitasm::Frontend
+		{
+			uintptr_t continueLocation;
+
+			virtual void InternalMain() override
+			{
+				lea(rcx, dword_ptr[rsp+0x20]);
+				mov(rax, (uintptr_t)ValidateScratchBufferGuard);
+				call(rax);
+				
+				lea(rcx, dword_ptr[rsp+0x20]);
+				mov(rax, continueLocation);
+				jmp(rax);
+			}
+		} stub;
+		stub.continueLocation = (uintptr_t)location + 5;
+		hook::nop(location, 5);
+		hook::jump_rcx(location, stub.GetCode());
+	}
+});
+
+static InitFunction initFunction([]()
+{
+	static bool sceneGraphPoolsEnabled = false;
+	static ConVar<bool> archetypeListVar("sceneGraphPools", ConVar_Archive | ConVar_UserPref, false, &sceneGraphPoolsEnabled);
+
+	ConHost::OnShouldDrawGui.Connect([](bool* should)
+	{
+		*should = *should || sceneGraphPoolsEnabled;
+	});
+
+	ConHost::OnDrawGui.Connect([]()
+	{
+		if (!sceneGraphPoolsEnabled)
+		{
+			return;
+		}
+		
+		if (ImGui::Begin("Scene Graph Pools", &sceneGraphPoolsEnabled))
+		{
+			int totalPools = poolList.size();
+			int totalSlots = 0;
+			int totalUsed = 0;
+			float maxUsage = -1.f, minUsage = 101.f;
+
+			for (auto& entry : poolList)
+			{
+				totalSlots += entry.pool->size;
+				totalUsed += entry.pool->slotsUsed;
+				float usage = (float)entry.pool->slotsUsed / entry.pool->size * 100.0f;
+			}
+
+			float totalUsage = (float)totalUsed / totalSlots * 100.0f;
+
+			ImGui::Text("Pools count: %d", totalPools);
+			ImGui::Text("Total slots: %d", totalSlots);
+			ImGui::Text("Used slots: %d (%.2f%%)", totalUsed, totalUsage);
+			
+			if (ImGui::BeginTable("Pools Data", 6,
+				ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
+			{
+				ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch, 2.0f);
+				ImGui::TableSetupColumn("Pool Size", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+				ImGui::TableSetupColumn("Used Slots", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+				ImGui::TableSetupColumn("Free Slots", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+				ImGui::TableSetupColumn("Entry Size", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+				ImGui::TableSetupColumn("Used Percentage", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+				ImGui::TableHeadersRow();
+
+				for(int i = 0; i < poolList.size(); i++)
+				{
+					const auto& entry = poolList[i];
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0); ImGui::Text("%s", entry.name);
+					ImGui::TableSetColumnIndex(1); ImGui::Text("%d", entry.pool->size);
+					ImGui::TableSetColumnIndex(2); ImGui::Text("%d", entry.pool->slotsUsed);
+					ImGui::TableSetColumnIndex(3); ImGui::Text("%d", entry.pool->size - entry.pool->slotsUsed);
+					ImGui::TableSetColumnIndex(4); ImGui::Text("%d", entry.pool->storageSize);
+					ImGui::TableSetColumnIndex(5); ImGui::Text("%.2f%%", (float)entry.pool->slotsUsed / (float)entry.pool->size * 100.0f);
+				}
+
+				ImGui::EndTable();
+			}
+		}
+		
+
+		ImGui::End();
+	});
+});

--- a/code/components/gta-streaming-five/src/SceneGraphPools.cpp
+++ b/code/components/gta-streaming-five/src/SceneGraphPools.cpp
@@ -1,0 +1,222 @@
+#include "StdInc.h"
+#include <Hooking.h>
+#include <jitasm.h>
+#include <mutex>
+
+struct PatternPair;
+
+enum class eSceneGraphPool : size_t
+{
+	FW_ENTITY_CONTAINER = 0,
+	FW_FIXED_ENTITY_CONTAINER = 1,
+	FW_SO_A_ENTITY_CONTAINER = 2,
+	FW_EXTERIOR_SCENE_GRAPH_NODE = 3,
+	FW_STREAMED_SCENE_GRAPH_NODE = 4,
+	FW_INTERIOR_SCENE_GRAPH_NODE = 5,
+	FW_ROOM_SCENE_GRAPH_NODE = 6,
+	FW_PORTAL_SCENE_GRAPH_NODE = 7,
+	COUNT
+};
+
+struct SceneGraphPoolData
+{
+	int classSize;
+	int poolSize;
+};
+
+constexpr size_t POOL_COUNT = static_cast<size_t>(eSceneGraphPool::COUNT);
+// Currently only FW_PORTAL_SCENE_GRAPH_NODE is editable
+constexpr SceneGraphPoolData pools[POOL_COUNT] = {
+	{48, 800},  // FW_ENTITY_CONTAINER
+	{48, 2},    // FW_FIXED_ENTITY_CONTAINER(Max pool size is 64)
+	{40, 1000}, // FW_SO_A_ENTITY_CONTAINER(This pool size will apply to FW_STREAMED_SCENE_GRAPH_NODE)
+	{80, 1},    // FW_EXTERIOR_SCENE_GRAPH_NODE(This pool size can't be changed, due to asm inc instruction)
+	{64, 1000}, // FW_STREAMED_SCENE_GRAPH_NODE (This pool size is going to be overwritten by FW_SO_A_ENTITY_CONTAINER)
+	{32, 150},  // FW_INTERIOR_SCENE_GRAPH_NODE
+	{48, 256},  // FW_ROOM_SCENE_GRAPH_NODE
+	{128, 800}  // FW_PORTAL_SCENE_GRAPH_NODE
+};
+
+constexpr int FW_ENTITY_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_ENTITY_CONTAINER)].poolSize;
+constexpr int FW_FIXED_ENTITY_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_FIXED_ENTITY_CONTAINER)].poolSize;
+constexpr int FW_SO_A_ENTITY_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_SO_A_ENTITY_CONTAINER)].poolSize;
+constexpr int FW_EXTERIOR_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_EXTERIOR_SCENE_GRAPH_NODE)].poolSize;
+constexpr int FW_STREAMED_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_STREAMED_SCENE_GRAPH_NODE)].poolSize;
+constexpr int FW_INTERIOR_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_INTERIOR_SCENE_GRAPH_NODE)].poolSize;
+constexpr int FW_ROOM_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_ROOM_SCENE_GRAPH_NODE)].poolSize;
+constexpr int FW_PORTAL_POOL_SIZE = pools[static_cast<size_t>(eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE)].poolSize;
+
+constexpr int FIRST_STREAMED_SCENE_NODE_INDEX = FW_EXTERIOR_POOL_SIZE;
+constexpr int FIRST_INTERIOR_SCENE_NODE_INDEX = FIRST_STREAMED_SCENE_NODE_INDEX + FW_STREAMED_POOL_SIZE;
+constexpr int FIRST_ROOM_SCENE_NODE_INDEX = FIRST_INTERIOR_SCENE_NODE_INDEX + FW_INTERIOR_POOL_SIZE;
+constexpr int FIRST_PORTAL_SCENE_NODE_INDEX = FIRST_ROOM_SCENE_NODE_INDEX + FW_ROOM_POOL_SIZE;
+constexpr int MAX_SCENE_NODE_COUNT = FIRST_PORTAL_SCENE_NODE_INDEX + FW_PORTAL_POOL_SIZE; // 2207
+constexpr int STORED_SCREEN_QUAD_COUNT = MAX_SCENE_NODE_COUNT - FIRST_ROOM_SCENE_NODE_INDEX + 1; // 2207 - 1151 + 1 = 1057
+
+int CalculateTotalSize(bool storage) {
+	int total = 0;
+	for (size_t i = 0; i < POOL_COUNT; ++i) {
+		const auto& pool = pools[i];
+		total += storage ? (pool.poolSize * pool.classSize) : pool.poolSize;
+	}
+	return total;
+}
+
+struct PatternPair
+{
+	std::string_view pattern;
+	int offset;
+};
+
+namespace rage
+{
+	struct alignas(16) Vec4V
+	{
+		float x, y, z, w;
+	};
+}
+
+static alignas(128) rage::Vec4V screenQuadStorage[4][STORED_SCREEN_QUAD_COUNT];
+
+static HookFunction hookFunction([]()
+{
+	auto initPoolsLocation = hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC ? BA ? ? ? ? B9");
+	auto assignStorageLocation = hook::get_pattern("48 8B C1 48 89 0D ? ? ? ? 48 81 C1");
+	auto assignScratchBufferLocation = hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 48 89 91");
+	auto clearVisDataLocation = hook::get_pattern("40 53 48 83 EC ? 48 8B D9 48 8B 89 ? ? ? ? 33 D2 41 B8");
+	auto clearTraversalDataLocation = hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 0F B7 81 ? ? ? ? 48 8B F9 48 8B 89");
+
+	const int poolStorageSize = CalculateTotalSize(true);
+	const int poolFlagSize = CalculateTotalSize(false);
+
+	// Change the size of poolStorage and poolFlags size
+	hook::put<uint32_t>((char*)initPoolsLocation + 44, poolStorageSize);
+	hook::put<uint32_t>((char*)initPoolsLocation + 34, poolStorageSize + poolFlagSize);
+	
+	hook::put((char*)initPoolsLocation + 725, FW_PORTAL_POOL_SIZE);
+
+	// Adjust offsets in AssignStorage function
+	hook::put<uint32_t>((char*)assignStorageLocation + 113, FW_PORTAL_POOL_SIZE * pools[static_cast<size_t>(eSceneGraphPool::FW_PORTAL_SCENE_GRAPH_NODE)].classSize); // 102400
+
+	// Adjust offsets in AssignScratchBuffer function
+	std::initializer_list<int> assignScratchBufferSizes = {
+		160, 177, 194, 211, 228
+	};
+	for(auto& offset : assignScratchBufferSizes)
+	{
+		// Combine two 16 bit values into a single 32 bit DWORD:
+		// - Upper 16 bits (bitSize)
+		// - Size: 69 (Currently unknown value, but seems to be a constant)
+		// Result: (bitSize << 16) | size
+		hook::put<uint32_t>((char*)assignScratchBufferLocation + offset, (MAX_SCENE_NODE_COUNT << 16) | 69);
+	}
+	hook::put<uint32_t>((char*)assignScratchBufferLocation + 28, MAX_SCENE_NODE_COUNT * 4);
+	hook::put<uint32_t>((char*)assignScratchBufferLocation + 54, STORED_SCREEN_QUAD_COUNT * 16);
+	hook::put<uint32_t>((char*)assignScratchBufferLocation + 79, 276);
+	
+	hook::put<uint32_t>((char*)clearVisDataLocation + 20, MAX_SCENE_NODE_COUNT * 4);
+	// Adjust screen quad count
+	hook::put<uint32_t>((char*)clearTraversalDataLocation + 236, STORED_SCREEN_QUAD_COUNT * 16);
+	hook::put<uint32_t>((char*)clearTraversalDataLocation + 269, STORED_SCREEN_QUAD_COUNT * 16);
+
+	// ScreenQuadStorages
+	{
+		// GetGbufScreenQuadPair
+		{
+			auto location = hook::get_pattern("48 0F BF C2 48 8D 15", 0x4);
+			static struct : jitasm::Frontend
+			{
+				uintptr_t continueLocation;
+
+				virtual void InternalMain() override
+				{
+					movsx(rax, dx);
+					mov(rdx, (uintptr_t)screenQuadStorage);
+					
+					mov(r8, continueLocation);
+					jmp(r8);
+				}
+			} stub;
+			stub.continueLocation = (uintptr_t)location + 7;
+			hook::nop(location, 7);
+			hook::jump(location, stub.GetCode());
+		}
+		
+		// GetGBuffExteriorScreenQuad
+		{
+			auto location = hook::get_pattern("48 8D 15 ? ? ? ? 48 03 C0 0F 28 0C C2");
+			static struct : jitasm::Frontend
+			{
+				uintptr_t continueLocation;
+
+				virtual void InternalMain() override
+				{
+					mov(rdx, (uintptr_t)screenQuadStorage);
+					
+					mov(r8, continueLocation);
+					jmp(r8);
+				}
+			} stub;
+			stub.continueLocation = (uintptr_t)location + 7;
+			hook::nop(location, 7);
+			hook::jump_reg<3>(location, stub.GetCode());
+		}
+
+		// fwScanEntities::RunFromDependency
+		{
+			auto location = hook::get_pattern("4C 8D 05 ? ? ? ? 48 C1 E0 ? 41 C1 E9");
+			static struct : jitasm::Frontend
+			{
+				uintptr_t continueLocation;
+
+				virtual void InternalMain() override
+				{
+					mov(r8, (uintptr_t)screenQuadStorage);
+					
+					mov(rcx, continueLocation);
+					jmp(rcx);
+				}
+			} stub;
+			stub.continueLocation = (uintptr_t)location + 7;
+			hook::nop(location, 7);
+			hook::jump_rcx(location, stub.GetCode());
+		}
+
+		// fwScanNodes::Run
+		{
+			auto location = hook::get_pattern("48 8D 05 ? ? ? ? 4A 8B 94 CB");
+			static struct : jitasm::Frontend
+			{
+				uintptr_t continueLocation;
+
+				virtual void InternalMain() override
+				{
+					mov(rax, (uintptr_t)screenQuadStorage);
+					
+					mov(rdx, continueLocation);
+					jmp(rdx);
+				}
+			} stub;
+			stub.continueLocation = (uintptr_t)location + 7;
+			hook::nop(location, 7);
+			hook::jump(location, stub.GetCode());
+		}
+
+		// Patch STORED_SCREEN_QUAD_COUNT
+		hook::put<uint32_t>(hook::get_pattern("41 B8 ? ? ? ? E8 ? ? ? ? 41 8B C6", 0x2), STORED_SCREEN_QUAD_COUNT); // fwScanNodes::Run
+		hook::put<uint32_t>(hook::get_pattern("48 8D 80 ? ? ? ? 0F 29 01", 0x3), STORED_SCREEN_QUAD_COUNT * 16); // fwScanEntities::RunFromDependency
+		auto scanNodesRunQuad = hook::get_pattern<char>("48 69 C9 ? ? ? ? 48 03 C8 48 8B C2 48 0B C1 83 E0 ? 75 ? B8");
+		hook::put<uint32_t>(scanNodesRunQuad + 0x3, STORED_SCREEN_QUAD_COUNT * 16);
+		hook::put<uint32_t>(scanNodesRunQuad + 0x16, STORED_SCREEN_QUAD_COUNT / 8);
+		/*
+		*  The value (0xFC) is derived from the offset difference between 
+		*  screenQuads and screenQuadPairs in the compiled class layout.
+		*  This is compiler-dependent and may change if the class structure is modified.
+		*  This can't be calculated based in STORED_SCREEN_QUAD_COUNT
+		*/
+		hook::put<char>(scanNodesRunQuad + 0x1D, 0xFC);
+	}
+
+	// Force ids to be up 1807, this can be added to the debug menu as offset id to test
+	// hook::put<uint32_t>(hook::get_pattern("49 81 C0 ? ? ? ? EB ? 4C 2B 05 ? ? ? ? 48 B8", 0x3), 1807);
+});


### PR DESCRIPTION
### Goal of this PR
The increase of `fwPortalSceneGraphNode` was suggested in the [forum](https://forum.cfx.re/t/expansion-of-fwportalscenegraphnode-pool/5302881).
Recently it was attempted to add the pool `fwPortalSceneGraphNode` to the gameconfig(#2695) but as prikolium said they are allocated from another precomputed heap and should be looked for in `fwSceneGraph::InitPools`.

This was already done by blattersturm [here](https://github.com/citizenfx/fivem/commit/ba52c98749a83d901af4dd4f5f415fc71d4611d0) but 2 days later they [reverted](https://github.com/citizenfx/fivem/commit/85be134d37afa561e669a9049c52d162bcf550e8) his change due to `Potential cause for 'missing doors after a while'.`

The same issue happen with my first [attempt](https://github.com/citizenfx/fivem/pull/3136) of increase.
After looking it a bit more deeper the issue was because the `AssignScratchBuffer` function that allocates and organizes a scratch buffer into aligned sections for scene graph traversal(flags, screen quads, visited bitsets, etc), my first attempt didn't increase that allocation size, which led to the same issue.

Around 2 months ago I noticed that and tried to patch, when testing again the issue was still happening, the week ago I find some missing stuff that needs patching related to screen quad storage and with that everything looks to work for now in my tests.
Also I notice that there's a var that store a guard buffer to make sure the scratch buffer doesn't get corrupted during scene graph traversal and is temporarily added in the SceneGraphPoolsDebug file for testing.

If this works in FiveM, I will try to implement it in RedM as well, because several months ago I saw that it was also a problem.

### How is this PR achieving the goal
The patch is almost identical to my previous pull request, but it fixes the screen quad storage used during visibility culling and portal traversal. More information about the patch can be found in my previous [pull request](https://github.com/citizenfx/fivem/pull/3136).


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.