### PR TITLE
feat(gta-net-five): increase vehicle orientation blend threshold

### DIFF
--- a/code/components/gta-net-five/src/netBlender.cpp
+++ b/code/components/gta-net-five/src/netBlender.cpp
@@ -1,7 +1,9 @@
 #include <StdInc.h>
 #include <Hooking.h>
-
 #include <netBlender.h>
+#include <CoreConsole.h>
+#include "nutsnbolts.h"
+
 
 static hook::cdecl_stub<void(rage::netBlender*, uint32_t timeStamp)> netBlender_SetTimestamp([]()
 {
@@ -15,3 +17,53 @@ void netBlender::SetTimestamp(uint32_t timestamp)
 	return netBlender_SetTimestamp(this, timestamp);
 }
 }
+
+static float* orientationDiffPtr = nullptr;
+
+static constexpr float kDefaultMinOrientationDelta = 0.05f;   // ~2.86 degrees (original)
+static constexpr float kRaisedMinOrientationDelta  = 0.08f;   // ~4.58 degrees (patched)
+
+static void MinBlendDiffChanged(internal::ConsoleVariableEntry<bool>* var)
+{
+	if (!orientationDiffPtr)
+	{
+		return;
+	}
+
+	if (var->GetRawValue())
+	{
+		*orientationDiffPtr = kRaisedMinOrientationDelta;
+	}
+	else
+	{
+		*orientationDiffPtr = kDefaultMinOrientationDelta;
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	// This patch increases the minimum orientation delta required to start an orientation blend
+	// in CNetBlenderPhysical. The original value (≈0.05 rad ≈ 2.8°) was tuned for high client tick
+	// rates in peer-to-peer networking, where entity snapshots are received very frequently
+	// (often 100–200 Hz). In that environment the angle difference between updates is extremely
+	// small, so even tiny deviations should trigger blending.
+	//
+	// In OneSync, however, the effective update tickrate is much lower (~20 Hz). This causes
+	// orientation changes from remote vehicles to arrive with larger deltas between frames,
+	// making the original low threshold too sensitive. As a result, vehicles frequently trigger
+	// orientation corrections, leading to visible “snaps” or jitter when racing or following
+	// other players.
+	//
+	// By raising the threshold to ~0.08 rad (~4.58°), small changes are ignored and only
+	// meaningful orientation deviations start a blend.
+	{
+		static ConVar<bool> enableAngleCorrectionDelta("game_forceLowerAngleCorrectionDelta", ConVar_Replicated, true, &MinBlendDiffChanged);
+		uint32_t orientationDiffOffset = *hook::get_pattern<uint32_t>("48 8D 44 24 ? 48 8B CB 48 89 44 24 ? E8 ? ? ? ? 48 8D 54 24", 48);
+		void* g_vehicleBlenderData = *hook::get_address<void**>(hook::get_pattern("4C 8B 05 ? ? ? ? 48 8B D6 48 8B C8 E8 ? ? ? ? 48 8B D8 EB ? 33 DB", 0x3));
+		orientationDiffPtr = reinterpret_cast<float*>(
+			reinterpret_cast<uint8_t*>(g_vehicleBlenderData) + orientationDiffOffset
+		);
+
+		*orientationDiffPtr = kRaisedMinOrientationDelta;
+	}
+});


### PR DESCRIPTION
### Goal of this PR
Improve remote vehicle smoothness under OneSync by increasing the minimum orientation delta required to trigger orientation blending.
The default threshold was tuned for high tickrate peer-to-peer networking, causing excessive angle corrections and visible snapping in OneSync’s lower-tick environment.


### How is this PR achieving the goal
This PR locates the vehicle blender data and adjusts its m_MinOrientationDiffToStartBlend value to 0.08(~4.58 degrees).


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3095

**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
