### PR TITLE
feat(core/rdr3): extended ped deletion circular buffer

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxPed.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxPed.cpp
@@ -11,6 +11,25 @@
 // This patch resolves this by improving logic to account for the increase size of "CNetObjPedBase" pool and removing a ped pool size check that would otherwise fatally error.
 //
 
+template<int EntitySize = 160>
+struct EntityCircularBuffer
+{
+	void* entity[EntitySize];
+
+	uint32_t cursorPos;
+	uint32_t baseOffset;
+	uint32_t totalEntries;
+};
+
+template<int instrLen = 7, int instrOffset = 3>
+static void PatchRelativeLocation(uintptr_t address, uintptr_t newLocation)
+{
+	uint8_t* instructions = reinterpret_cast<uint8_t*>(address);
+	uintptr_t instrNext = reinterpret_cast<uintptr_t>(instructions) + instrLen;
+	int32_t newOffset = (int32_t)((uintptr_t)newLocation - instrNext);
+	hook::put<int32_t>(instructions + instrOffset, newOffset);
+}
+
 static HookFunction hookFunction([]()
 {
 	constexpr size_t kDefaultMaxPeds = 110;
@@ -26,7 +45,7 @@ static HookFunction hookFunction([]()
 
 	// Don't fatally error if "Peds" pool is greater then 160.
 	hook::put<uint8_t>(hook::get_pattern("76 ? BA ? ? ? ? 41 B8 ? ? ? ? 83 C9 ? E8 ? ? ? ? 33 D2 8B CF"), 0xEB);
-	
+
 	// Set total desired peds.
 	*hook::get_address<uint32_t*>(hook::get_pattern("89 05 ? ? ? ? C6 05 ? ? ? ? ? 89 15", 2)) = kDefaultMaxPeds + increaseSize;
 	
@@ -35,4 +54,68 @@ static HookFunction hookFunction([]()
 
 	// Allow registration of script/mission peds up to and past the 110 limit.
 	hook::put<uint32_t>(hook::get_pattern("BB ? ? ? ? E9 ? ? ? ? E8 ? ? ? ? 48 8B 0D", 1), kDefaultMaxPeds + increaseSize);
+
+	// Resize ped circular buffer to support greater then 160 peds.
+	{
+		// Allocate 270 as:
+		// + 150 for base peds
+		// + 110 for ped increase
+		// + 10 extra.
+		constexpr int kMaxPedRingBuffer = 270;
+		const size_t kMagicDivideNumber = 0x4EC4EC4F;
+
+		using CircularBuffer = EntityCircularBuffer<kMaxPedRingBuffer>; 
+
+		const size_t kNewEntrySize = sizeof(CircularBuffer);
+		const size_t kNewCursorPosOffset = (size_t)offsetof(CircularBuffer, cursorPos);
+		const size_t kNewBaseOffset = (size_t)offsetof(CircularBuffer, baseOffset);
+		const size_t kNewTotalEntryOffset = (size_t)offsetof(CircularBuffer, totalEntries);
+
+		// allocate new location
+		static CircularBuffer* newArray = (CircularBuffer*)hook::AllocateStubMemory(kNewEntrySize);
+		memset(newArray, 0, kNewEntrySize);
+
+		// Patch RIP relatives
+		const uintptr_t kTotalEntriesOffset = (uintptr_t)newArray + kNewTotalEntryOffset;
+		const uintptr_t kBaseOffset = (uintptr_t)newArray + kNewBaseOffset;
+		const uintptr_t kCurPosOffset = (uintptr_t)newArray + kNewCursorPosOffset;
+
+		PatchRelativeLocation((uintptr_t)hook::get_pattern("44 8B 05 ? ? ? ? 83 F9 ? 8B F1"), kTotalEntriesOffset);
+		PatchRelativeLocation((uintptr_t)hook::get_pattern("44 8B 05 ? ? ? ? FF C3 41 3B D8 0F 82 ? ? ? ? 48 8B 5C 24 ? 8B C7"), kTotalEntriesOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("8B 0D ? ? ? ? 8B 05 ? ? ? ? FF C0 3B C7"), kTotalEntriesOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("89 0D ? ? ? ? 48 8D 0D ? ? ? ? 48 98"), kTotalEntriesOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("8B 0D ? ? ? ? BF ? ? ? ? 3B F9"), kTotalEntriesOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("8B 05 ? ? ? ? 44 03 C9"), kTotalEntriesOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("39 0D ? ? ? ? 89 1D"), kTotalEntriesOffset);
+
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("8B 0D ? ? ? ? B8 ? ? ? ? FF C1 03 CB F7 E9 C1 FA ? 8B C2 C1 E8 ? 03 D0 8D 04 92"), kBaseOffset);
+
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("8B 05 ? ? ? ? FF C0 3B C7"), kCurPosOffset);
+		PatchRelativeLocation<6, 2>((uintptr_t)hook::get_pattern("89 05 ? ? ? ? 89 0D ? ? ? ? 48 8D 0D"), kCurPosOffset);
+
+		PatchRelativeLocation((uintptr_t)hook::get_pattern("4C 8D 3D ? ? ? ? 8B 0D"), (uintptr_t)newArray);
+		PatchRelativeLocation((uintptr_t)hook::get_pattern("48 8D 0D ? ? ? ? 48 98 48 8D 3C C1"), (uintptr_t)newArray);
+
+		// Patch out old magic numbers
+		hook::put<uint32_t>(hook::get_pattern("B8 ? ? ? ? 44 03 C6", 1), kMagicDivideNumber);
+		hook::put<uint32_t>(hook::get_pattern("B8 ? ? ? ? 41 F7 E8 C1 FA ? 8B C2 C1 E8 ? 03 D0 8D 04 92", 1), kMagicDivideNumber);
+
+		// Patch new limit.
+		hook::put<uint32_t>(hook::get_pattern("B8 ? ? ? ? EB ? FF C8 89 83 ? ? ? ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 ? 5F C3 40 53", 1), kMaxPedRingBuffer - 1);
+		// Patch fatal error limit, from 160 to 270 also controls circular buffer cursorPos.
+		hook::put<uint32_t>(hook::get_pattern("BF ? ? ? ? 3B F9 75", 1), kMaxPedRingBuffer);
+
+		// Patch new offsets, some of these patterns are intended to break if a future updates alters the struct.
+		//+0x500 (cursorPos)
+		hook::put<uint32_t>(hook::get_pattern("8B 83 00 05 00 00 85 C0", 2), kNewCursorPosOffset);
+		hook::put<uint32_t>(hook::get_pattern("89 83 00 05 00 00 48 8B 5C", 2), kNewCursorPosOffset);
+
+		//+0x504 (baseOffset/unused)
+		hook::put<uint32_t>(hook::get_pattern("44 8B 83 ? ? ? ? B8 ? ? ? ? 44 03 C6", 3), kNewBaseOffset);
+
+		//+0x508 (totalEntries)
+		hook::put<uint32_t>(hook::get_pattern("8B 81 ? ? ? ? 8D 72 ? 48 8B D9 E9 ? ? ? ? 44 8B 83", 2), kNewTotalEntryOffset);
+		hook::put<uint32_t>(hook::get_pattern("8B 83 08 05 00 00 FF C6", 2), kNewTotalEntryOffset);
+		hook::put<uint32_t>(hook::get_pattern("89 83 08 05 00 00 8B 83", 2), kNewTotalEntryOffset);
+	}
 });

