### PR TITLE
feat(citizen-resource-gta): add resource binds natives

### DIFF
--- a/code/components/gta-core-five/include/GameInput.h
+++ b/code/components/gta-core-five/include/GameInput.h
@@ -15,4 +15,22 @@ namespace game
 	GAMEINPUT_EXPORT bool IsControlKeyDown(int control);
 
 	GAMEINPUT_EXPORT void SetKeyMappingHideResources(bool hide);
+
+	struct BindingKeyInfo
+	{
+		std::string command;
+		std::string tag;
+		std::string description;
+		std::string keyName;
+		std::string sourceName;
+		uint32_t parameter;
+		bool found;
+		bool hasKey;
+	};
+
+	GAMEINPUT_EXPORT BindingKeyInfo GetBindingInfo(const std::string& command);
+
+	GAMEINPUT_EXPORT bool RebindCommand(const std::string& command, const std::string& sourceName, const std::string& keyName);
+
+	GAMEINPUT_EXPORT bool UnbindCommand(const std::string& command);
 }

--- a/ext/native-decls/GetBindInfoFromCommand.md
+++ b/ext/native-decls/GetBindInfoFromCommand.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_BIND_INFO_FROM_COMMAND
+
+```c
+object GET_BIND_INFO_FROM_COMMAND(char* command);
+```
+
+Return a object with the info of the bind, containing tag, description, keyName, sourceName, parameter, found and hasKey.
+
+## Parameters
+* **command**: The command string to get the binding info for.

--- a/ext/native-decls/SetBindKeyForCommand.md
+++ b/ext/native-decls/SetBindKeyForCommand.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_BIND_KEY_FOR_COMMAND
+
+```c
+BOOL SET_BIND_KEY_FOR_COMMAND(char* command, char* source, char* key);
+```
+
+Set the key binding for the specified command.
+
+## Parameters
+* **command**: The command string to set the binding info for.
+* **source**: The source of the key, e.g. "KEYBOARD", "MOUSE_BUTTON", etc.
+* **key**: The key string to bind to the command.

--- a/ext/native-decls/UnbindKeyForCommand.md
+++ b/ext/native-decls/UnbindKeyForCommand.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## UNBIND_KEY_FOR_COMMAND
+
+```c
+BOOL UNBIND_KEY_FOR_COMMAND(char* command);
+```
+
+Unbind the key for the specified command.
+
+## Parameters
+* **command**: The command string to unbind the key for.


### PR DESCRIPTION
### Goal of this PR
Currently, the binding systems used by Fivem scripts are based on RegisterCommand and RegisterKeyMapping. This solution would allow you to retrieve and modify existing bindings without having to create new ones. The video shows a menu using these new native options for editing existing bindings.

I'm currently marking this PR as draft because I'd like to get feedback on what people think and whether or not this is a good idea. I'm also considering changing the result of `GET_BIND_INFO_FROM_COMMAND` so that it returns multiple pieces of data instead of just one object containing the data.

https://github.com/user-attachments/assets/f95ff46a-4585-40bd-8f25-06bbd1c776f2


### How is this PR achieving the goal
Three new native functions `GET_BIND_INFO_FROM_COMMAND`, `SET_BIND_KEY_FOR_COMMAND`, `UNBIND_KEY_FOR_COMMAND` have been added that allow modifying binds at runtime from scripts.


### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258
**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.