### PR TITLE
feat(extra-natives-rdr3): Add interior natives

### DIFF
--- a/code/components/extra-natives-rdr3/component.lua
+++ b/code/components/extra-natives-rdr3/component.lua
@@ -15,6 +15,7 @@ return function()
 		'components/extra-natives-five/src/TimecycleNatives.cpp',
 		'components/extra-natives-five/src/VisualSettingsNatives.cpp',
 		'components/extra-natives-five/src/PoolTraversalNatives.cpp',
+		'components/extra-natives-five/src/InteriorExtraNatives.cpp',
 		'components/extra-natives-five/src/RadioDSP.cpp',
 		'components/extra-natives-five/src/NuiAudioSink.cpp',
 		'components/extra-natives-five/src/InputNatives.cpp',

--- a/ext/native-decls/GetInteriorEntitiesExtents.md
+++ b/ext/native-decls/GetInteriorEntitiesExtents.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ENTITIES_EXTENTS
 

--- a/ext/native-decls/GetInteriorPortalCornerPosition.md
+++ b/ext/native-decls/GetInteriorPortalCornerPosition.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_CORNER_POSITION
 

--- a/ext/native-decls/GetInteriorPortalCount.md
+++ b/ext/native-decls/GetInteriorPortalCount.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_COUNT
 

--- a/ext/native-decls/GetInteriorPortalEntityArchetype.md
+++ b/ext/native-decls/GetInteriorPortalEntityArchetype.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ENTITY_ARCHETYPE
 

--- a/ext/native-decls/GetInteriorPortalEntityCount.md
+++ b/ext/native-decls/GetInteriorPortalEntityCount.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ENTITY_COUNT
 

--- a/ext/native-decls/GetInteriorPortalEntityFlag.md
+++ b/ext/native-decls/GetInteriorPortalEntityFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ENTITY_FLAG
 

--- a/ext/native-decls/GetInteriorPortalEntityPosition.md
+++ b/ext/native-decls/GetInteriorPortalEntityPosition.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ENTITY_POSITION
 

--- a/ext/native-decls/GetInteriorPortalEntityRotation.md
+++ b/ext/native-decls/GetInteriorPortalEntityRotation.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ENTITY_ROTATION
 

--- a/ext/native-decls/GetInteriorPortalFlag.md
+++ b/ext/native-decls/GetInteriorPortalFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_FLAG
 

--- a/ext/native-decls/GetInteriorPortalRoomFrom.md
+++ b/ext/native-decls/GetInteriorPortalRoomFrom.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ROOM_FROM
 

--- a/ext/native-decls/GetInteriorPortalRoomTo.md
+++ b/ext/native-decls/GetInteriorPortalRoomTo.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_PORTAL_ROOM_TO
 

--- a/ext/native-decls/GetInteriorRoomCount.md
+++ b/ext/native-decls/GetInteriorRoomCount.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_COUNT
 

--- a/ext/native-decls/GetInteriorRoomExtents.md
+++ b/ext/native-decls/GetInteriorRoomExtents.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_EXTENTS
 

--- a/ext/native-decls/GetInteriorRoomFlag.md
+++ b/ext/native-decls/GetInteriorRoomFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_FLAG
 

--- a/ext/native-decls/GetInteriorRoomIndexByHash.md
+++ b/ext/native-decls/GetInteriorRoomIndexByHash.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_INDEX_BY_HASH
 

--- a/ext/native-decls/GetInteriorRoomName.md
+++ b/ext/native-decls/GetInteriorRoomName.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_NAME
 

