### PR TITLE
fix(input/rdr3): incorrect clipping from switching focus

### DIFF
--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -22,25 +22,10 @@ static rage::ioMouse* g_input;
 
 static bool* g_isClippedCursor;
 
-static void(*disableFocus)();
-
-static void DisableFocus()
+static hook::cdecl_stub<void(bool)> _setCursorClipState([]()
 {
-	if (!g_isFocusStolen)
-	{
-		disableFocus();
-	}
-}
-
-static void(*enableFocus)();
-
-static void EnableFocus()
-{
-	if (!g_isFocusStolen)
-	{
-		enableFocus();
-	}
-}
+	return hook::get_pattern("40 53 48 83 EC ? 8A D9 48 8D 0D ? ? ? ? E8 ? ? ? ? 38 1D ? ? ? ? 74 ? 88 1D ? ? ? ? E8 ? ? ? ? E8");
+});
 
 static void (*recaptureLostDevices)();
 
@@ -137,13 +122,6 @@ void InputHook::SetGameMouseFocus(bool focus, bool flushMouse)
 
 		memset(g_gameKeyArray, 0, 0x100);
 	}
-
-	if (!enableFocus || !disableFocus)
-	{
-		return;
-	} 
-
-	return (focus) ? enableFocus() : disableFocus();
 }
 
 void InputHook::EnableSetCursorPos(bool enabled)
@@ -221,10 +199,11 @@ LRESULT APIENTRY sgaWindowProcedure(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
 	if (uMsg == WM_ACTIVATEAPP)
 	{
 		g_isFocused = (wParam) ? true : false;
-		if (!g_isFocused)
-		{
-			ClipHostCursor(NULL);
-		}
+		// Inform the game of the new cursor state based on if the window is focused or not
+		// Most cursor clip calls and checks happen on a different thread.
+		// This function locks/unlocks the mutex related to ioMouse operations, along with properly informing WndProc of input changes
+		// Resolving some cases where mouse clipping would essentially freeze mouse input in areas like conhost.
+		_setCursorClipState(g_isFocused);
 	}
 
 	if (uMsg >= WM_KEYFIRST && uMsg <= WM_KEYLAST)


### PR DESCRIPTION
### Goal of this PR

Fixes stuck input's that was originally fixed in https://github.com/citizenfx/fivem/pull/3520 but reintroduced with https://github.com/citizenfx/fivem/pull/3637 as it caused inconsistent cursor clipping state from switching focus leading to the cursor leaving the window during gameplay.

This PR fixes the incorrect clipping that led to cases where the cursor would be frozen in conhost, which made it impossible to clear link confirmations introduced in https://github.com/citizenfx/fivem/commit/39881dab7360332623f4ecd6d53c45a9a76592f7

### How is this PR achieving the goal

Remove the old ClipHostCursor call and replace it with an game function that properly handled clipping states. 

### This PR applies to the following area(s)

RedM

### Successfully tested on

Tested with Raw Input and Direct Input.

**Game builds:**  1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

RedM Support thread from Cfx.re Project Hub https://discord.com/channels/192358910387159041/1473068673232015360/1473068673232015360

