### PR TITLE
fix(server/net): make sure we don't overwrite sv_proxyIPRanges in the case that we use `set sv_proxyIPRanges [value]`

### DIFF
--- a/code/components/citizen-server-net/src/ProxyAddressList.cpp
+++ b/code/components/citizen-server-net/src/ProxyAddressList.cpp
@@ -20,6 +20,7 @@
 
 #include <folly/IPAddress.h>
 #include <folly/String.h>
+#include <ServerInstanceBase.h>
 
 class NetworkList
 {
@@ -194,15 +195,18 @@ bool DLL_EXPORT IsProxyAddress(const net::PeerAddress& ep)
 
 static InitFunction initFunction([]()
 {
-	static ConVar<NetworkList> allowedIpCidr("sv_proxyIPRanges", ConVar_None, NetworkList{ "10.0.0.0/8 127.0.0.0/8 192.168.0.0/16 172.16.0.0/12" });
-	static auto allowedIpCidrVar = &allowedIpCidr;
-
-	auto update = [](auto)
+	fx::ServerInstanceBase::OnServerCreate.Connect([](fx::ServerInstanceBase* instance)
 	{
-		std::unique_lock _(g_networkListMutex);
-		g_networkList = allowedIpCidrVar->GetValue();
-	};
+		static auto allowedIpCidr = instance->AddVariable<NetworkList>("sv_proxyIPRanges", ConVar_None, NetworkList{ "10.0.0.0/8 127.0.0.0/8 192.168.0.0/16 172.16.0.0/12" });
+		static auto allowedIpCidrVar = &allowedIpCidr;
 
-	allowedIpCidr.GetHelper()->SetChangeCallback(update);
-	update(nullptr);
+		auto update = [](auto)
+		{
+			std::unique_lock _(g_networkListMutex);
+			g_networkList = (*allowedIpCidrVar)->GetValue();
+		};
+
+		allowedIpCidr->GetHelper()->SetChangeCallback(update);
+		update(nullptr);
+	});
 });


### PR DESCRIPTION

### Goal of this PR
Fixes `set sv_proxyIPRanges` overwriting the `sv_proxyIPRanges`  making it so that you can never change the `sv_proxyIPRanges` until you restart the server.


### This PR applies to the following area(s)
Server


### Successfully tested on

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


