### PR TITLE
feat(rage-graphics-rdr3): add frame capture for NUI

### DIFF
--- a/code/components/rage-graphics-rdr3/include/DrawCommands.h
+++ b/code/components/rage-graphics-rdr3/include/DrawCommands.h
@@ -75,6 +75,12 @@ extern GFX_EXPORT GraphicsAPI GetCurrentGraphicsAPI();
 // VK context or D3D12 device
 extern GFX_EXPORT void* GetGraphicsDriverHandle();
 
+// Set Vulkan device handles for frame capture
+extern GFX_EXPORT void SetVulkanDeviceHandles(void* device, void* physicalDevice, void* queue, uint32_t queueFamily);
+
+// Capture Vulkan swapchain image from vkQueuePresentKHR hook
+extern GFX_EXPORT void CaptureVulkanSwapchainImage(void* swapchain, uint32_t imageIndex, int width, int height);
+
 namespace rage::sga
 {
 class GFX_EXPORT GraphicsContext

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -6,6 +6,15 @@
 #include <CrossBuildRuntime.h>
 
 #include <Hooking.h>
+#include <HostSharedData.h>
+#include <d3d12.h>
+#include <d3d11.h>
+#include <vulkan/vulkan.h>
+#include <chrono>
+#pragma comment(lib, "d3d12.lib")
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "vulkan-1.lib")
 
 static rage::grcTextureFactory* g_textureFactory;
 
@@ -502,6 +511,954 @@ void SetScissorRect(int x, int y, int z, int w)
 
 static uint64_t** sgaDriver;
 
