### PR TITLE
fix(rt2) Extend RT2 end date

### DIFF
--- a/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
+++ b/code/components/citizen-scripting-mono-v2/src/MonoScriptRuntime.cpp
@@ -264,11 +264,12 @@ int MonoScriptRuntime::HandlesFile(char* filename, IScriptHostWithResourceData* 
 	}
 
 	// last supported date for this pilot of mono_rt2, in UTC
-	constexpr int maxYear = 2025, maxMonth = 12, maxDay = 31;
+	constexpr int maxYear = 2026, maxMonth = 6, maxDay = 30;
 
 	// Allowed values for mono_rt2
 	constexpr std::string_view allowedValues[] = {
 		// put latest on top, right here ↓
+		"Prerelease expiring 2026-06-30. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2025-12-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2025-06-30. See https://aka.cfx.re/mono-rt2-preview for info."sv,
 		"Prerelease expiring 2024-12-31. See https://aka.cfx.re/mono-rt2-preview for info."sv,


### PR DESCRIPTION
Extending prerelease date

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Extend the period of mono rt2
...


### How is this PR achieving the goal
By extending the end date
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
RT2
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [X ] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


