### PR TITLE
feat(extra-natives-five): Add GET/SET_ENTITY_CAN_SPAWN_PEDS

### DIFF
--- a/code/components/extra-natives-five/src/EntityExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/EntityExtraNatives.cpp
@@ -114,4 +114,41 @@ static InitFunction initFunction([]()
 
 		context.SetResult<bool>(result);
 	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_CAN_SPAWN_PEDS", [](fx::ScriptContext& context)
+	{
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+		bool canSpawnPeds = context.GetArgument<bool>(1);
+
+		if (entity)
+		{
+			auto address = (char*)entity;
+			// CEntityFlags is at offset 0xC0, bWillSpawnPeds is bit 10
+			DWORD* flags = (DWORD*)(address + 0xC0);
+			if (canSpawnPeds)
+			{
+				*flags |= (1 << 10);
+			}
+			else
+			{
+				*flags &= ~(1 << 10);
+			}
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_CAN_SPAWN_PEDS", [](fx::ScriptContext& context)
+	{
+		bool result = false;
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+
+		if (entity)
+		{
+			auto address = (char*)entity;
+			// CEntityFlags is at offset 0xC0, bWillSpawnPeds is bit 10
+			DWORD flags = *(DWORD*)(address + 0xC0);
+			result = (flags & (1 << 10)) != 0;
+		}
+
+		context.SetResult<bool>(result);
+	});
 });

--- a/ext/native-decls/GetEntityCanSpawnPeds.md
+++ b/ext/native-decls/GetEntityCanSpawnPeds.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+---
+## GET_ENTITY_CAN_SPAWN_PEDS
+
+```c
+bool GET_ENTITY_CAN_SPAWN_PEDS(Entity entity);
+```
+
+## Parameters
+* **entity**: The entity to get the value for.
+
+## Return value
+Returns whether or not the entity can spawn scenario peds.

--- a/ext/native-decls/SetEntityCanSpawnPeds.md
+++ b/ext/native-decls/SetEntityCanSpawnPeds.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+---
+## SET_ENTITY_CAN_SPAWN_PEDS
+
+```c
+void SET_ENTITY_CAN_SPAWN_PEDS(Entity entity, bool canSpawn);
+```
+
+It sets whether or not the entity can spawn scenario peds.
+
+## Parameters
+* **entity**: The entity to set the value for.
+* **canSpawn**: Whether or not the entity can spawn scenario peds.


### PR DESCRIPTION
### Goal of this PR
Add native to prevent scenario peds to spawn on entities
Useful for scripted entities


### How is this PR achieving the goal

By adding a new setter and a new getter

### This PR applies to the following area(s)
FiveM


### Successfully tested on

**Game builds:** 2699, 3095, 3258

**Platforms:** Windows

![spawner](https://github.com/user-attachments/assets/d4531a52-d31c-405b-a438-0aac41add98e)


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

N/A