### PR TITLE
feat(extra-natives-rdr3): add `SET_UI_VISIBLE_WHEN_DEAD` native

### DIFF
--- a/code/components/extra-natives-rdr3/src/HudNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/HudNatives.cpp
@@ -3,8 +3,16 @@
 #include <Hooking.h>
 #include <MinHook.h>
 
+#include "atArray.h"
+#include "fxScripting.h"
+#include "Hooking.Stubs.h"
+#include "Resource.h"
+#include "om/OMPtr.h"
+
 static void* g_sm_bootstrapInstance;
 static void* g_uiMinimap;
+
+static bool g_UI_VISIBILE_WHEN_DEAD = false;
 
 static hook::cdecl_stub<void(void*, char)> g_uiMinimap_SetType([]()
 {
@@ -16,6 +24,39 @@ static hook::cdecl_stub<uint32_t(void*)> g_uiMinimap_GetType([]()
 	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 83 F8 ? 74 ? 48 8D 15"));
 });
 
+static bool (*g_origUICondContextStoreEval)(hook::FlexStruct* self, void* a2);
+static bool UICondContextStoreEval(hook::FlexStruct* self, void* a2)
+{
+	int contextHash = self->At<int>(0x10);
+	
+	if(g_UI_VISIBILE_WHEN_DEAD && contextHash == 0xFC83EE25) // HUD_CTX_IN_RESPAWN
+	{
+		return false;
+	}
+	
+	return g_origUICondContextStoreEval(self, a2);
+}
+
+static bool (*g_origCAIConditionIsDead)(void* self, void* context);
+static bool CAIConditionIsDead(void* self, void* context)
+{
+	if(g_UI_VISIBILE_WHEN_DEAD)
+	{
+		return false;
+	}
+	return g_origCAIConditionIsDead(self, context);
+}
+
+static bool (*g_origIsDeathCameraRunning)();
+static bool IsDeathCameraRunning()
+{
+	if(g_UI_VISIBILE_WHEN_DEAD)
+	{
+		return false;
+	}
+	return g_origIsDeathCameraRunning();
+}
+
 static HookFunction hookFunction([]()
 {
 	{
@@ -24,6 +65,16 @@ static HookFunction hookFunction([]()
 		uint32_t uiMinimapOffset = *hook::get_pattern<uint32_t>("33 D2 48 8B CB 45 8D 44 24 ? E8", -16);
 
 		g_uiMinimap = (char*)g_sm_bootstrapInstance + uiMinimapOffset;
+	}
+
+	{
+		g_origUICondContextStoreEval = hook::trampoline(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 8B 05 ? ? ? ? 4C 8B C2 48 8B F9 89 44 24 ? 49 8B C8 48 8D 54 24 ? E8"), UICondContextStoreEval);
+		g_origCAIConditionIsDead = hook::trampoline(
+			hook::get_pattern(
+				"8B 41 ? 48 8B 8C C2 ? ? ? ? 48 85 C9 74 ? 80 79 ? ? 74 ? 33 C9 48 85 C9 74 ? 8B 81 ? ? ? ? 25 ? ? ? ? 2B 05 ? ? ? ? 48 69 C8 ? ? ? ? 48 8B 05 ? ? ? ? 48 8B 94 01 ? ? ? ? 48 8B CA 48 83 E1 ? 48 F7 DA 48 1B C0 48 23 C1 8B 88 ? ? ? ? C1 E1"
+			), CAIConditionIsDead
+		);
+		g_origIsDeathCameraRunning = hook::trampoline(hook::get_pattern("48 83 EC ? 32 C0 38 05 ? ? ? ? 88 44 24"), IsDeathCameraRunning);
 	}
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_MINIMAP_TYPE", [](fx::ScriptContext& context)
@@ -38,6 +89,23 @@ static HookFunction hookFunction([]()
 	{
 		uint32_t minimapType = g_uiMinimap_GetType(g_uiMinimap);
 		context.SetResult<int>(minimapType);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_UI_VISIBLE_WHEN_DEAD", [](fx::ScriptContext& context) 
+	{
+		bool value = context.GetArgument<bool>(0);
+		g_UI_VISIBILE_WHEN_DEAD = value;
+
+		fx::OMPtr<IScriptRuntime> runtime;
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+			resource->OnStop.Connect([]()
+			{
+				g_UI_VISIBILE_WHEN_DEAD = false;
+			});
+		}
 	});
 
 	/*

--- a/ext/native-decls/SetUiVisibleWhenDead.md
+++ b/ext/native-decls/SetUiVisibleWhenDead.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_UI_VISIBLE_WHEN_DEAD
+
+```c
+void SET_UI_VISIBLE_WHEN_DEAD(BOOL display);
+```
+
+Toggles the display of the UI when the player is dead.
+
+## Parameters
+* **display**: On/Off


### PR DESCRIPTION
### Goal of this PR
Allow to keep showing the UIs when the local player is dead, this is especially useful for notifications, which are also hidden by default when you die.


### How is this PR achieving the goal
Hooked 3 conditions evaluate methods of `VisibilityConditions.ymt`, and return a specific value to make the UI thinks the local player is still alive.


### This PR applies to the following area(s)
RedM, Natives


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.