### PR TITLE
tweak(streaming/five): fetch CNetObjObject damage vtable index

### DIFF
--- a/code/components/gta-streaming-five/src/GameEventHooks.cpp
+++ b/code/components/gta-streaming-five/src/GameEventHooks.cpp
@@ -336,29 +336,9 @@ static HookFunction hookFunction([]()
 	if (xbr::IsGameBuildOrGreater<2060>())
 	{
 		void** cNetObjPhys_vtable = hook::get_address<void**>(hook::get_pattern<unsigned char>("88 44 24 20 E8 ? ? ? ? 33 C9 48 8D 05", 14));
-		int vtableIdx = 0;
-
-		if (xbr::IsGameBuildOrGreater<3258>())
-		{
-			vtableIdx = 137;
-		}
-		else if (xbr::IsGameBuildOrGreater<2802>())
-		{
-			vtableIdx = 136;
-		}
-		else if (xbr::IsGameBuildOrGreater<2545>())
-		{
-			vtableIdx = 130;
-		}
-		else if (xbr::IsGameBuildOrGreater<2189>())
-		{
-			vtableIdx = 128;
-		}
-		else if (xbr::IsGameBuildOrGreater<2060>())
-		{
-			vtableIdx = 127;
-		}
-
+		int vtableIdx = *hook::get_pattern<int>("FF 90 ? ? ? ? B8 ? ? ? ? 84 87", 2) / 8;
+		// sane assertion to make sure the pattern isn't pointing at a different location.
+		assert(vtableIdx > 0 && vtableIdx < 200); 
 		MH_CreateHook(cNetObjPhys_vtable[vtableIdx], OnEntityTakeDmg, (void**)&origOnEntityTakeDmg);
 	}
 


### PR DESCRIPTION
### Goal of this PR

Fixes fall damage not being correctly registered in build 3751, also removing the need to manually check and update the vtable index by fetching it automatically.

### How is this PR achieving the goal

Replaces vtableIdx with a pattern to its usage in >1604 game builds.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on

**Game builds:** 3751, 3258, 2802, 2545, 2189, 2060

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

fixes #3838 