### PR TITLE
feat(graphics/rdr3): various graphics improvements

### DIFF
--- a/code/components/glue/src/ConnectToNative.cpp
+++ b/code/components/glue/src/ConnectToNative.cpp
@@ -1038,7 +1038,6 @@ static InitFunction initFunction([] ()
 		{
 			static bool done = ([]
 			{
-#ifdef GTA_FIVE
 				std::thread([]
 				{
 					UiDone();
@@ -1051,7 +1050,6 @@ static InitFunction initFunction([] ()
 					SetForegroundWindow(hWnd);
 				})
 				.detach();
-#endif
 
 				MarkNuiLoaded();
 

--- a/code/components/rage-graphics-rdr3/component.lua
+++ b/code/components/rage-graphics-rdr3/component.lua
@@ -1,1 +1,13 @@
-includedirs { '../../../vendor/vulkan-headers/include/' }
+includedirs { 
+    '../../../vendor/vulkan-headers/include/',
+    '../rage-graphics-five/include'
+}
+
+return function()
+    filter {}
+
+    files {
+        'components/rage-graphics-five/include/dxerr.h',
+        'components/rage-graphics-five/src/dxerr.cpp'
+    }
+end

--- a/code/components/rage-graphics-rdr3/include/DrawCommands.h
+++ b/code/components/rage-graphics-rdr3/include/DrawCommands.h
@@ -75,6 +75,9 @@ extern GFX_EXPORT GraphicsAPI GetCurrentGraphicsAPI();
 // VK context or D3D12 device
 extern GFX_EXPORT void* GetGraphicsDriverHandle();
 
+// VK physicalDevice
+extern GFX_EXPORT VkPhysicalDevice GetVulkanPhysicalHandle();
+
 namespace rage::sga
 {
 class GFX_EXPORT GraphicsContext

--- a/code/components/rage-graphics-rdr3/include/VulkanHelper.h
+++ b/code/components/rage-graphics-rdr3/include/VulkanHelper.h
@@ -3,6 +3,9 @@
 #if IS_RDR3
 #include <string_view>
 #include <vulkan/vulkan_core.h>
+#include <vulkan/vulkan_win32.h>
+
+#include <DrawCommands.h>
 
 inline std::string_view ResultToString(VkResult result)
 {
@@ -70,6 +73,78 @@ inline std::string_view ResultToString(VkResult result)
 			return "VK_ERROR_INVALID_DEVICE_ADDRESS_EXT A buffer creation failed because the requested address is not available.";
 		default:
 			return std::to_string(static_cast<uint32_t>(result));
+	}
+}
+
+static uint32_t FindMemoryType(VkPhysicalDevice physicalDevice, uint32_t typeFilter, VkMemoryPropertyFlags properties)
+{
+	VkPhysicalDeviceMemoryProperties memProperties;
+	vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProperties);
+
+	for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++)
+	{
+		if ((typeFilter & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & properties) == properties)
+		{
+			return i;
+		}
+	}
+
+	return INT32_MAX;
+}
+
+static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsigned int width, unsigned int height, VkImage& outImage, VkDeviceMemory& outMemory)
+{
+	VkExternalMemoryImageCreateInfo ExternalMemoryImageCreateInfo = { VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO };
+	ExternalMemoryImageCreateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+	VkImageCreateInfo ImageCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+	ImageCreateInfo.pNext = &ExternalMemoryImageCreateInfo;
+	ImageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+	ImageCreateInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
+	ImageCreateInfo.extent = { width, height, 1 };
+	ImageCreateInfo.mipLevels = 1;
+	ImageCreateInfo.arrayLayers = 1;
+	ImageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+	ImageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+	ImageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+	ImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	ImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+	VkResult result;
+	if (result = vkCreateImage(device, &ImageCreateInfo, nullptr, &outImage); result != VK_SUCCESS)
+	{
+		FatalError("Failed to create a Vulkan image. VkResult: %s", ResultToString(result));
+	}
+
+	VkMemoryRequirements MemoryRequirements;
+	vkGetImageMemoryRequirements(device, outImage, &MemoryRequirements);
+
+	VkMemoryDedicatedAllocateInfo MemoryDedicatedAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO };
+	MemoryDedicatedAllocateInfo.image = outImage;
+	VkImportMemoryWin32HandleInfoKHR ImportMemoryWin32HandleInfo = { VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR };
+	ImportMemoryWin32HandleInfo.pNext = &MemoryDedicatedAllocateInfo;
+	ImportMemoryWin32HandleInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+	ImportMemoryWin32HandleInfo.handle = handle;
+	VkMemoryAllocateInfo MemoryAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
+	MemoryAllocateInfo.pNext = &ImportMemoryWin32HandleInfo;
+	MemoryAllocateInfo.allocationSize = MemoryRequirements.size;
+
+	VkPhysicalDeviceMemoryProperties memProps;
+	vkGetPhysicalDeviceMemoryProperties(GetVulkanPhysicalHandle(), &memProps);
+
+	MemoryAllocateInfo.memoryTypeIndex = FindMemoryType(GetVulkanPhysicalHandle(), MemoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	if (MemoryAllocateInfo.memoryTypeIndex == INT32_MAX)
+	{
+		FatalError("Failed to compatible memory type for NUI. This system may not be equipped to run RedM under Vulkan.\n");
+	}
+
+	if (result = vkAllocateMemory(device, &MemoryAllocateInfo, nullptr, &outMemory); result != VK_SUCCESS)
+	{
+		FatalError("Failed to allocate memory for Vulkan. VkResult: %s", ResultToString(result));
+	}
+
+	if (result = vkBindImageMemory(device, outImage, outMemory, 0); result != VK_SUCCESS)
+	{
+		FatalError("Failed to bind Vulkan image memory. VkResult: %s", ResultToString(result));
 	}
 }
 #endif

--- a/code/components/rage-graphics-rdr3/include/grcTexture.h
+++ b/code/components/rage-graphics-rdr3/include/grcTexture.h
@@ -177,7 +177,10 @@ namespace rage
 				uint32_t pad[24];
 			};
 
-			char pad[64];
+			char pad[0x10];
+			uint16_t width;
+			uint16_t height;
+			char pad2[44];
 			ImageData* image;
 		};
 


