### PR TITLE
fix(gta-core-five): guard vertex pool pop against stale head pointer …

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.VertexPoolRace.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.VertexPoolRace.cpp
@@ -1,0 +1,58 @@
+#include <StdInc.h>
+
+#include <jitasm.h>
+#include <Hooking.h>
+
+static struct VertexSlotPopFixStub : jitasm::Frontend
+{
+	uintptr_t retryAddr = 0;
+	uintptr_t continueAddr = 0;
+
+	void InternalMain() override
+	{
+		//   48 8B 45 20     MOV RAX, [RBP+20h]
+		//   89 4D B8        MOV [RBP-48h], ECX
+		//   45 8D 43 01     LEA R8D, [R11+1]
+		mov(rax, qword_ptr[rbp + 0x20]);
+		mov(dword_ptr[rbp - 0x48], ecx);
+		lea(r8d, dword_ptr[r11 + 0x1]);
+
+		// Validate RAX before dereference
+		bt(rax, 47);
+		jc("stale_pointer");
+
+		// Safe to dereference: MOV RCX, [RAX]
+		mov(rcx, qword_ptr[rax]);
+
+		mov(rax, continueAddr);
+		jmp(rax);
+
+		// atomic snapshot, same as the original CAS failure path.
+		L("stale_pointer");
+		mov(rax, retryAddr);
+		jmp(rax);
+	}
+} g_vertexSlotPopFixStub;
+
+static HookFunction hookFunction([]()
+{
+	auto callSite = hook::get_pattern<char>("48 8D 4B 30 48 8D 54 24 61 E8 ? ? FF FF");
+	char* popFn = hook::get_call(callSite + 9);
+
+	auto patchPoint = hook::range_pattern((uintptr_t)popFn, (uintptr_t)popFn + 0x100,
+		"48 8B 45 20 89 4D B8 45 8D 43 01 48 8B 08").get_one().get<char>();
+
+	auto cmpAfterCas = hook::range_pattern((uintptr_t)popFn, (uintptr_t)popFn + 0x100,
+		"48 3B 55 E8 0F 85").get_one().get<char>();
+	char* jnzInsn = cmpAfterCas + 4;                          // points to 0F 85
+	int32_t rel32 = *(int32_t*)(jnzInsn + 2);                 // read rel32
+	char* loopTop = jnzInsn + 6 + rel32;
+
+	constexpr size_t kPatchSize = 14;  // 4 instructions, 14 bytes
+
+	g_vertexSlotPopFixStub.retryAddr = (uintptr_t)loopTop;
+	g_vertexSlotPopFixStub.continueAddr = (uintptr_t)(patchPoint + kPatchSize);
+
+	hook::nop(patchPoint, kPatchSize);
+	hook::jump(patchPoint, g_vertexSlotPopFixStub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR

Fix a crash that occurs on servers with many players when multiple peds are being rendered simultaneously.
This is a widely reported crash across many servers and has been the # 1 crash on my server.
<img width="640" height="101" alt="image" src="https://github.com/user-attachments/assets/5507c835-66ce-4700-8431-6dc56a9e6572" />


### How is this PR achieving the goal

The vertex pool uses a lock-free pop with `CMPXCHG16B`. A TOCTOU race allows another thread to pop and reuse a slot before the first thread dereferences the head pointer, causing it to read vertex data instead of a valid next pointer. This results in a non-canonical address dereference.

So I validate the head pointer before the dereference (bit 47 check). If stale, we jump back to the top of the existing CAS retry loop which is matching the original retry-on-failure semantics instead of crashing. 
And I try to pattern scanning with no hardcoded offsets in case future build have another match.

### This PR applies to the following area(s)
FiveM

### Successfully tested on

**Game builds:** v3095, v3258, v3717
**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
GTA5_b3258.exe!sub_1416BEE88 (0x5e), GTA5_b3095.exe!sub_1416A8D60 (0x5e)
[3258 user report in discord](https://discord.com/channels/192358910387159041/1359588015177207808) 
[3095 user report in discord](https://discord.com/channels/192358910387159041/1321123696752070666)
