### PR TITLE
feat(script-runtimes/v8): add memory info per context

### DIFF
--- a/code/client/citicore/om/core.h
+++ b/code/client/citicore/om/core.h
@@ -16,6 +16,7 @@ typedef uint32_t result_t;
 #define FX_S_OK					0x0
 #define FX_E_NOTIMPL			0x80004001
 #define FX_E_NOINTERFACE		0x80004002
+#define FX_E_WAITING_FOR_DATA	0x80004004
 #define FX_E_INVALIDARG			0x80070057
 
 // Success/failure macros

--- a/code/components/citizen-scripting-node/include/NodeScriptRuntime.h
+++ b/code/components/citizen-scripting-node/include/NodeScriptRuntime.h
@@ -31,7 +31,7 @@ using namespace fx::invoker;
 
 namespace fx::nodejs
 {
-class NodeScriptRuntime : public OMClass<NodeScriptRuntime, IScriptRuntime, IScriptFileHandlingRuntime, IScriptTickRuntime, IScriptEventRuntime,
+class NodeScriptRuntime : public OMClass<NodeScriptRuntime, IScriptRuntime, IScriptFileHandlingRuntime, IScriptMemInfoRuntime, IScriptTickRuntime, IScriptEventRuntime,
 	IScriptRefRuntime, IScriptStackWalkingRuntime, IScriptWarningRuntime>
 {
 private:
@@ -175,5 +175,6 @@ public:
 	NS_DECL_ISCRIPTREFRUNTIME;
 	NS_DECL_ISCRIPTSTACKWALKINGRUNTIME;
 	NS_DECL_ISCRIPTWARNINGRUNTIME;
+	NS_DECL_ISCRIPTMEMINFORUNTIME;
 };
 }


### PR DESCRIPTION
This uses the experimental `MeasureMemory` api to measure all of the context's used memory and stores the amount of used memory into the global `g_memoryInfo`.

This should add a decent bit of debugability to existing scripts that use V8, and hopefully help script devs figure out if they're using a lot of memory.

In the future it might make sense to have a "common" v8 class that we can use to share structure between the new Node ScRT and the v8 ScRT to reduce the duplication here.

This also cleans up some existing code by using the `CfxV8EmbeddedData` enum to better describe what certain embedder data does.

### Goal of this PR
Add memory tracking to the v8 environment


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
ScRT: JS, ScRT: Node


### Successfully tested on
**Game builds:** 1491

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