### PR DESCRIPTION
### Goal of this PR

This PR consists of dozens of small graphics changes combined to fix several issues and improve startup behaviour within RedM.

The core changes in this patch are:
- Improve Vulkan NUI implementation, obtaining correct memoryTypeIndexes for memory allocating. Resolving common "Vulkan failed to allocate" errors users faced on startup.
- Force D3D12 implementation to use the dedicated GPU similar to Vulkan (and matches the behaviour in FiveM with D3D11)
- While the game is stating up, create dummy D3D12 and Vulkan devices similar to FiveM to speed up the UMD for D3D12. However we also do this for Vulkan to provide startup checks to ensure that the system has the vulkan features required by RedM that aren't used/checked by RDR2.
- Block Vulkan from being used if the Vulkan startup checks fails. Falling back to D3D12
- Integrated #3761 into this patch, now informing the game to invalidate pipeline cache on the next launch. This should help prevent infinite ERR_GFX_STATE errors caused by corrupted pipeline cache data.
- Backported "No ShowWindow Early" (Now only showing the window when the NUI/Game is ready to render) and Renderer wait (removing long sleeps with a WaitForSingleObject call) patches from FiveM along side the "UiDone" functionality used to show the game window when mpMenu is ready. 

### How is this PR achieving the goal


### This PR applies to the following area(s)

RedM

### Successfully tested on

Tested on a feature branch given to users having issues with Vulkan.

**Game builds:** 1491

**Platforms:** Windows, 

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://forum.cfx.re/t/redm-fails-during-rockstar-launcher-initialization-vulkan-memory-error-rtx-4060-ti/5383341
https://forum.cfx.re/t/failed-to-allocate-memory-for-vulkan-vkresult-4294967283/5384919/2
https://forum.cfx.re/t/failed-to-allocate-memory-for-vulkan-upon-launching-redm/5374697/4
https://forum.cfx.re/t/failed-to-allocate-memory-for-vulkan-upon-launching-redm/5375052
https://forum.cfx.re/t/getting-failed-to-allocate-memory-for-vulcan-when-using-dx12/5371039/5
https://forum.cfx.re/t/failed-to-allocate-memory-for-vulkan-upon-launching-redm/5375052/2
https://forum.cfx.re/t/have-to-delete-the-data-folder-every-time-i-want-to-play-redm/5378511
https://forum.cfx.re/t/redm-giving-me-a-vulkan-issue/5341791
