### PR TITLE
feat(gta-streaming-five): add face overlays data mounter

### DIFF
--- a/code/components/gta-core-five/include/RageParser.h
+++ b/code/components/gta-core-five/include/RageParser.h
@@ -185,6 +185,8 @@ namespace rage
 	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(const char* structType);
 
 	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(uint32_t structHash);
+
+	COMPONENT_EXPORT(GTA_CORE_TARGET) bool LoadFromStructure(const char* fileName, const char* ext, rage::parStructure* parStruct, void* target, bool typeChecks, void* unk);
 }
 
 #undef GTA_CORE_TARGET

--- a/code/components/gta-core-five/src/RageParser.cpp
+++ b/code/components/gta-core-five/src/RageParser.cpp
@@ -2,11 +2,18 @@
 #include <Hooking.h>
 #include <RageParser.h>
 
+#include "Hooking.Stubs.h"
+
 static void** g_parser;
 
 static hook::cdecl_stub<rage::parStructure* (void* parser, uint32_t)> _parser_getStructure([]()
 {
 	return hook::get_call(hook::get_pattern("8B 10 E8 ? ? ? ? 4C 8D 5C 24", 2));
+});
+
+static hook::cdecl_stub<rage::parStructure* (void* parser, const char*, const char*, rage::parStructure*, void*, bool, void*)> _parser_loadFromStructure([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 0F B7 7D 10"));
 });
 
 namespace rage
@@ -19,6 +26,11 @@ namespace rage
 	DLL_EXPORT rage::parStructure* GetStructureDefinition(uint32_t structHash)
 	{
 		return _parser_getStructure(*g_parser, structHash);
+	}
+
+	DLL_EXPORT bool LoadFromStructure(const char* fileName, const char* ext, rage::parStructure* parStruct, void* target, bool typeChecks, void* unk)
+	{
+		return _parser_loadFromStructure(*g_parser, fileName, ext, parStruct, target, typeChecks, unk);
 	}
 }
 


### PR DESCRIPTION
### Goal of this PR
Add a file builder for `CPedFacialOverlays` as suggested in this forum post: https://forum.cfx.re/t/addon-make-up-lipstick-brows-beards-etc/5224039

This allows you to add blemishes, facial hair, eyebrow, makeup, aging, etc. addons without replacing an existing one.

The default file used is `update/update.rpf/common/data/effects/peds/facial_overlays.meta`. You can use this as a base to create new facial overlays. Here is a test script to demonstrate a makeup addon.
[FacialOverlay.zip](https://github.com/user-attachments/files/21956408/FacialOverlay.zip)
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/699caa59-fb7d-4245-b57e-8b11f105018a" />

The code for this pull request was created by **Disquse**. I simply checked that it works and created a test script, but all the work is theirs. If for any reason they want me to delete this PR, I have no problem doing so.


### How is this PR achieving the goal
Declaring the `LoadFromStructure` function to parse the .meta file and read its data. A custom file mounter has been created, and the LoadDataFile and UnloadDataFile functions insert it into the game's overlay store.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.