### PR TITLE
feat(citizen-server-gui): add state bags viewer gui

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string_view>
+#include <map>
 
 #include <msgpack.hpp>
 
@@ -183,6 +184,33 @@ public:
 	// Set the StateBagRole, used when the StateBagRole dynamically changes depending on protocol version between the server and client
 	//
 	virtual void SetRole(StateBagRole role) = 0;
+
+	//
+	// Diagnostic accessors used by the /onesync debug HTTP endpoints.
+	//
+	virtual size_t GetStateBagCount() = 0;
+	virtual size_t GetActiveStateBagCount() = 0;
+	virtual size_t GetExpiredStateBagCount() = 0;
+	virtual size_t GetTargetCount() = 0;
+	virtual size_t GetPreCreatedStateBagCount() = 0;
+	virtual size_t GetErasureListCount() = 0;
+	virtual size_t GetPreCreatePrefixCount() = 0;
+	virtual std::vector<int> GetRegisteredTargets() = 0;
+	virtual size_t GetStateBagCountForTarget(int target) = 0;
+	virtual std::vector<std::pair<std::string, bool>> GetPreCreatePrefixes() = 0;
+
+	struct StateBagDetails {
+		std::string id;
+		bool useParentTargets;
+		bool replicationEnabled;
+		std::optional<int> owningPeer;
+		std::vector<int> routingTargets;
+		std::map<std::string, std::string> storedData;
+		std::map<std::string, size_t> queuedData; // key -> size
+		bool isExpired;
+	};
+
+	virtual std::optional<StateBagDetails> GetStateBagDetails(const std::string& id) = 0;
 
 	//
 	// An event handling a state bag value change.

--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -5,6 +5,7 @@
 
 #include <shared_mutex>
 #include <unordered_set>
+#include <unordered_map>
 
 //#include <EASTL/fixed_set.h>
 #include <EASTL/fixed_vector.h>
@@ -54,6 +55,18 @@ public:
 	{
 		m_role = role;
 	}
+
+	virtual size_t GetStateBagCount() override;
+	virtual size_t GetActiveStateBagCount() override;
+	virtual size_t GetExpiredStateBagCount() override;
+	virtual size_t GetTargetCount() override;
+	virtual size_t GetPreCreatedStateBagCount() override;
+	virtual size_t GetErasureListCount() override;
+	virtual size_t GetPreCreatePrefixCount() override;
+	virtual std::vector<int> GetRegisteredTargets() override;
+	virtual size_t GetStateBagCountForTarget(int target) override;
+	virtual std::vector<std::pair<std::string, bool>> GetPreCreatePrefixes() override;
+	virtual std::optional<StateBagDetails> GetStateBagDetails(const std::string& id) override;
 
 	void UnregisterStateBag(std::string_view id);
 
@@ -111,6 +124,7 @@ private:
 
 class StateBagImpl : public StateBag
 {
+	friend class StateBagComponentImpl;
 public:
 	StateBagImpl(StateBagComponentImpl* parent, std::string_view id, bool useParentTargets = false);
 
@@ -829,6 +843,210 @@ void StateBagComponentImpl::Reset()
 		std::unique_lock _(m_preCreatedStateBagsMutex);
 		m_preCreatedStateBags.clear();
 	}
