### PR TITLE
fix(ext/native): remove gta5 game field for font natives

### DIFF
--- a/ext/native-decls/RegisterFontFile.md
+++ b/ext/native-decls/RegisterFontFile.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## REGISTER_FONT_FILE
 

--- a/ext/native-decls/RegisterFontId.md
+++ b/ext/native-decls/RegisterFontId.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## REGISTER_FONT_ID
 


### PR DESCRIPTION
### Goal of this PR

With #3543, ``REGISTER_FONT_ID`` and ``REGISTER_FONT_FILE`` was added to RedM, however the ``game: gta5`` field was not removed from either natives causing them to not be generated for RedM.

### How is this PR achieving the goal

Remove ``game: gta5`` fields from RegisterFontId and RegisterFontFile native declaration 

### This PR applies to the following area(s)

RedM, Natives

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

