### PR TITLE
tweak(build): use legitimacy C API

### DIFF
--- a/code/client/shared/CfxLegitimacyAPI.h
+++ b/code/client/shared/CfxLegitimacyAPI.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#if defined(_WIN32)
+#if defined(COMPILING_CFX_LEGITIMACY)
+#define CFX_API __declspec(dllexport)
+#else
+#define CFX_API __declspec(dllimport)
+#endif
+#define CFX_CALL __stdcall
+#else
+#define CFX_API
+#define CFX_CALL
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void(CFX_CALL* cfx_auth_callback)(bool success, const char* data, size_t data_length);
+typedef void(CFX_CALL* cfx_steam_ticket_callback)(const char* ticket, size_t ticket_len, const char* response, size_t response_len, void* user_data);
+
+CFX_API void CFX_CALL cfx_discord_authenticate(const char* user_id, const char* code, cfx_auth_callback callback);
+CFX_API void CFX_CALL cfx_discourse_authenticate(const char* client_id, const char* auth_token, cfx_auth_callback callback);
+
+CFX_API bool CFX_CALL cfx_should_process_headers(const char* hostname);
+CFX_API void CFX_CALL cfx_process_headers(char*, char*);
+
+CFX_API void CFX_CALL cfx_steam_init(void);
+CFX_API bool CFX_CALL cfx_steam_is_running(void);
+CFX_API bool CFX_CALL cfx_steam_is_initialized(void);
+CFX_API void CFX_CALL cfx_steam_get_auth_ticket(cfx_steam_ticket_callback callback, bool enforce_auth, void* user_data);
+CFX_API uint64_t CFX_CALL cfx_steam_get_id(void);
+CFX_API const char* CFX_CALL cfx_steam_get_username(void);
+CFX_API void CFX_CALL cfx_steam_set_rich_presence(const char* key, const char* value);
+CFX_API void CFX_CALL cfx_steam_reset_rich_presence(void);
+CFX_API bool CFX_CALL cfx_steam_set_app_id(int legacy);
+CFX_API void CFX_CALL cfx_steam_wait_for_app_switch(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/code/client/shared/SharedLegitimacyAPI.cpp
+++ b/code/client/shared/SharedLegitimacyAPI.cpp
@@ -1,0 +1,97 @@
+#include "SharedLegitimacyAPI.h"
+#include "CfxLegitimacyAPI.h"
+
+namespace cfx::legitimacy
+{
+void AuthenticateDiscord(const char* userId, const char* code, AuthCallback callback)
+{
+	return cfx_discord_authenticate(userId, code, callback);
+}
+void AuthenticateDiscourse(const char* clientId, const char* authToken, AuthCallback callback)
+{
+	return cfx_discourse_authenticate(clientId, authToken, callback);
+}
+
+bool ShouldProcessHeaders(const char* hostname)
+{
+	return cfx_should_process_headers(hostname);
+}
+
+void ProcessHeaders(char* key, char* value)
+{
+	return cfx_process_headers(key, value);
+}
+
+void InitSteamSDKConnection()
+{
+	return cfx_steam_init();
+}
+
+bool IsSteamRunning()
+{
+	return cfx_steam_is_running();
+}
+
+bool IsSteamInitializedWrapper()
+{
+	return cfx_steam_is_initialized();
+}
+
+void GetSteamAuthTicketWrapper(const SteamAuthTicketCallback& callback, bool enforceSteamAuth)
+{
+	auto* fn = new SteamAuthTicketCallback(callback);
+	cfx_steam_get_auth_ticket([](const char* ticket, size_t ticket_len, const char* response, size_t response_len, void* user_data)
+	{
+		auto cb = static_cast<SteamAuthTicketCallback*>(user_data);
+		std::string ticketStr;
+		if (ticket && ticket_len > 0)
+		{
+			ticketStr.assign(ticket, ticket_len);
+		}
+		std::string responseStr;
+		if (response && response_len > 0)
+		{
+			responseStr.assign(response, response_len);
+		}
+		(*cb)(std::make_pair(responseStr, ticketStr));
+		delete cb;
+	},
+	enforceSteamAuth, fn);
+}
+
+uint64_t GetSteamIdAsIntWrapper()
+{
+	return cfx_steam_get_id();
+}
+
+std::string GetSteamUsernameWrapper()
+{
+	std::string result;
+	const char* username = cfx_steam_get_username();
+	if (username)
+	{
+		result = std::string(username);
+	}
+	return result;
+}
+
+void SetSteamRichPresenceWrapper(std::string key, std::string value)
+{
+	return cfx_steam_set_rich_presence(key.c_str(), value.c_str());
+}
+
+void ResetSteamRichPresenceWrapper()
+{
+	return cfx_steam_reset_rich_presence();
+}
+
+bool SetSteamAppId(bool legacy)
+{
+	return cfx_steam_set_app_id(legacy);
+}
+
+void WaitForAppSwitchWrapper()
+{
+	return cfx_steam_wait_for_app_switch();
+}
+}

--- a/code/client/shared/SharedLegitimacyAPI.h
+++ b/code/client/shared/SharedLegitimacyAPI.h
@@ -9,22 +9,22 @@
 namespace cfx::legitimacy
 {
 using AuthCallback = void(bool success, const char* data, size_t length);
-using ProcessHeadersCallback = void(const char*, const char*);
+using SteamAuthTicketCallback = std::function<void(std::pair<std::string, std::string>)>;
 
-void DLL_IMPORT AuthenticateDiscord(const char* userId, const char* code, AuthCallback callback);
-void DLL_IMPORT AuthenticateDiscourse(const char* clientId, const char* authToken, AuthCallback callback);
+void AuthenticateDiscord(const char* userId, const char* code, AuthCallback callback);
+void AuthenticateDiscourse(const char* clientId, const char* authToken, AuthCallback callback);
 
-bool DLL_IMPORT ShouldProcessHeaders(const char* hostname);
-void DLL_IMPORT ProcessHeaders(char*, char*);
+bool ShouldProcessHeaders(const char* hostname);
+void ProcessHeaders(char* key, char* value);
 
-void DLL_IMPORT InitSteamSDKConnection();
-bool DLL_IMPORT IsSteamRunning();
-bool DLL_IMPORT IsSteamInitializedWrapper();
-void DLL_IMPORT GetSteamAuthTicketWrapper(const std::function<void(std::pair<std::string, std::string>)>& callback, bool enforceSteamAuth);
-uint64_t DLL_IMPORT GetSteamIdAsIntWrapper();
-std::string DLL_IMPORT GetSteamUsernameWrapper();
-void DLL_IMPORT SetSteamRichPresenceWrapper(std::string key, std::string value);
-void DLL_IMPORT ResetSteamRichPresenceWrapper();
-bool DLL_IMPORT SetSteamAppId(bool legacy);
-void DLL_IMPORT WaitForAppSwitchWrapper();
+void InitSteamSDKConnection();
+bool IsSteamRunning();
+bool IsSteamInitializedWrapper();
+void GetSteamAuthTicketWrapper(const SteamAuthTicketCallback& callback, bool enforceSteamAuth);
+uint64_t GetSteamIdAsIntWrapper();
+std::string GetSteamUsernameWrapper();
+void SetSteamRichPresenceWrapper(std::string key, std::string value);
+void ResetSteamRichPresenceWrapper();
+bool SetSteamAppId(bool legacy);
+void WaitForAppSwitchWrapper();
 }


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Legitimacy is distributed as a prebuilt library and is not guaranteed to be compatible with the latest MSVC toolsets (e.g., VS2026, or even certain VS2022 toolset versions).

This PR aims to allow the client to be built independently of the Visual Studio version or installed MSVC toolset.


### How is this PR achieving the goal

Implements the SharedLegitimacyAPI C++ interface on top of a C-compatible Legitimacy API.

FiveM developers with access to the Legitimacy source should implement the new C API and provide an updated prebuilt library.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** N/A

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
fixes #3801 

