### PR TITLE
fix(premake): fix gcc15 builds

### DIFF
--- a/code/vendor/cpr.lua
+++ b/code/vendor/cpr.lua
@@ -24,5 +24,9 @@ return {
 		files {
 			"../vendor/cpr/cpr/*.cpp",
 		}
+
+		if os.istarget('linux') then
+			buildoptions { "-include", "stdint.h" }
+		end
 	end
 }

--- a/code/vendor/node.lua
+++ b/code/vendor/node.lua
@@ -593,6 +593,10 @@ return {
 			'src/inspector/worker_inspector.h',
 		}
 
+		if os.istarget('linux') then
+			buildoptions { "-include", "stdint.h" }
+		end
+
 		project 'icu-base'
 			language 'C++'
 			kind 'StaticLib'

--- a/code/vendor/rocksdb.lua
+++ b/code/vendor/rocksdb.lua
@@ -371,5 +371,9 @@ return {
 		files {
 			'vendor/rocksdb/build_version.cc'
 		}
+
+		if os.istarget('linux') then
+			buildoptions { "-include", "stdint.h" }
+		end
 	end
 }


### PR DESCRIPTION
GCC has been updated in Alpine Linux edge repository, which causes Linux builds to fail: https://pkgs.alpinelinux.org/package/edge/main/x86_64/gcc
The build container setup (`code/tools/ci/docker-builder/proot_prepare.sh`) fetches the latest version, so GCC 15 is used.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix compilation errors when building with GCC 15.


### How is this PR achieving the goal

Explicitly include `stdint.h` using `-include` build option in affected vendor projects.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Premake (Linux)


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


