### PR TITLE
tweak(build): support Visual Studio 2026

### DIFF
--- a/code/tools/ci/psm1/cfxSetupVS.psm1
+++ b/code/tools/ci/psm1/cfxSetupVS.psm1
@@ -14,7 +14,10 @@ function Invoke-CfxSetupVS {
 
     $VSFullVersion = [System.Version]::Parse($VSVersionString)
     
-    if ($VSFullVersion -ge [System.Version]::Parse("17.0")) {
+    if ($VSFullVersion -ge [System.Version]::Parse("18.0")) {
+        $Context.PremakeVSVersion = "vs2026"
+    }
+    elseif ($VSFullVersion -ge [System.Version]::Parse("17.0")) {
         $Context.PremakeVSVersion = "vs2022"
     }
     elseif ($VSFullVersion -ge [System.Version]::Parse("16.0")) {

--- a/code/tools/fxd/gen.ps1
+++ b/code/tools/fxd/gen.ps1
@@ -23,7 +23,9 @@ param(
 )
 
 $VSVersion = [System.Version]::Parse((& "$PSScriptRoot\..\ci\vswhere.exe" -prerelease -latest -property catalog_buildVersion -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64))
-if ($VSVersion -ge [System.Version]::Parse("17.0")) {
+if ($VSVersion -ge [System.Version]::Parse("18.0")) {
+	$VSLine = "vs2026"
+} elseif ($VSVersion -ge [System.Version]::Parse("17.0")) {
 	$VSLine = "vs2022"
 } elseif ($VSVersion -ge [System.Version]::Parse("16.0")) {
 	$VSLine = "vs2019"

--- a/docs/building.md
+++ b/docs/building.md
@@ -4,7 +4,7 @@
 
 To build FiveM, RedM or FXServer on Windows you need the following dependencies:
 
-* [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) (Community edition or higher) including the following:
+* [Visual Studio 2022/2026](https://visualstudio.microsoft.com/downloads/) (Community edition or higher) including the following:
   - Workloads
     - .NET desktop development
     - Desktop development with C++


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Support VisualStudio 2026 builds


### How is this PR achieving the goal

update build scripts that detect vs version

this PR depends on:
https://github.com/citizenfx/fivem/pull/3805
https://github.com/citizenfx/fivem/pull/3804
https://github.com/citizenfx/fivem/pull/3802


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** FiveM

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


