### PR TITLE
feat(extra-natives-rdr3): add `SET_CLIENT_CONFIG_BOOL` native

### DIFF
--- a/code/components/extra-natives-rdr3/include/ClientConfig.h
+++ b/code/components/extra-natives-rdr3/include/ClientConfig.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <bitset>
+#include <cstdint>
+
+enum class ClientConfigFlag : uint16_t
+{
+	WeaponsNoAutoReload = 0,
+	UIVisibleWhenDead = 1,
+	DisableDeathAudioScene = 2,
+};
+
+extern std::bitset<256> g_clientConfigBits;
+
+void SetClientConfigFlag(ClientConfigFlag flag, bool enabled);
+bool IsClientConfigEnabled(ClientConfigFlag flag);

--- a/code/components/extra-natives-rdr3/src/AudioNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/AudioNatives.cpp
@@ -1,0 +1,86 @@
+#include "StdInc.h"
+
+#include "ClientConfig.h"
+#include "Hooking.Patterns.h"
+
+static HookFunction hookFunction([]()
+{
+	// Disable the audDynamicMixer::StartScene calls to prevent audio from cutting out on death.
+	{
+		// 0x48A61B5F, ambient sounds
+		{
+			auto location = hook::get_pattern<char>("C7 45 ? ? ? ? ? E8 ? ? ? ? 48 8D 4D ? E8 ? ? ? ? 8A 83 ? ? ? ? 48 8B 0D ? ? ? ? BF");
+			auto failLocation = location + 34;
+			
+			static struct : jitasm::Frontend
+			{
+				uintptr_t successLocation;
+				uintptr_t failLocation;
+
+				void Init(uintptr_t success, uintptr_t fail)
+				{
+					successLocation = success;
+					failLocation = fail;
+				}
+				
+				virtual void InternalMain() override
+				{
+					mov(dword_ptr[rbp+0x20], 0x48A61B5F);
+
+					mov(rax, (uintptr_t)&g_clientConfigBits);
+					bt(qword_ptr[rax], (int)ClientConfigFlag::DisableDeathAudioScene);
+					jnc("success");
+
+					mov(rax, failLocation);
+					jmp(rax);
+
+					L("success");
+					mov(rax, successLocation);
+					jmp(rax);
+				}
+			} stub;
+			
+			stub.Init((uintptr_t)location + 0x7, (uintptr_t)failLocation);
+			hook::nop(location, 0x7);
+			hook::jump(location, stub.GetCode());
+		}
+
+		// 0x8B8B8CB1, related to scripted sounds?
+		{
+			auto location = hook::get_pattern("BA ? ? ? ? 49 89 73");
+			auto failLocation = hook::get_pattern("48 8D 55 ? 0F 29 45 ? 48 8B CB E8 ? ? ? ? 4C 8D 9C 24", 16);
+			
+			static struct : jitasm::Frontend
+			{
+				uintptr_t successLocation;
+				uintptr_t failLocation;
+
+				void Init(uintptr_t success, uintptr_t fail)
+				{
+					successLocation = success;
+					failLocation = fail;
+				}
+				
+				virtual void InternalMain() override
+				{
+					mov(edx, 0x8B8B8CB1);
+
+					mov(rax, (uintptr_t)&g_clientConfigBits);
+					bt(qword_ptr[rax], (int)ClientConfigFlag::DisableDeathAudioScene);
+					jnc("success");
+
+					mov(rax, failLocation);
+					jmp(rax);
+
+					L("success");
+					mov(rax, successLocation);
+					jmp(rax);
+				}
+			} stub;
+			
+			stub.Init((uintptr_t)location + 0x5, (uintptr_t)failLocation);
+			hook::nop(location, 0x5);
+			hook::jump(location, stub.GetCode());
+		}
+	}
+});

