### PR TITLE
tweak(mumble): reduce locking around GetTalkers

### DIFF
--- a/code/components/gta-net-five/src/MumbleVoice.cpp
+++ b/code/components/gta-net-five/src/MumbleVoice.cpp
@@ -730,7 +730,7 @@ static bool(*g_origIsAnyoneTalking)(void*);
 
 static bool _isAnyoneTalking(void* mgr)
 {
-	return (g_origIsAnyoneTalking(mgr) || g_mumbleClient->IsAnyoneTalking());
+	return g_origIsAnyoneTalking(mgr) || g_talkers.any() || o_talkers.any();
 }
 
 static bool(*g_origIsPlayerTalking)(void*, void*);
@@ -964,8 +964,7 @@ static HookFunction hookFunction([]()
 				return;
 			}
 
-			std::vector<std::string> talkers;
-			g_mumbleClient->GetTalkers(&talkers);
+			auto talkers = g_mumbleClient->GetTalkers();
 
 			std::set<std::string> talkerSet(talkers.begin(), talkers.end());
 

--- a/code/components/voip-mumble/include/MumbleAudioOutput.h
+++ b/code/components/voip-mumble/include/MumbleAudioOutput.h
@@ -60,7 +60,7 @@ public:
 
 	void SetVolume(float volume);
 
-	void GetTalkers(std::vector<uint32_t>* talkers);
+	void GetTalkers(std::vector<uint32_t>& talkers);
 
 	void SetMatrix(float position[3], float front[3], float up[3]);
 

--- a/code/components/voip-mumble/include/MumbleClient.h
+++ b/code/components/voip-mumble/include/MumbleClient.h
@@ -69,8 +69,6 @@ public:
 
 	virtual MumbleConnectionInfo* GetConnectionInfo() = 0;
 
-	virtual bool IsAnyoneTalking() = 0;
-
 	virtual float GetInputAudioLevel() = 0;
 
 	virtual void SetChannel(const std::string& channelName) = 0;
@@ -83,7 +81,7 @@ public:
 
 	virtual std::string GetVoiceChannelFromServerId(uint32_t serverId) = 0;
 
-	virtual void GetTalkers(std::vector<std::string>* names) = 0;
+	virtual std::vector<std::string> GetTalkers() = 0;
 
 	virtual void SetPositionHook(const TPositionHook& hook) = 0;
 

--- a/code/components/voip-mumble/include/MumbleClientImpl.h
+++ b/code/components/voip-mumble/include/MumbleClientImpl.h
@@ -136,8 +136,6 @@ public:
 
 	virtual void SetVoiceTarget(int idx) override;
 
-	virtual bool IsAnyoneTalking() override;
-
 	virtual float GetInputAudioLevel() override;
 
 	virtual void SetChannel(const std::string& channelName) override;
@@ -158,7 +156,7 @@ public:
 
 	virtual std::string GetVoiceChannelFromServerId(uint32_t serverId) override;
 
-	virtual void GetTalkers(std::vector<std::string>* referenceIds) override;
+	virtual std::vector<std::string> GetTalkers() override;
 
 	virtual void SetPositionHook(const TPositionHook& hook) override;
 

--- a/code/components/voip-mumble/include/MumbleClientState.h
+++ b/code/components/voip-mumble/include/MumbleClientState.h
@@ -122,6 +122,25 @@ public:
 
 	inline std::map<uint32_t, MumbleChannel>& GetChannels() { return m_channels; }
 
+	inline std::vector<std::string> GetUserNamesFromSessionIds(const std::vector<uint32_t>& sessionIds)
+	{
+		// preallocate because this could be a larger list on bigger servers
+		// +1 because in GetTalkers we might add our local client to the talkers list
+		std::vector<std::string> userNames(sessionIds.size() + 1);
+
+		std::shared_lock<std::shared_mutex> lock(m_usersMutex);
+		for (auto session : sessionIds)
+		{
+			auto it = m_users.find(session);
+			if (it != m_users.end())
+			{
+				userNames.push_back(it->second->GetName());
+			}
+		}
+
+		return userNames;
+	}
+
 	inline std::shared_ptr<MumbleUser> GetUser(uint32_t id)
 	{
 		std::shared_lock<std::shared_mutex> lock(m_usersMutex);

--- a/code/components/voip-mumble/src/MumbleAudioOutput.cpp
+++ b/code/components/voip-mumble/src/MumbleAudioOutput.cpp
@@ -1442,9 +1442,9 @@ void MumbleAudioOutput::HandleClientDisconnect(const MumbleUser& user)
 	}
 }
 
-void MumbleAudioOutput::GetTalkers(std::vector<uint32_t>* talkers)
+void MumbleAudioOutput::GetTalkers(std::vector<uint32_t>& talkers)
 {
-	talkers->clear();
+	talkers.clear();
 
 	std::shared_lock<std::shared_mutex> _(m_clientsMutex);
 
@@ -1457,7 +1457,7 @@ void MumbleAudioOutput::GetTalkers(std::vector<uint32_t>* talkers)
 
 		if (client.second->IsTalking())
 		{
-			talkers->push_back(client.first);
+			talkers.push_back(client.first);
 		}
 	}
 }

--- a/code/components/voip-mumble/src/MumbleClient.cpp
+++ b/code/components/voip-mumble/src/MumbleClient.cpp
@@ -668,36 +668,20 @@ bool MumbleClient::DoesChannelExist(const std::string& channelName)
 	return false;
 }
 
-void MumbleClient::GetTalkers(std::vector<std::string>* referenceIds)
+std::vector<std::string> MumbleClient::GetTalkers()
 {
-	referenceIds->clear();
-
 	std::vector<uint32_t> sessions;
-	m_audioOutput.GetTalkers(&sessions);
+	m_audioOutput.GetTalkers(sessions);
 
-	for (uint32_t session : sessions)
-	{
-		auto user = m_state.GetUser(session);
-
-		if (user)
-		{
-			referenceIds->push_back(user->GetName());
-		}
-	}
+	auto talkers = m_state.GetUserNamesFromSessionIds(sessions);
 
 	// local talker talking?
 	if (m_audioInput.IsTalking())
 	{
-		referenceIds->push_back(m_state.GetUsername());
+		talkers.push_back(m_state.GetUsername());
 	}
-}
 
-bool MumbleClient::IsAnyoneTalking()
-{
-	std::vector<uint32_t> talkers;
-	m_audioOutput.GetTalkers(&talkers);
-
-	return (!talkers.empty());
+	return talkers;
 }
 
 void MumbleClient::SetActorPosition(float position[3])


### PR DESCRIPTION
### Goal of this PR
Reduce locking around user list access


### How is this PR achieving the goal

- `_isAnyoneTalking` gets called a decent bit in game code, and for some reason the code here iterates *the entire talker list* again, and this can presumably happen multiple times a frame and cause lock contention. Most of the work here is already handled by another call that happens per frame so we just reuse `g_talkers` and `o_talkers`.

- `GetTalkers` also did a bunch of un-needed locking on every `GetUser` call when it was trying to get users from their session id's, so we change how we expect data to be handed back down and add a new function to handle getting all of the user names and reduce the amount of locking/unlocking we do.


### This PR applies to the following area(s)
FiveM/RedM


### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


