### PR TITLE
feat(extra-natives-five): Add ped accuracy natives

### DIFF
--- a/code/components/extra-natives-five/src/PedAccuracyExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/PedAccuracyExtraNatives.cpp
@@ -1,0 +1,91 @@
+#include <StdInc.h>
+#include <Hooking.h>
+
+#include <ScriptEngine.h>
+
+#include <Resource.h>
+#include <fxScripting.h>
+
+struct PlayerRecoilModifiers
+{
+	float recoilModifierMin;
+	float recoilModifierMax;
+	float recoilCrouchedModifier;
+	float blindFireModifierMin;
+	float blindFireModifierMax;
+	float recentlyDamagedModifier;
+};
+
+static PlayerRecoilModifiers* g_playerModifiers;
+
+static HookFunction initFunction([]()
+{
+	auto location = hook::get_pattern<char>("48 8B C8 E8 ? ? ? ? F3 0F 10 1D ? ? ? ? F3 0F 5C 1D ? ? ? ? 0F 28 C8");
+	g_playerModifiers = hook::get_address<PlayerRecoilModifiers*>(location + 20);
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_RECOIL_MODIFIER_MIN", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->recoilModifierMin);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_RECOIL_MODIFIER_MIN", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->recoilModifierMin = value;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_RECOIL_MODIFIER_MAX", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->recoilModifierMax);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_RECOIL_MODIFIER_MAX", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->recoilModifierMax = value;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_RECOIL_CROUCHED_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->recoilCrouchedModifier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_RECOIL_CROUCHED_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->recoilCrouchedModifier = value;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_BLIND_FIRE_MODIFIER_MIN", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->blindFireModifierMin);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_BLIND_FIRE_MODIFIER_MIN", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->blindFireModifierMin = value;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_BLIND_FIRE_MODIFIER_MAX", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->blindFireModifierMax);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_BLIND_FIRE_MODIFIER_MAX", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->blindFireModifierMax = value;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_RECENTLY_DAMAGED_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		context.SetResult<float>(g_playerModifiers->recentlyDamagedModifier);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_RECENTLY_DAMAGED_MODIFIER", [=](fx::ScriptContext& context)
+	{
+		const float value = context.GetArgument<float>(0);
+		g_playerModifiers->recentlyDamagedModifier = value;
+	});
+});

