### PR TITLE
fix(scripting): use `onResourceStop` for exports cache clearing

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -655,7 +655,8 @@ end
 
 -- Remove cache when resource stop to avoid calling unexisting exports
 local function lazyEventHandler() -- lazy initializer so we don't add an event we don't need
-	AddEventHandler(('on%sResourceStop'):format(isDuplicityVersion and 'Server' or 'Client'), function(resource)
+	-- Use onResourceStop to not break cached exports for onResourceStart
+	AddEventHandler('onResourceStop', function(resource)
 		exportsCallbackCache[resource] = {}
 	end)
 

--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -568,7 +568,8 @@ const EXT_LOCALFUNCREF = 11;
 		}
 	});
 
-	on(`on${eventType}ResourceStop`, (resource) => {
+	// clear cache with onResourceStop to not break cached exports for onResourceStart
+	on('onResourceStop', (resource) => {
 		exportsCallbackCache[resource] = {};
 	});
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix exports not working for resources when listening to `onResourceStart` and restarting.

For example, I have a resource `A` that provides an export, and resource `B` that wants to run the export *immediately* when resource `A` starts. This would work at first; the exports cache is still empty, so resource `B` can request the export from resource `A`. However, if I restart resource `A`, resource `B` still has the old export cached, which would now have an invalid function reference, as resource `A` has been stopped, resulting in an error like this:
<img width="1166" height="157" alt="image" src="https://github.com/user-attachments/assets/52a14499-1f40-418b-8dc7-3f8660da2d59" />

### How is this PR achieving the goal

This PR changes the `scheduler.lua` and `main.js` to use `onResourceStop` instead of `onClientResourceStop`/`onServerResourceStop` to clear the cache, to prevent delaying the cache clearing until after `onResourceStart`. C# doesn't seem to cache exports like this, so no changes were made there, as the error does not occur.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

ScRT: Lua, ScRT: JS

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

<!-- ### Fixes issues -->
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
