### PR TITLE
fix(input/rdr3): correct diMouseDevice pattern

### DIFF
--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -411,7 +411,7 @@ static HookFunction hookFunction([]()
 
 	// DirectInput patches
 	{
-		g_diMouseDevice = hook::get_address<LPDIRECTINPUTDEVICEW*>(hook::get_pattern("48 8B 0D ? ? ? ? 88 1D ? ? ? ? 48 8B 01", 3), 0x0, 0x7);
+		g_diMouseDevice = hook::get_address<IDirectInputDeviceW**>(hook::get_pattern("48 8B 0D ? ? ? ? 48 8B 01 FF 50 ? 8B D8 3D ? ? ? ? 75 ? E8 ? ? ? ? 83 FB ? 7F ? B1", 3));
 
 		auto location = hook::get_pattern("48 83 EC ? 8B 0D ? ? ? ? 85 C9 74 ? 83 E9", 45);
 		hook::set_call(&recaptureLostDevices, location);


### PR DESCRIPTION
### Goal of this PR

Fixes crash when using F8/NUI under DirectInput mode.

### How is this PR achieving the goal

Correct pattern which broke from a different directInput patch.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:**  1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


