### PR TITLE
fix(imgui): update modifier keys and mouse button keys after consuming the message queue

### DIFF
--- a/code/components/conhost-v2/src/ConsoleHostImpl.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostImpl.cpp
@@ -438,10 +438,6 @@ void OnConsoleFrameDraw(int width, int height, bool usedSharedD3D11)
 		}
 	}
 
-	io.KeyCtrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
-	io.KeyShift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
-	io.KeyAlt = (GetKeyState(VK_MENU) & 0x8000) != 0;
-	io.KeySuper = false;
 
 	if (ImGui::GetPlatformIO().Viewports.Size > 1)
 	{


### PR DESCRIPTION
### Goal of this PR
Fix Ctrl+A sporadically not being usable on RedM and fixes `neteventlog 1` (or other windows that get moved outside of the main viewport) being forced to be permanently dragged even when it shouldn't be.

### How is this PR achieving the goal
We use `GetAsyncKeyState` instead of `GetKeyState`, since [`GetKeyState`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeystate) relies on the message queue, which we [consume before](https://github.com/citizenfx/fivem/blob/c42eaa5d6eaa45219581c90416829d360f7f4543/code/components/conhost-v2/src/ConsoleHostImpl.cpp#L446-L461) this.

~~I'm not sure why this works on FiveM, it might be related to the [OffThreadWindowing](https://github.com/citizenfx/fivem/blob/c42eaa5d6eaa45219581c90416829d360f7f4543/code/components/rage-graphics-five/src/ZOffThreadWindowing.cpp) code that's used~~ That code is practically no-oped.

### This PR applies to the following area(s)
RedM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows 


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


