### PR TITLE
feat(graphics/rdr3): improve ERR_GFX_STATE error messages

### DIFF
--- a/code/components/rage-graphics-five/src/dxerr.cpp
+++ b/code/components/rage-graphics-five/src/dxerr.cpp
@@ -15,6 +15,9 @@
 #include <ddraw.h>
 #include <d3d10_1.h>
 #include <d3d11.h>
+#ifdef IS_RDR3
+#include <d3d12.h>
+#endif
 #include <wincodec.h>
 #include <d2d1.h>
 #include <dwrite.h>
@@ -3152,6 +3155,14 @@ const WCHAR* WINAPI DXGetErrorStringW( _In_ HRESULT hr )
         CHK_ERRA(D3D11_ERROR_FILE_NOT_FOUND)
         CHK_ERRA(D3D11_ERROR_TOO_MANY_UNIQUE_VIEW_OBJECTS)
         CHK_ERRA(D3D11_ERROR_DEFERRED_CONTEXT_MAP_WITHOUT_INITIAL_DISCARD)
+
+#ifdef IS_RDR3
+// -------------------------------------------------------------
+// d3d12.h error codes
+// -------------------------------------------------------------
+		CHK_ERR(D3D12_ERROR_ADAPTER_NOT_FOUND, "The specified cached PSO was created on a different adapter and cannot be reused on the current adapter.")
+		CHK_ERR(D3D12_ERROR_DRIVER_VERSION_MISMATCH, "The specified cached PSO was created on a different driver version and cannot be reused on the current adapter.")
+#endif
 
 // -------------------------------------------------------------
 // Direct2D error codes

--- a/code/components/rage-graphics-rdr3/component.lua
+++ b/code/components/rage-graphics-rdr3/component.lua
@@ -1,1 +1,13 @@
-includedirs { '../../../vendor/vulkan-headers/include/' }
+includedirs { 
+    '../../../vendor/vulkan-headers/include/',
+    '../rage-graphics-five/include'
+}
+
+return function()
+    filter {}
+
+    files {
+        'components/rage-graphics-five/include/dxerr.h',
+        'components/rage-graphics-five/src/dxerr.cpp'
+    }
+end


### PR DESCRIPTION
### Goal of this PR

Remove ~200 instances of ERR_GFX_STATE errors that users hit, instead replacing them with more meaningful and verbose error messages that can help with troubleshooting the issue. This also improves crash metrics for server owners, allowing better monitoring of graphical crashes potentially in relation to new/changed contents.

### How is this PR achieving the goal

Backport from some of my own work on updating cef and redm game-view.

Replacing three calls that act as D3D12 Failed macro, Vulkan VK_ERROR_DEVICE_LOST check and Vulkan swapchain creation error checking that when receiving an non success code, will throw the ERR_GFX_STATE error. These are then replaced with more in-depth errors based on the dxerr library return results and VkResult information.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues


