### PR TITLE
feat(extra-natives-five): Add natives to manage entity artificial lig…

### DIFF
--- a/code/components/extra-natives-five/src/ArtificialLightsNatives.cpp
+++ b/code/components/extra-natives-five/src/ArtificialLightsNatives.cpp
@@ -1,0 +1,174 @@
+#include "StdInc.h"
+#include <ScriptEngine.h>
+#include <scrEngine.h>
+#include <EntitySystem.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <Hooking.Patterns.h>
+#include <ScriptSerialization.h>
+#include <MinHook.h>
+#include <GameInit.h>
+#include <unordered_set>
+#include <shared_mutex>
+
+// These natives allow controlling which specific entities ignore the artificial lights
+// "blackout" mode. When SET_ARTIFICIAL_LIGHTS_STATE(true) is called (blackout enabled),
+// entities marked with SET_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE will keep their lights on.
+//
+// Implementation hooks Lights::AddSceneLight which is called for all entity lights.
+// CLightEntity has m_parentEntity at offset 0xD0 which points to the actual entity.
+//
+
+// Set of raw entity pointers that should ignore artificial lights state
+static std::unordered_set<void*> g_entitiesIgnoringBlackout;
+static std::shared_mutex g_entitiesMutex;
+
+// globals
+static bool* g_disableArtificialLights = nullptr;
+static bool* g_disableArtificialVehLights = nullptr;
+
+// CLightEntity::m_parentEntity offset
+constexpr ptrdiff_t LIGHT_ENTITY_PARENT_OFFSET = 0xD0;
+
+// original function
+static bool (*g_origAddSceneLight)(void* sceneLight, void* lightEntity, bool addToPreviousLightList);
+
+static bool DoesEntityIgnoreBlackout(void* entity)
+{
+	if (!entity)
+		return false;
+	std::shared_lock lock(g_entitiesMutex);
+	return g_entitiesIgnoringBlackout.find(entity) != g_entitiesIgnoringBlackout.end();
+}
+
+static void* GetParentEntityFromLightEntity(void* lightEntity)
+{
+	if (!lightEntity)
+		return nullptr;
+
+	// m_parentEntity is at offset 0xD0, it's a rage::fwRegdRef<CEntity>
+	// The actual pointer is at the start of the fwRegdRef
+	void** parentPtr = (void**)((char*)lightEntity + LIGHT_ENTITY_PARENT_OFFSET);
+	return *parentPtr;
+}
+
+static bool AddSceneLightHook(void* sceneLight, void* lightEntity, bool addToPreviousLightList)
+{
+	void* parentEntity = GetParentEntityFromLightEntity(lightEntity);
+	bool shouldOverride = DoesEntityIgnoreBlackout(parentEntity);
+
+	bool origLightsState = false;
+	bool origVehLightsState = false;
+
+	if (shouldOverride && g_disableArtificialLights && g_disableArtificialVehLights)
+	{
+		// save original states
+		origLightsState = *g_disableArtificialLights;
+		origVehLightsState = *g_disableArtificialVehLights;
+
+		// temporarily disable blackout for this entitys lights
+		*g_disableArtificialLights = false;
+		*g_disableArtificialVehLights = false;
+	}
+
+	// call original function
+	bool result = g_origAddSceneLight(sceneLight, lightEntity, addToPreviousLightList);
+
+	if (shouldOverride && g_disableArtificialLights && g_disableArtificialVehLights)
+	{
+		// restore original states
+		*g_disableArtificialLights = origLightsState;
+		*g_disableArtificialVehLights = origVehLightsState;
+	}
+
+	return result;
+}
+
+static HookFunction hookFunction([]()
+{
+	{
+		auto location = hook::get_pattern<char>("48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 4C 89 60 ? 55 41 56 41 57 48 8D 68 ? 48 81 EC ? ? ? ? 0F 29 70 ? 45 33 E4");
+
+		// Find CRenderer::sm_disableArtificialLights and CRenderer::sm_disableArtificialVehLights
+		// Both are referenced within AddSceneLight using "cmp [rip+offset], r12b" pattern: "44 38 25 ? ? ? ?"
+		// Search within the first 0x80 bytes of the function
+		{
+			hook::range_pattern p((uintptr_t)location, (uintptr_t)location + 0x80, "44 38 25");
+
+			auto firstMatch = p.get(0).get<char>(0);
+			g_disableArtificialLights = hook::get_address<bool*>(firstMatch + 3);
+
+			auto secondMatch = p.get(1).get<char>(0);
+			g_disableArtificialVehLights = hook::get_address<bool*>(secondMatch + 3);
+		}
+
+		MH_Initialize();
+		MH_CreateHook(location, AddSceneLightHook, (void**)&g_origAddSceneLight);
+		MH_EnableHook(location);
+	}
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE", [](fx::ScriptContext& ctx)
+	{
+		int entityHandle = ctx.GetArgument<int>(0);
+		bool ignoreBlackout = ctx.GetArgument<bool>(1);
+
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(entityHandle);
+		if (!entity)
+		{
+			return;
+		}
+
+		std::unique_lock lock(g_entitiesMutex);
+		if (ignoreBlackout)
+		{
+			g_entitiesIgnoringBlackout.insert(entity);
+		}
+		else
+		{
+			g_entitiesIgnoringBlackout.erase(entity);
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE", [](fx::ScriptContext& ctx)
+	{
+		int entityHandle = ctx.GetArgument<int>(0);
+
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(entityHandle);
+		if (!entity)
+		{
+			ctx.SetResult<bool>(false);
+			return;
+		}
+
+		ctx.SetResult<bool>(DoesEntityIgnoreBlackout(entity));
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("CLEAR_ALL_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE", [](fx::ScriptContext& ctx)
+	{
+		std::unique_lock lock(g_entitiesMutex);
+		g_entitiesIgnoringBlackout.clear();
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ALL_ENTITIES_IGNORING_ARTIFICIAL_LIGHTS_STATE", [](fx::ScriptContext& ctx)
+	{
+		std::vector<int> entityList;
+
+		std::shared_lock lock(g_entitiesMutex);
+		for (void* entityPtr : g_entitiesIgnoringBlackout)
+		{
+			int handle = rage::fwScriptGuid::GetGuidFromBase(reinterpret_cast<fwEntity*>(entityPtr));
+			if (handle != 0)
+			{
+				entityList.push_back(handle);
+			}
+		}
+
+		ctx.SetResult(fx::SerializeObject(entityList));
+	});
+
+	OnKillNetworkDone.Connect([]()
+	{
+		std::unique_lock lock(g_entitiesMutex);
+		g_entitiesIgnoringBlackout.clear();
+	});
+});

--- a/ext/native-decls/ClearAllEntityLightsIgnoreArtificialState.md
+++ b/ext/native-decls/ClearAllEntityLightsIgnoreArtificialState.md
@@ -1,0 +1,12 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## CLEAR_ALL_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE
+
+```c
+void CLEAR_ALL_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE();
+```
+
+Clears all entities from the artificial lights ignore list, restoring default blackout behavior for all previously marked entities.

--- a/ext/native-decls/DoesEntityLightsIgnoreArtificialState.md
+++ b/ext/native-decls/DoesEntityLightsIgnoreArtificialState.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DOES_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE
+
+```c
+BOOL DOES_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE(Entity entity);
+```
+
+Returns whether an entity's lights are set to ignore the artificial lights blackout state.
+
+## Parameters
+* **entity**: The entity handle.
+
+## Return value
+`true` if the entity's lights ignore blackout, `false` otherwise.

--- a/ext/native-decls/GetAllEntitiesIgnoringArtificialLightsState.md
+++ b/ext/native-decls/GetAllEntitiesIgnoringArtificialLightsState.md
@@ -1,0 +1,23 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## GET_ALL_ENTITIES_IGNORING_ARTIFICIAL_LIGHTS_STATE
+
+```c
+object GET_ALL_ENTITIES_IGNORING_ARTIFICIAL_LIGHTS_STATE();
+```
+
+Returns all entity handles that are currently set to ignore the artificial lights blackout state.
+
+## Return value
+An array of entity handles.
+
+## Examples
+```lua
+local entities = GetAllEntitiesIgnoringArtificialLightsState()
+for _, entity in ipairs(entities) do
+    print("Entity ignoring blackout: " .. entity)
+end
+```

--- a/ext/native-decls/SetEntityLightsIgnoreArtificialState.md
+++ b/ext/native-decls/SetEntityLightsIgnoreArtificialState.md
@@ -1,0 +1,29 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE
+
+```c
+void SET_ENTITY_LIGHTS_IGNORE_ARTIFICIAL_STATE(Entity entity, BOOL toggle);
+```
+
+Sets whether an entity's lights should ignore the artificial lights blackout state.
+When `SET_ARTIFICIAL_LIGHTS_STATE(true)` is active (blackout mode), entities marked with this native will keep their lights on.
+
+## Parameters
+* **entity**: The entity handle.
+* **toggle**: `true` to make the entity's lights ignore blackout, `false` to restore default behavior.
+
+## Examples
+```lua
+-- Spawn a vehicle
+local vehicle = CreateVehicle(modelHash, x, y, z, heading, true, false)
+
+-- Enable blackout
+SetArtificialLightsState(true)
+
+-- This specific vehicle keeps its lights on during blackout
+SetEntityLightsIgnoreArtificialState(vehicle, true)
+```


### PR DESCRIPTION
…ht states

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add natives to manage the light states of entities, useful to manually enable lights for specific entities when using "blackout" script(s)
...


### How is this PR achieving the goal
Implementation hooks Lights::AddSceneLight which is called for all entity lights.
CLightEntity has m_parentEntity at offset 0xD0 which points to the actual entity.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM, Natives
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->
**Game builds:** .. 
3095, 3258
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


