### PR TITLE
fix(resource): prevent duplicate hash parameter in resource URL

### DIFF
--- a/code/components/citizen-resources-client/src/CachedResourceMounter.cpp
+++ b/code/components/citizen-resources-client/src/CachedResourceMounter.cpp
@@ -308,7 +308,7 @@ void CachedResourceMounter::AddResourceEntry(const std::string& resourceName, co
 
 	auto refUrl = remoteUrl;
 	
-	if (refUrl.find("hash=") == std::string::npos)
+	if (refUrl.find("?hash=") == std::string::npos)
 	{
 		refUrl += "?hash=" + referenceHash;
 	}
@@ -408,3 +408,4 @@ static InitFunction initFunction([]()
 		resource->SetComponent(new ResourceCacheEntryList());
 	});
 });
+


### PR DESCRIPTION
### Goal of this PR
This PR prevents the duplication of the `hash` query parameter in resource URLs within `CachedResourceMounter`.

Currently, if a resource URL is serialized with its hash (e.g., during Replay recording) and then re-loaded, `AddResourceEntry` blindly appends the hash again. This results in malformed URLs like:
![hash demonstration](https://image.afterliferp.ca/uploads/2026-01/6a0df53ece749a19f60762ed2f083f18.png)

`https://cache-southside.fiveshield.co/files/SOUTHSIDE_pedmenu/resource.rpf?hash=8bd808a2c18580d08e38f8bf7caaef6e45220a4b?hash=8bd808a2c18580d08e38f8bf7caaef6e45220a4b`

### How is this PR achieving the goal
I have modified the logic in `code/components/citizen-resources-client/src/CachedResourceMounter.cpp` to check if the `hash=` parameter is already present in the `remoteUrl` before appending it.

If `refUrl.find("hash=")` returns a match, the existing hash is preserved and no new parameter is appended. This ensures that the URL remains valid regardless of whether it's a fresh load or a restored state.

### This PR applies to the following area(s)
FiveM, RedM, Client (Resource System)

### Successfully tested on
**Game builds:** 3095 (or whichever build you tested on)

**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
