### PR TITLE
fix(system-resources/chat): colorize message parameters directly

### DIFF
--- a/ext/system-resources/resources/chat/html/Message.ts
+++ b/ext/system-resources/resources/chat/html/Message.ts
@@ -18,12 +18,12 @@ export default defineComponent({
       s = s.replace(`@default`, this.templates[this.templateId]);
 
       s = s.replace(/{(\d+)}/g, (match, number) => {
-        const argEscaped = this.args[number] != undefined ? this.escape(this.args[number]) : match;
+        let argEscaped = this.args[number] != undefined ? this.escape(this.args[number]) : match;
         if (number == 0 && this.color) {
           //color is deprecated, use templates or ^1 etc.
-          return this.colorizeOld(argEscaped);
+          argEscaped = this.colorizeOld(argEscaped);
         }
-        return argEscaped;
+        return this.colorize(argEscaped);
       });
 
       // format variant args
@@ -32,7 +32,7 @@ export default defineComponent({
       if (params) {
         s = s.replace(/\{\{([a-zA-Z0-9_\-]+?)\}\}/g, (match, id) => {
           const argEscaped = params[id] != undefined ? this.escape(params[id]) : match;
-          return argEscaped;
+          return this.colorize(argEscaped);
         });
       }
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix a bug where given a chat template such as `<span class="content">{0}</span>`, sending colored messages such as `~b~test` or `^1test` would remove the surrounding `<span class="content">` element.

### How is this PR achieving the goal

Colorize the template parameters directly before passing them to the template.

Currently, the entire template is passed to the `colorize` method, which:
- Takes the element, such as `<span class="content">^1test</span>` (`^1test` is the `{0}` parameter in this case)
- Wraps it in a span element: `<span><span class="content">^1test</span></span>`
- Replaces the colors with `</span><span class="some-color-class">`: `<span><span class="content"></span><span class="color-1">test</span></span>`
- Removes empty span elements: `<span><span class="color-1">test</span></span>`

If we colorize the parameters beforehand, the surrounding template element would not be affected by the parameters, as they would already be colorized.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, RedM

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.