### PR TITLE
fix(voip-server-mumble): cleanup channel listeners when client is freed

### DIFF
--- a/code/components/voip-server-mumble/src/ChannelListener.cpp
+++ b/code/components/voip-server-mumble/src/ChannelListener.cpp
@@ -30,6 +30,22 @@ void ChannelListener::removeListenerImpl(unsigned int userSession, int channelID
 	m_listenedChannels[channelID].erase(userSession);
 }
 
+void ChannelListener::removeAllListenersForUserImpl(unsigned int userSession)
+{
+	std::unique_lock lock(m_listenerLock);
+
+	auto it = m_listeningUsers.find(userSession);
+	if (it != m_listeningUsers.end())
+	{
+		for (int channelID : it->second)
+		{
+			m_listenedChannels[channelID].erase(userSession);
+		}
+
+		m_listeningUsers.erase(it);
+	}
+}
+
 bool ChannelListener::isListeningImpl(unsigned int userSession, int channelID) const
 {
 	std::shared_lock lock(m_listenerLock);
@@ -150,6 +166,16 @@ void ChannelListener::removeListener(unsigned int userSession, int channelID)
 void ChannelListener::removeListener(const User* user, const Channel* channel)
 {
 	get().removeListenerImpl(user->sessionId, channel->id);
+}
+
+void ChannelListener::removeAllListenersForUser(unsigned int userSession)
+{
+	get().removeAllListenersForUserImpl(userSession);
+}
+
+void ChannelListener::removeAllListenersForUser(const User* user)
+{
+	get().removeAllListenersForUserImpl(user->sessionId);
 }
 
 bool ChannelListener::isListening(unsigned int userSession, int channelID)

--- a/code/components/voip-server-mumble/src/ChannelListener.h
+++ b/code/components/voip-server-mumble/src/ChannelListener.h
@@ -49,6 +49,11 @@ protected:
 	/// @param channelID The ID of the channel
 	void removeListenerImpl(unsigned int userSession, int channelID);
 
+	/// Removes all listeners for the given user.
+	///
+	/// @param userSession The session ID of the user
+	void removeAllListenersForUserImpl(unsigned int userSession);
+
 	/// @param userSession The session ID of the user
 	/// @param channelID The ID of the channel
 	/// @returns Whether the given user is listening to the given channel
@@ -108,6 +113,16 @@ public:
 	/// @param userSession The session ID of the user
 	/// @param channelID The ID of the channel
 	static void removeListener(const User* user, const Channel* channel);
+
+	/// Removes all listeners for the given user.
+	///
+	/// @param userSession The session ID of the user
+	static void removeAllListenersForUser(unsigned int userSession);
+
+	/// Removes all listeners for the given user.
+	///
+	/// @param user A pointer to the user object
+	static void removeAllListenersForUser(const User* user);
 
 	/// @param userSession The session ID of the user
 	/// @param channelID The ID of the channel

--- a/code/components/voip-server-mumble/src/client.cpp
+++ b/code/components/voip-server-mumble/src/client.cpp
@@ -435,6 +435,7 @@ void Client_free(client_t *client)
 	Client_codec_free(client);
 	Voicetarget_free_all(client);
 	Client_token_free(client);
+	ChannelListener::removeAllListenersForUser(client->sessionId);
 
 	list_del(&client->node);
 	/*if (client->ssl)


### PR DESCRIPTION
### Goal of this PR
Remove mubmle channel listeners when a client gets freed in order to prevent newly connected users form listening to channels that were left behind by the previous owner of that session id.

### How is this PR achieving the goal
It adds new methods to the `ChannelListener` class that erase all the channels the user is listening to from both maps at once. I didn't use the exsiting API since that would mean holding the mutex per channel instead of once for the whole operation.

### This PR applies to the following area(s)
Server

### Successfully tested on
**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.