### PR TITLE
fix(extra-natives-five): add bound box validation to CREATE_DRY_VOLUME

### DIFF
--- a/code/components/extra-natives-five/src/WaterExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/WaterExtraNatives.cpp
@@ -361,9 +361,23 @@ static HookFunction initFunction([]()
 
 	fx::ScriptEngine::RegisterNativeHandler("CREATE_DRY_VOLUME", [=](fx::ScriptContext& context)
 	{
+		float minX = context.GetArgument<float>(0);
+		float minY = context.GetArgument<float>(1);
+		float minZ = context.GetArgument<float>(2);
+		float maxX = context.GetArgument<float>(3);
+		float maxY = context.GetArgument<float>(4);
+		float maxZ = context.GetArgument<float>(5);
+
+		if (maxX < minX || maxY < minY || maxZ < minZ)
+		{
+			trace("Inverted bounding box for dry volume, min coordinates must be less than or equal to max coordinates.\n");
+			context.SetResult<int>(-1);
+			return;
+		}
+
 		auto newVolume = sDepthBound(
-		{ context.GetArgument<float>(0), context.GetArgument<float>(1), context.GetArgument<float>(2), 0.f },
-		{ context.GetArgument<float>(3), context.GetArgument<float>(4), context.GetArgument<float>(5), 0.f });
+			{ minX, minY, minZ, 0.f },
+			{ maxX, maxY, maxZ, 0.f });
 
 		std::vector<sDepthBound>::iterator v = std::find(g_dryAreas.begin(), g_dryAreas.end(), newVolume);
 		if (v != g_dryAreas.end())


### PR DESCRIPTION
currently it lets you create broken dry volumes, leading to incorrect behaviour, we should prevent this

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Validate native arguements
...


### How is this PR achieving the goal
adding validation
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3258, 3095
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


