### PR TITLE
tweak(server/gamestate): CreatePed RPC & CreatePedServerSetter

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerRPC.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerRPC.cpp
@@ -132,7 +132,7 @@ static InitFunction initFunction([]()
 		{
 			// deprecated by ServerSetters
 #ifdef STATE_FIVE
-			if (native->GetName() == "CREATE_PED" || native->GetName() == "CREATE_OBJECT_NO_OFFSET")
+			if (native->GetName() == "CREATE_OBJECT_NO_OFFSET")
 			{
 				continue;
 			}

--- a/code/components/citizen-server-impl/src/state/ServerSetters.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerSetters.cpp
@@ -443,7 +443,7 @@ static InitFunction initFunction([]()
 			ctx.SetResult(guid);
 		});
 
-		fx::ScriptEngine::RegisterNativeHandler("CREATE_PED", [=](fx::ScriptContext& ctx)
+		fx::ScriptEngine::RegisterNativeHandler("CREATE_PED_SERVER_SETTER", [=](fx::ScriptContext& ctx)
 		{
 			uint32_t resourceHash = 0;
 

--- a/ext/native-decls/server/CreatePedServerSetter.md
+++ b/ext/native-decls/server/CreatePedServerSetter.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: server
+---
+## CREATE_PED_SERVER_SETTER
+
+```c
+Ped CREATE_PED_SERVER_SETTER(int pedType, Hash modelHash, float x, float y, float z, float heading, BOOL isNetwork, BOOL bScriptHostPed);
+```
+
+Equivalent to CREATE_PED, but it uses 'server setter' logic as a workaround for
+reliability concerns regarding entity creation RPC.
+
+Creates a ped (biped character, pedestrian, actor) with the specified model at the specified position and heading.
+
+## Parameters
+* **pedType**: Unused. Peds get set to CIVMALE/CIVFEMALE/etc. no matter the value specified.
+* **modelHash**: The model of ped to spawn.
+* **x**: Spawn coordinate X component.
+* **y**: Spawn coordinate Y component.
+* **z**: Spawn coordinate Z component.
+* **heading**: Heading to face towards, in degrees.
+* **isNetwork**: Whether to create a network object for the ped. If false, the ped exists only locally.
+* **bScriptHostPed**: Whether to register the ped as pinned to the script host in the R* network model.
+
+## Return value
+A script handle (fwScriptGuid index) for the ped, or `0` if the ped failed to be created.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Allow the usage of CreatePed RPC and create CreatePedServerSetter. Currently, the documentation states that CreatePed is an RPC, but it actually is a server setter. By separating these natives, users gain finer control over which method they want to use for spawning peds.


### How is this PR achieving the goal

This PR changes the ServerSetters code to separate 2 natives, the server setter and the RPC.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM, Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


