### PR TITLE
feat(resources): add version constraints for resource dependencies

### DIFF
--- a/code/components/citizen-resources-core/src/ResourceDependencyLoader.cpp
+++ b/code/components/citizen-resources-core/src/ResourceDependencyLoader.cpp
@@ -6,6 +6,56 @@
 #include <ResourceMetaDataComponent.h>
 #include <ResourceManagerConstraintsComponent.h>
 
+// Returns true if installed >= required using numeric segment comparison.
+// Segments are split on '.', compared as integers left-to-right, missing segments treated as 0.
+static bool IsVersionSufficient(const std::string& installed, const std::string& required)
+{
+	auto splitVersion = [](const std::string& ver)
+	{
+		std::vector<int> segments;
+		size_t start = 0;
+
+		while (start < ver.size())
+		{
+			auto dot = ver.find('.', start);
+			if (dot == std::string::npos)
+			{
+				dot = ver.size();
+			}
+
+			try
+			{
+				segments.push_back(std::stoi(ver.substr(start, dot - start)));
+			}
+			catch (...)
+			{
+				segments.push_back(0);
+			}
+
+			start = dot + 1;
+		}
+
+		return segments;
+	};
+
+	auto installedParts = splitVersion(installed);
+	auto requiredParts = splitVersion(required);
+	auto maxLen = std::max(installedParts.size(), requiredParts.size());
+
+	for (size_t i = 0; i < maxLen; i++)
+	{
+		int a = (i < installedParts.size()) ? installedParts[i] : 0;
+		int b = (i < requiredParts.size()) ? requiredParts[i] : 0;
+
+		if (a != b)
+		{
+			return a > b;
+		}
+	}
+
+	return true; // equal
+}
+
 static InitFunction initFunction([]()
 {
 	static std::multimap<std::string, std::string> resourceDependencies;
@@ -53,11 +103,22 @@ static InitFunction initFunction([]()
 						}
 					}
 
-					fwRefContainer<fx::Resource> other = manager->GetResource(dependency.second);
+					// Parse optional version constraint from "resourceName:version" format
+					std::string depName = dependency.second;
+					std::string requiredVersion;
+
+					auto colonPos = depName.find(':');
+					if (colonPos != std::string::npos)
+					{
+						requiredVersion = depName.substr(colonPos + 1);
+						depName = depName.substr(0, colonPos);
+					}
+
+					fwRefContainer<fx::Resource> other = manager->GetResource(depName);
 
 					if (!other.GetRef())
 					{
-						trace("Could not find dependency %s for resource %s.\n", dependency.second, resource->GetName());
+						trace("Could not find dependency %s for resource %s.\n", depName, resource->GetName());
 						return false;
 					}
 
@@ -66,19 +127,50 @@ static InitFunction initFunction([]()
 
 					if (other->GetState() == fx::ResourceState::Starting || other->GetState() == fx::ResourceState::Started)
 					{
-						continue;
+						// already running, skip to version check
+					}
+					else
+					{
+						bool success = other->Start();
+
+						if (!success)
+						{
+							trace("Could not start dependency %s for resource %s.\n", depName, resource->GetName());
+
+							// store for deferred use (e.g. build systems)
+							resourceDependencies.insert({ other->GetName(), resource->GetName() });
+
+							return false;
+						}
 					}
 
-					bool success = other->Start();
-
-					if (!success)
+					// Check minimum version constraint if specified
+					if (!requiredVersion.empty())
 					{
-						trace("Could not start dependency %s for resource %s.\n", dependency.second, resource->GetName());
+						auto otherMetaData = other->GetComponent<fx::ResourceMetaDataComponent>();
+						auto versionEntries = otherMetaData->GetEntries("version");
 
-						// store for deferred use (e.g. build systems)
-						resourceDependencies.insert({ other->GetName(), resource->GetName() });
+						bool hasVersion = false;
+						std::string installedVersion;
 
-						return false;
+						for (const auto& versionEntry : versionEntries)
+						{
+							hasVersion = true;
+							installedVersion = versionEntry.second;
+							break;
+						}
+
+						if (!hasVersion)
+						{
+							trace("Warning: resource %s requires %s ^3v%s^7, but %s does not specify a version.\n",
+								resource->GetName(), depName, requiredVersion, depName);
+						}
+						else if (!IsVersionSufficient(installedVersion, requiredVersion))
+						{
+							trace("Could not start resource %s: requires %s ^2v%s^7 or newer, but ^3v%s^7 is installed.\n",
+								resource->GetName(), depName, requiredVersion, installedVersion);
+							return false;
+						}
 					}
 				}
 
@@ -116,7 +208,7 @@ static InitFunction initFunction([]()
 
 			// copy in case the container gets mutated
 			std::set<std::pair<std::string, std::string>> deps(pendingDeps.first, pendingDeps.second);
-			
+
 			for (auto dep : deps)
 			{
 				auto dependant = manager->GetResource(dep.second);


### PR DESCRIPTION
### Goal of this PR

Adds optional minimum version enforcement to the `dependency` directive in fxmanifest.lua.

Currently, `dependency 'onex-base'` only ensures load order ,  there's no way to require a minimum version. If a resource depends on APIs added in onex-base v3.0, but the server has v2.5 installed, the resource starts and produces cryptic runtime errors.

This extends the existing syntax to support `dependency 'onex-base:3.0.0'`, which checks the dependency's `version` metadata before allowing the resource to start.

### How is this PR achieving the goal

Parses an optional `:version` suffix from the dependency string in `ResourceDependencyLoader.cpp`. After the dependency resource is confirmed running, its `version` metadata is compared against the required version using numeric segment comparison (major.minor.patch).

- No version specified → works exactly as before (zero breaking changes)
- Version specified, met → resource starts normally
- Version specified, not met → resource blocked with a clear error message
- Dependency has no version metadata → warning printed, startup allowed

**Usage:**
```lua
dependency 'ox_lib:3.0.0'
dependency 'es_extended:1.9'
dependencies { 'qb-core:1.2.6', 'ox_lib:3.0.0' }
```

<img width="1234" height="135" alt="image" src="https://github.com/user-attachments/assets/48b9e786-eb84-4928-8071-46f336f653a8" />

### This PR applies to the following area(s)

FiveM, RedM, Server

### Successfully tested on

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
