### PR TITLE
fix(gta-core-five): validate SweepAim clip dictionary index

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.SweepAimDict.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.SweepAimDict.cpp
@@ -1,0 +1,40 @@
+#include "StdInc.h"
+
+#include "Hooking.FlexStruct.h"
+#include "Hooking.Patterns.h"
+#include "Hooking.Stubs.h"
+
+static hook::cdecl_stub<bool(int)> fwAnimManager_IsValidSlot([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 84 C0 74 ? 8B D3 48 8B CF E8 ? ? ? ? FF C3"));
+});
+
+static int32_t clipDictIdOffset;
+
+static int (*g_origTaskGeneralSweepOnUpdate)(hook::FlexStruct*);
+static int TaskGeneralSweepOnUpdate(hook::FlexStruct* task)
+{
+	int clipDictId = task->Get<int>(clipDictIdOffset);
+
+	if (!fwAnimManager_IsValidSlot(clipDictId))
+	{
+		return 0x2; // FSM_QUIT
+	}
+
+	return g_origTaskGeneralSweepOnUpdate(task);
+}
+
+static HookFunction hookFunction([]()
+{
+	// This hook prevents a client crash caused by invalid clip dictionary IDs in SweepAim tasks.
+	// When a player triggers TaskSweepAimEntity using a clip dictionary that exists only on their
+	// local client (e.g., a modded or unloaded anim dict), the task is replicated to remote clients.
+	// During replication, the clipDictId may resolve to an invalid local index on other clients.
+	// Later, the CTaskGeneralSweep task uses this invalid clipDictId inside fwAnimManager, which
+	// eventually reaches fwClipDictionaryStore::GetNumRefs and tries to access:
+	//     m_aStorage[index * size]
+	// If 'index' is invalid, this causes an out-of-range pointer dereference, leading to a client
+	// crash.
+	g_origTaskGeneralSweepOnUpdate = hook::trampoline(hook::get_pattern("EB ? 8B 93 ? ? ? ? 48 81 C1", -0x2F), TaskGeneralSweepOnUpdate);
+	clipDictIdOffset = *hook::get_pattern<int32_t>("8B 93 ? ? ? ? 48 81 C1 ? ? ? ? E8 ? ? ? ? 84 C0", 0x2);
+});


### PR DESCRIPTION
### Goal of this PR
Prevent a client crash caused by malicious or invalid usage of `TaskSweepAimEntity`, where remote players received an invalid `clipDictId` during the SweepAim update phase, leading to an invalid access inside `fwClipDictionaryStore::GetNumRefs` and eventually a crash.


### How is this PR achieving the goal
Adds a validation step inside the SweepAim update logic, checking whether the received `clipDictId` corresponds to a valid animation dictionary slot before continuing.
If the slot is invalid, the SweepAim task is aborted (`FSM_QUIT`) to avoid executing animation streaming code with corrupted or unexpected indices.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3716 
https://discord.com/channels/779705925577080842/779739477642838036/1438517263534784512 (Engineering Group)