### PR TITLE
fix(citizen-server-impl): validate onesync range when reassigning entity ownership

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -2137,7 +2137,7 @@ void ServerGameState::UpdateEntities()
 		else
 		{
 			// workaround: force-migrate a stuck entity
-			if ((time - entity->lastReceivedAt) > 10s)
+			if ((time - entity->lastReceivedAt) > 5s)
 			{
 				if (g_oneSyncForceMigration->GetValue() || fx::IsBigMode())
 				{


### PR DESCRIPTION
### Goal of this PR
Fixes a bug where vehicle entities become stuck/frozen after players change routing buckets or disconnect. The issue occurred when entity ownership was incorrectly transferred to players outside of OneSync range, causing entities to be uninteractable until the assigned owner (who is too far away) teleports back to the entity.


### How is this PR achieving the goal
Validate that the candidate player is in the same routing bucket and is in the culling radius of the entity.


### This PR applies to the following area(s)
Server


### Successfully tested on
I couldn't test this because the user that report this on the forum said that to reproduce the issue I need 20-30 players.


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://forum.cfx.re/t/server-side-vehicles-being-frozen-at-random/