+}
+
+size_t StateBagComponentImpl::GetStateBagCount()
+{
+	std::shared_lock lock(m_mapMutex);
+	return m_stateBags.size();
+}
+
+size_t StateBagComponentImpl::GetActiveStateBagCount()
+{
+	std::shared_lock lock(m_mapMutex);
+	size_t count = 0;
+	for (const auto& [id, weakBag] : m_stateBags)
+	{
+		if (!weakBag.expired())
+			count++;
+	}
+	return count;
+}
+
+size_t StateBagComponentImpl::GetExpiredStateBagCount()
+{
+	std::shared_lock lock(m_mapMutex);
+	size_t count = 0;
+	for (const auto& [id, weakBag] : m_stateBags)
+	{
+		if (weakBag.expired())
+			count++;
+	}
+	return count;
+}
+
+size_t StateBagComponentImpl::GetTargetCount()
+{
+	std::shared_lock lock(m_mapMutex);
+	return m_targets.size();
+}
+
+size_t StateBagComponentImpl::GetPreCreatedStateBagCount()
+{
+	std::shared_lock lock(m_preCreatedStateBagsMutex);
+	return m_preCreatedStateBags.size();
+}
+
+size_t StateBagComponentImpl::GetErasureListCount()
+{
+	std::shared_lock lock(m_erasureMutex);
+	return m_erasureList.size();
+}
+
+size_t StateBagComponentImpl::GetPreCreatePrefixCount()
+{
+	std::shared_lock lock(m_preCreatePrefixMutex);
+	return m_preCreatePrefixes.size();
+}
+
+
+
+std::vector<int> StateBagComponentImpl::GetRegisteredTargets()
+{
+	std::shared_lock lock(m_mapMutex);
+	std::vector<int> targets;
+	targets.reserve(m_targets.size());
+	for (int target : m_targets)
+	{
+		targets.push_back(target);
+	}
+	return targets;
+}
+
+size_t StateBagComponentImpl::GetStateBagCountForTarget(int target)
+{
+	std::shared_lock lock(m_mapMutex);
+	size_t count = 0;
+	for (const auto& [id, weakBag] : m_stateBags)
+	{
+		if (auto bag = weakBag.lock())
+		{
+			auto bagImpl = std::static_pointer_cast<StateBagImpl>(bag);
+			std::shared_lock routingLock(bagImpl->m_routingTargetsMutex);
+			if (bagImpl->m_routingTargets.count(target) > 0)
+				count++;
+		}
+	}
+	return count;
+}
+
+std::vector<std::pair<std::string, bool>> StateBagComponentImpl::GetPreCreatePrefixes()
+{
+	std::shared_lock lock(m_preCreatePrefixMutex);
+	return m_preCreatePrefixes;
+}
+
+std::optional<StateBagComponent::StateBagDetails> StateBagComponentImpl::GetStateBagDetails(const std::string& id)
+{
+	std::shared_lock lock(m_mapMutex);
+	auto it = m_stateBags.find(id);
+	
+	if (it == m_stateBags.end())
+	{
+		return std::nullopt;
+	}
+	
+	auto bag = it->second.lock();
+	if (!bag)
+	{
+		StateBagComponent::StateBagDetails details;
+		details.id = id;
+		details.isExpired = true;
+		details.useParentTargets = false;
+		details.replicationEnabled = false;
+		details.owningPeer = std::nullopt;
+		return details;
+	}
+	
+	auto bagImpl = std::static_pointer_cast<StateBagImpl>(bag);
+	
+	StateBagComponent::StateBagDetails details;
+	details.id = id;
+	details.isExpired = false;
+	details.useParentTargets = bagImpl->m_useParentTargets;
+	details.replicationEnabled = bagImpl->m_replicationEnabled.load();
+	details.owningPeer = bagImpl->GetOwningPeer();
+	
+	{
+		std::shared_lock routingLock(bagImpl->m_routingTargetsMutex);
+		details.routingTargets.reserve(bagImpl->m_routingTargets.size());
+		for (int target : bagImpl->m_routingTargets)
+		{
+			details.routingTargets.push_back(target);
+		}
+	}
+	
+	{
+		std::shared_lock dataLock(bagImpl->m_dataMutex);
+		for (const auto& [key, value] : bagImpl->m_data)
+		{
+			try
+			{
+				msgpack::unpacked up = msgpack::unpack(value.data(), value.size());
+				const auto& obj = up.get();
+				std::string jsonStr;
+
+				if (obj.type == msgpack::type::EXT)
+				{
+					const auto& ext = obj.via.ext;
+					const int8_t extType = ext.type();
+					std::ostringstream oss;
+					oss.precision(7);
+
+					if (extType == 20 && ext.size == 8) // vector2
+					{
+						float x = *(float*)(ext.data() + 0);
+						float y = *(float*)(ext.data() + 4);
+						oss << "{\"x\":" << x << ",\"y\":" << y << "}";
+					}
+					else if (extType == 21 && ext.size == 12) // vector3
+					{
+						float x = *(float*)(ext.data() + 0);
+						float y = *(float*)(ext.data() + 4);
+						float z = *(float*)(ext.data() + 8);
+						oss << "{\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << "}";
+					}
+					else if ((extType == 22 || extType == 23) && ext.size == 16) // vector4/quat
+					{
+						float x = *(float*)(ext.data() + 0);
+						float y = *(float*)(ext.data() + 4);
+						float z = *(float*)(ext.data() + 8);
+						float w = *(float*)(ext.data() + 12);
+						oss << "{\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << ",\"w\":" << w << "}";
+					}
+					else
+					{
+						oss << "\"EXT(type:" << static_cast<int>(extType) << ",size:" << ext.size << ")\"";
+					}
+					jsonStr = oss.str();
+				}
+				else
+				{
+					std::ostringstream oss;
+					oss << obj;
+					jsonStr = oss.str();
+				}
+
+				if (jsonStr.length() > 500)
+					jsonStr = jsonStr.substr(0, 497) + "...";
+				details.storedData[key] = jsonStr;
+			}
+			catch (...)
+			{
+				details.storedData[key] = "[" + std::to_string(value.size()) + " bytes]";
+			}
+		}
+	}
+	
+	{
+		std::unique_lock replicateLock(bagImpl->m_replicateDataMutex);
+		for (const auto& [key, value] : bagImpl->m_replicateData)
+		{
+			details.queuedData[key] = value.size();
+		}
+	}
+	
+	return details;
 }
 
 fwRefContainer<StateBagComponent> StateBagComponent::Create(StateBagRole role)

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -919,8 +919,8 @@ struct SyncEntityState
 	std::array<uint64_t, MAX_CLIENTS> lastFramesPreSent;
 
 	std::chrono::milliseconds createdAt{ 0 };
