### PR TITLE
fix(gta-core-five): task NMShot behaviour failure exploit

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.TaskNMShotFailureExploit.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.TaskNMShotFailureExploit.cpp
@@ -1,0 +1,46 @@
+#include <StdInc.h>
+#include <jitasm.h>
+#include <Hooking.h>
+#include "XBRVirtual.h"
+
+static HookFunction hookFunction([]
+{
+	// There's an exploit where a remote ped can trigger BehaviourFailure with an
+	// invalid PedIntelligence pointer. The game dereferences it without checking,
+	// causing a null pointer crash on other clients. This patch adds a check and
+	// skips the code path if PedIntelligence is null.
+	auto location = xbr::IsGameBuildOrGreater<2802>() ?
+		hook::get_pattern("48 8B 88 ? ? ? ? 48 85 C9 74 ? 8B 41 ? D1 E8 83 E0 ? EB ? 41 8B C6 EB ? 8B 51 ? D1 EA 83 E2 ? 3B C2 73 ? 83 F8 ? 73 ? 81 79 ? ? ? ? ? 8B C2 74 ? 48 8B 49 ? 48 85 C9 75 ? 49 8B CE 48 85 C9 74")
+	:
+		hook::get_pattern("48 8B 88 ? ? ? ? 48 85 C9 74 ? 8B 41 ? D1 E8 83 E0 ? EB ? 41 8B C6 EB ? 8B 51 ? D1 EA 83 E2 ? 3B C2 73 ? 83 F8 ? 73 ? 81 79 ? ? ? ? ? 8B C2 74 ? 48 8B 49 ? 48 85 C9 75 ? 49 8B CE 48 85 C9 74 ? F3 0F 10 05 ? ? ? ? 44 88 74 24 ? C7 44 24 ? ? ? ? ? 44 88 74 24 ? 44 89 74 24 ? 83 C8 ? F3 0F 11 44 24 ? 89 44 24 ? 44 89 74 24 ? 4C 89 74 24 ? 89 44 24 ? 48 8D 15 ? ? ? ? 45 33 C9 45 33 C0 48 8B CB 44 88 74 24 ? E8 ? ? ? ? 8B 86 ? ? ? ? 48 8D 15");
+
+	static struct : jitasm::Frontend
+	{
+		intptr_t ret;
+
+		void Init(intptr_t location)
+		{
+			this->ret = location;
+		}
+
+		void InternalMain() override
+		{
+			test(rax, rax);
+			jz("fail");
+			mov(rcx, qword_ptr[rax+0xB08]); // PedIntelligence->m_queriableInterface
+
+			mov(rax, ret);
+			jmp(rax);
+			
+			L("fail");
+			// Clear the rcx register, in the next jmp the game will check if it's null and skip the code
+			xor(rcx, rcx);
+			mov(rax, ret);
+			jmp(rax);
+		}
+	} stub;
+
+	stub.Init((intptr_t)location + 0x7);
+	hook::nop(location, 0x7);
+	hook::jump_rcx(location, stub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR
Fix a client crash that could be triggered when `CTaskNMShot::BehaviourFailure` dereferences a null PedIntelligence pointer.


### How is this PR achieving the goal
The PR adds a hook that validates the PedIntelligence pointer before it is dereferenced. If the pointer is null, the code path that accesses m_queriableInterface is skipped.


### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 2060, 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


Thanks @imLocutor for reporting this exploit