### PR TITLE
tweak(graphics/rdr3): include handle properties when fetching memory type

### DIFF
--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -625,38 +625,26 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 	}
 	else if (GetCurrentGraphicsAPI() == GraphicsAPI::Vulkan)
 	{
-		// meanwhile in Vulkan, this is infinitely annoying
 		return new GtaNuiTexture([shareHandle, width, height](GtaNuiTexture* texture)
 		{
-			std::vector<uint8_t> pixelData(size_t(width) * size_t(height) * 4);
+			rage::grcManualTextureDef textureDef;
+			memset(&textureDef, 0, sizeof(textureDef));
+			textureDef.isStaging = 0;
+			textureDef.arraySize = 1;
 
-			rage::grcTextureReference reference;
-			memset(&reference, 0, sizeof(reference));
-			reference.width = width;
-			reference.height = height;
-			reference.depth = 1;
-			reference.stride = width * 4;
-			reference.format = 11;
-			reference.pixelData = (uint8_t*)pixelData.data();
-
-			auto texRef = (rage::sga::TextureVK*)rage::grcTextureFactory::getInstance()->createImage(&reference, nullptr);
-
+			auto texRef = (rage::sga::TextureVK*)rage::grcTextureFactory::getInstance()->createManualTexture(width, height, 2, nullptr, true, &textureDef);
 			if (texRef)
 			{
 				rage::sga::Driver_Destroy_Texture(texRef);
 
 				VkDevice device = (VkDevice)GetGraphicsDriverHandle();
-				VkPhysicalDevice physicalDevice = GetVulkanPhysicalHandle();
 
 				VkImage Image;
 				VkDeviceMemory DeviceMemory;
 				CreateVKImageFromShareHandle(device, shareHandle, width, height, Image, DeviceMemory);
 
 				auto newImage = new rage::sga::TextureVK::ImageData;
-				//memcpy(newImage, texRef->image, sizeof(*newImage));
 				memset(newImage, 0, sizeof(*newImage));
-				// these come from a fast allocator(?)
-				//delete texRef->image;
 				texRef->image = newImage;
 
 				texRef->image->image = Image;

--- a/code/components/rage-graphics-rdr3/include/VulkanHelper.h
+++ b/code/components/rage-graphics-rdr3/include/VulkanHelper.h
@@ -7,7 +7,7 @@
 
 #include <DrawCommands.h>
 
-inline std::string_view ResultToString(VkResult result)
+inline std::string ResultToString(VkResult result)
 {
 	switch (result)
 	{
@@ -72,7 +72,7 @@ inline std::string_view ResultToString(VkResult result)
 		case VK_ERROR_INVALID_DEVICE_ADDRESS_EXT:
 			return "VK_ERROR_INVALID_DEVICE_ADDRESS_EXT A buffer creation failed because the requested address is not available.";
 		default:
-			return std::to_string(static_cast<uint32_t>(result));
+			return std::to_string(static_cast<int32_t>(result));
 	}
 }
 
@@ -94,6 +94,8 @@ static uint32_t FindMemoryType(VkPhysicalDevice physicalDevice, uint32_t typeFil
 
 static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsigned int width, unsigned int height, VkImage& outImage, VkDeviceMemory& outMemory)
 {
+	assert(handle != NULL && handle != INVALID_HANDLE_VALUE);
+
 	VkExternalMemoryImageCreateInfo ExternalMemoryImageCreateInfo = { VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO };
 	ExternalMemoryImageCreateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
 	VkImageCreateInfo ImageCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
@@ -120,21 +122,31 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 
 	VkMemoryDedicatedAllocateInfo MemoryDedicatedAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO };
 	MemoryDedicatedAllocateInfo.image = outImage;
+
 	VkImportMemoryWin32HandleInfoKHR ImportMemoryWin32HandleInfo = { VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR };
 	ImportMemoryWin32HandleInfo.pNext = &MemoryDedicatedAllocateInfo;
 	ImportMemoryWin32HandleInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
 	ImportMemoryWin32HandleInfo.handle = handle;
+
 	VkMemoryAllocateInfo MemoryAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
 	MemoryAllocateInfo.pNext = &ImportMemoryWin32HandleInfo;
-	MemoryAllocateInfo.allocationSize = MemoryRequirements.size;
+	
+	static auto _vkGetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR");
+	if (_vkGetMemoryWin32HandlePropertiesKHR == nullptr)
+	{
+		FatalError("Unable to retrieve 'vkGetMemoryWin32HandlePropertiesKHR'");
+	}
 
-	VkPhysicalDeviceMemoryProperties memProps;
-	vkGetPhysicalDeviceMemoryProperties(GetVulkanPhysicalHandle(), &memProps);
+	VkMemoryWin32HandlePropertiesKHR handleProps = { VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR };
+	if (result = _vkGetMemoryWin32HandlePropertiesKHR(device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT, handle, &handleProps); result != VK_SUCCESS)
+	{
+		FatalError("Failed to query Win32 handle properties. VkResult: %s", ResultToString(result));
+	}
 
-	MemoryAllocateInfo.memoryTypeIndex = FindMemoryType(GetVulkanPhysicalHandle(), MemoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+	MemoryAllocateInfo.memoryTypeIndex = FindMemoryType(GetVulkanPhysicalHandle(), MemoryRequirements.memoryTypeBits & handleProps.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 	if (MemoryAllocateInfo.memoryTypeIndex == INT32_MAX)
 	{
-		FatalError("Failed to compatible memory type for NUI. This system may not be equipped to run RedM under Vulkan.\n");
+		FatalError("Failed to compatible memory type for NUI. This system may not be equipped to run RedM under Vulkan.");
 	}
 
 	if (result = vkAllocateMemory(device, &MemoryAllocateInfo, nullptr, &outMemory); result != VK_SUCCESS)


### PR DESCRIPTION
### Goal of this PR

Further improve the external handle import logic for Vulkan. Hopefully should address any remaining cases of ``Failed to allocate memory for Vulkan. VkResult: VK_ERROR_OUT_OF_DEVICE_MEMORY A device memory allocation has failed.`` that's occur on some mobile (laptop) GPU configurations.

### How is this PR achieving the goal

Introduce assertion to clearly point out if NUI/CEF has given us a null or invalid handle to clearly separate these problems from the error mentioned above.

Change ResultToString default error to be formatted as a signed int32_t as VkResult is signed and all error codes are negative.

Fetch the D3D11 shareHandles memoryTypeBits with _vkGetMemoryWin32HandlePropertiesKHR and takes that into consideration when fetching the memoryType index to be used with allocation

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:** 1491

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues


