### PR TITLE
fix(streaming): reinitialize scaleform .gfx on resource restart

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1901,11 +1901,24 @@ static void LoadStreamingFiles(LoadType loadType)
 					newGfx.push_back({ strId, nameWithoutExt });
 				}
 			}
+			else if (ext == "gfx" && g_pendingRemovals.count({ strModule, strId }))
+			{
+				// GH-1576: slot exists from previous load but was pending removal —
+				// CScaleformStore has stale state, reinitialize it
+				newGfx.push_back({ strId, nameWithoutExt });
+			}
 #elif IS_RDR3
 			strModule->FindSlotFromHashKey(&strId, HashString(nameWithoutExt.c_str()));
 #endif
 
 			g_ourIndexes.insert(strId + strModule->baseIdx);
+			// GH-1576: for .gfx files pending removal, release the stale object first
+			if (ext == "gfx" && g_pendingRemovals.count({ strModule, strId }))
+			{
+				auto fullIdx = strId + strModule->baseIdx;
+				cstreaming->ReleaseObject(fullIdx, 0xF1);
+				cstreaming->ReleaseObject(fullIdx);
+			}
 			g_pendingRemovals.erase({ strModule, strId });
 
 			// get the raw streamer and make an entry in there


### PR DESCRIPTION
### Goal of this PR

Fix `.gfx` scaleform files failing to load after a resource restart, eventually causing a crash.

When a resource containing a `.gfx` file is restarted, `FindSlot` finds the existing streaming slot so `initGfxTexture` is skipped (it only runs for newly created slots). `CScaleformStore` retains stale internal state, causing `RequestScaleformMovie` to fail with native error `0x11fe353cf9733e6f` and eventually crash.

### How is this PR achieving the goal

Two changes in `LoadStreamingFile.cpp`:

1. When a `.gfx` entry's slot already exists and is pending removal, push it onto `newGfx` so `initGfxTexture` runs again after reload.
2. Before clearing the pending-removal flag, call `ReleaseObject` on the old streaming entry so `CScaleformStore` drops its stale state, allowing a clean reinit.

Both paths are gated on `g_pendingRemovals.count(...)`, so they only fire during resource restart — normal first-load and non-`.gfx` paths are untouched.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** FiveM

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

Fixes #1576