--- a/ext/native-decls/GetInteriorRoomReflectionProbeCenterOffset.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeCenterOffset.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET
+
+```c
+void GET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET(int interiorId, int roomId, int probeId, float* x, float* y, float* z);
+```
+
+## Description
+
+Gets the center offset of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: Pointer to store the X coordinate
+* **y**: Pointer to store the Y coordinate
+* **z**: Pointer to store the Z coordinate
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+local x, y, z = 0.0, 0.0, 0.0
+
+GET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET(interiorId, roomId, probeId, x, y, z)
+print("Probe center offset: (" .. x .. ", " .. y .. ", " .. z .. ")")
+```
+
+## Notes
+
+- This native is only available in RDR3
+- The pointers are not modified if the interior, room, or probe is invalid

--- a/ext/native-decls/GetInteriorRoomReflectionProbeCount.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeCount.md
@@ -1,0 +1,37 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_COUNT
+
+```c
+int GET_INTERIOR_ROOM_REFLECTION_PROBE_COUNT(int interiorId, int roomId);
+```
+
+## Description
+
+Returns the number of reflection probes in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+
+## Return value
+
+The number of reflection probes in the room.
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeCount = GET_INTERIOR_ROOM_REFLECTION_PROBE_COUNT(interiorId, roomId)
+print("Room has " .. probeCount .. " reflection probes")
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Returns 0 if the interior or room is invalid

--- a/ext/native-decls/GetInteriorRoomReflectionProbeExtents.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeExtents.md
@@ -1,0 +1,44 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS
+
+```c
+void GET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS(int interiorId, int roomId, int probeId, float* minX, float* minY, float* minZ, float* maxX, float* maxY, float* maxZ);
+```
+
+## Description
+
+Gets the extents (bounding box) of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **minX**: Pointer to store the minimum X coordinate
+* **minY**: Pointer to store the minimum Y coordinate
+* **minZ**: Pointer to store the minimum Z coordinate
+* **maxX**: Pointer to store the maximum X coordinate
+* **maxY**: Pointer to store the maximum Y coordinate
+* **maxZ**: Pointer to store the maximum Z coordinate
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+local minX, minY, minZ = 0.0, 0.0, 0.0
+local maxX, maxY, maxZ = 0.0, 0.0, 0.0
+
+GET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS(interiorId, roomId, probeId, minX, minY, minZ, maxX, maxY, maxZ)
+print("Probe extents: min(" .. minX .. ", " .. minY .. ", " .. minZ .. ") max(" .. maxX .. ", " .. maxY .. ", " .. maxZ .. ")")
+```
+
+## Notes
+
+- This native is only available in RDR3
+- The pointers are not modified if the interior, room, or probe is invalid

--- a/ext/native-decls/GetInteriorRoomReflectionProbeGuid.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeGuid.md
@@ -1,0 +1,35 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_GUID
+
+```c
+unsigned long long GET_INTERIOR_ROOM_REFLECTION_PROBE_GUID(int interiorId, int roomId, int probeId);
+```
+
+### Description
+Gets the GUID of a reflection probe in an interior room.
+
+### Parameters
+- **interiorId** (int): The interior ID
+- **roomId** (int): The room index
+- **probeId** (int): The reflection probe index
+
+### Returns
+- **unsigned long long**: The GUID of the reflection probe, or 0 if invalid
+
+### Example
+```lua
+local guid = GetInteriorRoomReflectionProbeGuid(interiorId, roomId, probeId)
+if guid ~= 0 then
+    print("Probe GUID: 0x" .. string.format("%016X", guid))
+end
+```
+
+### Notes
+- Returns 0 if the interior, room, or probe index is invalid
+- GUID is a unique 64-bit identifier for the reflection probe
+- RDR3 only

