### PR TITLE
Fix crashes while pausing

### DIFF
--- a/code/components/rage-scripting-five/src/scrEngine.cpp
+++ b/code/components/rage-scripting-five/src/scrEngine.cpp
@@ -83,6 +83,9 @@ static std::unordered_map<uint64_t, int> g_nativeBlockedBeforeBuild = {
 	{0xA6EEF01087181EDD, std::numeric_limits<int>::max()},
 	{0xDBF860CF1DB8E599, std::numeric_limits<int>::max()},
 
+	{0xC8B189ED9138BCD4, std::numeric_limits<int>::max()}, // TERMINATE_THREAD
+	{0x1090044AD1DA76FA, std::numeric_limits<int>::max()}, // TERMINATE_THIS_THREAD
+
 	// Natives that were introduces after a certain build and are closely coupled with the DLC content.
 	// When running new game executable with old DLC set - we have to explicitly disable these natives.
 


### PR DESCRIPTION
### Goal of this PR
The goal of this PR is to fix #3079. The issue is caused by calling `TerminateThread()` with a threadId occupied by a script started by the pause menu. In Singleplayer and GTAO, certain pause menu tabs may stream in and start additional scripts/threads to fill in dynamic content. For example to handle clicking on race/deathmatch join blips on the map, or fill in the mission objective in the GAME tab. See [pausemenu.xml](https://github.com/citizenfx/fivem/blob/6a796486ab67e507d8c4107f9d39d2c8ff507bf7/data/client/citizen/common/data/ui/pausemenu.xml#L4), looking for `<type>SCRIPT</type>`. 

As you cannot stream pausemenu.xml, this feature is entirely unused in FiveM (outside of Story Mode) but the scripts are still started and can cause issues.

### How is this PR achieving the goal
1. Disable the starting and updating of pause menu scripts outside of Story Mode
2. Prevent the use of `TerminateThread()` and `TerminateThisThread()` outside of Story Mode, as they only work for .ysc scripts, are not intended to be used in FiveM, and can cause issues with script registration.

See https://forum.cfx.re/t/terminatethisthread-not-working-at-all/788684/2 and other threads on the forum about these natives.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
Pattern checked statically on all supported FiveM builds.

**Game builds:**  3095, 3258, 3407 in both a server (disabled) and in Story Mode (enabled)

**Platforms:** Windows, 


### Checklist

- [x ] Code compiles and has been tested successfully.
- [x ] Code explains itself well and/or is documented.
- [x ] My commit message explains what the changes do and what they are for.
- [x ] No extra compilation warnings are added by these changes.


### Fixes issues
 #3079


