### PR TITLE
fix(scripting/v8): handle Proxy objects in msgpack serialization

### DIFF
--- a/data/shared/citizen/scripting/v8/main.js
+++ b/data/shared/citizen/scripting/v8/main.js
@@ -47,7 +47,35 @@ const EXT_LOCALFUNCREF = 11;
 		binarraybuffer: true
 	});
 
-	const pack = data => msgpack.encode(data, { codec });
+	function materialize(value, refs = new WeakMap()) {
+		if (!value || typeof value !== 'object') return value;
+		if (refs.has(value)) return refs.get(value);
+		if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value;
+
+		if (Array.isArray(value)) {
+			const copy = [];
+			refs.set(value, copy);
+			for (let i = 0; i < value.length; i++) copy[i] = materialize(value[i], refs);
+			return copy;
+		}
+
+		const copy = {};
+		refs.set(value, copy);
+		for (const key of Object.keys(value)) copy[key] = materialize(value[key], refs);
+		return copy;
+	}
+
+	const pack = data => {
+		try {
+			return msgpack.encode(data, { codec });
+		} catch (e) {
+			if (e instanceof TypeError) {
+				console.warn('msgpack encode failed, materializing data:', e.message);
+				return msgpack.encode(materialize(data), { codec });
+			}
+			throw e;
+		}
+	};
 	const unpack = data => msgpack.decode(data, { codec });
 
 	// store for use by natives.js


### PR DESCRIPTION
## Goal of this PR
Fix the `TypeError: r.toArray is not a function` crash that occurs when passing Proxy objects to msgpack serialization (e.g. via `emitNet`).

## How is this PR achieving the goal
Adds a `materialize()` fallback in the `pack()` function that deep-clones Proxy objects into plain objects/arrays before encoding. The fallback only triggers on `TypeError`, so there is zero performance impact on the normal path.

1. `pack()` first tries the normal `msgpack.encode`
2. If it throws a `TypeError` (the specific error Proxies cause), it retries with `materialize(data)` which recursively converts Proxies to plain objects
3. `materialize` handles circular references via `WeakMap` and preserves `ArrayBuffer`/`TypedArray`

## This PR applies to the following area(s)
FiveM, RedM (shared V8 scripting runtime)

## Successfully tested on
- `emitNet` with a Proxy object as parameter — serializes without crash
- `emitNet` with plain objects — works as before, no fallback triggered
- Nested Proxy objects — serialize correctly
- `console.warn` is emitted when fallback activates

## Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

## Fixes issues
Fixes #3824