--- a/ext/native-decls/GetInteriorRoomReflectionProbeInfluenceExtents.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeInfluenceExtents.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS
+
+```c
+void GET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS(int interiorId, int roomId, int probeId, float* x, float* y, float* z);
+```
+
+## Description
+
+Gets the influence extents of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: Pointer to store the X influence extent
+* **y**: Pointer to store the Y influence extent
+* **z**: Pointer to store the Z influence extent
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+local x, y, z = 0.0, 0.0, 0.0
+
+GET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS(interiorId, roomId, probeId, x, y, z)
+print("Probe influence extents: (" .. x .. ", " .. y .. ", " .. z .. ")")
+```
+
+## Notes
+
+- This native is only available in RDR3
+- The pointers are not modified if the interior, room, or probe is invalid

--- a/ext/native-decls/GetInteriorRoomReflectionProbePriority.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbePriority.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY
+
+```c
+int GET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY(int interiorId, int roomId, int probeId);
+```
+
+## Description
+
+Gets the priority of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+
+## Return value
+
+The priority of the reflection probe (0-255).
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+local priority = GET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY(interiorId, roomId, probeId)
+print("Probe priority: " .. priority)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Returns 0 if the interior, room, or probe is invalid
+- Priority values range from 0 to 255

--- a/ext/native-decls/GetInteriorRoomReflectionProbeRotation.md
+++ b/ext/native-decls/GetInteriorRoomReflectionProbeRotation.md
@@ -1,0 +1,42 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## GET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION
+
+```c
+void GET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION(int interiorId, int roomId, int probeId, float* x, float* y, float* z, float* w);
+```
+
+## Description
+
+Gets the rotation quaternion of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: Pointer to store the X component of the quaternion
+* **y**: Pointer to store the Y component of the quaternion
+* **z**: Pointer to store the Z component of the quaternion
+* **w**: Pointer to store the W component of the quaternion
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+local x, y, z, w = 0.0, 0.0, 0.0, 0.0
+
+GET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION(interiorId, roomId, probeId, x, y, z, w)
+print("Probe rotation: (" .. x .. ", " .. y .. ", " .. z .. ", " .. w .. ")")
+```
+
+## Notes
+
+- This native is only available in RDR3
+- The pointers are not modified if the interior, room, or probe is invalid
+- The rotation is stored as a quaternion (x, y, z, w)

--- a/ext/native-decls/GetInteriorRoomTimecycle.md
+++ b/ext/native-decls/GetInteriorRoomTimecycle.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROOM_TIMECYCLE
 

--- a/ext/native-decls/GetInteriorRotation.md
+++ b/ext/native-decls/GetInteriorRotation.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## GET_INTERIOR_ROTATION
 

--- a/ext/native-decls/SetInteriorPortalCornerPosition.md
+++ b/ext/native-decls/SetInteriorPortalCornerPosition.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_PORTAL_CORNER_POSITION
 

--- a/ext/native-decls/SetInteriorPortalEntityFlag.md
+++ b/ext/native-decls/SetInteriorPortalEntityFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_PORTAL_ENTITY_FLAG
 

--- a/ext/native-decls/SetInteriorPortalFlag.md
+++ b/ext/native-decls/SetInteriorPortalFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_PORTAL_FLAG
 

--- a/ext/native-decls/SetInteriorPortalRoomFrom.md
+++ b/ext/native-decls/SetInteriorPortalRoomFrom.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_PORTAL_ROOM_FROM
 

--- a/ext/native-decls/SetInteriorPortalRoomTo.md
+++ b/ext/native-decls/SetInteriorPortalRoomTo.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_PORTAL_ROOM_TO
 

--- a/ext/native-decls/SetInteriorRoomExtents.md
+++ b/ext/native-decls/SetInteriorRoomExtents.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_ROOM_EXTENTS
 

--- a/ext/native-decls/SetInteriorRoomFlag.md
+++ b/ext/native-decls/SetInteriorRoomFlag.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_ROOM_FLAG
 

--- a/ext/native-decls/SetInteriorRoomReflectionProbeCenterOffset.md
+++ b/ext/native-decls/SetInteriorRoomReflectionProbeCenterOffset.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET
+
+```c
+void SET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET(int interiorId, int roomId, int probeId, float x, float y, float z);
+```
+
+## Description
+
+Sets the center offset of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: The X coordinate offset
+* **y**: The Y coordinate offset
+* **z**: The Z coordinate offset
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+
+-- Set probe center offset
+SET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET(interiorId, roomId, probeId, 0.0, 2.0, -0.8)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Changes are applied immediately to the reflection probe
+- No effect if the interior, room, or probe is invalid

