### PR TITLE
fix(input/rdr3): inconsistent clipping after alt tab

### DIFF
--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -221,6 +221,10 @@ LRESULT APIENTRY sgaWindowProcedure(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
 	if (uMsg == WM_ACTIVATEAPP)
 	{
 		g_isFocused = (wParam) ? true : false;
+		if (!g_isFocused)
+		{
+			ClipHostCursor(NULL);
+		}
 	}
 
 	if (uMsg >= WM_KEYFIRST && uMsg <= WM_KEYLAST)
@@ -342,7 +346,7 @@ HKL WINAPI ActivateKeyboardLayoutWrap(IN HKL hkl, IN UINT flags)
 
 BOOL WINAPI SetCursorPosWrap(int X, int Y)
 {
-	if (!g_isFocused || g_enableSetCursorPos)
+	if (!g_isFocusStolen || g_enableSetCursorPos)
 	{
 		return SetCursorPos(X, Y);
 	}


### PR DESCRIPTION
### Goal of this PR

Resolves an issue where mouse clipping is inconsistent after alt + tab into the game. Leading to cases where the cursor can escape the window during gameplay.

### How is this PR achieving the goal

By clipping cursor when not focused on the game, on re-entering the window the game properly restores the cursor clipping.

### This PR applies to the following area(s)

RedM


### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