--- a/code/components/extra-natives-rdr3/src/ClientConfig.cpp
+++ b/code/components/extra-natives-rdr3/src/ClientConfig.cpp
@@ -1,0 +1,84 @@
+#include "StdInc.h"
+#include "ClientConfig.h"
+
+#include <bitset>
+#include <unordered_set>
+
+#include "fxScripting.h"
+#include "Resource.h"
+#include "ScriptEngine.h"
+
+std::bitset<256> g_clientConfigBits;
+static std::unordered_map<fx::Resource*, std::unordered_set<ClientConfigFlag>> g_resourceFlags;
+
+void SetClientConfigFlag(ClientConfigFlag flag, bool enabled)
+{
+	g_clientConfigBits.set(static_cast<size_t>(flag), enabled);
+}
+
+bool IsClientConfigEnabled(ClientConfigFlag flag)
+{
+	return g_clientConfigBits.test(static_cast<size_t>(flag));
+}
+
+void ResetClientConfigFlagsFor(fx::Resource* resource)
+{
+    auto it = g_resourceFlags.find(resource);
+    if (it == g_resourceFlags.end())
+        return;
+
+    for (auto flag : it->second)
+    {
+        // Disable only the flags this resource enabled
+        SetClientConfigFlag(flag, false);
+    }
+
+    g_resourceFlags.erase(it);
+}
+
+static HookFunction hookFunction([]()
+{
+    fx::ScriptEngine::RegisterNativeHandler("SET_CLIENT_CONFIG_BOOL", [](fx::ScriptContext& context)
+    {
+        int flagIndex = context.GetArgument<int>(0);
+        bool enabled = context.GetArgument<bool>(1);
+
+        ClientConfigFlag flag = static_cast<ClientConfigFlag>(flagIndex);
+        SetClientConfigFlag(flag, enabled);
+
+        fx::OMPtr<IScriptRuntime> runtime;
+        if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+        {
+            fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+            if (enabled)
+            {
+                g_resourceFlags[resource].insert(flag);
+            }
+            else
+            {
+                auto it = g_resourceFlags.find(resource);
+                if (it != g_resourceFlags.end())
+                {
+                    it->second.erase(flag);
+                    if (it->second.empty())
+                        g_resourceFlags.erase(it);
+                }
+            }
+
+            resource->OnStop.Connect([resource]()
+            {
+                ResetClientConfigFlagsFor(resource);
+            });
+        }
+    });
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_CLIENT_CONFIG_BOOL", [](fx::ScriptContext& context)
+	{
+		int flagIndex = context.GetArgument<int>(0);
+		ClientConfigFlag flag = static_cast<ClientConfigFlag>(flagIndex);
+
+		bool result = IsClientConfigEnabled(flag);
+		context.SetResult<bool>(result);
+	});
+});

--- a/ext/native-decls/GetClientConfigBool.md
+++ b/ext/native-decls/GetClientConfigBool.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_CLIENT_CONFIG_BOOL
+
+```c
+BOOL GET_CLIENT_CONFIG_BOOL(int flagIndex);
+```
+
+Returns whether a specific client configuration flag is currently enabled.
+You can find a list of configuration flags in [`SET_CLIENT_CONFIG_BOOL`](#_0xD174EF7E).
+
+
+## Parameters
+* **flagIndex**: The index of the configuration flag to get.

--- a/ext/native-decls/SetClientConfigBool.md
+++ b/ext/native-decls/SetClientConfigBool.md
@@ -1,0 +1,26 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_CLIENT_CONFIG_BOOL
+
+```c
+void SET_CLIENT_CONFIG_BOOL(int flagIndex, BOOL enabled);
+```
+
+```c
+enum ClientConfigFlag
+{
+    WeaponsNoAutoReload = 0,
+	UIVisibleWhenDead = 1,
+	DisableDeathAudioScene = 2
+}
+```
+
+Sets the value of a client configuration flag.
+This native allows enabling or disabling specific one-time client-side features.
+
+## Parameters
+* **flagIndex**: The index of the configuration flag to set.
+* **enabled**: Whether to enable or disable the flag.


### PR DESCRIPTION
### Goal of this PR
Allow to disable the audio scenes `0x8B8B8CB1 ` and `0x48A61B5F` to allow players hear sounds including voice chat, right now when a player dead he cannot hear others but others can hear he.

Allow to keep showing the UIs when the local player is dead, this is especially useful for notifications, which are also hidden by default when you die.

Added the native `SET_WEAPONS_NO_AUTORELOAD` to RedM, to make the character not auto-reload weapons when they run out of ammo.


### How is this PR achieving the goal
Skipping calls to `audDynamicMixer::StartScene` where the audio scenes are setup.

Hooked 3 conditions evaluate methods of `VisibilityConditions.ymt`, and return a specific value to make the UI thinks the local player is still alive.

Intercepting the `GetNeedsToReload` function and checking if the weapon owner is the local player to avoid causing issues for other peds.


### This PR applies to the following area(s)
RedM, Natives

### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3297 
