### PR TITLE
fix(server/state): use signed integer for weaponType in weaponDamageEvent

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5046,7 +5046,7 @@ struct CWeaponDamageEvent
 	}
 
 	uint8_t damageType;
-	uint32_t weaponType; // weaponHash
+	int32_t weaponType; // weaponHash
 
 	bool overrideDefaultDamage;
 	bool hitEntityWeapon;
@@ -6308,7 +6308,7 @@ struct CWeaponDamageEvent
 	}
 
 	uint8_t damageType;
-	uint32_t weaponType; // weaponHash
+	int32_t weaponType; // weaponHash
 	uint32_t f92;
 
 	bool overrideDefaultDamage;


### PR DESCRIPTION
Closes #3827. The weaponType in CWeaponDamageEvent was being serialized as a uint32_t, causing a signed/unsigned mismatch in Lua where hashes are expected to be signed 32-bit integers.