### PR TITLE
docs: Deprecate SET_MANUAL_SHUTDOWN_LOADING_SCREEN_NUI

### DIFF
--- a/ext/native-decls/SetManualShutdownLoadingScreenNui.md
+++ b/ext/native-decls/SetManualShutdownLoadingScreenNui.md
@@ -9,8 +9,7 @@ apiset: client
 void SET_MANUAL_SHUTDOWN_LOADING_SCREEN_NUI(BOOL manualShutdown);
 ```
 
-Sets whether or not `SHUTDOWN_LOADING_SCREEN` automatically shuts down the NUI frame for the loading screen. If this is enabled,
-you will have to manually invoke `SHUTDOWN_LOADING_SCREEN_NUI` whenever you want to hide the NUI loading screen.
+**Note**: This native is deprecated and doesn't work anymore. Use [loadscreen_manual_shutdown](https://docs.fivem.net/docs/scripting-reference/resource-manifest/resource-manifest/#loadscreen_manual_shutdown) in the fxmanifest.lua instead.
 
 ## Parameters
 * **manualShutdown**: TRUE to manually shut down the loading screen NUI.


### PR DESCRIPTION
### Goal of this PR
This native was removed years ago and now just throws a deprecation warning referencing to the new way of achieving what this native used to do and this should be written in the docs.
The source code that manages this is [/code/components/loading-screens-five/src/LoadingScreens.cpp lines 251-256](https://github.com/citizenfx/fivem/blob/0b6d5de3902cda6dd91be0c489d9b7243e554bb1/code/components/loading-screens-five/src/LoadingScreens.cpp#L251).

### How is this PR achieving the goal
Updated description and reference to alternative solution.


### This PR applies to the following area(s)
Native Reference documentation