### PR TITLE
fix(citizen-server-impl): prevent clients from creating multiple CNetObjPlayer

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3545,6 +3545,18 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 			std::unique_lock _lock(data->playerEntityMutex);
 			sync::SyncEntityPtr playerEntity = data->playerEntity.lock();
 
+			// Prevent clients from creating multiple CNetObjPlayer entities
+			if (createdHere && playerEntity)
+			{
+				GS_LOG("%s: client %d %s tried to create duplicate player entity %d, but already has player entity %d. Rejecting!\n",
+					__func__,
+					client->GetNetId(),
+					client->GetName(),
+					objectId,
+					playerEntity->handle & 0xFFFF);
+				return false;
+			}
+
 			if (!playerEntity)
 			{
 				SendWorldGrid(nullptr, client);


### PR DESCRIPTION
### Goal of this PR
It fixes an exploit: malicious clients created multiple CNetObjPlayer instances, and when teleporting away, the reference to the player's PlayerInfo was lost because they left their CNetObjPlayer clones in the same place, causing nearby players to crash because they didn't have a valid pointer to the PlayerInfo from those "clones".


### How is this PR achieving the goal
Not allowing clients to create more than one CNetObjPlayer.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3570
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3751, fixes #3754 