-	std::chrono::milliseconds lastReceivedAt;
-	std::chrono::milliseconds lastMigratedAt;
+	std::chrono::milliseconds lastReceivedAt{ 0 };
+	std::chrono::milliseconds lastMigratedAt{ 0 };
 
 	std::shared_ptr<SyncTreeBase> syncTree;
 
@@ -1540,6 +1540,8 @@ public:
 	std::tuple<std::unique_lock<std::mutex>, std::shared_ptr<GameStateClientData>> ExternalGetClientData(const fx::ClientSharedPtr& client);
 
 	void ForAllEntities(const std::function<void(sync::Entity*)>& cb);
+
+	std::vector<StateEntityDebugInfo> GetEntityDebugInfoList() override;
 
 	inline auto GetServerInstance() const
 	{

--- a/code/components/citizen-server-impl/include/state/ServerGameStatePublic.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameStatePublic.h
@@ -3,6 +3,10 @@
 #include <ClientRegistry.h>
 #include <OneSyncVars.h>
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #define GLM_ENABLE_EXPERIMENTAL
 
 #if defined(_M_IX86) || defined(_M_AMD64) || defined(__x86_64__) || defined(__i386__)
@@ -57,6 +61,34 @@ public:
 
 class StateBag;
 
+struct StateEntityDebugInfo
+{
+	uint32_t id;
+	uint32_t netId;
+	uint32_t routingBucket;
+	uint32_t ownerClientID;
+	uint32_t firstOwningClientID;
+	bool firstOwnerDropped;
+	uint32_t lastOwningClientID;
+	int type;
+	uint16_t uniquer;
+	uint32_t scriptHash;
+	bool ownedByScript;
+	bool ownedByServerScript;
+	bool shouldServerKeepEntity;
+	bool relevant;
+	int64_t createdAt;
+	uint64_t frameIndex;
+	uint64_t lastFrameIndex;
+	uint32_t timestamp;
+	uint32_t creationToken;
+	int64_t lastMigratedAt;
+	bool hasStateBag;
+	std::string stateBagName;
+	bool hasPosition;
+	float position[3];
+};
+
 class ServerGameStatePublic : public fwRefCountable
 {
 public:
@@ -75,6 +107,8 @@ public:
 	virtual void ParseGameStatePacket(const fx::ClientSharedPtr& client, const net::packet::ClientRoute& packetData) = 0;
 
 	virtual void ForAllEntities(const std::function<void(sync::Entity*)>& cb) = 0;
+
+	virtual std::vector<StateEntityDebugInfo> GetEntityDebugInfoList() = 0;
 
 	virtual bool SetEntityStateBag(uint8_t playerId, uint16_t objectId, std::function<std::shared_ptr<StateBag>()> createStateBag) = 0;
 

--- a/code/components/citizen-server-impl/src/OneSyncHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/OneSyncHttpHandler.cpp
@@ -1,0 +1,289 @@
+#include "StdInc.h"
+
+#include <ServerInstanceBase.h>
+#include <HttpServerManager.h>
+#include <ResourceManager.h>
+#include <StateBagComponent.h>
+#include <ClientRegistry.h>
+#include <state/ServerGameStatePublic.h>
+
+#include <CoreConsole.h>
+#include <botan/base64.h>
+
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+namespace
+{
+std::shared_ptr<ConVar<std::string>> g_onesyncBasicAuthUser;
+std::shared_ptr<ConVar<std::string>> g_onesyncBasicAuthPassword;
+}
+
+static std::string MakeBasicAuthHash(const std::string& user, const std::string& password)
+{
+	if (user.empty() && password.empty())
+		return {};
+
+	std::string authString = user + ":" + password;
+	return "Basic " + Botan::base64_encode(reinterpret_cast<const uint8_t*>(authString.data()), authString.size());
+}
+
+static bool IsAuthorizedRequest(const fwRefContainer<net::HttpRequest>& request)
+{
+	if (!g_onesyncBasicAuthUser)
+		return false;
+
+	const std::string authHash = MakeBasicAuthHash(g_onesyncBasicAuthUser->GetValue(), g_onesyncBasicAuthPassword->GetValue());
+
+	if (authHash.empty())
+		return false;
+
+	const auto auth = request->GetHeader("Authorization", "");
+	return !auth.empty() && auth == authHash;
+}
+
+static std::string GetBagIdFromPath(std::string_view prefix, const char* path)
+{
+	constexpr std::string_view suffix = "/stateBag.json";
+	std::string_view pathView(path);
+
+	if (pathView.size() <= prefix.size() + suffix.size())
+		return {};
+	if (pathView.substr(0, prefix.size()) != prefix)
+		return {};
+	auto inner = pathView.substr(prefix.size());
+	if (inner.size() < suffix.size())
+		return {};
+	if (inner.substr(inner.size() - suffix.size()) != suffix)
+		return {};
+	return std::string(inner.substr(0, inner.size() - suffix.size()));
+}
+
+static json DecodeStoredData(const std::map<std::string, std::string>& storedData)
+{
+	json result = json::object();
+	for (const auto& [key, value] : storedData)
+	{
+		json parsed = json::parse(value, nullptr, false);
+		result[key] = parsed.is_discarded() ? json(value) : std::move(parsed);
+	}
+	return result;
+}
+
+static InitFunction initFunction([]()
+{
+	fx::ServerInstanceBase::OnServerCreate.Connect([](fx::ServerInstanceBase* instance)
+	{
+		g_onesyncBasicAuthUser = instance->AddVariable<std::string>("sv_onesyncBasicAuthUser", ConVar_None, "");
+		g_onesyncBasicAuthPassword = instance->AddVariable<std::string>("sv_onesyncBasicAuthPassword", ConVar_None, "");
+
+		auto httpManager = instance->GetComponent<fx::HttpServerManager>();
+
+		httpManager->AddEndpoint("/onesync/statebags.json",
+			[instance](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
+			{
+				if (!IsAuthorizedRequest(request))
+				{
+					response->SetStatusCode(403);
+					response->End("Forbidden.");
+					return;
+				}
+
+				auto stateBags = instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::StateBagComponent>();
+
+				auto globalDetails = stateBags->GetStateBagDetails("global");
+				json globalStateJson = globalDetails.has_value()
+					? DecodeStoredData(globalDetails->storedData)
+					: json::object();
+
+				json targetsJson = json::array();
+				for (int targetId : stateBags->GetRegisteredTargets())
+				{
+					targetsJson.push_back({
+						{ "id", targetId },
+						{ "bagCount", stateBags->GetStateBagCountForTarget(targetId) }
+					});
+				}
+
+				json prefixesJson = json::array();
+				for (const auto& [prefix, useParentTargets] : stateBags->GetPreCreatePrefixes())
+				{
+					prefixesJson.push_back({
+						{ "prefix", prefix },
+						{ "useParentTargets", useParentTargets }
+					});
+				}
+
+				json result = {
+					{ "totalBags", stateBags->GetStateBagCount() },
+					{ "activeBags", stateBags->GetActiveStateBagCount() },
+					{ "expiredBags", stateBags->GetExpiredStateBagCount() },
+					{ "targetCount", stateBags->GetTargetCount() },
+					{ "preCreatedBags", stateBags->GetPreCreatedStateBagCount() },
+					{ "erasureListCount", stateBags->GetErasureListCount() },
+					{ "preCreatePrefixCount", stateBags->GetPreCreatePrefixCount() },
+					{ "globalState", std::move(globalStateJson) },
+					{ "targets", std::move(targetsJson) },
+					{ "prefixes", std::move(prefixesJson) }
+				};
+
+				response->SetHeader("Content-Type", "application/json; charset=utf-8");
+				response->End(result.dump());
+			});
+
+		httpManager->AddEndpoint("/onesync/entities.json",
+			[instance](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
+			{
+				if (!IsAuthorizedRequest(request))
+				{
+					response->SetStatusCode(403);
+					response->End("Forbidden.");
+					return;
+				}
+
+				auto gameState = instance->GetComponent<fx::ServerGameStatePublic>();
+
+				json entitiesJson = json::array();
+				for (const auto& e : gameState->GetEntityDebugInfoList())
+				{
+					json entityJson = {
+						{ "id", e.id },
+						{ "netId", e.netId },
+						{ "routingBucket", e.routingBucket },
+						{ "ownerClientID", e.ownerClientID },
+						{ "firstOwningClientID", e.firstOwningClientID },
+						{ "firstOwnerDropped", e.firstOwnerDropped },
+						{ "lastOwningClientID", e.lastOwningClientID },
+						{ "type", e.type },
+						{ "uniquer", e.uniquer },
+						{ "scriptHash", e.scriptHash },
+						{ "ownedByScript", e.ownedByScript },
+						{ "ownedByServerScript", e.ownedByServerScript },
+						{ "shouldServerKeepEntity", e.shouldServerKeepEntity },
+						{ "relevant", e.relevant },
+						{ "createdAt", e.createdAt },
+						{ "frameIndex", e.frameIndex },
+						{ "lastFrameIndex", e.lastFrameIndex },
+						{ "timestamp", e.timestamp },
+						{ "creationToken", e.creationToken },
+						{ "lastMigratedAt", e.lastMigratedAt }
+					};
+
+					if (e.hasStateBag)
+					{
+						entityJson["stateBag"] = e.stateBagName;
+					}
+
+					if (e.hasPosition)
+					{
+						entityJson["position"] = { e.position[0], e.position[1], e.position[2] };
+					}
+
+					entitiesJson.push_back(std::move(entityJson));
+				}
+
+				response->SetHeader("Content-Type", "application/json; charset=utf-8");
+				response->End(entitiesJson.dump());
+			});
+
+		httpManager->AddEndpoint("/onesync/entities/",
+			[instance](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
+			{
+				if (!IsAuthorizedRequest(request))
+				{
+					response->SetStatusCode(403);
+					response->End("Forbidden.");
+					return;
+				}
+
+				auto entityId = GetBagIdFromPath("/onesync/entities/", request->GetPath().c_str());
+				if (entityId.empty())
+				{
+					response->SetStatusCode(400);
+					response->SetHeader("Content-Type", "application/json; charset=utf-8");
+					response->End(json{ { "error", "Invalid path. Expected /onesync/entities/{netId}/stateBag.json" } }.dump());
+					return;
+				}
+
+				auto stateBags = instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::StateBagComponent>();
+				auto details = stateBags->GetStateBagDetails("entity:" + entityId);
+
+				if (!details.has_value())
+				{
+					response->SetStatusCode(404);
+					response->SetHeader("Content-Type", "application/json; charset=utf-8");
+					response->End(json{ { "error", "StateBag not found." } }.dump());
+					return;
+				}
+
+				json result = DecodeStoredData(details->storedData);
+
+				response->SetHeader("Content-Type", "application/json; charset=utf-8");
+				response->End(result.dump());
+			});
+
+		httpManager->AddEndpoint("/onesync/clients.json",
+			[instance](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
+			{
+				if (!IsAuthorizedRequest(request))
+				{
+					response->SetStatusCode(403);
+					response->End("Forbidden.");
+					return;
+				}
+
+				auto clientRegistry = instance->GetComponent<fx::ClientRegistry>();
+
+				json clientsJson = json::array();
+				clientRegistry->ForAllClients([&clientsJson](const fx::ClientSharedPtr& client)
+				{
+					if (!client->HasConnected())
+					{
+						return;
+					}
+
+					clientsJson.push_back({ { "id", client->GetNetId() } });
+				});
+
+				response->SetHeader("Content-Type", "application/json; charset=utf-8");
+				response->End(clientsJson.dump());
+			});
+
+		httpManager->AddEndpoint("/onesync/clients/",
+			[instance](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
+			{
+				if (!IsAuthorizedRequest(request))
+				{
+					response->SetStatusCode(403);
+					response->End("Forbidden.");
+					return;
+				}
+
+				auto clientId = GetBagIdFromPath("/onesync/clients/", request->GetPath().c_str());
+				if (clientId.empty())
+				{
+					response->SetStatusCode(400);
+					response->SetHeader("Content-Type", "application/json; charset=utf-8");
+					response->End(json{ { "error", "Invalid path. Expected /onesync/clients/{netId}/stateBag.json" } }.dump());
+					return;
+				}
+
+				auto stateBags = instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::StateBagComponent>();
+				auto details = stateBags->GetStateBagDetails("player:" + clientId);
+
+				if (!details.has_value())
+				{
+					response->SetStatusCode(404);
+					response->SetHeader("Content-Type", "application/json; charset=utf-8");
+					response->End(json{ { "error", "StateBag not found." } }.dump());
+					return;
+				}
+
+				json result = DecodeStoredData(details->storedData);
+
+				response->SetHeader("Content-Type", "application/json; charset=utf-8");
+				response->End(result.dump());
+			});
+	});
+});

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -528,6 +528,75 @@ void ServerGameState::ForAllEntities(const std::function<void(sync::Entity*)>& c
 	}
 }
 
+std::vector<StateEntityDebugInfo> ServerGameState::GetEntityDebugInfoList()
+{
+	std::vector<StateEntityDebugInfo> result;
+
+	std::shared_lock _(m_entityListMutex);
+	result.reserve(m_entityList.size());
+
+	for (auto& entity : m_entityList)
+	{
+		if (!entity)
+		{
+			continue;
+		}
+
+		StateEntityDebugInfo info{};
+
+		info.id = entity->handle;
+		info.netId = entity->handle;
+		info.routingBucket = entity->routingBucket;
+
+		auto owner = entity->GetClient();
+		info.ownerClientID = owner ? owner->GetNetId() : 0xFFFF;
+
+		auto firstOwner = entity->GetFirstOwner();
+		info.firstOwningClientID = firstOwner ? firstOwner->GetNetId() : 0xFFFF;
+
+		auto lastOwner = entity->GetLastOwner();
+		info.lastOwningClientID = lastOwner ? lastOwner->GetNetId() : 0xFFFF;
+
+		info.firstOwnerDropped = entity->firstOwnerDropped;
+		info.type = static_cast<int>(entity->type);
+		info.uniquer = entity->uniqifier;
+		info.scriptHash = entity->GetScriptHash();
+		info.ownedByScript = entity->IsOwnedByScript();
+		info.ownedByServerScript = entity->IsOwnedByServerScript();
+		info.shouldServerKeepEntity = entity->ShouldServerKeepEntity();
+
+		{
+			std::shared_lock guidLock(entity->guidMutex);
+			info.relevant = entity->relevantTo.any();
+		}
+
+		info.createdAt = entity->createdAt.count();
+		info.frameIndex = entity->frameIndex;
+		info.lastFrameIndex = entity->lastFrameIndex;
+		info.timestamp = entity->timestamp;
+		info.creationToken = entity->creationToken;
+		info.lastMigratedAt = entity->lastMigratedAt.count();
+
+		info.hasStateBag = entity->HasStateBag();
+		if (info.hasStateBag)
+		{
+			info.stateBagName = fmt::sprintf("entity:%d", entity->handle & 0xFFFF);
+		}
+
+		info.hasPosition = false;
+		info.position[0] = info.position[1] = info.position[2] = 0.0f;
+		if (entity->syncTree)
+		{
+			entity->syncTree->GetPosition(info.position);
+			info.hasPosition = true;
+		}
+
+		result.push_back(std::move(info));
+	}
+
+	return result;
+}
+
 uint32_t ServerGameState::MakeScriptHandle(const fx::sync::SyncEntityPtr& ptr)
 {
 	// only one unique lock here since we can't upgrade from reader to writer

--- a/code/tests/server/ServerGameStatePublicInstance.cpp
+++ b/code/tests/server/ServerGameStatePublicInstance.cpp
@@ -60,6 +60,11 @@ public:
 	{
 	}
 
+	std::vector<fx::StateEntityDebugInfo> GetEntityDebugInfoList() override
+	{
+		return {};
+	}
+
 	bool SetEntityStateBag(uint8_t playerId, uint16_t objectId, std::function<std::shared_ptr<fx::StateBag>()> createStateBag) override
 	{
 		return false;


### PR DESCRIPTION
### Goal of this PR
Add a new debug menu that displays state bag statistics, rate limit data, a list of state bags, and the ability to view information about each one.
I know the description is lacking right now, but I'm too tired to write a proper one at the moment :sweat_smile:.

<img width="1545" height="1122" alt="image" src="https://github.com/user-attachments/assets/c4b85f12-6f30-40e5-8de8-c46729cae0c1" />


### How is this PR achieving the goal
Create multiple functions in StateBagComponent that return information to be able to render them in the GUI


### This PR applies to the following area(s)
Server


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3528 