### PR TITLE
tweak(native/codegen): only check that we're not server before filtering

### DIFF
--- a/ext/native-decls/GetMount.md
+++ b/ext/native-decls/GetMount.md
@@ -6,10 +6,11 @@ game: rdr3
 ## GET_MOUNT
 
 ```c
-int GET_MOUNT(Ped ped);
+Ped GET_MOUNT(Ped ped);
 ```
-returns the entity of the mount the ped is on
 
 ## Parameters
 * **ped**: the ped id
 
+## Return value
+Returns the entity the `ped` is currently on, or `0` if they're not on a mount.

--- a/ext/native-decls/GetSeatPedIsUsing.md
+++ b/ext/native-decls/GetSeatPedIsUsing.md
@@ -7,8 +7,9 @@ apiset: server
 ```c
 int GET_SEAT_PED_IS_USING(Ped ped);
 ```
-returns the seat index of the specified ped, if not seated or not in vehicle returns -3 just client natives
 
 ## Parameters
 * **ped**: the ped id
 
+## Return Value
+Returns the seat index for specified `ped`, if the ped is not sitting in a vehicle it will return -3.

--- a/ext/native-decls/IsPedInAnyVehicle.md
+++ b/ext/native-decls/IsPedInAnyVehicle.md
@@ -7,9 +7,9 @@ apiset: server
 ```c
 BOOL IS_PED_IN_ANY_VEHICLE(Ped ped);
 ```
-returns true if the specified ped is in any vehicle
 
 ## Parameters
 * **ped**: the ped id
 
-
+## Return value
+Returns `true` if the specified `ped` is in any vehicle

--- a/ext/native-decls/IsPedInVehicle.md
+++ b/ext/native-decls/IsPedInVehicle.md
@@ -7,9 +7,11 @@ apiset: server
 ```c
 BOOL IS_PED_IN_VEHICLE(Ped ped, Vehicle vehicle);
 ```
-returns true if the specified ped is in the speficied vehicle
 
 ## Parameters
 * **ped**: the ped id
 * **vehicle**: the vehicle id
+
+## Return value
+Returns `true` if the specified `ped` is in the specified `vehicle`
 

--- a/ext/native-decls/IsPedOnMount.md
+++ b/ext/native-decls/IsPedOnMount.md
@@ -8,8 +8,10 @@ game: rdr3
 ```c
 BOOL IS_PED_ON_MOUNT(Ped ped);
 ```
-returns true if the specified ped is on a mount
 
 ## Parameters
 * **ped**: the ped id
+
+## Return value
+Returns `true` if the specified `ped` is on a mount.
 

--- a/ext/natives/codegen.lua
+++ b/ext/natives/codegen.lua
@@ -550,7 +550,7 @@ local ourGame = 'gta5'
 function matchApiSet(native)
 	local game = native.game
 
-	if ourGame and native.game and native.game ~= ourGame then
+	if ourGame and native.game and native.game ~= ourGame and gApiSet ~= 'server' then
 		return false
 	end
 


### PR DESCRIPTION

### Goal of this PR
Currently if we set server natives to be for specific games (like `gta5` or `rdr3`) it will be filtered out of server codegen because the default game value is 'gta5' when doing server codegen.

On the server all server natives exist at all times, so we just adjust the native filtering to respect this.

This also cleans up the return descriptions of the new natives.


### This PR applies to the following area(s)
Server

### Successfully tested on
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


