### PR TITLE
fix(build/server): remove txAdmin from rev-list check

### DIFF
--- a/code/tools/build/run_postbuild.ps1
+++ b/code/tools/build/run_postbuild.ps1
@@ -138,7 +138,7 @@ if (!$IsServer) {
     Push-Location $WorkDir\ext\system-resources
 
     Push-Location $WorkDir
-    $SRCommit = (git rev-list -1 HEAD ext/txAdmin ext/system-resources/)
+    $SRCommit = (git rev-list -1 HEAD ext/system-resources/)
     Pop-Location
 
     if (!(Test-Path .commit) -or $SRCommit -ne (Get-Content .commit)) {


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

With 9921389966c3e3b1b7a0ab6c169a7d01e4d1fb7d, `ext/txAdmin` was removed. However, it remains in the server's postbuild script, resulting in the following error:

```
5>  fatal: ambiguous argument 'ext/txAdmin': unknown revision or path not in the working tree.
5>  Use '--' to separate paths from revisions, like this:
5>  'git <command> [<revision>...] -- [<file>...]'
```

This can result in some system resources not being copied over in the future.

### How is this PR achieving the goal

Remove `ext/txAdmin` from the postbuild script, as it no longer exists.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