+// D3D12 frame capture
+static ID3D12Resource* g_d3d12StagingBuffer = nullptr;
+static ID3D11Device* g_d3d11Device = nullptr;
+static ID3D11DeviceContext* g_d3d11Context = nullptr;
+static ID3D11Texture2D* g_d3d11StagingTexture = nullptr;
+static ID3D11Texture2D* g_d3d11SharedTexture = nullptr;
+static HANDLE g_d3d11SharedHandle = nullptr;
+static ID3D12CommandQueue* g_captureCommandQueue = nullptr;
+static ID3D12Fence* g_fence = nullptr;
+static HANDLE g_fenceEvent = nullptr;
+static UINT64 g_fenceValue = 0;
+static ID3D12CommandQueue** g_commandQueuePtr = nullptr;
+static int g_lastWidth = 0;
+static int g_lastHeight = 0;
+
+// Vulkan frame capture
+static VkDevice g_vkDevice = VK_NULL_HANDLE;
+static VkPhysicalDevice g_vkPhysicalDevice = VK_NULL_HANDLE;
+static VkQueue g_vkGraphicsQueue = VK_NULL_HANDLE;
+static uint32_t g_vkGraphicsQueueFamily = 0;
+static VkCommandPool g_vkCommandPool = VK_NULL_HANDLE;
+static VkImage g_vkIntermediateImage = VK_NULL_HANDLE;
+static VkDeviceMemory g_vkIntermediateImageMemory = VK_NULL_HANDLE;
+static int g_vkIntermediateImageWidth = 0;
+static int g_vkIntermediateImageHeight = 0;
+static VkBuffer g_vkStagingBuffer = VK_NULL_HANDLE;
+static VkDeviceMemory g_vkStagingBufferMemory = VK_NULL_HANDLE;
+static int g_vkStagingBufferSize = 0;
+static VkFence g_vkCopyFence = VK_NULL_HANDLE;
+static bool g_vkCopyInProgress = false;
+static VkCommandBuffer g_vkReusableCommandBuffer = VK_NULL_HANDLE;
+static std::vector<VkImage> g_cachedSwapchainImages;
+static VkSwapchainKHR g_cachedSwapchain = VK_NULL_HANDLE;
+
+struct GameRenderData
+{
+	HANDLE handle;
+	int width;
+	int height;
+	bool requested;
+
+	GameRenderData()
+		: requested(false), handle(NULL), width(0), height(0)
+	{
+	}
+};
+
+static HostSharedData<GameRenderData> g_renderData("CfxGameRenderHandle");
+
+static bool InitializeD3D11Device(int width, int height)
+{
+	if (g_d3d11Device)
+	{
+		return true;
+	}
+
+	D3D_FEATURE_LEVEL featureLevels[] = {
+		D3D_FEATURE_LEVEL_11_1,
+		D3D_FEATURE_LEVEL_11_0,
+	};
+
+	HRESULT hr = D3D11CreateDevice(
+		nullptr,
+		D3D_DRIVER_TYPE_HARDWARE,
+		nullptr,
+		D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+		featureLevels,
+		ARRAYSIZE(featureLevels),
+		D3D11_SDK_VERSION,
+		&g_d3d11Device,
+		nullptr,
+		&g_d3d11Context
+	);
+
+	if (FAILED(hr))
+	{
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC stagingDesc = {};
+	stagingDesc.Width = width;
+	stagingDesc.Height = height;
+	stagingDesc.MipLevels = 1;
+	stagingDesc.ArraySize = 1;
+	stagingDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	stagingDesc.SampleDesc.Count = 1;
+	stagingDesc.Usage = D3D11_USAGE_DYNAMIC;
+	stagingDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+	hr = g_d3d11Device->CreateTexture2D(&stagingDesc, nullptr, &g_d3d11StagingTexture);
+	if (FAILED(hr))
+	{
+		g_d3d11Context->Release();
+		g_d3d11Device->Release();
+		g_d3d11Context = nullptr;
+		g_d3d11Device = nullptr;
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC sharedDesc = {};
+	sharedDesc.Width = width;
+	sharedDesc.Height = height;
+	sharedDesc.MipLevels = 1;
+	sharedDesc.ArraySize = 1;
+	sharedDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	sharedDesc.SampleDesc.Count = 1;
+	sharedDesc.Usage = D3D11_USAGE_DEFAULT;
+	sharedDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+	sharedDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+
+	hr = g_d3d11Device->CreateTexture2D(&sharedDesc, nullptr, &g_d3d11SharedTexture);
+	if (FAILED(hr))
+	{
+		g_d3d11StagingTexture->Release();
+		g_d3d11Context->Release();
+		g_d3d11Device->Release();
+		g_d3d11StagingTexture = nullptr;
+		g_d3d11Context = nullptr;
+		g_d3d11Device = nullptr;
+		return false;
+	}
+
+	IDXGIResource* dxgiResource = nullptr;
+	hr = g_d3d11SharedTexture->QueryInterface(__uuidof(IDXGIResource), (void**)&dxgiResource);
+	if (SUCCEEDED(hr))
+	{
+		hr = dxgiResource->GetSharedHandle(&g_d3d11SharedHandle);
+		dxgiResource->Release();
+		
+		if (SUCCEEDED(hr))
+		{
+			return true;
+		}
+	}
+
+	g_d3d11SharedTexture->Release();
+	g_d3d11StagingTexture->Release();
+	g_d3d11Context->Release();
+	g_d3d11Device->Release();
+	g_d3d11SharedTexture = nullptr;
+	g_d3d11StagingTexture = nullptr;
+	g_d3d11Context = nullptr;
+	g_d3d11Device = nullptr;
+	return false;
+}
+
+static void CaptureFrame_D3D12(void* backbuffer, int width, int height)
+{
+	static int frameCount = 0;
+	frameCount++;
+	
+	if (!IsOnRenderThread() || width <= 0 || height <= 0 || !backbuffer)
+	{
+		return;
+	}
+
+	// Capture only once per second
+	static auto lastCaptureTime = std::chrono::steady_clock::now();
+	auto currentTime = std::chrono::steady_clock::now();
+	auto elapsedSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - lastCaptureTime).count() / 1000.0;
+	
+	if (elapsedSeconds < 1.0)
+	{
+		return;
+	}
+	
+	lastCaptureTime = currentTime;
+
+	if (!g_commandQueuePtr || !*g_commandQueuePtr)
+	{
+		return;
+	}
+	
+	ID3D12CommandQueue* commandQueue = *g_commandQueuePtr;
+	ID3D12Device* device = (ID3D12Device*)GetGraphicsDriverHandle();
+	
+	if (!device || !commandQueue)
+	{
+		return;
+	}
+
+	// Recreate D3D12 staging buffer and D3D11 textures on resolution change
+	if (g_lastWidth != width || g_lastHeight != height)
+	{
+		if (g_d3d12StagingBuffer)
+		{
+			g_d3d12StagingBuffer->Release();
+			g_d3d12StagingBuffer = nullptr;
+		}
+		
+		D3D12_RESOURCE_DESC textureDesc = {};
+		textureDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		textureDesc.Width = width;
+		textureDesc.Height = height;
+		textureDesc.DepthOrArraySize = 1;
+		textureDesc.MipLevels = 1;
+		textureDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		textureDesc.SampleDesc.Count = 1;
+		textureDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+
+		UINT64 bufferSize;
+		device->GetCopyableFootprints(&textureDesc, 0, 1, 0, nullptr, nullptr, nullptr, &bufferSize);
+		
+		D3D12_RESOURCE_DESC bufferDesc = {};
+		bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+		bufferDesc.Width = bufferSize;
+		bufferDesc.Height = 1;
+		bufferDesc.DepthOrArraySize = 1;
+		bufferDesc.MipLevels = 1;
+		bufferDesc.Format = DXGI_FORMAT_UNKNOWN;
+		bufferDesc.SampleDesc.Count = 1;
+		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+		D3D12_HEAP_PROPERTIES heapProps = {};
+		heapProps.Type = D3D12_HEAP_TYPE_READBACK;
+		
+		HRESULT hr = device->CreateCommittedResource(
+			&heapProps,
+			D3D12_HEAP_FLAG_NONE,
+			&bufferDesc,
+			D3D12_RESOURCE_STATE_COPY_DEST,
+			nullptr,
+			IID_PPV_ARGS(&g_d3d12StagingBuffer)
+		);
+
+		if (FAILED(hr) || !InitializeD3D11Device(width, height))
+		{
+			return;
+		}
+
+		g_lastWidth = width;
+		g_lastHeight = height;
+	}
+
+	// Initialize command queue and fence
+	if (!g_captureCommandQueue)
+	{
+		HRESULT hr = commandQueue->GetDevice(__uuidof(ID3D12Device), (void**)&device);
+		if (SUCCEEDED(hr) && device)
+		{
+			D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+			queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+			queueDesc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
+			queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+			queueDesc.NodeMask = 0;
+			
+			hr = device->CreateCommandQueue(&queueDesc, __uuidof(ID3D12CommandQueue), (void**)&g_captureCommandQueue);
+			if (FAILED(hr))
+			{
+				device->Release();
+				return;
+			}
+			
+			hr = device->CreateFence(0, D3D12_FENCE_FLAG_NONE, __uuidof(ID3D12Fence), (void**)&g_fence);
+			if (FAILED(hr))
+			{
+				g_captureCommandQueue->Release();
+				g_captureCommandQueue = nullptr;
+				device->Release();
+				return;
+			}
+			
+			g_fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+			if (!g_fenceEvent)
+			{
+				g_fence->Release();
+				g_fence = nullptr;
+				g_captureCommandQueue->Release();
+				g_captureCommandQueue = nullptr;
+			}
+			
+			device->Release();
+		}
+	}
+
+	if (!g_captureCommandQueue || !g_fence || !g_fenceEvent)
+	{
+		return;
+	}
+
+	// Extract backbuffer resource
+	uint8_t* innerStruct = *reinterpret_cast<uint8_t**>(reinterpret_cast<uint8_t*>(backbuffer) + 0x08);
+	if (!innerStruct)
+	{
+		return;
+	}
+
+	uint8_t unk0x10 = *(innerStruct + 0x10);
+	uint16_t unk0x0C = *reinterpret_cast<uint16_t*>(innerStruct + 0x0C);
+	
+	ID3D12Resource* backbufferResource = ((unk0x10 & 7) != 0 || (unk0x0C & 0xF000) != 0xC000)
+		? *reinterpret_cast<ID3D12Resource**>(innerStruct + 0x20)
+		: *reinterpret_cast<ID3D12Resource**>(innerStruct + 0x48);
+
+	if (!backbufferResource)
+	{
+		return;
+	}
+
+	ID3D12CommandAllocator* frameAllocator = nullptr;
+	ID3D12GraphicsCommandList* frameCommandList = nullptr;
+	
+	HRESULT hr = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, __uuidof(ID3D12CommandAllocator), (void**)&frameAllocator);
+	if (FAILED(hr) || !frameAllocator)
+	{
+		return;
+	}
+	
+	hr = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, frameAllocator, nullptr, __uuidof(ID3D12GraphicsCommandList), (void**)&frameCommandList);
+	if (FAILED(hr) || !frameCommandList)
+	{
+		frameAllocator->Release();
+		return;
+	}
+
+	// Copy backbuffer to staging buffer
+	D3D12_TEXTURE_COPY_LOCATION srcLocation = {};
+	srcLocation.pResource = backbufferResource;
+	srcLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+	srcLocation.SubresourceIndex = 0;
+
+	D3D12_TEXTURE_COPY_LOCATION dstLocation = {};
+	dstLocation.pResource = g_d3d12StagingBuffer;
+	dstLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+	dstLocation.PlacedFootprint.Footprint.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	dstLocation.PlacedFootprint.Footprint.Width = width;
+	dstLocation.PlacedFootprint.Footprint.Height = height;
+	dstLocation.PlacedFootprint.Footprint.Depth = 1;
+	dstLocation.PlacedFootprint.Footprint.RowPitch = width * 4;
+
+	frameCommandList->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, nullptr);
+
+	hr = frameCommandList->Close();
+	if (FAILED(hr))
+	{
+		frameCommandList->Release();
+		frameAllocator->Release();
+		return;
+	}
+
+	// Execute and wait for GPU
+	ID3D12CommandList* commandLists[] = { frameCommandList };
+	g_captureCommandQueue->ExecuteCommandLists(1, commandLists);
+	
+	g_fenceValue++;
+	hr = g_captureCommandQueue->Signal(g_fence, g_fenceValue);
+	if (FAILED(hr))
+	{
+		frameCommandList->Release();
+		frameAllocator->Release();
+		return;
+	}
+
+	hr = g_fence->SetEventOnCompletion(g_fenceValue, g_fenceEvent);
+	if (FAILED(hr))
+	{
+		frameCommandList->Release();
+		frameAllocator->Release();
+		return;
+	}
+
+	if (WaitForSingleObject(g_fenceEvent, 1000) != WAIT_OBJECT_0)
+	{
+		frameCommandList->Release();
+		frameAllocator->Release();
+		return;
+	}
+
+	// Read D3D12 buffer and transfer to D3D11 shared texture
+	void* mappedData = nullptr;
+	D3D12_RANGE readRange = { 0, static_cast<SIZE_T>(width * height * 4) };
+	hr = g_d3d12StagingBuffer->Map(0, &readRange, &mappedData);
+	
+	if (SUCCEEDED(hr))
+	{
+		D3D11_MAPPED_SUBRESOURCE d3d11Mapped = {};
+		hr = g_d3d11Context->Map(g_d3d11StagingTexture, 0, D3D11_MAP_WRITE_DISCARD, 0, &d3d11Mapped);
+		
+		if (SUCCEEDED(hr))
+		{
+			uint8_t* srcData = static_cast<uint8_t*>(mappedData);
+			uint8_t* dstData = static_cast<uint8_t*>(d3d11Mapped.pData);
+			
+			// Copy with vertical flip (DirectX coordinates are inverted)
+			for (int y = 0; y < height; ++y)
+			{
+				uint8_t* srcRow = srcData + ((height - 1 - y) * width * 4);
+				memcpy(dstData, srcRow, width * 4);
+				dstData += d3d11Mapped.RowPitch;
+			}
+
+			g_d3d11Context->Unmap(g_d3d11StagingTexture, 0);
+			g_d3d11Context->CopyResource(g_d3d11SharedTexture, g_d3d11StagingTexture);
+
+			// Update shared memory for NUI
+			g_renderData->handle = g_d3d11SharedHandle;
+			g_renderData->width = width;
+			g_renderData->height = height;
+			g_renderData->requested = false;
+		}
+		
+		D3D12_RANGE writtenRange = { 0, 0 };
+		g_d3d12StagingBuffer->Unmap(0, &writtenRange);
+	}
+	
+	// Clean up frame resources
+	frameCommandList->Release();
+	frameAllocator->Release();
+}
+
+static uint32_t FindVulkanMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
+{
+	VkPhysicalDeviceMemoryProperties memProperties;
+	vkGetPhysicalDeviceMemoryProperties(g_vkPhysicalDevice, &memProperties);
+
+	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++)
+	{
+		if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+		{
+			return i;
+		}
+	}
+
+	trace("^1[Vulkan Frame Capture] Failed to find suitable memory type!\n");
+	return 0;
+}
+
+static bool InitializeVulkanCaptureResources(int width, int height)
+{
+	if (!g_vkDevice || g_vkDevice == VK_NULL_HANDLE)
+	{
+		return false;
+	}
+
+	if (!g_vkPhysicalDevice || g_vkPhysicalDevice == VK_NULL_HANDLE)
+	{
+		return false;
+	}
+
+	if (!g_vkGraphicsQueue || g_vkGraphicsQueue == VK_NULL_HANDLE)
+	{
+		return false;
+	}
+
+	if (g_vkCommandPool == VK_NULL_HANDLE)
+	{
+		VkCommandPoolCreateInfo poolInfo = {};
+		poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		poolInfo.queueFamilyIndex = g_vkGraphicsQueueFamily;
+		poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+		VkResult result = vkCreateCommandPool(g_vkDevice, &poolInfo, nullptr, &g_vkCommandPool);
+		if (result != VK_SUCCESS || g_vkCommandPool == VK_NULL_HANDLE)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to create command pool: %d\n", result);
+			return false;
+		}
+	}
+
+	if (g_vkIntermediateImage == VK_NULL_HANDLE || g_vkIntermediateImageWidth != width || g_vkIntermediateImageHeight != height)
+	{
+		if (g_vkIntermediateImage != VK_NULL_HANDLE)
+		{
+			vkDestroyImage(g_vkDevice, g_vkIntermediateImage, nullptr);
+			g_vkIntermediateImage = VK_NULL_HANDLE;
+		}
+		if (g_vkIntermediateImageMemory != VK_NULL_HANDLE)
+		{
+			vkFreeMemory(g_vkDevice, g_vkIntermediateImageMemory, nullptr);
+			g_vkIntermediateImageMemory = VK_NULL_HANDLE;
+		}
+
+		VkImageCreateInfo imageInfo = {};
+		imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imageInfo.imageType = VK_IMAGE_TYPE_2D;
+		imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+		imageInfo.extent.width = width;
+		imageInfo.extent.height = height;
+		imageInfo.extent.depth = 1;
+		imageInfo.mipLevels = 1;
+		imageInfo.arrayLayers = 1;
+		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		imageInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+		VkResult result = vkCreateImage(g_vkDevice, &imageInfo, nullptr, &g_vkIntermediateImage);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to create intermediate image: %d\n", result);
+			return false;
+		}
+
+		VkMemoryRequirements memReq;
+		vkGetImageMemoryRequirements(g_vkDevice, g_vkIntermediateImage, &memReq);
+
+		VkMemoryAllocateInfo allocInfo = {};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memReq.size;
+		allocInfo.memoryTypeIndex = FindVulkanMemoryType(memReq.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+		result = vkAllocateMemory(g_vkDevice, &allocInfo, nullptr, &g_vkIntermediateImageMemory);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to allocate intermediate image memory: %d\n", result);
+			vkDestroyImage(g_vkDevice, g_vkIntermediateImage, nullptr);
+			g_vkIntermediateImage = VK_NULL_HANDLE;
+			return false;
+		}
+
+		result = vkBindImageMemory(g_vkDevice, g_vkIntermediateImage, g_vkIntermediateImageMemory, 0);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to bind intermediate image memory: %d\n", result);
+			return false;
+		}
+
+		g_vkIntermediateImageWidth = width;
+		g_vkIntermediateImageHeight = height;
+	}
+
+	int requiredBufferSize = width * height * 4;
+	if (g_vkStagingBuffer == VK_NULL_HANDLE || g_vkStagingBufferSize < requiredBufferSize)
+	{
+		if (g_vkStagingBuffer != VK_NULL_HANDLE)
+		{
+			vkDestroyBuffer(g_vkDevice, g_vkStagingBuffer, nullptr);
+			g_vkStagingBuffer = VK_NULL_HANDLE;
+		}
+		if (g_vkStagingBufferMemory != VK_NULL_HANDLE)
+		{
+			vkFreeMemory(g_vkDevice, g_vkStagingBufferMemory, nullptr);
+			g_vkStagingBufferMemory = VK_NULL_HANDLE;
+		}
+
+		VkBufferCreateInfo bufferInfo = {};
+		bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+		bufferInfo.size = requiredBufferSize;
+		bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+		bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+		auto result = vkCreateBuffer(g_vkDevice, &bufferInfo, nullptr, &g_vkStagingBuffer);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to create staging buffer: %d\n", result);
+			return false;
+		}
+
+		VkMemoryRequirements memReq;
+		vkGetBufferMemoryRequirements(g_vkDevice, g_vkStagingBuffer, &memReq);
+
+		VkMemoryAllocateInfo allocInfo = {};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memReq.size;
+		allocInfo.memoryTypeIndex = FindVulkanMemoryType(memReq.memoryTypeBits, 
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+		result = vkAllocateMemory(g_vkDevice, &allocInfo, nullptr, &g_vkStagingBufferMemory);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to allocate staging buffer memory: %d\n", result);
+			vkDestroyBuffer(g_vkDevice, g_vkStagingBuffer, nullptr);
+			g_vkStagingBuffer = VK_NULL_HANDLE;
+			return false;
+		}
+
+		result = vkBindBufferMemory(g_vkDevice, g_vkStagingBuffer, g_vkStagingBufferMemory, 0);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to bind staging buffer memory: %d\n", result);
+			return false;
+		}
+
+		g_vkStagingBufferSize = requiredBufferSize;
+	}
+
+	if (g_vkCopyFence == VK_NULL_HANDLE)
+	{
+		VkFenceCreateInfo fenceInfo = {};
+		fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+		fenceInfo.flags = 0;
+
+		auto result = vkCreateFence(g_vkDevice, &fenceInfo, nullptr, &g_vkCopyFence);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to create fence: %d\n", result);
+			return false;
+		}
+	}
+
+	if (g_vkReusableCommandBuffer == VK_NULL_HANDLE)
+	{
+		VkCommandBufferAllocateInfo allocInfo = {};
+		allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		allocInfo.commandPool = g_vkCommandPool;
+		allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		allocInfo.commandBufferCount = 1;
+
+		auto result = vkAllocateCommandBuffers(g_vkDevice, &allocInfo, &g_vkReusableCommandBuffer);
+		if (result != VK_SUCCESS)
+		{
+			trace("^1[Vulkan Frame Capture] Failed to allocate reusable command buffer: %d\n", result);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void TransferVulkanDataToD3D11(uint8_t* vulkanPixels, int width, int height)
+{
+	if (!g_d3d11Device)
+	{
+		if (!InitializeD3D11Device(width, height))
+		{
+			return;
+		}
+	}
+	else
+	{
+		D3D11_TEXTURE2D_DESC desc;
+		g_d3d11StagingTexture->GetDesc(&desc);
+		
+		if (desc.Width != width || desc.Height != height)
+		{
+			if (g_d3d11SharedHandle)
+			{
+				g_d3d11SharedHandle = nullptr;
+			}
+			if (g_d3d11SharedTexture)
+			{
+				g_d3d11SharedTexture->Release();
+				g_d3d11SharedTexture = nullptr;
+			}
+			if (g_d3d11StagingTexture)
+			{
+				g_d3d11StagingTexture->Release();
+				g_d3d11StagingTexture = nullptr;
+			}
+			
+			D3D11_TEXTURE2D_DESC stagingDesc = {};
+			stagingDesc.Width = width;
+			stagingDesc.Height = height;
+			stagingDesc.MipLevels = 1;
+			stagingDesc.ArraySize = 1;
+			stagingDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+			stagingDesc.SampleDesc.Count = 1;
+			stagingDesc.Usage = D3D11_USAGE_DYNAMIC;
+			stagingDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+			stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+			HRESULT hr = g_d3d11Device->CreateTexture2D(&stagingDesc, nullptr, &g_d3d11StagingTexture);
+			if (FAILED(hr))
+			{
+				return;
+			}
+
+			D3D11_TEXTURE2D_DESC sharedDesc = {};
+			sharedDesc.Width = width;
+			sharedDesc.Height = height;
+			sharedDesc.MipLevels = 1;
+			sharedDesc.ArraySize = 1;
+			sharedDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+			sharedDesc.SampleDesc.Count = 1;
+			sharedDesc.Usage = D3D11_USAGE_DEFAULT;
+			sharedDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+			sharedDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+
+			hr = g_d3d11Device->CreateTexture2D(&sharedDesc, nullptr, &g_d3d11SharedTexture);
+			if (FAILED(hr))
+			{
+				g_d3d11StagingTexture->Release();
+				g_d3d11StagingTexture = nullptr;
+				return;
+			}
+
+			IDXGIResource* dxgiResource = nullptr;
+			hr = g_d3d11SharedTexture->QueryInterface(__uuidof(IDXGIResource), (void**)&dxgiResource);
+			if (SUCCEEDED(hr))
+			{
+				hr = dxgiResource->GetSharedHandle(&g_d3d11SharedHandle);
+				dxgiResource->Release();
+			}
+		}
+	}
+
+	D3D11_MAPPED_SUBRESOURCE mapped;
+	HRESULT hr = g_d3d11Context->Map(g_d3d11StagingTexture, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+	if (FAILED(hr))
+	{
+		return;
+	}
+
+	uint8_t* dst = (uint8_t*)mapped.pData;
+	for (int y = 0; y < height; y++)
+	{
+		int srcY = height - 1 - y;
+		memcpy(dst + y * mapped.RowPitch, 
+		       vulkanPixels + srcY * width * 4, 
+		       width * 4);
+	}
+
+	g_d3d11Context->Unmap(g_d3d11StagingTexture, 0);
+	g_d3d11Context->CopyResource(g_d3d11SharedTexture, g_d3d11StagingTexture);
+
+	auto nuiRenderData = HostSharedData<GameRenderData>("CfxGameRenderHandle");
+	nuiRenderData->handle = g_d3d11SharedHandle;
+	nuiRenderData->width = width;
+	nuiRenderData->height = height;
+}
+
+GFX_EXPORT void CaptureVulkanSwapchainImage(void* swapchainPtr, uint32_t imageIndex, int width, int height)
+{
+	VkSwapchainKHR swapchain = (VkSwapchainKHR)swapchainPtr;
+	
+	if (!g_vkCommandPool)
+	{
+		if (!InitializeVulkanCaptureResources(width, height))
+		{
+			return;
+		}
+	}
+
+	// Check if previous copy finished
+	if (g_vkCopyInProgress)
+	{
+		VkResult fenceStatus = vkGetFenceStatus(g_vkDevice, g_vkCopyFence);
+		if (fenceStatus == VK_SUCCESS)
+		{
+			void* mappedData = nullptr;
+			VkResult result = vkMapMemory(g_vkDevice, g_vkStagingBufferMemory, 0, g_vkStagingBufferSize, 0, &mappedData);
+			if (result == VK_SUCCESS)
+			{
+				TransferVulkanDataToD3D11((uint8_t*)mappedData, width, height);
+				vkUnmapMemory(g_vkDevice, g_vkStagingBufferMemory);
+			}
+			
+			g_vkCopyInProgress = false;
+			vkResetFences(g_vkDevice, 1, &g_vkCopyFence);
+		}
+	}
+	
+	// Capture only once per second
+	static auto lastCaptureTime = std::chrono::steady_clock::now();
+	auto currentTime = std::chrono::steady_clock::now();
+	auto elapsedSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - lastCaptureTime).count() / 1000.0;
+	
+	if (elapsedSeconds < 1.0)
+	{
+		return;
+	}
+	
+	// If copy is in progress, skip
+	if (g_vkCopyInProgress)
+	{
+		return;
+	}
+	
+	lastCaptureTime = currentTime;
+
+	// Cache swapchain images
+	if (g_cachedSwapchain != swapchain)
+	{
+		uint32_t imageCount = 0;
+		VkResult result = vkGetSwapchainImagesKHR(g_vkDevice, swapchain, &imageCount, nullptr);
+		if (result != VK_SUCCESS || imageCount == 0)
+		{
+			return;
+		}
+
+		g_cachedSwapchainImages.resize(imageCount);
+		result = vkGetSwapchainImagesKHR(g_vkDevice, swapchain, &imageCount, g_cachedSwapchainImages.data());
+		if (result != VK_SUCCESS)
+		{
+			return;
+		}
+		
+		g_cachedSwapchain = swapchain;
+	}
+
+	if (imageIndex >= g_cachedSwapchainImages.size())
+	{
+		return;
+	}
+
+	VkImage swapchainImage = g_cachedSwapchainImages[imageIndex];
+
+	// Reset and reuse command buffer instead of allocating new one
+	VkCommandBuffer cmdBuffer = g_vkReusableCommandBuffer;
+	
+	VkResult result = vkResetCommandBuffer(cmdBuffer, 0);
+	if (result != VK_SUCCESS)
+	{
+		return;
+	}
+
+	VkCommandBufferBeginInfo beginInfo = {};
+	beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+	beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+	result = vkBeginCommandBuffer(cmdBuffer, &beginInfo);
+	if (result != VK_SUCCESS)
+	{
+		return;
+	}
+
+	// Transition intermediate image to TRANSFER_DST
+	VkImageMemoryBarrier intermediateBarrier = {};
+	intermediateBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+	intermediateBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	intermediateBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+	intermediateBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	intermediateBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	intermediateBarrier.image = g_vkIntermediateImage;
+	intermediateBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	intermediateBarrier.subresourceRange.baseMipLevel = 0;
+	intermediateBarrier.subresourceRange.levelCount = 1;
+	intermediateBarrier.subresourceRange.baseArrayLayer = 0;
+	intermediateBarrier.subresourceRange.layerCount = 1;
+	intermediateBarrier.srcAccessMask = 0;
+	intermediateBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+	vkCmdPipelineBarrier(
+		cmdBuffer,
+		VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		0,
+		0, nullptr,
+		0, nullptr,
+		1, &intermediateBarrier
+	);
+
+	// Transition swapchain to TRANSFER_SRC
+	VkImageMemoryBarrier swapchainBarrier = {};
+	swapchainBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+	swapchainBarrier.oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+	swapchainBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+	swapchainBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	swapchainBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	swapchainBarrier.image = swapchainImage;
+	swapchainBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	swapchainBarrier.subresourceRange.baseMipLevel = 0;
+	swapchainBarrier.subresourceRange.levelCount = 1;
+	swapchainBarrier.subresourceRange.baseArrayLayer = 0;
+	swapchainBarrier.subresourceRange.layerCount = 1;
+	swapchainBarrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+	swapchainBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+
+	vkCmdPipelineBarrier(
+		cmdBuffer,
+		VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		0,
+		0, nullptr,
+		0, nullptr,
+		1, &swapchainBarrier
+	);
+
+	// Copy swapchain → intermediate
+	VkImageCopy copyRegion = {};
+	copyRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	copyRegion.srcSubresource.mipLevel = 0;
+	copyRegion.srcSubresource.baseArrayLayer = 0;
+	copyRegion.srcSubresource.layerCount = 1;
+	copyRegion.srcOffset = {0, 0, 0};
+	copyRegion.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	copyRegion.dstSubresource.mipLevel = 0;
+	copyRegion.dstSubresource.baseArrayLayer = 0;
+	copyRegion.dstSubresource.layerCount = 1;
+	copyRegion.dstOffset = {0, 0, 0};
+	copyRegion.extent = {(uint32_t)width, (uint32_t)height, 1};
+
+	vkCmdCopyImage(
+		cmdBuffer,
+		swapchainImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		g_vkIntermediateImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		1, &copyRegion
+	);
+
+	// Restore swapchain to PRESENT_SRC
+	swapchainBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+	swapchainBarrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+	swapchainBarrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+	swapchainBarrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+
+	vkCmdPipelineBarrier(
+		cmdBuffer,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+		0,
+		0, nullptr,
+		0, nullptr,
+		1, &swapchainBarrier
+	);
+
+	// Transition intermediate to TRANSFER_SRC
+	intermediateBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+	intermediateBarrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+	intermediateBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+	intermediateBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+
+	vkCmdPipelineBarrier(
+		cmdBuffer,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		0,
+		0, nullptr,
+		0, nullptr,
+		1, &intermediateBarrier
+	);
+
+	// Copy image → staging buffer
+	VkBufferImageCopy bufferCopyRegion = {};
+	bufferCopyRegion.bufferOffset = 0;
+	bufferCopyRegion.bufferRowLength = 0;
+	bufferCopyRegion.bufferImageHeight = 0;
+	bufferCopyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	bufferCopyRegion.imageSubresource.mipLevel = 0;
+	bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
+	bufferCopyRegion.imageSubresource.layerCount = 1;
+	bufferCopyRegion.imageOffset = {0, 0, 0};
+	bufferCopyRegion.imageExtent = {(uint32_t)width, (uint32_t)height, 1};
+
+	vkCmdCopyImageToBuffer(
+		cmdBuffer,
+		g_vkIntermediateImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		g_vkStagingBuffer,
+		1, &bufferCopyRegion
+	);
+
+	vkEndCommandBuffer(cmdBuffer);
+
+	VkSubmitInfo submitInfo = {};
+	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	submitInfo.commandBufferCount = 1;
+	submitInfo.pCommandBuffers = &cmdBuffer;
+
+	result = vkQueueSubmit(g_vkGraphicsQueue, 1, &submitInfo, g_vkCopyFence);
+	if (result != VK_SUCCESS)
+	{
+		return;
+	}
+	
+	g_vkCopyInProgress = true;
+}
+
 static void(*origEndDraw)(void*);
 static void WrapEndDraw(void* cxt)
 {
@@ -515,6 +1472,16 @@ static void WrapEndDraw(void* cxt)
 	setRTs(cxt, 1, rt, true);
 	setDSs(cxt, nullptr, 0, 0);
 	(*(void(__fastcall**)(__int64, void*, uint64_t, uint64_t, uint64_t, char, char))(**(uint64_t**)sgaDriver + 0x318))(*(uint64_t*)sgaDriver, cxt, NULL, NULL, NULL, 1, 0);
+
+	// Vulkan capture is handled in RenderHooks.cpp
+	if (rt[0] && GetCurrentGraphicsAPI() == GraphicsAPI::D3D12)
+	{
+		int width, height;
+		GetGameResolution(width, height);
+		
+		CaptureFrame_D3D12(rt[0], width, height);
+	}
+
 	InvokeRender();
 	// end draw
 	(*(void(__fastcall**)(__int64, void*))(**(uint64_t**)sgaDriver + 0x328))(*(uint64_t*)sgaDriver, cxt);
@@ -554,6 +1521,14 @@ GraphicsAPI GetCurrentGraphicsAPI()
 
 void** g_d3d12Device;
 VkDevice* g_vkHandle;
+
+void SetVulkanDeviceHandles(void* device, void* physicalDevice, void* queue, uint32_t queueFamily)
+{
+	g_vkDevice = (VkDevice)device;
+	g_vkPhysicalDevice = (VkPhysicalDevice)physicalDevice;
+	g_vkGraphicsQueue = (VkQueue)queue;
+	g_vkGraphicsQueueFamily = queueFamily;
+}
 
 void* GetGraphicsDriverHandle()
 {
@@ -730,6 +1705,8 @@ static HookFunction hookFunction([]()
 	}
 
 	// #TODORDR: badly force d3d12 sga driver (vulkan crashes on older Windows 10?)
+	g_commandQueuePtr = hook::get_address<ID3D12CommandQueue**>(hook::get_pattern("4C 8D 0D ? ? ? ? 4C 89 65", 3));
+
 	hook::iat("kernel32.dll", GetCommandLineWHook, "GetCommandLineW");
 
 	MH_EnableHook(MH_ALL_HOOKS);


### PR DESCRIPTION
### Goal of this PR
Allow to use the `x-cfx-game-view` in RedM sharing d3d12 & vulkan backbuffers with NUI. Already tested with `screenshot-basic`:

<img width="834" height="470" alt="image" src="https://github.com/user-attachments/assets/a8eabde5-11fc-4fc4-9751-288952bba6c4" />


### How is this PR achieving the goal
Implementing a dual-backend frame capture system that intercepts the game's rendered frames and makes them available to the NUI layer through a shared texture.

For the D3D12 backend, the implementation captures the backbuffer directly using D3D12 copy commands and transfers it to a D3D11 shared texture. The captured frame is exposed via a shared handle that NUI can consume through the `CfxGameRenderHandle` shared data structure.

The Vulkan backend required a more sophisticated approach. The solution hooks `vkQueuePresentKHR` to intercept frames after presentation, then implements a multi-stage async pipeline: swapchain image -> intermediate GPU image -> staging buffer -> D3D11 shared texture -> NUI.


### This PR applies to the following area(s)
RedM


### Successfully tested on
**Game builds:** 1491
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.