### PR TITLE
fix(net): don't call SetWindowText in rdr3

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -360,6 +360,8 @@ void NetLibrary::ProcessOOB(const NetAddress& from, const char* oob, size_t leng
 
 				StripColors(hostname, cleaned, 8192);
 
+				// Setting window text in RDR3's render thread causes the game to hang.
+#ifndef IS_RDR3
 				SetWindowText(CoreGetGameWindow(), va(
 #ifdef GTA_FIVE
 					L"FiveM® by Cfx.re"
@@ -367,6 +369,7 @@ void NetLibrary::ProcessOOB(const NetAddress& from, const char* oob, size_t leng
 					L"RedM® by Cfx.re"
 #endif
 					L" - %s", ToWide(cleaned)));
+#endif
 
 				auto richPresenceSetTemplate = [&](const auto& tpl)
 				{


### PR DESCRIPTION
### Goal of this PR

With the introduction of the new steam integration, the SetWindowText call for infoResponse was re-enabled accidently in RedM. Causing random hanging for certain users/system configurations while the game was loading. This removes the call again for RedM while providing a comment to clarify the reason behind this logic being disabled.

### How is this PR achieving the goal


### This PR applies to the following area(s)

RedM


### Successfully tested on

**Game builds:** RedM

**Platforms:** Windows

### Checklist

Unable to repro locally, but process dump from a user suffering from this issue shows the render thread getting stuck in win32.dll following this call.

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues


