### PR TITLE
fix(rdr3/net): fire trail applicability

### DIFF
--- a/code/components/gta-net-five/src/netGameEvent.cpp
+++ b/code/components/gta-net-five/src/netGameEvent.cpp
@@ -1326,6 +1326,7 @@ static HookFunction hookFunction([]()
 	MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 3B 87 ? ? ? ? 75 ? B3")), GetFireApplicability, (void**)&g_origGetFireApplicability);
 #elif IS_RDR3
 	MH_CreateHook(hook::get_pattern("48 8B 0C C1 4C 39 24 0A 75 04 33 C0", -0x3A), GetFireApplicability, (void**)&g_origGetFireApplicability);
+	MH_CreateHook(hook::get_pattern("89 07 E8 ? ? ? ? 8B D8 E8 ? ? ? ? 48 8B F0", -0x48), GetFireApplicability, NULL);
 #endif
 
 #ifdef GTA_FIVE


### PR DESCRIPTION
### Goal of this PR

Fixes fire trails updates not being properly replicated across clients. This should fix fire sync between remote clients and it did from testing with a cl2 client with several weapons that created both fire and ignitable trials.

### How is this PR achieving the goal

Patch other fire applicability function added in 1491. Which is used in ``FIRE_TRAIL_UPDATE_EVENT`` and also ``FIRE_EVENT`` in some cases.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


