### PR TITLE
fix(RDR3-SyncTree): fixes animals poptype for `GetPopulationType`

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_RDR3.h
@@ -1541,7 +1541,12 @@ struct SyncTree : public SyncTreeBaseImpl<TNode, true>
 			return true;
 		}
 
-		// TODO: objects(?)
+		auto [hasAcn, animalCreationNode] = this->template GetData<CAnimalCreationDataNode>();
+		if (hasAcn)
+		{
+			*popType = animalCreationNode->m_popType;
+			return true;
+		}
 
 		return false;
 	}


### PR DESCRIPTION
### Goal of this PR
The goal is to support animals population type for the server side

### How is this PR achieving the goal
this pr allows the use of the native `GET_POPULATION_TYPE` for animals 

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RedM Server
### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
1491
**Platforms:** Windows, Linux
windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


