### PR TITLE
feat(gta-core-five): increase blip map legend limit

### DIFF
--- a/code/components/gta-core-five/src/PatchBlipMapLegend.cpp
+++ b/code/components/gta-core-five/src/PatchBlipMapLegend.cpp
@@ -1,0 +1,50 @@
+#include "StdInc.h"
+#include "CrossBuildRuntime.h"
+#include <Hooking.h>
+#include <jitasm.h>
+
+constexpr int kMaxBlipLegend = 256;
+
+static HookFunction hookFunction([]()
+{
+	if (!xbr::IsGameBuildOrGreater<2372>()) return;
+
+	static struct : jitasm::Frontend
+	{
+		intptr_t toJae, toNext;
+
+		void Init(intptr_t jTarget, intptr_t nTarget)
+		{
+			toJae = jTarget;
+			toNext = nTarget;
+		}
+
+		void InternalMain() override
+		{
+			cmp(r8w, kMaxBlipLegend);
+			jae("maxBlipReached");
+			mov(rax, toNext);
+			jmp(rax);
+			L("maxBlipReached");
+			mov(rax, toJae);
+			jmp(rax);
+		}
+	} stub;
+
+	const char* pattern = xbr::IsGameBuildOrGreater<3407>()
+		? "66 44 3B C0 73 ? 44 8B 74 24 30 EB"
+		: "66 41 83 F8 ? 73 ? 44 8B 74 24 30 EB";
+
+	const int jaeOffset = xbr::IsGameBuildOrGreater<3407>() ? 4 : 5;
+
+	auto location = hook::get_pattern<char>(pattern);
+	auto jae = location + jaeOffset;
+	const int8_t disp = *(int8_t*)(jae + 1);
+	const intptr_t toJae  = (intptr_t)(jae + 2 + disp);
+	const intptr_t toNext = (intptr_t)(jae + 2);
+
+	stub.Init(toJae, toNext);
+
+	hook::nop(location, jaeOffset + 2);
+	hook::jump(location, stub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR
Follow up on [PR #3343](https://github.com/citizenfx/fivem/pull/3343) to increase the blip limit in the pause menu map legend.

Contrary to my initial assumption, the blip legend limit still exists in recent builds but has been increased from 100 to 110 in 3258 and 150 in 3407/3570.

Note: builds lower than 2372 require a different kind of patch. Given the deprecation of older builds, I’m not including a patch for these versions.

### How is this PR achieving the goal

Raises the maximum allowed blip legend entries up to 256.

### This PR applies to the following area(s)

FiveM


### Successfully tested on

**Game builds:** 2372,3095,3258,3407

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