--- a/ext/native-decls/GetPlayerBlindFireModifierMax.md
+++ b/ext/native-decls/GetPlayerBlindFireModifierMax.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_BLIND_FIRE_MODIFIER_MAX
+
+```c
+float GET_PLAYER_BLIND_FIRE_MODIFIER_MAX();
+```
+
+A getter for [`SET_PLAYER_BLIND_FIRE_MODIFIER_MAX`](#_0X39AC373D).
+
+## Return value
+The current blind fire maximum recoil modifier value.

--- a/ext/native-decls/GetPlayerBlindFireModifierMin.md
+++ b/ext/native-decls/GetPlayerBlindFireModifierMin.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_BLIND_FIRE_MODIFIER_MIN
+
+```c
+float GET_PLAYER_BLIND_FIRE_MODIFIER_MIN();
+```
+
+A getter for [`SET_PLAYER_BLIND_FIRE_MODIFIER_MIN`](#_0X695C0D48).
+
+## Return value
+The current blind fire minimum recoil modifier value.

--- a/ext/native-decls/GetPlayerRecentlyDamagedModifier.md
+++ b/ext/native-decls/GetPlayerRecentlyDamagedModifier.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_RECENTLY_DAMAGED_MODIFIER
+
+```c
+float GET_PLAYER_RECENTLY_DAMAGED_MODIFIER();
+```
+
+A getter for [`SET_PLAYER_RECENTLY_DAMAGED_MODIFIER`](#_0XC5A3A790).
+
+## Return value
+The current recently damaged recoil modifier value.

--- a/ext/native-decls/GetPlayerRecoilCrouchedModifier.md
+++ b/ext/native-decls/GetPlayerRecoilCrouchedModifier.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_RECOIL_CROUCHED_MODIFIER
+
+```c
+float GET_PLAYER_RECOIL_CROUCHED_MODIFIER();
+```
+
+Getter for [`SET_PLAYER_RECOIL_CROUCHED_MODIFIER`](#_0X432FBA5C).
+
+## Return value
+The current crouched recoil modifier value.

--- a/ext/native-decls/GetPlayerRecoilModifierMax.md
+++ b/ext/native-decls/GetPlayerRecoilModifierMax.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_RECOIL_MODIFIER_MAX
+
+```c
+float GET_PLAYER_RECOIL_MODIFIER_MAX();
+```
+
+Getter for [`SET_PLAYER_RECOIL_MODIFIER_MAX`](#_0X37C2D9F4).
+
+## Return value
+The current maximum recoil modifier value.

--- a/ext/native-decls/GetPlayerRecoilModifierMin.md
+++ b/ext/native-decls/GetPlayerRecoilModifierMin.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_PLAYER_RECOIL_MODIFIER_MIN
+
+```c
+float GET_PLAYER_RECOIL_MODIFIER_MIN();
+```
+
+Getter for [`SET_PLAYER_RECOIL_MODIFIER_MIN`](#_0X104413EF).
+
+## Return value
+The current minimum recoil modifier value.

--- a/ext/native-decls/SetPlayerBlindFireModifierMax.md
+++ b/ext/native-decls/SetPlayerBlindFireModifierMax.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_BLIND_FIRE_MODIFIER_MAX
+
+```c
+void SET_PLAYER_BLIND_FIRE_MODIFIER_MAX(float value);
+```
+
+Sets the maximum recoil modifier when firing blindly from cover. 
+Default value `4.0`.
+
+## Parameters
+* **value**: New modifier

--- a/ext/native-decls/SetPlayerBlindFireModifierMin.md
+++ b/ext/native-decls/SetPlayerBlindFireModifierMin.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_BLIND_FIRE_MODIFIER_MIN
+
+```c
+void SET_PLAYER_BLIND_FIRE_MODIFIER_MIN(float value);
+```
+
+Sets the minimum recoil modifier when firing blindly from cover. 
+Default value `2.0`.
+
+## Parameters
+* **value**: New modifier

--- a/ext/native-decls/SetPlayerRecentlyDamagedModifier.md
+++ b/ext/native-decls/SetPlayerRecentlyDamagedModifier.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_RECENTLY_DAMAGED_MODIFIER
+
+```c
+void SET_PLAYER_RECENTLY_DAMAGED_MODIFIER(float value);
+```
+
+Sets the recoil modifier applied when the player has been recently damaged.
+The default value is `0.3`.
+
+## Parameters
+* **value**: New modifier

--- a/ext/native-decls/SetPlayerRecoilCrouchedModifier.md
+++ b/ext/native-decls/SetPlayerRecoilCrouchedModifier.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_RECOIL_CROUCHED_MODIFIER
+
+```c
+void SET_PLAYER_RECOIL_CROUCHED_MODIFIER(float value);
+```
+
+Sets the recoil modifier applied when the player is crouching.
+The default value is `0.5`.
+
+## Parameters
+* **value**: New modifier

--- a/ext/native-decls/SetPlayerRecoilModifierMax.md
+++ b/ext/native-decls/SetPlayerRecoilModifierMax.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_RECOIL_MODIFIER_MAX
+
+```c
+void SET_PLAYER_RECOIL_MODIFIER_MAX(float value);
+```
+
+Sets the recoil modifier.
+The default value is `1.0`.
+
+## Parameters
+* **value**: New modifier

--- a/ext/native-decls/SetPlayerRecoilModifierMin.md
+++ b/ext/native-decls/SetPlayerRecoilModifierMin.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_PLAYER_RECOIL_MODIFIER_MIN
+
+```c
+void SET_PLAYER_RECOIL_MODIFIER_MIN(float value);
+```
+
+Sets the recoil modifier.
+The default value is `0.8`.
+
+## Parameters
+* **value**: New modifier


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Add new natives to get and set various player recoil/accuracy related modifiers. These modifiers are set in the pedaccuracy.meta data file, which cannot be streamed.


### How is this PR achieving the goal

Hook the in-memory struct, and register setter and getter natives. Add corresponding declaration.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 1604, 3095, 3407

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


