### PR TITLE
fix(graphics/rdr3): pipeline cache clearing checks

### DIFF
--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -677,16 +677,14 @@ void DynamicTexture2::UnmapInternal(GraphicsContext* context, const MapData& map
 
 static bool ShouldUsePipelineCache(const char* pipelineCachePrefix)
 {
-	// This file is created on any hooked graphics related crashes (currently ERR_GFX_STATE)
-	FILE* f = _wfopen(MakeRelativeCitPath("data/cache/clearPipelineCache").c_str(), L"r");
-	if (!f)
+	std::wstring path = MakeRelativeCitPath("data\\cache\\clearPipelineCache");
+	if (_waccess(path.c_str(), 0))
 	{
-		fclose(f);
-		return true;
+		_wunlink(path.c_str());
+		return false;
 	}
 
-	_wunlink(MakeRelativeCitPath("data/cache/clearPipelineCache").c_str());
-	return false;
+	return true;
 }
 
 static HookFunction hookFunction([]()

--- a/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
@@ -402,7 +402,7 @@ static bool InitalizeVulkanLibrary()
 // Helps resolves issues where bad pipeline cache data causes an infinite loop of D3D12/Vulkan Crashes.
 static void InvalidatePipelineCache()
 {
-	FILE* f = _wfopen(MakeRelativeCitPath("data/cache/clearPipelineCache").c_str(), L"ab");
+	FILE* f = _wfopen(MakeRelativeCitPath("data\\cache\\clearPipelineCache").c_str(), L"wb");
 	if (f)
 	{
 		fclose(f);


### PR DESCRIPTION
### Goal of this PR

Fixes a crash tied to pipeline cache clearing checks that was accidently introduced while cleaning up pr #3840 and only occurred on fresh installations or installations with their data/cache directories being missing


### How is this PR achieving the goal

correct file paths and change ShouldUsePipelineCache to not open a file handle to check if it exists.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
