### PR TITLE
fix(nui): use correct queue key for frameCall messages

### DIFF
--- a/code/components/nui-core/src/CefOverlay.cpp
+++ b/code/components/nui-core/src/CefOverlay.cpp
@@ -318,16 +318,8 @@ namespace nui
 			else
 			{
 				// TriggerLoadEnd flushes queued events by frame name, not by event type.
-				std::string queueName = "__root";
-
-				if (type == "frameCall" && argumentList->GetSize() > 1)
-				{
-					queueName = argumentList->GetString(1);
-				}
-				else if (type != "rootCall")
-				{
-					queueName = argumentList->GetString(0);
-				}
+				auto queueName = (type == "frameCall" && argumentList->GetSize() > 1) ? argumentList->GetString(1)
+				               : (type != "rootCall") ? argumentList->GetString(0) : std::string("__root");
 
 				std::unique_lock _(g_processMessageQueueMutex);
 				g_processMessageQueue[queueName].push_back(processMessage);


### PR DESCRIPTION
## Goal of this PR

Fix NUI messages being silently lost when sent before the UI has finished loading. The message queue was using the wrong key for `frameCall` messages, causing `TriggerLoadEnd` to never find and flush them.

## How is this PR achieving the goal

The `g_processMessageQueue` uses frame names as keys, and `TriggerLoadEnd` flushes queued messages by frame name. However, the original code used `argumentList->GetString(0)` as the queue key for all non-`rootCall` messages — this is the **message type** (e.g. `"frameCall"`), not the frame name.

For `frameCall` messages created via `PostJSEvent("frameCall", { frame, jsonData })`, the frame name is at index 1, not index 0. The fix correctly extracts the frame name from the argument list based on the message type:

- `frameCall`: uses `argumentList->GetString(1)` (the frame name)
- `rootCall`: uses `"__root"`
- Other types: uses `argumentList->GetString(0)` (unchanged behavior)

## This PR applies to the following area(s)

FiveM and RedM NUI core (`nui-core`)

## Successfully tested on

- Verified that `frameCall` messages sent before UI load are correctly queued under the frame name and flushed by `TriggerLoadEnd`
- Verified that `rootCall` messages continue to queue under `"__root"` as before
- No regression in normal message delivery when the browser is already loaded

## Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

## Fixes issues

Fixes #3847