### PR TITLE
feat(connection): add server blacklist validation during initConnect

### DIFF
--- a/code/components/citizen-server-impl/include/GameServer.h
+++ b/code/components/citizen-server-impl/include/GameServer.h
@@ -254,6 +254,12 @@ namespace fx
 			return m_useAccurateSendsVar->GetValue();
 		}
 
+		inline std::string GetSentinelError()
+		{
+			std::shared_lock<std::shared_mutex> lock(m_sentinelMutex);
+			return m_sentinelError;
+		}
+
 	private:
 		void InitializeSyncUv();
 
@@ -342,6 +348,10 @@ namespace fx
 		std::unique_ptr<CallbackListBase> m_syncThreadCallbacks;
 
 		detached_mpsc_queue<GameServerPacket> m_netSendList;
+
+		std::string m_sentinelError;
+
+		std::shared_mutex m_sentinelMutex;
 	};
 
 	using TPacketTypeHandler = std::function<void(const fx::ClientSharedPtr& client, net::ByteReader& reader, ENetPacketPtr packet)>;

--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -1031,6 +1031,43 @@ namespace fx
 						}
 
 						firstRun = false;
+
+						std::unique_lock<std::shared_mutex> lock(m_sentinelMutex);
+
+						if (m_sentinelError.empty())
+						{
+							try
+							{
+								auto j = nlohmann::json::parse(d, d + s);
+
+								if (j.is_object() && j.contains("lastError"))
+								{
+									m_sentinelError = j["lastError"].get<std::string>();
+								}
+							}
+							catch (...)
+							{
+							}
+						}
+						else
+						{
+							try
+							{
+								auto j = nlohmann::json::parse(d, d + s);
+
+								if (j.is_object() && !j.contains("lastError"))
+								{
+									m_sentinelError = "";
+								}
+								else if (j.is_object() && j.contains("lastError"))
+								{
+									m_sentinelError = j["lastError"].get<std::string>();
+								}
+							}
+							catch (...)
+							{
+							}
+						}
 					});
 				}
 			};

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -545,6 +545,12 @@ static InitFunction initFunction([]()
 				return;
 			}
 
+			if (auto sentinelError = gameServer->GetSentinelError(); !sentinelError.empty())
+			{
+				sendError(sentinelError);
+				return;
+			}
+
 			auto nameIt = postMap.find("name");
 			auto guidIt = postMap.find("guid");
 			auto gameBuildIt = postMap.find("gameBuild");


### PR DESCRIPTION
This PR introduces a validation step in the initConnect flow to check whether the target server is present in a blacklist before completing the connection handshake.