### PR TITLE
tweak(rdr3-poolmanagement): relocated the logic for increasing pool sizes

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -777,6 +777,13 @@ static int64_t GetSizeOfPool(void* configManager, uint32_t poolHash, int default
 {
 	int64_t size = g_origGetSizeOfPool(configManager, poolHash, defaultSize);
 
+	// At the top to allow increase pool sizes that are being automatically increased this way we can increase specifc pool sizes if needed, some of them need a little bump like CPedSyncData.
+	auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find(poolEntries.LookupHash(poolHash));
+	if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
+	{
+		size += sizeIncreaseEntry->second;
+	}
+
 	// There are several pools that are tied to Peds/CNetObjPedBase. We want to ensure that the increased value is applied to all of these components.
 	if (auto it = pedPoolEntries.find(poolHash); it != pedPoolEntries.end())
 	{
@@ -807,12 +814,6 @@ static int64_t GetSizeOfPool(void* configManager, uint32_t poolHash, int default
 			size += sizeIncreaseEntry->second;
 		}
 		return size;
-	}
-
-	auto sizeIncreaseEntry = fx::PoolSizeManager::GetIncreaseRequest().find(poolEntries.LookupHash(poolHash));
-	if (sizeIncreaseEntry != fx::PoolSizeManager::GetIncreaseRequest().end())
-	{
-		size += sizeIncreaseEntry->second;
 	}
 
 	return size;


### PR DESCRIPTION
### Goal of this PR
Relocated the logic for increasing pool sizes to the beginning of GetSizeOfPool to ensure specific pool size increases are applied before other adjustments

Please add to the pool size allow list `CPedSyncData` 

### How is this PR achieving the goal

This change allows for more predictable and targeted pool size modifications, especially for pools like `CPedSyncData` that need more than the amount requested by `CNetObjPedBase`

### This PR applies to the following area(s)

RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


