### PR TITLE
fix(vfs): ensure directory suffix when finding device

### DIFF
--- a/code/components/vfs-impl-server/src/Manager.cpp
+++ b/code/components/vfs-impl-server/src/Manager.cpp
@@ -20,6 +20,17 @@ fwRefContainer<Device> ManagerServer::FindDevice(const std::string& absolutePath
 	std::string absoluteGenericString = std::filesystem::absolute(absolute).generic_string();
 	std::lock_guard<std::recursive_mutex> lock(m_mountMutex);
 
+	// ensure directories have a / suffix
+	// e.g. /usr/local should be matched for /usr/local/
+	if (!absoluteGenericString.empty() && absoluteGenericString.back() != '/')
+	{
+		std::error_code ec;
+		if (std::filesystem::is_directory(absoluteGenericString, ec) && !ec)
+		{
+			absoluteGenericString += '/';
+		}
+	}
+
 	size_t longestPrefixLength = 0;
 	fwRefContainer<Device> foundDevice {nullptr};
 	for (const auto& mount : m_mounts)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Fix an edge case in file system sandboxing permissions, where acting on the current resource's directory without a leading `/` would lead to blocked permissions.

For example, [`project-error/npwd`](https://github.com/project-error/npwd) uses the JS `winston` library for logging, which checks whether the directory to write logs to exists. It does not ensure a `/` suffix, which results in an error:
```
[    c-scripting-node] Filesystem permission check from 'npwd' for permission fs.read on resource 'D:\Servers\Dev\FiveM\qbox-test\resources\[npwd]\npwd' - no device found
[         script:npwd] Error loading script dist/game/server/server.js in resource npwd: Error: Access to this API has been restricted. Use --allow-fs-read to manage permissions.
[         script:npwd] stack:
[         script:npwd] Error: Access to this API has been restricted. Use --allow-fs-read to manage permissions.
[         script:npwd]     at Object.existsSync (node:fs:290:18)
[         script:npwd]     at File._createLogDirIfNotExist (@npwd/dist/game/server/server.js:14755:18)
[         script:npwd]     at new File (@npwd/dist/game/server/server.js:14393:16)
[         script:npwd]     at @npwd/dist/game/server/server.js:49875:5
[    c-scripting-core] Failed to load script dist/game/server/server.js.
```

### How is this PR achieving the goal

In `ManagerServer::FindDevice`, ensure a `/` is appended to the directory path before performing checks on it.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
