### PR TITLE
feat(net/rdr3): SetWindowText support

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -360,15 +360,15 @@ void NetLibrary::ProcessOOB(const NetAddress& from, const char* oob, size_t leng
 
 				StripColors(hostname, cleaned, 8192);
 
-				// Setting window text in RDR3's render thread causes the game to hang.
 #ifndef IS_RDR3
-				SetWindowText(CoreGetGameWindow(), va(
-#ifdef GTA_FIVE
-					L"FiveM® by Cfx.re"
-#elif defined(IS_RDR3)
-					L"RedM® by Cfx.re"
-#endif
-					L" - %s", ToWide(cleaned)));
+				SetWindowText(CoreGetGameWindow(), va(L"FiveM® by Cfx.re - %s", ToWide(cleaned)));
+#else
+				// Ensure that we only ever call SetWindowText in the main thread
+				// ProcessOOB can be called from the renderthread when the game is still loading.
+				m_mainFrameQueue.push([]()
+				{
+					SetWindowText(CoreGetGameWindow(), va(L"RedM® by Cfx.re - %s", ToWide(cleaned)));
+				});
 #endif
 
 				auto richPresenceSetTemplate = [&](const auto& tpl)

--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -204,18 +204,14 @@ LRESULT APIENTRY sgaWindowProcedure(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM 
 {
 	if (uMsg == WM_CREATE)
 	{
-		std::string userEmail;
-		std::string userName;
+		SetWindowText(FindWindow(L"sgaWindow", nullptr), ToWide(fmt::sprintf("RedM™ by Cfx.re")).c_str());
+	}
 
-		if (Instance<ICoreGameInit>::Get()->GetData("rosUserName", &userName) && Instance<ICoreGameInit>::Get()->GetData("rosUserEmail", &userEmail))
-		{
-			if (HashString(userEmail.c_str()) == 0x448645b5 || HashString(userEmail.c_str()) == 0x96ea6c22)
-			{
-				userName = "root";
-			}
-		}
-
-		SetWindowText(FindWindow(L"sgaWindow", nullptr), ToWide(fmt::sprintf("RedM™ by Cfx.re - %s", userName)).c_str());
+	// WM_SETTEXT shouldn't be passed to the games WndProc handler
+	// Doing so can lead to potential deadlocking as the message may not get handled.
+	if (uMsg == WM_SETTEXT)
+	{
+		return DefWindowProc(hwnd, uMsg, wParam, lParam);
 	}
 
 	if (uMsg == WM_ACTIVATEAPP)


### PR DESCRIPTION
### Goal of this PR

Introduce support for updating window title when connecting to servers in RedM. This was previously reintroduced into https://github.com/citizenfx/fivem/commit/c6345f85952e00aa4eedcd27a21cdec8ede885b7 but backed out similar to the last time   https://github.com/citizenfx/fivem/commit/4eb62f50b48ba0bc556d5c0f52f66917257c5f72 as it would lead to the game freezing.

This was caused as before the game finished loading ``INIT_CORE`` NetLibrary::ProcessOOB could be called from the games render thread, calling SetWindowText in that context would usually lead to the call never returning or hitting WndProc leading to the game freezing in the render thread. Calling SetWindowText from the main thread always along with not passing the WM_SETTEXT message to the games WndProc handler resolves both of these issues.

While this PR is complete and works I've marked it as a draft as The branding for the window text introduced with https://github.com/citizenfx/fivem/commit/c6345f85952e00aa4eedcd27a21cdec8ede885b7 differs from the one in rage-input-rdr3. I'm not sure exactly which one is to be used, along with the removal of the username in the windows title as this behaviour differed to FiveM and seemed out of place.

### How is this PR achieving the goal

Pass WM_SETTEXT directly to DefWindowProc rather then the games WndProc handler. Add the SetWindowText call to ``m_mainFrameQueue`` to be executed on the main thread only.

### This PR applies to the following area(s)

RedM

### Successfully tested on

Tested with about 20 game startup connecting to a server as soon as the game is loaded where it would usually freeze in that time. Zero instances of the game freezing. Change was also tested by AvarianKnight back in Janurary.

**Game builds:** 1491

**Platforms:** Windows, Linux

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
