### PR TITLE
tweak(server): remove warning about the identifiers change

### DIFF
--- a/code/components/citizen-server-main/src/ServerInstance.cpp
+++ b/code/components/citizen-server-main/src/ServerInstance.cpp
@@ -256,12 +256,6 @@ namespace fx
 				consoleCtx->GetVariableManager()->ShouldSuppressReadOnlyWarning(false);
 
 				OnInitialConfiguration();
-
-				console::PrintWarning(
-					_CFX_NAME_STRING(_CFX_COMPONENT_NAME),
-					"The players.json endpoint has been modified to no longer return the player identifiers without authentication.\n"
-					"To learn more about this change read our announcement at https://aka.cfx.re/players-json-privacy\n"
-				);
 			});
 		}
 


### PR DESCRIPTION
### Goal of this PR

The goal of this PR is to remove the players.json endpoint warning that was added when identifiers got removed from the API back in september last year. I think the message could be removed by now as this sometimes causes confusion and nobody asks about the identifiers change anymore. It was added in: https://github.com/citizenfx/fivem/commit/cf1984ab77dcc1f19e2b1ce61ede57eabb2b48d6

### How is this PR achieving the goal
This PR removes the players.json endpoint warning

### This PR applies to the following area(s)
FXServer

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
**Platforms:** 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.