### PR TITLE
tweak(core/rdr3): improve startup meta block logic

### DIFF
--- a/code/components/gta-core-rdr3/src/GameInitRage.cpp
+++ b/code/components/gta-core-rdr3/src/GameInitRage.cpp
@@ -248,15 +248,18 @@ static void LogStubLog1(void* stub, const char* type, const char* format, ...)
 	}
 }
 
-static bool (*g_fiAssetManagerExists)(void*, const char*, const char*);
-static bool fiAssetManagerExists(void* self, const char* name, const char* extension)
+static void* (*g_loadStartupFile)(void*, const char*, uint8_t, void*);
+static void* LoadStartupFile(void* self, const char* filePath, uint8_t a3, void* a4)
 {
-	if ((extension && strcmp(extension, "meta") == 0) && strcmp(name, "platformcrc:/data/startup") == 0)
-	{
-		return false;
-	}
+	// Hasn't changed between gamebuilds.
+	static const size_t kMetaOffset = 0xE1;
+	assert(*(uint8_t*)((uintptr_t)g_loadStartupFile + kMetaOffset) == 0x74);
 
-	return g_fiAssetManagerExists(self, name, extension);
+	// Skip loading .meta for startup even if the file exists.
+	hook::put<uint8_t>((uintptr_t)g_loadStartupFile + kMetaOffset, 0xEB);
+	void* retnResult = g_loadStartupFile(self, filePath, a3, a4);
+	hook::put<uint8_t>((uintptr_t)g_loadStartupFile + kMetaOffset, 0x74);
+	return retnResult;
 }
 
 static HookFunction hookFunctionNet([]()
@@ -297,8 +300,10 @@ static HookFunction hookFunctionNet([]()
 	// allow the game to ensure static bounds, but don't block on it.
 	hook::nop(hook::get_pattern("E8 ? ? ? ? 66 44 39 65 ? 74 ? 48 8B 4D ? E8 ? ? ? ? 4C 8D 5C 24 ? 49 8B 5B ? 49 8B 73 ? 49 8B 7B ? 4D 8B 63"), 5);
 
-	// Block loading of custom startup.meta file. Completely breaks game loading
-	MH_Initialize();
-	MH_CreateHook(hook::get_call(hook::get_pattern("E8 ? ? ? ? 3C ? 75 ? 48 8B 0D")), fiAssetManagerExists, (void**)&g_fiAssetManagerExists);
-	MH_EnableHook(MH_ALL_HOOKS);
+	// Don't allow the game to load a startup.meta file if present. This breaks game loading entirely.
+	{
+		auto location = hook::get_pattern("E8 ? ? ? ? 40 8A CE E8 ? ? ? ? E8");
+		hook::set_call(&g_loadStartupFile, location);
+		hook::call(location, LoadStartupFile);
+	}
 });


### PR DESCRIPTION
### Goal of this PR

Improve the startup.meta block which was originally introduced in #3318.  This patch improves on it by scoping the hook to only the instance where startup.meta existence is checked for.

### How is this PR achieving the goal

Remove original hook and replace the call to load platformcrc:/data/startup(.ymt/.meta) with a stub call that forces the call to skip over loading .meta if present.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

Tested with/without the custom startup.meta file from #3318 

**Game builds:**  1491

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues


