### PR TITLE
fix(onesync): prevent allocation of out-of-bounds network object ID 65535

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4029,7 +4029,7 @@ void ServerGameState::GetFreeObjectIds(const fx::ClientSharedPtr& client, uint8_
 	{
 		bool hadId = false;
 
-		for (; id < m_objectIdsSent.size(); id++)
+		for (; id < static_cast<uint16_t>(MaxObjectId); id++)
 		{
 			if (!m_objectIdsSent.test(id) && !m_objectIdsUsed.test(id))
 			{


### PR DESCRIPTION
## Goal of this PR

Fix a bug where network object ID `65535` (`0xFFFF`) could be allocated to clients, leading to entities that can never be resolved by the server.

## How is this PR achieving the goal

`GetFreeObjectIds()` used `m_objectIdsSent.size()` as the upper bound for the ID allocation loop. The bitset is sized `roundToWord(MaxObjectId)` = **65536**, but the entity lookup vector `m_entitiesById` is only sized `MaxObjectId` = **65535** (valid indices 0–65534).

This off-by-one mismatch allowed ID `65535` to be allocated in the bitset and handed out to clients. However:

1. `ProcessClonePacket` rejects `objectId == 0xFFFF` as a sentinel value (_"that's not an object ID, that's a snail!"_)
2. `GetEntity(65535)` returns empty due to its bounds check (`65535 >= 65535`)
3. Direct `m_entitiesById[65535]` accesses in unchecked paths are out-of-bounds UB

The fix caps the allocation loop at `MaxObjectId` instead of `m_objectIdsSent.size()`, ensuring all allocated IDs fall within the valid vector range (1–65534).

## This PR applies to the following area(s)

FiveM, OneSync

## Successfully tested on

- Code review confirms the off-by-one: bitset size (65536) > vector size (65535)
- `CreateEntityFromTree` already correctly caps at `MaxObjectId - 1` (65534)
- The fix aligns `GetFreeObjectIds` with the same upper bound

## Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

## Fixes issues

Fixes #3849