### PR TITLE
(DOC) Swap on_key_up and on_key_down in RegisterRawKeymap

### DIFF
--- a/ext/native-decls/RegisterRawKeymap.md
+++ b/ext/native-decls/RegisterRawKeymap.md
@@ -37,5 +37,5 @@ local KEY_E = 69
 local canBeDisabled = false
 
 
-RegisterRawKeymap("our_keymap", on_key_up, on_key_down, KEY_E, canBeDisabled)
+RegisterRawKeymap("our_keymap", on_key_down, on_key_up, KEY_E, canBeDisabled)
 ```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix the RegisterRawKeymap arguments order in the example; the down function is the second argument, not the third: 
`on_key_down` <-> `on_key_up`


### How is this PR achieving the goal
Swap two functions name in the LUA example


### This PR applies to the following area(s)
RedM

### Successfully tested on
It's a documentation example


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues



