### PR TITLE
fix(conhost-v2): console key repeat delay/rate

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostImpl.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostImpl.cpp
@@ -661,6 +661,9 @@ static HookFunction initFunction([]()
 	io.ConfigWindowsResizeFromEdges = true;
 	io.ConfigWindowsMoveFromTitleBarOnly = true;
 
+	io.KeyRepeatDelay = 0.250f;  // 250ms initial delay before repeat starts
+	io.KeyRepeatRate = 0.050f;   // 50ms between repeats (20 repeats per second)
+
 	io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
 	io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
 
@@ -958,3 +961,4 @@ static HookFunction hookFunction([]()
 {
 	g_origReleaseCapture = (decltype(g_origReleaseCapture))hook::iat("user32.dll", ReleaseCaptureStub, "ReleaseCapture");
 });
+


### PR DESCRIPTION
### Goal of this PR

Fix inconsistent key repeat behaviour in the F8 console, where high FPS causes keys (e.g. arrow up/down) to repeat much faster than intended. This ensures consistent key repeat timing regardless of framerate.

### How is this PR achieving the goal

By explicitly setting `io.KeyRepeatDelay` and `io.KeyRepeatRate`:

```cpp
io.KeyRepeatDelay = 0.250f;  // 250ms initial delay before repeat starts
io.KeyRepeatRate  = 0.050f;  // 50ms between repeats (20 repeats per second)
```

This provides a stable, framerate-independent key repeat.

### Successfully tested on

**Game builds:** 19032
**Platforms:** Windows

### Checklist

* [x] Code compiles and has been tested successfully.
* [x] Code explains itself well and/or is documented.
* [x] My commit message explains what the changes do and what they are for.
* [x] No extra compilation warnings are added by these changes.

### Fixes issues

Fixes high FPS causing extremely fast key repeats in the F8 console (e.g. pressing the up arrow can skip through nearly the entire command history during loading screens).

**Related Issue**: #3600 