### PR TITLE
fix(server): prevent potential null dereference in ClientRegistry

### DIFF
--- a/code/components/citizen-server-impl/src/ClientRegistry.cpp
+++ b/code/components/citizen-server-impl/src/ClientRegistry.cpp
@@ -135,7 +135,10 @@ namespace fx
 
 		client->OnAssignTcpEndPoint.Connect([this, weakClient]()
 		{
-			m_clientsByTcpEndPoint[weakClient.lock()->GetTcpEndPoint()] = weakClient;
+			if (auto client = weakClient.lock())
+			{
+				m_clientsByTcpEndPoint[client->GetTcpEndPoint()] = weakClient;
+			}
 		});
 
 		client->OnAssignConnectionToken.Connect([this, weakClient]()


### PR DESCRIPTION
### Goal of this PR

Prevent a potential crash caused by dereferencing an invalid `weak_ptr` in `ClientRegistry`.

---

### How is this PR achieving the goal

This PR ensures that `weakClient.lock()` is validated before being dereferenced in the `OnAssignTcpEndPoint` callback.

Since this callback is event-driven and may execute after the client has been destroyed, directly dereferencing the result of `lock()` could lead to undefined behavior or a crash.

This change aligns the implementation with other callbacks in the same file where `weak_ptr` is safely validated before use.

A possible scenario is during rapid client disconnect/reconnect cycles, where the callback executes after the client object has already been destroyed.

No functional behavior is changed.

---

### This PR applies to the following area(s)

Server

---

### Successfully tested on

**Game builds:** N/A

**Platforms:** Windows

---

### Checklist

* [x] Code compiles and has been tested successfully.
* [x] Code explains itself well and/or is documented.
* [x] My commit message explains what the changes do and what they are for.
* [x] No extra compilation warnings are added by these changes.

---

### Fixes issues

N/A
