### PR TITLE
feat(extra-natives/five): weapon range getter & setter natives

### DIFF
--- a/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WeaponExtraNatives.cpp
@@ -21,6 +21,7 @@ static int PedOffset = 0x10;
 static int CurrentPitchOffset = 0x1CC;
 static int NetworkObjectOffset = 0xD0;
 static int IsCloneOffset = 0x4B;
+static int RangeOffset = 0x28C;
 
 static uint16_t* g_weaponCount;
 static uint64_t** g_weaponList;
@@ -458,6 +459,25 @@ static HookFunction hookFunction([]()
 		{
 			float weaponSpreadAccuracy = context.GetArgument<float>(1);
 			reinterpret_cast<hook::FlexStruct*>(weapon)->Set<float>(WeaponSpreadOffset, weaponSpreadAccuracy);
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_WEAPON_RANGE", [](fx::ScriptContext& context)
+	{
+		float weaponRange = 0.0f;
+		if (uintptr_t weapon = getWeaponFromHash(context))
+		{
+			weaponRange = reinterpret_cast<hook::FlexStruct*>(weapon)->Get<float>(RangeOffset);
+		}
+		context.SetResult<float>(weaponRange);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_WEAPON_RANGE", [](fx::ScriptContext& context)
+	{
+		if (uintptr_t weapon = getWeaponFromHash(context))
+		{
+			float weaponRange = context.GetArgument<float>(1);
+			reinterpret_cast<hook::FlexStruct*>(weapon)->Set<float>(RangeOffset, weaponRange);
 		}
 	});
 

--- a/ext/native-decls/GetWeaponRange.md
+++ b/ext/native-decls/GetWeaponRange.md
@@ -1,0 +1,21 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+
+## GET_WEAPON_RANGE
+
+```c
+float GET_WEAPON_RANGE(Hash weaponHash);
+```
+
+A getter for the range of a weapon.
+
+## Parameters
+
+- **weaponHash**: Weapon name hash.
+
+## Return value
+
+The range of the weapon as a float.

--- a/ext/native-decls/SetWeaponRange.md
+++ b/ext/native-decls/SetWeaponRange.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+
+## SET_WEAPON_RANGE
+
+```c
+void SET_WEAPON_RANGE(Hash weaponHash, float range);
+```
+
+A setter for the range of a weapon.
+
+## Parameters
+
+- **weaponHash**: Weapon name hash.
+- **range**: Ramge.


### PR DESCRIPTION
### Goal of this PR
Introduces a way for client scripts to get & set the range of a weapon via it's hash.

### How is this PR achieving the goal
By introducing `GET_WEAPON_RANGE` & `SET_WEAPON_RANGE` to allow client scripts to retrieve and set the range of a weapon.


### This PR applies to the following area(s)
FiveM, Natives


### Successfully tested on
**Game builds:** 3258, 2699, 3095, 3570, 3407
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
n/a


