### PR TITLE
fix(rage-device-rdr3): ignore memory backed pack files

### DIFF
--- a/code/components/rage-device-rdr3/src/HookInitialMount.cpp
+++ b/code/components/rage-device-rdr3/src/HookInitialMount.cpp
@@ -74,6 +74,15 @@ static void CheckPackFile(const char* headerData, const char* fileName)
 
 static HookFunction hookFunction([] ()
 {
+	// RDO mounts certain RPFs (e.g. catalog_mp.rpf / catalog_awards_mp.rpf)
+	// directly into memory by creating a virtual memory-backed fiDevice. These packfiles are not real
+	// on-disk archives; instead they are generated at runtime and only exist transiently during Online
+	// sessions. Because they are unencrypted, their contents and hashes do not match the encrypted
+	// on-disk originals, which causes pure-mode file validation  to incorrectly flag them as modified.
+	// To prevent these false positives, this call responsible for setting up the memory-backed device
+	// is noped, effectively disabling the mounting of virtual memory-backed packfiles.
+	hook::nop(hook::get_pattern("E8 ? ? ? ? 40 8A E8 48 8B 84 24"), 0x5);
+
 	/*static hook::inject_call<void, int> injectCall(0x7B2E27);
 
 	injectCall.inject([] (int)


### PR DESCRIPTION
### Goal of this PR
Some packfiles generated by Red Dead Online (e.g. catalog_mp.rpf / catalog_awards_mp.rpf) are not stored on disk but are dynamically mounted into memory by RAGE as memory-backed virtual packfiles. These files do not represent user-modified game data, but runtime DLC/ progression catalogs that only exist transiently while the Online environment is active.
Since they are not real RPFs on disk, attempting to validate them under pure mode would incorrectly flag them as modified because memory-backed packfiles are unencrypted and their hashes are derived from encrypted on-disk data.


### How is this PR achieving the goal
Nop the function that start mounting memory-backed virtual packfiles.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes https://github.com/citizenfx/fivem/pull/3499#issuecomment-3469166280