### PR TITLE
feat(scripting/v8): add better api for doing raw events

### DIFF
--- a/data/shared/citizen/scripting/v8/index.d.ts
+++ b/data/shared/citizen/scripting/v8/index.d.ts
@@ -315,8 +315,10 @@ declare function RegisterNetEvent(eventName: string): void;
   * guarantee that more prefixes will not be added in the future, your logic
   * should take that into consideration.
   * @param eventName - the name to listen for the event
+  * @param callback - the callback to call for the raw event
+  * @param [netSafe=false] - If the event is network safe, by default this will be false.
   */
-declare function addRawEventListener(eventName: string, callback: RawEventCallback): void
+declare function addRawEventListener(eventName: string, callback: RawEventCallback, netSafe: boolean = false): void
 
 /**
   * Declares a function that will be called before any msgpack deserialization
@@ -332,6 +334,21 @@ declare function addRawEventListener(eventName: string, callback: RawEventCallba
   * @param eventName - the name to listen for the event
   */
 declare function addRawEventHandler(eventName: string, callback: RawEventCallback): void
+
+/**
+  * Adds a raw event listener for the specified {@link eventName} and automatically
+  * registers the event to be network safe.
+  *
+  * @param eventName - the event name we should listen to
+  * @param callback - the function that should be called whenever an event is triggered
+  */
+declare function onRawNet(eventName: string, callback: RawEventCallback): void;
+
+/**
+  * Removes the event listener with the specified {@link eventName} and {@link callback}
+  */
+declare function removeRawEventListener(eventName: string, callback: EventCallback): void
+
 /**
   * Sets the maximum amount of listeners all raw events can have.
   *
@@ -342,6 +359,39 @@ declare function addRawEventHandler(eventName: string, callback: RawEventCallbac
   * @param [max=10] the maximum amount of raw events that can be registered, by default this is 10.
   */
 declare function setMaxRawEventListeners(max: number): void
+
+/**
+  * Sends an event across the network to the client/server, if the client/server
+  * hasn't registered the event as network safe it will automatically be dropped.
+  *
+  * WARNING: Raw net emits should only be used with raw net events, like {@link onRawNetEvent}.
+  * Using these on a regular event will return without calling any of the regular event emitters
+  *
+  * NOTE: This is a sequential channel internally, this means that packets will be
+  * sent/received in the same order, which also means that if you send large net
+  * events the client will *have* to wait to receive those events.
+  *
+  * Sending too large of events can cause the client to timeout.
+  *
+  * @param eventName - the event name to trigger under
+  * @param source - on the server this defines the player to send the event to, or `-1` for everyone.
+  * @param data - the data to send to the client/server
+  * @throws this will throw if `data` isn't an instance of Uint8Array
+  */
+declare function emitRawNet(eventName: string, data: Uint8Array): void
+declare function emitRawNet(eventName: string, source: number, data: Uint8Array): void
+
+/**
+  * Sends an event across the local event system that other resources can listen
+  * to.
+  *
+  * WARNING: Raw emits should only be used with raw events, like {@link addRawEventHandler}, and {@link addRawEventListener}.
+  * Using these on a regular event will return without calling any of the regular event emitters
+  *
+  * @param eventName - the event name to trigger under
+  * @param [args=undefined] - the arguments to send
+  */
+declare function emitRaw(eventName: string, data: Uint8Array): void;
 
 /**
   * Adds an event listener for the specified {@link eventName}, and optionally
@@ -437,6 +487,8 @@ declare function TriggerEvent(eventName: string, ...args: any[]): void
   */
 declare function emitNet(eventName: string, ...args: any[]): void
 declare function emitNet(eventName: string, source: number, ...args: any[]): void
