### PR TITLE
feat(extra-natives-rdr3): allow disabling remote attachments in RedM

### DIFF
--- a/code/components/extra-natives-rdr3/include/ClientConfig.h
+++ b/code/components/extra-natives-rdr3/include/ClientConfig.h
@@ -8,6 +8,7 @@ enum class ClientConfigFlag : uint16_t
 	WeaponsNoAutoReload = 0,
 	UIVisibleWhenDead = 1,
 	DisableDeathAudioScene = 2,
+	DisableRemoteAttachments = 3,
 };
 
 extern std::bitset<256> g_clientConfigBits;

--- a/ext/native-decls/SetClientConfigBool.md
+++ b/ext/native-decls/SetClientConfigBool.md
@@ -14,7 +14,8 @@ enum ClientConfigFlag
 {
     WeaponsNoAutoReload = 0,
 	UIVisibleWhenDead = 1,
-	DisableDeathAudioScene = 2
+	DisableDeathAudioScene = 2,
+	DisableRemoteAttachments = 3
 }
 ```
 


### PR DESCRIPTION
### Goal of this PR
Port the `ONESYNC_ENABLE_REMOTE_ATTACHMENT_SANITIZATION` native to RedM using the `SET_CLIENT_CONFIG_BOOL` native.
I think the object is teleporting because the sector pos data node is being updated by the remote client so it "follows" you, but this is the same behavior as FiveM, if you exit the scope of the remote player the object stop following.

https://github.com/user-attachments/assets/c278ea35-d35e-44d9-a819-9e2afdfe272a


### How is this PR achieving the goal
Hook `CNetObjPhysical::CanProcessPendingAttachment` and return false if the remote attachments are disabled.


### This PR applies to the following area(s)
RedM, Natives


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://discord.com/channels/779705925577080842/779739506286002196/1450523787861819523 CFX Engineering Group