### PR TITLE
feat: add onServerResourcesReady event and ARE_ALL_RESOURCES_LOADED native

### DIFF
--- a/code/components/citizen-resources-core/include/ResourceManagerImpl.h
+++ b/code/components/citizen-resources-core/include/ResourceManagerImpl.h
@@ -28,6 +28,13 @@ private:
 
 	std::vector<fwRefContainer<ResourceMounter>> m_mounters;
 
+	// Resources ready detection (fires once at server startup only)
+	bool m_allResourcesLoadedEventFired;
+
+	std::chrono::steady_clock::time_point m_lastResourceStartTime;
+
+	static constexpr int STABILITY_DELAY_MS = 2000; // 2 seconds of stability before firing event
+
 public:
 	ResourceManagerImpl();
 
@@ -54,5 +61,12 @@ public:
 	virtual void Tick() override;
 
 	virtual std::string CallReferenceInternal(const std::string& functionReference, const std::string& argsSerialized) override;
+
+	// Resources ready detection
+	bool AreAllResourcesLoaded() const { return m_allResourcesLoadedEventFired; }
+
+	void OnResourceStarted();
+
+	void CheckAndFireResourcesReadyEvent();
 };
 }

--- a/code/components/citizen-resources-core/src/ResourceEventComponent.cpp
+++ b/code/components/citizen-resources-core/src/ResourceEventComponent.cpp
@@ -10,6 +10,7 @@
 
 #include <Resource.h>
 #include <ResourceManager.h>
+#include <ResourceManagerImpl.h>
 
 #include <msgpack.hpp>
 
@@ -56,6 +57,16 @@ void ResourceEventComponent::AttachToObject(Resource* object)
 	{
 		// on[type]ResourceStart is queued so that clients will only run it during the first tick
 		m_managerComponent->QueueEvent2(fmt::sprintf("on%sResourceStart", IsServer() ? "Server" : "Client"), {}, m_resource->GetName());
+
+		// Notify the resource manager that a resource has started (for resources ready detection)
+		if (IsServer())
+		{
+			auto resourceManager = dynamic_cast<ResourceManagerImpl*>(m_resource->GetManager());
+			if (resourceManager)
+			{
+				resourceManager->OnResourceStarted();
+			}
+		}
 	});
 
 	object->OnStart.Connect([=]()

--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -10,6 +10,7 @@
 
 #include <Resource.h>
 #include <ResourceManager.h>
+#include <ResourceManagerImpl.h>
 #include <fxScripting.h>
 
 #include <ScriptSerialization.h>
@@ -248,6 +249,27 @@ static InitFunction initFunction([] ()
 			context.SetResult<const char*>("unknown");
 			break;
 		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("ARE_ALL_RESOURCES_LOADED", [](fx::ScriptContext& context)
+	{
+#ifdef IS_FXSERVER
+		// Server-only native
+		fx::ResourceManager* resourceManager = fx::ResourceManager::GetCurrent();
+		auto resourceManagerImpl = dynamic_cast<fx::ResourceManagerImpl*>(resourceManager);
+
+		if (resourceManagerImpl)
+		{
+			context.SetResult(resourceManagerImpl->AreAllResourcesLoaded());
+		}
+		else
+		{
+			context.SetResult(false);
+		}
+#else
+		// Always return false on client (not supported)
+		context.SetResult(false);
+#endif
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("IS_ACE_ALLOWED", [](fx::ScriptContext& context)


### PR DESCRIPTION
# Add `onServerResourcesReady` event and `ARE_ALL_RESOURCES_LOADED()` native

## Summary

This PR adds new server-side functionality to reliably detect when all FiveM resources have finished loading during server startup.

## New Features

### 1. Event: `onServerResourcesReady`

Fires **once** when all server resources have finished starting and the server has stabilized.

```lua
AddEventHandler('onServerResourcesReady', function()
  print('All server resources have finished loading!')
  -- Safe to perform cross-resource initialization here
end)
```

**Behavior:**
- Fires only **once** per server startup (not on resource restarts)
- Uses stability-based detection (2 seconds without new resource starts)
- Server-side only

### 2. Native: `ARE_ALL_RESOURCES_LOADED()`

Returns a boolean indicating whether all resources have completed loading.

```lua
if AreAllResourcesLoaded() then
  print('Server is ready')
else
  print('Server is still starting up')
end
```

**Behavior:**
- Returns `false` during initial startup
- Returns `true` after `onServerResourcesReady` has fired
- Remains `true` for the lifetime of the server (doesn't reset on resource restarts)
- Server-side only (returns `false` on client)

## Use Cases

### ✅ Good Use Cases

1. **One-time initialization after all resources are available:**
```lua
on('onServerResourcesReady', function()
  -- Initialize cross-resource systems
  -- Start monitoring/logging
  -- Perform health checks
end)
```

2. **Checking if a resource restart happened after startup:**
```lua
on('onServerResourceStart', function(resourceName)
  if AreAllResourcesLoaded() then
    print(resourceName .. ' was restarted after server startup')
  end
end)
```

### ❌ Bad Use Cases

1. **Don't use it to detect resource restarts** - The event fires only once
2. **Don't use it on client-side** - Server-only functionality

## Implementation Details

- **Detection method:** Stability-based (2 second window without new resource starts)
- **Components modified:**
  - `ResourceManagerImpl.h` - Added state tracking variables
  - `ResourceManager.cpp` - Added detection logic and event triggering
  - `ResourceEventComponent.cpp` - Hook into resource start events
  - `ResourceScriptFunctions.cpp` - Register new native function
- **Thread safety:** Uses existing resource mutex for safe access
- **Performance:** Minimal overhead (early return after first trigger)

## Testing

**Note:** I was unable to compile and test this implementation locally due to build environment constraints. The code has been carefully reviewed for correctness and follows existing FiveM patterns (similar to `onServerResourceStart` implementation).

To test this PR:
1. Compile FiveM with these changes
2. Create a test script and add to your `server.cfg`
3. Start the server
4. Verify console output shows event fires after ~2 seconds of stability

Example test script:
```lua
on('onServerResourcesReady', function()
  print('✓ All server resources loaded!')
  print('ARE_ALL_RESOURCES_LOADED() =', AreAllResourcesLoaded())
end)

on('onServerResourceStart', function(resourceName)
  if AreAllResourcesLoaded() then
    print('Resource "' .. resourceName .. '" restarted after server ready')
  end
end)
```

A parallel JavaScript implementation with identical behavior has been tested successfully and is available for comparison.

## Breaking Changes

None. This is a purely additive change.

## Related Issues

This addresses a common pain point where developers need to know when all resources are available. Currently, the workarounds are:
- Using `setTimeout()` with arbitrary delays (unreliable)
- Manually tracking resource states (complex)
- Assuming resources are ready (error-prone)

## Documentation Updates Needed

If merged, documentation should be added to:
- https://docs.fivem.net/docs/scripting-reference/events/server-events/
- https://docs.fivem.net/natives/?_0xAREALLRESOURCESLOADED

## Development Note

This feature was developed with assistance from Claude (Anthropic's AI assistant) for:
- C++ implementation guidance
- Code review and best practices
- Documentation and testing strategy

All code has been reviewed and understood by the contributor before submission.

---

**Note:** This PR follows the "fires once at startup" pattern similar to other "ready" events in common frameworks (DOM's `DOMContentLoaded`, jQuery's `$(document).ready()`, etc.)
