### PR TITLE
fix(state/fivem): Fix CPedHealthDataNode parsing on b3717+

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -2356,14 +2356,14 @@ struct CPedHealthDataNode
 
 		if (maxHealthChanged)
 		{
-			maxHealth = state.buffer.Read<int>(13);
+			maxHealth = IsWinterUpdate25() ? state.buffer.Read<int>(14) : state.buffer.Read<int>(13);
 		}
 
 		data.maxHealth = maxHealth;
 
 		if (!isFine)
 		{
-			int pedHealth = state.buffer.Read<int>(13);
+			int pedHealth = IsWinterUpdate25() ? state.buffer.Read<int>(14) : state.buffer.Read<int>(13);
 			auto killedWithHeadshot = state.buffer.ReadBit();
 			auto killedWithMelee = state.buffer.ReadBit();
 


### PR DESCRIPTION
The health related fields (maxHealth and pedHealth) in CPedHealthDataNode were changed from 13 to 14-bit in b3717. The armor and "unk" fields were left at 13-bit.

This caused the server-side GetEntityHealth native to read incorrect values when the entity had taken damage (isFine=false) or had modified maxHeath (maxHealthChanged=true).

Decompilation from build 3717:
<img width="854" height="365" alt="image" src="https://github.com/user-attachments/assets/423d6235-b9cf-4555-a000-646c6e9d721e" />


### Goal of this PR
Fix the server-side parsing of CPedHealthDataNode on b3717+.

### How is this PR achieving the goal
By changing the Read call for maxHealth and pedHealth to take 14 bits for builds 3717+.


### This PR applies to the following area(s)
Server


### Successfully tested on
**Game builds:** 3717, 3570
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Reported in txAdmin lounge Discord https://discord.com/channels/577993482761928734/885648611768139838/1452049703326847119

