### PR TITLE
fix(scripting/node): remove premature Stop() call before FreeEnvironment()

### DIFF
--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -495,7 +495,9 @@ result_t NodeScriptRuntime::Destroy()
 
 	node::EmitProcessBeforeExit(m_nodeEnvironment);
 	node::EmitProcessExit(m_nodeEnvironment);
-	node::Stop(m_nodeEnvironment);
+	// FreeEnvironment() stops and joins sub-workers as part of shutdown.
+	// Calling Stop() first can terminate the main isolate while worker threads
+	// are still entered, which trips V8 during worker teardown.
 	node::FreeEnvironment(m_nodeEnvironment);
 	node::FreeIsolateData(m_isolateData);
 


### PR DESCRIPTION
## Goal of this PR

Fix a server crash (`FATAL ERROR: v8::Isolate::Dispose() Disposing the isolate that is entered by a thread`) when a Node 22 worker thread is terminated or when a script using workers is stopped.

## How is this PR achieving the goal

The `Destroy()` shutdown sequence called `node::Stop(m_nodeEnvironment)` right before `node::FreeEnvironment(m_nodeEnvironment)`. This is problematic because:

1. `node::Stop()` calls `isolate_->TerminateExecution()`, which sets a V8 termination flag on the isolate
2. `node::FreeEnvironment()` then calls `stop_sub_worker_contexts()`, which tries to `Exit()` and `JoinThread()` each worker
3. Workers are still entered on the isolate when it gets terminated, causing the V8 fatal error

The fix removes the `node::Stop()` call. `node::FreeEnvironment()` already handles the full shutdown sequence: it sets `stopping = true`, sets `can_call_into_js = false`, stops and joins sub-workers, runs cleanup hooks, runs AtExit hooks, and deletes the environment. This matches Node.js's own `CommonEnvironmentSetup` destructor which does not call `Stop()` before `FreeEnvironment()`.

## This PR applies to the following area(s)

FiveM and RedM Node.js scripting runtime (`citizen-scripting-node`)

## Successfully tested on

- Worker thread creation and termination via `worker.terminate()` no longer crashes
- Script stop/restart with active workers no longer crashes
- Normal script shutdown without workers remains unaffected

## Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

## Fixes issues

Fixes #3846