### PR TITLE
tweak(core/rdr3): patch GET_MAX_NUM_NETWORK_* natives for pool increase

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxObjects.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxObjects.cpp
@@ -28,4 +28,7 @@ static HookFunction hookFunction([]()
 	
 	// Allow registration of script/mission objects up to and past the 60 limit.
 	hook::put<uint32_t>(hook::get_pattern("BB ? ? ? ? EB ? BB ? ? ? ? EB ? BB ? ? ? ? EB ? 8B CF", 1), kDefaultMaxObjects + increaseSize);
+
+	// Patch GET_MAX_NUM_NETWORK_OBJECTS/0xC7BE335216B5EC7C to reflect the increased network object limit.
+	hook::put<uint32_t>(hook::get_pattern("48 8B 01 C7 00 3C 00 00 00", 5), kDefaultMaxObjects + increaseSize);
 });

--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxPed.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxPed.cpp
@@ -55,6 +55,9 @@ static HookFunction hookFunction([]()
 	// Allow registration of script/mission peds up to and past the 110 limit.
 	hook::put<uint32_t>(hook::get_pattern("BB ? ? ? ? E9 ? ? ? ? E8 ? ? ? ? 48 8B 0D", 1), kDefaultMaxPeds + increaseSize);
 
+	// Patch GET_MAX_NUM_NETWORK_PEDS/0xC1F7D49C39D2289 to reflect the increased network ped limit.
+	hook::put<uint32_t>(hook::get_pattern("48 8B 01 C7 00 6E 00 00 00 C3", 5), kDefaultMaxPeds + increaseSize);
+
 	// Resize ped circular buffer to support greater then 160 peds.
 	{
 		// Allocate 270 as:

--- a/code/components/gta-core-rdr3/src/PatchIncreaseMaxVehicles.cpp
+++ b/code/components/gta-core-rdr3/src/PatchIncreaseMaxVehicles.cpp
@@ -72,4 +72,7 @@ static HookFunction hookFunction([]()
 
 	// Ignore hard coded limit of CVehicle to 128
 	hook::put<char>(hook::get_pattern("76 ? BA ? ? ? ? 41 B8 ? ? ? ? 83 C9 ? E8 ? ? ? ? 33 D2 8B CB"), 0xEB);
+
+	// Patch GET_MAX_NUM_NETWORK_VEHICLES/0x0AFCE529F69B21FF to reflect the increased network vehicle limit.
+	hook::put<uint32_t>(hook::get_pattern("48 8B 01 C7 00 28 00 00 00", 5), kDefaultMaxVehicles + increaseSize);
 });


### PR DESCRIPTION
### Goal of this PR

Something that was missed in the initial commits implementing pool increases for ``CNetObjPedBase``, ``CNetObjObject`` and ``CNetObjVehicle`` and brought up by Avarian.

Patches ``GET_MAX_NUM_NETWORK_PEDS``, ``GET_MAX_NUM_NETWORK_OBJECTS`` and ``GET_MAX_NUM_NETWORK_VEHICLES`` in order for them to reflect any increases to their respective network pools rather then always being at the previous hardcoded limited for those pools.

### How is this PR achieving the goal

Patch the underlying native function to have the increaseSize factored in.


### This PR applies to the following area(s)

RedM


### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