--- a/ext/native-decls/SetInteriorRoomReflectionProbeExtents.md
+++ b/ext/native-decls/SetInteriorRoomReflectionProbeExtents.md
@@ -1,0 +1,43 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS
+
+```c
+void SET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS(int interiorId, int roomId, int probeId, float minX, float minY, float minZ, float maxX, float maxY, float maxZ);
+```
+
+## Description
+
+Sets the extents (bounding box) of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **minX**: The minimum X coordinate
+* **minY**: The minimum Y coordinate
+* **minZ**: The minimum Z coordinate
+* **maxX**: The maximum X coordinate
+* **maxY**: The maximum Y coordinate
+* **maxZ**: The maximum Z coordinate
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+
+-- Set probe extents to a 10x10x5 box centered at origin
+SET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS(interiorId, roomId, probeId, -5.0, -5.0, -2.5, 5.0, 5.0, 2.5)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Changes are applied immediately to the reflection probe
+- No effect if the interior, room, or probe is invalid

--- a/ext/native-decls/SetInteriorRoomReflectionProbeInfluenceExtents.md
+++ b/ext/native-decls/SetInteriorRoomReflectionProbeInfluenceExtents.md
@@ -1,0 +1,40 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS
+
+```c
+void SET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS(int interiorId, int roomId, int probeId, float x, float y, float z);
+```
+
+## Description
+
+Sets the influence extents of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: The X influence extent
+* **y**: The Y influence extent
+* **z**: The Z influence extent
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+
+-- Set probe influence extents
+SET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS(interiorId, roomId, probeId, 1.0, 1.0, 1.0)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Changes are applied immediately to the reflection probe
+- No effect if the interior, room, or probe is invalid

--- a/ext/native-decls/SetInteriorRoomReflectionProbePriority.md
+++ b/ext/native-decls/SetInteriorRoomReflectionProbePriority.md
@@ -1,0 +1,39 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY
+
+```c
+void SET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY(int interiorId, int roomId, int probeId, int priority);
+```
+
+## Description
+
+Sets the priority of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **priority**: The priority value (0-255)
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+
+-- Set probe priority to maximum
+SET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY(interiorId, roomId, probeId, 255)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Changes are applied immediately to the reflection probe
+- No effect if the interior, room, or probe is invalid
+- Priority values should be between 0 and 255

--- a/ext/native-decls/SetInteriorRoomReflectionProbeRotation.md
+++ b/ext/native-decls/SetInteriorRoomReflectionProbeRotation.md
@@ -1,0 +1,42 @@
+---
+ns: CFX
+apiset: client
+game: rdr3
+---
+## SET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION
+
+```c
+void SET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION(int interiorId, int roomId, int probeId, float x, float y, float z, float w);
+```
+
+## Description
+
+Sets the rotation quaternion of a reflection probe in the specified room.
+
+## Parameters
+
+* **interiorId**: The interior ID
+* **roomId**: The room ID
+* **probeId**: The reflection probe ID
+* **x**: The X component of the quaternion
+* **y**: The Y component of the quaternion
+* **z**: The Z component of the quaternion
+* **w**: The W component of the quaternion
+
+## Examples
+
+```lua
+local interiorId = GetInteriorFromEntity(PlayerPedId())
+local roomId = 0
+local probeId = 0
+
+-- Set probe rotation (no rotation)
+SET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION(interiorId, roomId, probeId, 0.0, 0.0, 0.0, 1.0)
+```
+
+## Notes
+
+- This native is only available in RDR3
+- Changes are applied immediately to the reflection probe
+- No effect if the interior, room, or probe is invalid
+- The rotation is stored as a quaternion (x, y, z, w)

--- a/ext/native-decls/SetInteriorRoomTimecycle.md
+++ b/ext/native-decls/SetInteriorRoomTimecycle.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_INTERIOR_ROOM_TIMECYCLE
 


### PR DESCRIPTION
### Goal of this PR
Port interior-related natives from FiveM to RDR3, enabling interior debugging and manipulation capabilities in RedM. This includes adding comprehensive interior archetype debugging, room/portal management, and reflection probe support specifically for RDR3.

