### PR TITLE
Validate the JSON of PoolSizesIncrease in CitizenFX.ini

### DIFF
--- a/code/components/pool-sizes-state/src/PoolSizesState.cpp
+++ b/code/components/pool-sizes-state/src/PoolSizesState.cpp
@@ -36,7 +36,15 @@ namespace fx
 			std::string request = ToNarrow(requestRaw);
 			if (!request.empty())
 			{
-				sizeIncrease = nlohmann::json::parse(request).get<std::unordered_map<std::string, uint32_t>>();
+				try
+				{
+					sizeIncrease = nlohmann::json::parse(request).get<std::unordered_map<std::string, uint32_t>>();
+				}
+				catch (std::exception& e)
+				{
+					trace("Error occured while parsing the pool size increase request json: %s.\n", e.what());
+					WritePrivateProfileString(L"Game", L"PoolSizesIncrease", L"", fpath.c_str());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Goal of this PR
Somehow, users are ending up with an invalid JSON in the PoolSizesIncrease field in CitizenFX.ini. This PR catches the parse_error exception and resets PoolSizesIncrease to an empty value.


### How is this PR achieving the goal
Catching the `nlohmann::json_abi_v3_11_2::detail::parse_error` exception, leaving the `sizeIncrease` map empty and emptying the PoolSizesIncrease  field


### This PR applies to the following area(s)
 FiveM, RedM

### Successfully tested on

**Game builds:** 3095, 3258

**Platforms:** Windows

**Notes:** Only tested on top of #3585 because I can't compile the client otherwise. I cherry-picked my commit and submitted only it

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ x] Code compiles and has been tested successfully.
- [x ] Code explains itself well and/or is documented.
- [x ] My commit message explains what the changes do and what they are for.
- [x ] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes this issue reported a few times on Discord https://discord.com/channels/192358910387159041/1409630888777613332/1409630888777613332

<img width="528" height="742" alt="image" src="https://github.com/user-attachments/assets/479d1860-bc4b-41fc-9942-3e46e728c6e2" />