+
+
 
 /**
   * NOTE: This function is only available on the client, you should generally use

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -233,22 +233,33 @@ const EXT_LOCALFUNCREF = 11;
 	const rawEmitter = new EventEmitter2();
 	const netSafeEventNames = new Set();
 
-	// Raw events
-	global.addRawEventListener = rawEmitter.on.bind(rawEmitter);
-	global.addRawEventHandler = global.addRawEventListener;
+	// reuse the same logic for raw and regular emitters to keep behavior consistent
+	const registerForHandler = (internalEmitter, name, callback, netSafe) => {
+		RegisterResourceAsEventHandler(name);
 
-	// Raw events configuration
-	global.setMaxRawEventListeners = rawEmitter.setMaxListeners.bind(rawEmitter);
-
-	// Client events
-	global.addEventListener = (name, callback, netSafe = false) => {
 		if (netSafe) {
 			netSafeEventNames.add(name);
 		}
 
-		RegisterResourceAsEventHandler(name);
+		internalEmitter.on(name, callback);
+	}
 
-		emitter.on(name, callback);
+	global.addRawEventListener = (name, callback, netSafe = false) => {
+		registerForHandler(rawEmitter, name, callback, netSafe);
+	}
+
+	// Raw events
+	global.addRawEventHandler = global.addRawEventListener;
+	global.onRawNet = (eventName, callback) => global.addRawEventListener(eventName, callback, true);
+
+	// Raw events configuration
+	global.setMaxRawEventListeners = rawEmitter.setMaxListeners.bind(rawEmitter);
+
+	global.removeRawEventListener = rawEmitter.off.bind(emitter);
+
+	// Client events
+	global.addEventListener = (name, callback, netSafe = false) => {
+		registerForHandler(emitter, name, callback, netSafe);
 	};
 	global.on = global.addEventListener;
 
@@ -276,6 +287,15 @@ const EXT_LOCALFUNCREF = 11;
 		});
 	};
 
+	global.emitRaw = (eventName, data) => {
+		if (!(data instanceof Uint8Array)) {
+			throw new TypeError(`Error emitting event ${name} to ${source}, "data" was not a Uint8Array.`);
+		}
+
+		// @ts-expect-error: `Uint8Array` is treated like a string internally so this is fine.
+		TriggerEventInternal(eventName, data, data.byteLength);
+	}
+
 	global.TriggerEvent = global.emit;
 
 	if (isDuplicityVersion) {
@@ -284,6 +304,15 @@ const EXT_LOCALFUNCREF = 11;
 
 			TriggerClientEventInternal(name, source, dataSerialized, dataSerialized.length);
 		};
+
+		global.emitRawNet = (name, source, data) => {
+			if (!(data instanceof Uint8Array)) {
+				throw new TypeError(`Error emitting event ${name} to ${source}, "data" was not a Uint8Array.`);
+			}
+
+			// @ts-expect-error: `Uint8Array` is treated like a string internally so this is fine.
+			TriggerClientEventInternal(name, source, data, data.byteLength);
+		}
 
 		global.TriggerClientEvent = global.emitNet;
 
@@ -332,6 +361,15 @@ const EXT_LOCALFUNCREF = 11;
 
 			TriggerServerEventInternal(name, dataSerialized, dataSerialized.length);
 		};
+
+		global.emitRawNet = (name, data) => {
+			if (!(data instanceof Uint8Array)) {
+				throw new TypeError(`Error emitting event ${name} to ${source}, "data" was not a Uint8Array.`);
+			}
+
+			// @ts-expect-error: `Uint8Array` is treated like a string internally so this is fine.
+			TriggerServerEventInternal(name, data, data.byteLength);
+		}
 
 		global.TriggerServerEvent = global.emitNet;
 
@@ -487,8 +525,11 @@ const EXT_LOCALFUNCREF = 11;
 			global.source = source;
 
 			if (source.startsWith('net')) {
-				if (emitter.listeners(name).length > 0 && !netSafeEventNames.has(name)) {
-					console.error(`Event ${name} was not safe for net`);
+				if (!netSafeEventNames.has(name)) {
+					// we should only log if we have a listener for this event
+					if (emitter.listeners(name).length !== 0 || rawEmitter.listeners(name).length !== 0) {
+						console.error(`Event ${name} was not safe for net`);
+					}
 
 					global.source = null;
 					return;
@@ -507,7 +548,7 @@ const EXT_LOCALFUNCREF = 11;
 			}
 
 			const listeners = emitter.listeners(name);
-			if (listeners.length == 0) {
+			if (listeners.length === 0) {
 				global.source = null;
 				return;
 			}


### PR DESCRIPTION
### Goal of this PR
Get feature parity for raw emitters and regular emitters

This makes it a lot easier to work with protobufs where the situation arises where we
need a more efficient packing format.

### How is this PR achieving the goal
Adds `onRawNet`, `emitRawNet`, `emitRaw` and `removeRawEventListener`


### This PR applies to the following area(s)
JS


### Successfully tested on
**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


