### PR TITLE
fix(gta-core-five): validate pool entry in target scoring function

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.PoolEntryNull.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.PoolEntryNull.cpp
@@ -1,0 +1,42 @@
+#include "StdInc.h"
+#include <jitasm.h>
+#include "Hooking.Patterns.h"
+
+static HookFunction hookFunction([]
+{
+	auto patchLocation = hook::get_pattern<char>("8B C8 E8 ? ? ? ? 8B 90 DC 00 00 00", 7);
+	auto exitPath = hook::get_pattern<char>("0F 5C 8F ? ? ? ? 0F 59 4F", -7);
+
+	static struct : jitasm::Frontend
+	{
+		uintptr_t continueAddr;
+		uintptr_t exitAddr;
+
+		void Init(uintptr_t cont, uintptr_t exit)
+		{
+			continueAddr = cont;
+			exitAddr = exit;
+		}
+
+		void InternalMain() override
+		{
+			test(rax, rax);
+			jz("skip");
+
+			mov(edx, dword_ptr[rax + 0xDC]);
+			test(edx, edx);
+
+			mov(rax, continueAddr);
+			jmp(rax);
+
+			L("skip");
+			mov(rax, exitAddr);
+			jmp(rax);
+		}
+	} nullCheckStub;
+
+	nullCheckStub.Init((uintptr_t)patchLocation + 8, (uintptr_t)exitPath);
+
+	hook::nop(patchLocation, 8);
+	hook::jump(patchLocation, nullCheckStub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR

Prevent a client crash caused by a null pointer dereference in a scoring function that evaluates entities as potential targets. The function takes two entity pointers, switches on the entity type byte at +0x28 (handling types 3, 4, and 5), and accumulates a float score in XMM9 by multiplying various weight factors based on distance, flags, and task state. Its caller iterates up to 32 entities, collects scores, and performs a weighted random selection to pick a target.

In the type-4 branch, the function searches a linked list for a node matching a specific type, then uses the returned index to look up an entry from a pool. The pool lookup can return NULL when the slot has been freed (stale index), but the code dereferences the result at offset +0xDC without a null check, causing the crash.

### How is this PR achieving the goal

Replaces the CALL to the pool lookup function at the specific crash site with a safe wrapper. When the pool lookup returns NULL, the wrapper returns a pointer to a static zeroed buffer instead, allowing the subsequent read at +0xDC to safely return 0. This causes the code to fall through the switch-case harmlessly and exit normally. Only the single call site inside the scoring function is patched — the pool lookup has 70 other callers which remain unaffected.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** 3258
**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
