### PR TITLE
fix(gta-core-five): crmtComposer stack underflow in BlendN child counting

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.CrmtComposerStackUnderflow.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.CrmtComposerStackUnderflow.cpp
@@ -1,0 +1,23 @@
+#include "StdInc.h"
+#include "Hooking.Patterns.h"
+
+static HookFunction hookFunction([]()
+{
+	// crmtComposer::Visit (kNodeBlendN / kNodeMergeN / kNodeAddN case)
+	// Root cause:
+	// The child counting logic uses an incorrect boolean condition:
+	//     if (!child->IsDisabled() || !child->IsSilent())
+	//
+	// This incorrectly counts children that are silent, even though silent
+	// nodes do NOT push a frame onto the composer stack during traversal.
+	//
+	// As a result, the computed 'count' may exceed the actual number of
+	// frames pushed onto m_FrameStack. When PushPair() is later executed,
+	// it assumes at least two frames are available and reads:
+	//     m_FrameStack[m_TopFrame - 1]
+	//
+	// If the stack is imbalanced, m_TopFrame can reach 0, causing an
+	// underflow access (m_FrameStack[-1]).
+	
+	hook::put<char>(hook::get_pattern("74 ? 38 5A ? 75 ? 41 8B 00"), 0x75);
+});


### PR DESCRIPTION
### Goal of this PR
Fix a stack underflow crash in `crmtComposer` that occurs when handling `kNodeBlendN`/`kNodeMergeN`/`kNodeAddN` nodes with specific child configurations.

The crash was caused by incorrect boolean logic when counting active children, which could result in more `PushPair()` calls than actual frames present on the composer stack. This led to an underflow access (`m_FrameStack[-1]`).


### How is this PR achieving the goal
This PR corrects the boolean condition used when counting active children in the BlendN code path.
The original logic used:
```cpp
if (!child->IsDisabled() || !child->IsSilent())
```

This incorrectly counted silent children, even though silent nodes do not push frames onto the stack during traversal.

The fix changes the logic to:
```cpp
if (!child->IsDisabled() && !child->IsSilent())
```

This ensures that only children that actually contribute frames are counted, keeping the internal composer stack balanced and preventing underflow in PushPair().


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** None
**Platforms:** Windows


### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3669 