### PR TITLE
feat(extra-natives-five): Add DOES_STREAMED_TEXTURE_DICT_EXIST

### DIFF
--- a/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/GraphicsExtraNatives.cpp
@@ -5,6 +5,7 @@
 #include <CfxRGBA.h>
 #include <Hooking.h>
 #include <Hooking.Stubs.h>
+#include <Streaming.h>
 
 struct scrVector
 {
@@ -163,5 +164,21 @@ static InitFunction initFunction([]()
 		command.m_marker = marker;
 
 		g_sphereDrawRequests[g_sphereDrawRequestCount++] = command;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_STREAMED_TEXTURE_DICT_EXIST", [](fx::ScriptContext& context)
+	{
+		auto str = streaming::Manager::GetInstance();
+        if (!str)
+        {
+			context.SetResult<bool>(false);
+            return;
+        }
+
+        std::string textureDict = context.CheckArgument<const char*>(0);
+		auto txdStore = str->moduleMgr.GetStreamingModule("ytd");
+        uint32_t id = -1;
+        txdStore->FindSlot(&id, textureDict.c_str());
+		context.SetResult<bool>(id != -1);
 	});
 });

--- a/ext/native-decls/DoesStreamedTextureDictExist.md
+++ b/ext/native-decls/DoesStreamedTextureDictExist.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DOES_STREAMED_TEXTURE_DICT_EXIST
+
+```c
+bool DOES_STREAMED_TEXTURE_DICT_EXIST(char* textureDict);
+```
+
+Returns whether or not the texture dictionary exists
+
+## Parameters
+* **textureDict**: Name of the texture dictionary
+
+## Return value
+True if the texture dictionary exists, false otherwise


### PR DESCRIPTION
### Goal of this PR
Add a way to check if a texture dictionary exists, similar to `DoesAnimDictExist` or `IsModelInCdimage`.

This is useful when working with runtime-created TXDs (e.g., `RegisterStreamingFileFromCache`, `CreateRuntimeTxd`).  
It is also useful because the common way to load a texture is to call `RequestStreamedTextureDict` and then wait for `HasStreamedTextureDictLoaded` to return true or a timeout. With this new native, we can avoid waiting on a non-existent TXD that will never load.

### How is this PR achieving the goal

Add `DOES_STREAMED_TEXTURE_DICT_EXIST` native.

### This PR applies to the following area(s)

FiveM


### Successfully tested on

**Game builds:** 3258

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


