### PR TITLE
fix(audioSink): safe-guard EnvironmentGroup allocation to stop voice crash

### DIFF
--- a/code/components/extra-natives-five/src/NuiAudioSink.cpp
+++ b/code/components/extra-natives-five/src/NuiAudioSink.cpp
@@ -1511,6 +1511,16 @@ void MumbleAudioEntity<Build>::MInit(float overrideVolume)
 {
 	std::lock_guard _(m_render);
 	m_environmentGroup = naEnvironmentGroup::Create();
+
+	// Some malicious clients can spam ped scenarios, indirectly exhausting
+	// the global audio EnvironmentGroup pool. When the pool is full,
+	// Create() may return nullptr. Previously this caused a crash because
+	// voice setup assumed the pointer was always valid.
+	if (m_environmentGroup == nullptr)
+	{
+		return;
+	}
+	
 	m_environmentGroup->Init(nullptr, 20.0f, 1000, 4000, 0.5f, 1000);
 	m_environmentGroup->SetPosition(m_position);
 
@@ -2953,3 +2963,4 @@ static InitFunction initFunction([]()
 });
 
 rage::audMixerDevice** rage::audDriver::sm_Mixer;
+


### PR DESCRIPTION
### Goal of this PR
Prevent a crash occurring when the audio `EnvironmentGroup` pool becomes exhausted due to excessive scenario-related allocations (often triggered maliciously).


### How is this PR achieving the goal
Adds a null-check after attempting to create an `EnvironmentGroup` like the game code does. 


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** None
**Platforms:** Windows, Linux


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3710 