### PR TITLE
feat(gta-core-five): Patch maximum imap dependencies

### DIFF
--- a/code/components/gta-core-five/src/PatchMaxImapDependencies.cpp
+++ b/code/components/gta-core-five/src/PatchMaxImapDependencies.cpp
@@ -1,0 +1,31 @@
+#include <StdInc.h>
+#include <Hooking.h>
+#include <CrossBuildRuntime.h>
+
+// By default, the game only allows a YMAP to have 6 YTYP dependencies in the manifest, the ones that come after just get ignored.
+// This can be problematic as for custom YMAPs you're very likely to use assets from more than 6 different YTYPs.
+
+static HookFunction hookFunction([]()
+{
+    auto pattern = hook::pattern("0F B7 41 26 8B EA 48 8B F9 66 83 F8 06");
+    if (!pattern.empty())
+    {
+        auto location = pattern.get_first<unsigned char>(12);
+        hook::put<uint8_t>(location, 0x10);  // 6 -> 16
+    }
+    else
+    {
+        auto pattern2 = hook::pattern("66 83 F8 06 73");
+        if (!pattern2.empty())
+        {
+            auto location = pattern2.get_first<unsigned char>(3);
+            hook::put<uint8_t>(location, 0x10);  // 6 -> 16
+        }
+    }
+    auto allocPattern = hook::pattern("8B 59 18 B9 18 00 00 00 E8");
+    if (!allocPattern.empty())
+    {
+        auto location = allocPattern.get_first<unsigned char>(4);
+        hook::put<uint8_t>(location, 0x40);
+    }
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Allow more freedom when creating custom ymaps
...


### How is this PR achieving the goal
patch the limit from 6 -> 16
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3095, 3258, 3570
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