### How is this PR achieving the goal

**Unified Codebase:**
- Integrated `InteriorExtraNatives.cpp` from FiveM into RDR3 component via `component.lua` to eliminate code duplication
- Used conditional compilation (`#ifdef GTA_FIVE` / `#elif IS_RDR3`) to handle platform-specific differences
- Implemented clean accessor pattern with `DECLARE_ACCESSOR` macro for consistent API across platforms

**RDR3-Specific Structures:**
- Added `InteriorProxy::Impl1491` struct with correct memory offsets for RDR3
- Implemented `CReflectionProbe` struct based on game file data analysis
- Updated `CMloRoomDef` to include `reflectionProbes` field for RDR3

**Enhanced Debugging:**
- Added comprehensive `INTERIOR_DEBUG` native with archetype info, position/rotation, entities extents
- Implemented systematic offset testing to verify correct struct layouts
- Added 256-byte memory dumps for both archetype and proxy structures

**Ported Natives from FiveM:**

**Core Interior Natives:**
- `GET_INTERIOR_ROTATION`
- `GET_INTERIOR_ENTITIES_EXTENTS`

**Room Natives:**
- `GET_INTERIOR_ROOM_COUNT`
- `GET_INTERIOR_ROOM_INDEX_BY_HASH`
- `GET_INTERIOR_ROOM_NAME`
- `GET_INTERIOR_ROOM_FLAG`
- `SET_INTERIOR_ROOM_FLAG`
- `GET_INTERIOR_ROOM_EXTENTS`
- `SET_INTERIOR_ROOM_EXTENTS`
- `GET_INTERIOR_ROOM_TIMECYCLE`
- `SET_INTERIOR_ROOM_TIMECYCLE`

**Portal Natives:**
- `GET_INTERIOR_PORTAL_COUNT`
- `GET_INTERIOR_PORTAL_CORNER_POSITION`
- `SET_INTERIOR_PORTAL_CORNER_POSITION`
- `GET_INTERIOR_PORTAL_ROOM_FROM`
- `SET_INTERIOR_PORTAL_ROOM_FROM`
- `GET_INTERIOR_PORTAL_ROOM_TO`
- `SET_INTERIOR_PORTAL_ROOM_TO`
- `GET_INTERIOR_PORTAL_FLAG`
- `SET_INTERIOR_PORTAL_FLAG`
- `GET_INTERIOR_PORTAL_ENTITY_COUNT`
- `GET_INTERIOR_PORTAL_ENTITY_ARCHETYPE`
- `GET_INTERIOR_PORTAL_ENTITY_FLAG`
- `SET_INTERIOR_PORTAL_ENTITY_FLAG`
- `GET_INTERIOR_PORTAL_ENTITY_POSITION`
- `GET_INTERIOR_PORTAL_ENTITY_ROTATION`

**New RDR3-Specific Natives:**

**Reflection Probe Getters:**
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_COUNT`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY`
- `GET_INTERIOR_ROOM_REFLECTION_PROBE_GUID`

**Reflection Probe Setters:**
- `SET_INTERIOR_ROOM_REFLECTION_PROBE_EXTENTS`
- `SET_INTERIOR_ROOM_REFLECTION_PROBE_CENTER_OFFSET`
- `SET_INTERIOR_ROOM_REFLECTION_PROBE_INFLUENCE_EXTENTS`
- `SET_INTERIOR_ROOM_REFLECTION_PROBE_ROTATION`
- `SET_INTERIOR_ROOM_REFLECTION_PROBE_PRIORITY`

### This PR applies to the following area(s)
- RedM
- Natives

### Successfully tested on
**Game builds:** RDR3 Build 1491

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
N/A - New feature implementation

Example of usage with dolu_tool
<img width="1917" height="1080" alt="image" src="https://github.com/user-attachments/assets/598ba2bd-1a3e-4b7b-8a70-c4637240f47a" />
