### PR TITLE
fix(input/rdr3): disable host cursors

### DIFF
--- a/code/components/rage-input-rdr3/include/InputHook.h
+++ b/code/components/rage-input-rdr3/include/InputHook.h
@@ -8,8 +8,6 @@
 #define INPUT_DECL __declspec(dllexport)
 #endif
 
-#define INPUT_HOOK_HOST_CURSOR_SUPPORT
-
 namespace rage
 {
 static constexpr uint32_t METHOD_RAW_INPUT = 0;


### PR DESCRIPTION
### Goal of this PR

Introduced in #3520, host cursors appear to cause issues with NUI's losing their cursors visibility. Removing it solves the issue 

### How is this PR achieving the goal

by not defining ``INPUT_HOOK_HOST_CURSOR_SUPPORT`` for RedM until the issue can be resolved.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


