### PR TITLE
feat(extra-natives-five): Add SET_VEHICLE_RAIN_GRIP_DISABLED

### DIFF
--- a/ext/native-decls/GetVehicleRainGripDisabled.md
+++ b/ext/native-decls/GetVehicleRainGripDisabled.md
@@ -1,0 +1,13 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_VEHICLE_RAIN_GRIP_DISABLED
+
+```c
+void GET_VEHICLE_RAIN_GRIP_DISABLED();
+```
+
+## Return value
+Returns whether rain grip variation is disabled.

--- a/ext/native-decls/SetVehicleRainGripDisabled.md
+++ b/ext/native-decls/SetVehicleRainGripDisabled.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_VEHICLE_RAIN_GRIP_DISABLED
+
+```c
+void SET_VEHICLE_RAIN_GRIP_DISABLED(BOOL state);
+```
+
+Disables grip variation caused by rain. When enabled, vehicles will not lose traction on wet surfaces.
+
+## Parameters
+* **state**: Toggle on or off.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
This PR adds the SET_VEHICLE_RAIN_GRIP_DISABLED native to prevent vehicles from slipping due to grip changes when it rains.


### How is this PR achieving the goal

This PR adds the SET_VEHICLE_RAIN_GRIP_DISABLED native, which sets a global flag and hooks into the rain grip calculation to skip grip reduction when enabled, preventing vehicles from losing traction in rainy conditions.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


