### PR TITLE
feat(server-impl): add convar to hide file size warnings

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
@@ -418,6 +418,7 @@ namespace fx
 		return (uint32_t)size;
 	}
 
+	static ConVar<bool> sv_hideSizeWarnings("sv_hideSizeWarnings", ConVar_ServerInfo, false);
 	void ResourceStreamComponent::ValidateSize(std::string_view name, uint32_t physSize, uint32_t virtSize, int* numWarnings)
 	{
 		auto checkSize = [this, &name, numWarnings](uint32_t size, std::string_view why)
@@ -440,12 +441,15 @@ namespace fx
 
 			if (warnColor != 0)
 			{
-				console::Printf(fmt::sprintf("resources:%s:stream", m_resource->GetName()),
-					"^%dAsset %s/%s uses %s MiB of %s memory.%s^7\n",
-					warnColor, m_resource->GetName(), name, divSize, why,
-					(size > (48 * 1024 * 1024))
-						? " Oversized assets can and WILL lead to streaming issues (such as models not loading/rendering)."
-						: "");
+				if (!sv_hideSizeWarnings.GetValue())
+				{
+					console::Printf(fmt::sprintf("resources:%s:stream", m_resource->GetName()),
+						"^%dAsset %s/%s uses %s MiB of %s memory.%s^7\n",
+						warnColor, m_resource->GetName(), name, divSize, why,
+						(size > (48 * 1024 * 1024))
+							? " Oversized assets can and WILL lead to streaming issues (such as models not loading/rendering)."
+							: "");
+				}
 
 				++*numWarnings;
 			}


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
added a server convar to disable file size warnings from the server console.

### How is this PR achieving the goal
adding a new convar


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3258
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