--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -640,10 +640,13 @@ static std::unordered_map<uint32_t, std::string_view> pedPoolEntries{
 	{ HashString("CPedVisibilityComponent"), "CPedVisibilityComponent" },
 	{ HashString("CNetBlenderPed"), "CNetBlenderPed" },
 	{ HashString("CPedSyncData"), "CPedSyncData" },
-
+	{ HashString("CEmotionalLocoHelper"), "CEmotionalLocoHelper" },
+	{ HashString("CCrimeObserver"), "CCrimeObserver" },
+	{ HashString("CAnimalGroupMember"), "CAnimalGroupMember" },
 	{ HashString("CPedFootstepComponent"), "CPedSyncData" },
 	{ HashString("CCharacterItem"), "CCharacterItem" },
-	{ HashString("CPedBreatheComponent"), "CPedBreatheComponent" }
+	{ HashString("CPedBreatheComponent"), "CPedBreatheComponent" },
+	{ HashString("CPedTargetingComponent"), "CPedTargetingComponent" }
 };
 
 static std::unordered_map<uint32_t, std::string_view> objectPoolEntries{


### PR DESCRIPTION
### Goal of this PR

With #3542 the max amounts of CNetObjPedBase and Peds was increased from 110/150 up to a max of 220/260 along with most pools known to be directly tied to Peds at the time, however since the patch has been merged, a few extra pools have been found to be directly related to Peds (although in testing some were tied to certain ped types such as animals, or were generally inconsistent whether they needed to be allocated or not), this PR includes 3 of them. With ``CPedAvoidanceComponent`` being intentionally omitted as it should be increased alongside ``CAvoidanceComponent`` if required.

This patch also resolves an hardcoded limit of 160 peds in a Circular Buffer related to entity deletion. In cases where 160+ entities are deleted/queued up for deletion in a short time window (from a couple of frames to a couple of seconds) would lead to ``Rage Error: 0x48B8ACBC:1758`` crashes. This patch resizes the Circular Buffer to a new max size of 270 to account for the new potential max size.

### How is this PR achieving the goal

Add ``CEmotionalLocoHelper``, ``CCrimeObserver``, ``CPedTargetingComponent``, ``CAnimalGroupMember`` to pool increases related to ``CNetObjPedBase`` to resolve several instances of ``Rage Error: 0x496AC5DF:961``

Allocate a larger block of memory for the ped deletion circular buffer to use. Along with replacing all references and offsets from the old ped buffer in order for it to take advantage of the new size.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

Test snippet used to test changes:

```lua
RegisterCommand("createNPC", function()
	local model = `MP_U_M_M_PROTECT_STRAWBERRY`
	RequestModel(model, false)
	repeat Wait(0) until HasModelLoaded(model)
	local coords = GetEntityCoords(PlayerPedId(), false, true)

	local c = 0
	local peds = {}

	for i=0, 220 do
		local ped = CreatePed(model, coords.x, coords.y, coords.z + 5.0, 0.0, true, true, true, true)
		if ped ~= 0 then
			peds[c] = ped
			c = c + 1
			SetRandomOutfitVariation(ped, true)
		end
		Wait(300)
	end
	print(c)

	Wait(1000)

	for i=0, 220 do
		if peds[i] then
			DeleteEntity(peds[i])
		end
	end
end, false)
```

Without patch: Crash past 150 for ``CEmotionalLocoHelper`` or ``CCrimeObserver`` pools being full. If these don't get allocated (e.g. using different peds). Crash with ``Rage Error: 0x48B8ACBC:1758`` from trying to delete more then 160 peds.

With patch: Don't crash when spawning up to 200+ peds. Also don't crash when deleting all the peds created. even if the number exceeds the previous 160 limit.

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

Rage Error: 0x48B8ACBC:1758

