### PR TITLE
fix(gta-net-rdr3): stucked wagons by unregistered propsets

### DIFF
--- a/code/components/gta-net-five/src/CloneManager.cpp
+++ b/code/components/gta-net-five/src/CloneManager.cpp
@@ -2109,7 +2109,7 @@ void CloneManagerLocal::WriteUpdates()
 		auto& objectData = m_trackedObjects[objectId];
 
 #ifdef IS_RDR3
-		if (objectData.lastSyncTime == 0ms && object->GetObjectType() == (int)NetObjEntityType::DraftVeh)
+		if (objectData.lastSyncTime == 0ms && (object->GetObjectType() == (int)NetObjEntityType::DraftVeh || object->GetObjectType() == (int)NetObjEntityType::PropSet))
 		{
 			uint32_t reason = 0;
 

--- a/code/components/gta-net-rdr3/src/netObjectPatchs.cpp
+++ b/code/components/gta-net-rdr3/src/netObjectPatchs.cpp
@@ -1,0 +1,34 @@
+#include "StdInc.h"
+
+#include <netPlayerManager.h>
+#include "Hooking.Patterns.h"
+#include "netObjectMgr.h"
+
+static bool (*CNetObjGame__CanClone)(hook::FlexStruct*, const void*, uint32_t*);
+
+static bool CNetObjPropSet__CanClone(hook::FlexStruct* self, void* player, uint32_t* reason)
+{
+	if(!CNetObjGame__CanClone(self, player, reason))
+	{
+		return false;
+	}
+	
+	auto parentId = self->At<int16_t>(0x43C);
+	if(parentId != 0)
+	{
+		if(auto parent = rage::netObjectMgr::GetInstance()->GetNetworkObject(parentId, true))
+		{
+			return parent->CanClone(rage::GetLocalPlayer(), reason);
+		}
+	}
+	
+	return true;
+}
+
+static HookFunction hookFunction([]()
+{
+	auto vtable = hook::get_address<uintptr_t*>(hook::get_pattern("48 8D 05 ? ? ? ? 48 89 03 0F 57 C0 48 8D 05 ? ? ? ? 48 8B CB", 0x3));
+	auto canCloneOffset = 0x190 / 8;
+	CNetObjGame__CanClone = (decltype(CNetObjGame__CanClone))vtable[canCloneOffset];
+	hook::put<uintptr_t>(&vtable[canCloneOffset], (uintptr_t)CNetObjPropSet__CanClone);
+});


### PR DESCRIPTION
### Goal of this PR
This PR fixes a long-standing synchronization issue affecting propsets in RedM where cloned propsets could become invalid or get immediately deleted when their parent vehicle entity was not yet synchronized across the network.

The root cause was that CNetObjPropSet would attempt to clone even if its associated parent (CNetObjVehicle) had not finished synchronizing. This often resulted in premature deletion of the propsets and cause to have invalid data in the draft vehicle class, this is the root cause of wagons becoming stuck.


### How is this PR achieving the goal
This PR introduces a hook that implements the CanClone override(right now CNetObjPropSet is using the default CNetObjGame::CanClone), with this custom method we ensure that a propset can only be cloned once its parent entity(if exists) is valid and ready to replicate.

Normally, propsets in RedM could request cloning even when their parent entity was not yet synchronized across the network. This caused the propset to be removed right after creation.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3139 