### PR TITLE
tweak(server-impl): Increase asset warning sizes

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
@@ -425,15 +425,15 @@ namespace fx
 			auto divSize = fmt::sprintf("%.1f", size / 1024.0 / 1024.0);
 			int warnColor = 0;
 
-			if (size > (64 * 1024 * 1024))
+			if (size > (80 * 1024 * 1024))
 			{
 				warnColor = 1;
 			}
-			else if (size > (32 * 1024 * 1024))
+			else if (size > (48 * 1024 * 1024))
 			{
 				warnColor = 3;
 			}
-			else if (size > (16 * 1024 * 1024))
+			else if (size > (32 * 1024 * 1024))
 			{
 				warnColor = 4;
 			}
@@ -443,7 +443,7 @@ namespace fx
 				console::Printf(fmt::sprintf("resources:%s:stream", m_resource->GetName()),
 					"^%dAsset %s/%s uses %s MiB of %s memory.%s^7\n",
 					warnColor, m_resource->GetName(), name, divSize, why,
-					(size > (48 * 1024 * 1024))
+					(size > (64 * 1024 * 1024))
 						? " Oversized assets can and WILL lead to streaming issues (such as models not loading/rendering)."
 						: "");
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Cleanup unnecessary warnings in server console


### How is this PR achieving the goal
upping the sizes for each warning level


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3258
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->



<img width="1623" height="353" alt="image" src="https://github.com/user-attachments/assets/0edcb1a4-9f9c-4b53-b6ef-19f9f3c0a5aa" />
with the current values, red highlights vanilla untouched assets.
<img width="1501" height="258" alt="image" src="https://github.com/user-attachments/assets/319ab2de-4e8b-4966-afac-d75e38939f4e" />
with proposed changed values

