### PR TITLE
fix(citizen-scripting-core): ClearTimeout works after Wait

### DIFF
--- a/code/components/citizen-scripting-core/include/fxScripting.idl
+++ b/code/components/citizen-scripting-core/include/fxScripting.idl
@@ -190,6 +190,8 @@ interface IScriptHostWithBookmarks : fxIBase
 
 	void RemoveBookmarks(in IScriptTickRuntimeWithBookmarks runtime);
 
+	void RemoveBookmark(in uint64_t bookmark);
+
 	void CreateBookmarks(in IScriptTickRuntimeWithBookmarks runtime);
 };
 

--- a/code/components/citizen-scripting-core/src/ScriptHost.cpp
+++ b/code/components/citizen-scripting-core/src/ScriptHost.cpp
@@ -112,6 +112,37 @@ static void RemoveBookmarks(IScriptTickRuntimeWithBookmarks* scRT)
 	bookmarkRefs.resourceInsertionIterators.erase(scRT);
 }
 
+static bool RemoveBookmark(uint64_t bookmark)
+{
+	auto exIt = (bookmarkRefs.executing) ? bookmarkRefs.executingIt : nullptr;
+
+	auto& list = bookmarkRefs.list;
+
+	for (auto it = list.begin(); it != list.end(); )
+	{
+		if (it->bookmark == bookmark)
+		{
+			if (exIt && *exIt == it)
+			{
+				*exIt = it = list.erase(it);
+			}
+			else
+			{
+				it = list.erase(it);
+			}
+
+			return true;
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	return false;
+}
+
+
 static void RunBookmarks()
 {
 	bookmarkRefs.executing = true;
@@ -521,6 +552,17 @@ result_t TestScriptHost::RemoveBookmarks(IScriptTickRuntimeWithBookmarks* scRT)
 {
 	::RemoveBookmarks(scRT);
 	return FX_S_OK;
+}
+
+result_t TestScriptHost::RemoveBookmark(uint64_t bookmark)
+{
+	bool removed = ::RemoveBookmark(bookmark);
+	if (removed)
+	{
+		return FX_S_OK;
+	}
+
+	return FX_E_INVALIDARG;
 }
 
 // TODO: don't ship with this in

--- a/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
+++ b/code/components/citizen-scripting-lua/include/LuaScriptRuntime.h
@@ -366,6 +366,8 @@ public:
 
 	void ScheduleBookmarkSoon(uint64_t bookmark, int timeout);
 
+	bool RemoveBookmark(uint64_t bookmark);
+
 	void SchedulePendingBookmarks();
 
 public:

--- a/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
+++ b/code/components/citizen-scripting-lua/src/LuaScriptRuntime.cpp
@@ -1154,6 +1154,11 @@ static int Lua_ClearTimeout(lua_State* L)
 		}
 	}
 
+	if (luaRuntime->RemoveBookmark(bookmark))
+	{
+		removed = true;
+	}
+
 	lua_pushboolean(L, removed);
 	return 1;
 }
@@ -1278,6 +1283,11 @@ void LuaScriptRuntime::SchedulePendingBookmarks()
 
 		m_pendingBookmarks.clear();
 	}
+}
+
+bool LuaScriptRuntime::RemoveBookmark(uint64_t bookmark)
+{
+	return GetScriptHostWithBookmarks()->RemoveBookmark(bookmark) == FX_S_OK;
 }
 
 void LuaScriptRuntime::SetTickRoutine(const std::function<void(uint64_t, bool)>& tickRoutine)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This PR duplicates #3260, but since that one hasn’t been updated, I opened a new one.
fixes the issue where calling `ClearTimeout` after another thread or after `Wait` has no effect.


### How is this PR achieving the goal
Implemented bookmark removal logic in ScriptHost.cpp to ensure ClearTimeout properly deletes the bookmark.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: Lua


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

#3259 
