### PR TITLE
feat(extra-natives-rdr3): Add CBlip in GetGamePool / Add natives GetB…

### DIFF
--- a/code/components/extra-natives-rdr3/src/BlipNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/BlipNatives.cpp
@@ -1,0 +1,100 @@
+#include "StdInc.h"
+
+#include <Hooking.h>
+#include <ScriptEngine.h>
+#include <ScriptSerialization.h>
+
+#include <atArray.h>
+#include <Pool.h>
+
+#include <GameInit.h>
+#include <Local.h>
+
+struct BlipData
+{
+    char pad1[32]; // 0x0000-0x001F (32 bytes)
+    float x; // 0x0020 (4 bytes)
+    float y; // 0x0024 (4 bytes)
+    float z; // 0x0028 (4 bytes)
+    char vpad[4]; // 0x002C-0x002F (4 bytes)
+    uint16_t rotation; // 0x0030 (2 bytes)
+    char pad2[542]; // 0x0032-0x024F (542 bytes)
+    atArray<uint32_t> modifiers; // 0x0250-0x025F (16 bytes)
+    char pad3[92]; // 0x0260-0x02BB (92 bytes)
+    uint32_t blipSprite; // 0x02BC (4 bytes)
+    char pad4[15]; // 0x02C0-0x02CE (15 bytes)
+    uint8_t blipFlags; // 0x02CF - bitfield containing blip type/flags
+    char pad5[16]; // 0x02D0-0x02DF (16 bytes)
+    void* vtable; // 0x02F0 (8 bytes)
+    void* unk; // 0x02F8 (8 bytes)
+};
+
+static auto GetBlipPool()
+{
+    static auto pool = rage::GetPoolBase("fwuiBlip");
+    return pool;
+}
+
+static BlipData* GetBlipData(uint32_t blipHandle)
+{
+    if (blipHandle == 0)
+        return nullptr;
+
+    auto pool = GetBlipPool();
+    if (!pool)
+        return nullptr;
+
+    auto blip = pool->GetAtHandle<BlipData>(blipHandle);
+    return blip;
+}
+
+static InitFunction initFunction([]()
+{
+    fx::ScriptEngine::RegisterNativeHandler("GET_BLIP_SPRITE", [](fx::ScriptContext& context)
+    {
+        uint32_t blipHandle = context.GetArgument<uint32_t>(0);
+        
+        auto blip = GetBlipData(blipHandle);
+        if (blip)
+        {
+            context.SetResult(blip->blipSprite);
+        }
+        else
+        {
+            context.SetResult(0);
+        }
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("GET_BLIP_ROTATION", [](fx::ScriptContext& context)
+    {
+        uint32_t blipHandle = context.GetArgument<uint32_t>(0);
+        
+        auto blip = GetBlipData(blipHandle);
+        if (blip)
+        {
+            float rotation = static_cast<float>(blip->rotation) * (360.0f / 65535.0f);
+            context.SetResult(rotation);
+        }
+        else
+        {
+            context.SetResult(0.0f);
+        }
+    });
+
+    fx::ScriptEngine::RegisterNativeHandler("GET_BLIP_MODIFIERS", [](fx::ScriptContext& context)
+    {
+        uint32_t blipHandle = context.GetArgument<uint32_t>(0);
+        
+        std::vector<uint32_t> modifiers;
+        auto blip = GetBlipData(blipHandle);
+        if (blip)
+        {
+            for (int i = 0; i < blip->modifiers.GetCount(); ++i)
+            {
+                modifiers.push_back(blip->modifiers[i]);
+            }
+        }
+        context.SetResult(fx::SerializeObject(modifiers));
+    });
+
+});

--- a/ext/native-decls/GetBlipModifiers.md
+++ b/ext/native-decls/GetBlipModifiers.md
@@ -1,0 +1,39 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_BLIP_MODIFIERS
+
+```c
+object GET_BLIP_MODIFIERS(int blipHandle);
+```
+
+Gets the modifiers array of a blip from its handle.
+
+## Parameters
+* **blipHandle**: The blip handle obtained from GET_GAME_POOL("CBlip")
+
+## Return value
+An array of uint32_t modifiers. Returns an empty array if the blip doesn't exist.
+
+## Examples
+```lua
+local blips = GetGamePool("CBlip")
+for _, blipHandle in ipairs(blips) do
+    local modifiers = GetBlipModifiers(blipHandle)
+    if #modifiers > 0 and modifiers[1] == 0x9D6AB6CB then -- BLIP_STYLE_POI
+        print("Found POI style blip with handle:", blipHandle)
+    end
+end
+```
+
+```js
+const blips = GetGamePool("CBlip");
+blips.forEach(blipHandle => {
+    const modifiers = GetBlipModifiers(blipHandle);
+    if (modifiers.length > 0 && modifiers[0] === 0x9D6AB6CB) { // BLIP_STYLE_POI
+        console.log(`Found POI style blip with handle: ${blipHandle}`);
+    }
+});
+```

--- a/ext/native-decls/GetBlipRotation.md
+++ b/ext/native-decls/GetBlipRotation.md
@@ -1,0 +1,35 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_BLIP_ROTATION
+
+```c
+float GET_BLIP_ROTATION(int blipHandle);
+```
+
+Gets the rotation of a blip from its handle.
+
+## Parameters
+* **blipHandle**: The blip handle obtained from GET_GAME_POOL("CBlip")
+
+## Return value
+The blip rotation in degrees as a float value (0.0 to 360.0). Returns 0.0 if the blip doesn't exist.
+
+## Examples
+```lua
+local blips = GetGamePool("CBlip")
+for _, blipHandle in ipairs(blips) do
+    local rotation = GetBlipRotation(blipHandle)
+    print(string.format("Blip %d rotation: %.2f degrees", blipHandle, rotation))
+end
+```
+
+```js
+const blips = GetGamePool("CBlip");
+blips.forEach(blipHandle => {
+    const rotation = GetBlipRotation(blipHandle);
+    console.log(`Blip ${blipHandle} rotation: ${rotation.toFixed(2)} degrees`);
+});
+```

--- a/ext/native-decls/GetBlipSprite.md
+++ b/ext/native-decls/GetBlipSprite.md
@@ -1,0 +1,39 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_BLIP_SPRITE
+
+```c
+Hash GET_BLIP_SPRITE(int blipHandle);
+```
+
+Gets the sprite/hash of a blip from its handle.
+
+## Parameters
+* **blipHandle**: The blip handle obtained from GET_GAME_POOL("CBlip")
+
+## Return value
+The blip sprite hash. Returns 0 if the blip doesn't exist.
+
+## Examples
+```lua
+local blips = GetGamePool("CBlip")
+for _, blipHandle in ipairs(blips) do
+    local sprite = GetBlipSprite(blipHandle)
+    if sprite == 0x866B73BE then -- BLIP_POI
+        print("Found POI blip with handle:", blipHandle)
+    end
+end
+```
+
+```js
+const blips = GetGamePool("CBlip");
+blips.forEach(blipHandle => {
+    const sprite = GetBlipSprite(blipHandle);
+    if (sprite === 0x866B73BE) { // BLIP_POI
+        console.log(`Found POI blip with handle: ${blipHandle}`);
+    }
+});
+```

--- a/ext/native-decls/GetGamePool.md
+++ b/ext/native-decls/GetGamePool.md
@@ -21,6 +21,7 @@ follows:
 * `CNetObject`: Networked objects
 * `CVehicle`: Vehicles.
 * `CPickup`: Pickups.
+* `CBlip`: Blips (RDR3 only).
 
 ## Examples
 ```lua
@@ -29,6 +30,15 @@ for i = 1, #vehiclePool do -- loop through each vehicle (entity)
     if GetPedInVehicleSeat(vehiclePool[i], -1) == 0 then
         DeleteEntity(vehiclePool[i]) -- Delete vehicles (entities) that don't have a driver
     end
+end
+
+-- RDR3 only: Get all blips
+local blipPool = GetGamePool('CBlip')
+for i = 1, #blipPool do
+    local sprite = GetBlipSprite(blipPool[i])
+    local rotation = GetBlipRotation(blipPool[i])
+    print(string.format("Blip %d: sprite=0x%X, rotation=%d", 
+          blipPool[i], sprite, rotation))
 end
 ```
 


### PR DESCRIPTION
…lipSprite, GetBlipRotation, GetBlipModifiers

### Goal of this PR

This PR adds new RedM (RDR3) blip-related natives to enhance script functionality for blip manipulation and inspection. The implementation provides direct access to blip data structures through the game pool system, enabling scripts to retrieve blip properties like sprite, rotation, and modifiers that were previously inaccessible.

Usage :
- With GamePool native we can get POI blip created by player on the map filtered by Sprite (`BLIP_POI`) or Modifiers (`BLIP_STYLE_POI`)
- With Modifiers we can also get the selected state of a blip on the map (`BLIP_MODIFIER_SELECTED_UP_SCALE `)

### How is this PR achieving the goal

**Core Implementation:**
Added BlipNatives.cpp with three main natives:
**GET_BLIP_SPRITE**: Retrieves the sprite/hash of a blip from its handle
**GET_BLIP_ROTATION**: Gets the rotation of a blip in degrees (0.0-360.0)
**GET_BLIP_MODIFIERS**: Returns an array of blip modifiers

**Technical Details:**
Implemented direct memory access to the fwuiBlip pool using rage::GetPoolBase()
Created a BlipData struct mapping the internal blip memory layout with proper padding
Added proper error handling for invalid blip handles
Used fx::SerializeObject() for returning modifier arrays to scripts
Added comprehensive native documentation with usage examples


### This PR applies to the following area(s)

RedM: Client-side native functions
ScRT: Lua: Enhanced blip functionality for Lua scripts
ScRT: JS: Enhanced blip functionality for JavaScript scripts


### Successfully tested on

Game builds: RedM (RDR3)
Platforms: Windows

### Checklist

- [ x] Code compiles and has been tested successfully.
- [ x] Code explains itself well and/or is documented.
- [ x] My commit message explains what the changes do and what they are for.
- [ x] No extra compilation warnings are added by these changes.




