### PR TITLE
fix(gta-streaming-five): add grcResourceCache pressure throttle to prevent streaming stalls

### DIFF
--- a/code/components/devtools-five/src/StreamingDebug.cpp
+++ b/code/components/devtools-five/src/StreamingDebug.cpp
@@ -429,9 +429,36 @@ static InitFunction initFunction([]()
 
 			ImGui::Text("Physical memory: %.2f MiB", usedPhys / 1024.0 / 1024.0);
 
-			ImGui::Text("grcore/ResourceCache usage: %.2f / %.2f MiB",
-				rage::grcResourceCache::GetInstance()->GetUsedPhysicalMemory() / 1024.0 / 1024.0,
-				rage::grcResourceCache::GetInstance()->GetTotalPhysicalMemory() / 1024.0 / 1024.0);
+			{
+				auto* rc = rage::grcResourceCache::GetInstance();
+				size_t rcUsed = rc->GetUsedPhysicalMemory();
+				size_t rcTotal = rc->GetTotalPhysicalMemory();
+				int rcPct = rcTotal > 0 ? (int)(rcUsed * 100 / rcTotal) : 0;
+
+				ImGui::Text("grcore/ResourceCache usage: %.2f / %.2f MiB (%d%%)",
+					rcUsed / 1024.0 / 1024.0,
+					rcTotal / 1024.0 / 1024.0,
+					rcPct);
+
+				// Look up the pressure threshold ConVar by name (lives in gta-streaming-five.dll)
+				int threshold = 0;
+				auto entry = console::GetDefaultContext()->GetVariableManager()->FindEntryRaw("str_resourceCachePressureThreshold");
+				if (entry)
+				{
+					threshold = atoi(entry->GetValue().c_str());
+				}
+				if (threshold > 0)
+				{
+					if (rcPct >= threshold)
+						ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Pressure throttle: ACTIVE (threshold %d%%)", threshold);
+					else
+						ImGui::TextColored(ImVec4(0.4f, 1.0f, 0.4f, 1.0f), "Pressure throttle: idle (threshold %d%%)", threshold);
+				}
+				else
+				{
+					ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "Pressure throttle: disabled");
+				}
+			}
 
 			if (ImGui::BeginTable("##strmem", 4, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable))
 			{

--- a/code/components/gta-streaming-five/src/PatchExtendedBudgeting.cpp
+++ b/code/components/gta-streaming-five/src/PatchExtendedBudgeting.cpp
@@ -99,7 +99,23 @@ static uint64_t SettingsVramTex(void* self, int quality, void* settings)
 	return g_vramLocation[quality + 1] - (1 * GB);
 }
 
+// RAGE's streaming eviction is reactive: it only evicts when a new asset must load and the
+// grcResourceCache is full, causing synchronous stalls (0.5-2s freezes) while the GPU
+// services page faults. Base game DLC content alone saturates the cache to 100% during
+// normal city traversal
+//
+// By throttling new streaming requests before the cache is completely full, we maintain
+// headroom so that new allocations can succeed without triggering synchronous eviction.
+// The engine's normal LRU/priority eviction still operates within the budget — we just
+// prevent it from being driven to the hard ceiling where every load causes a stall.
+//
+// Tunable via ConVar: 0 (default/off) disables, 90 recommended (keeps ~280 MiB
+// headroom on 4 GB cards, ~700 MiB on 10 GB cards). Valid range: 1-100.
+static ConVar<int> strResourceCachePressureThreshold("str_resourceCachePressureThreshold", ConVar_Archive, 0);
+
 static uint64_t (*g_origGetAvailableMemoryForStreamer)(void* self);
+static bool g_pressureThrottleActive = false;
+
 static uint64_t _getAvailableMemoryForStreamer(void* self)
 {
 	if (auto strMgr = streaming::Manager::GetInstance())
@@ -110,6 +126,50 @@ static uint64_t _getAvailableMemoryForStreamer(void* self)
 			return 0;
 		}
 	}
+
+	int threshold = strResourceCachePressureThreshold.GetValue();
+	if (threshold > 0 && threshold <= 100)
+	{
+		auto cache = rage::grcResourceCache::GetInstance();
+		if (cache)
+		{
+			size_t used = cache->GetUsedPhysicalMemory();
+			size_t total = cache->GetTotalPhysicalMemory();
+
+			if (total > 0 && (used * 100 / total) >= static_cast<size_t>(threshold))
+			{
+#ifdef _DEBUG
+				if (!g_pressureThrottleActive)
+				{
+					trace("grcResourceCache pressure throttle ACTIVATED: %llu / %llu MiB (%d%% >= %d%% threshold)\n",
+						(unsigned long long)(used / (1024 * 1024)),
+						(unsigned long long)(total / (1024 * 1024)),
+						(int)(used * 100 / total),
+						threshold);
+				}
+#endif
+				g_pressureThrottleActive = true;
+				return 0;
+			}
+		}
+	}
+
+#ifdef _DEBUG
+	if (g_pressureThrottleActive)
+	{
+		auto cache = rage::grcResourceCache::GetInstance();
+		if (cache)
+		{
+			size_t used = cache->GetUsedPhysicalMemory();
+			size_t total = cache->GetTotalPhysicalMemory();
+			trace("grcResourceCache pressure throttle DEACTIVATED: %llu / %llu MiB (%d%%)\n",
+				(unsigned long long)(used / (1024 * 1024)),
+				(unsigned long long)(total / (1024 * 1024)),
+				(int)(total > 0 ? (used * 100 / total) : 0));
+		}
+	}
+#endif
+	g_pressureThrottleActive = false;
 
 	return g_origGetAvailableMemoryForStreamer(self);
 }


### PR DESCRIPTION
## Summary

Adds an opt-in pressure threshold gate to `_getAvailableMemoryForStreamer()` that throttles new streaming requests before the `grcResourceCache` reaches 100% capacity, preventing synchronous eviction stalls (0.5-2s freezes).

## Problem

RAGE's streaming eviction is purely reactive — it only evicts when a new asset must load and the cache is completely full. Base game DLC content alone saturates the cache to 100% during normal city traversal, causing the GPU to service page faults synchronously. This affects all VRAM tiers (4-16 GB) and is reproducible on localhost with zero custom content.

## Solution

When `grcResourceCache` usage exceeds a configurable percentage threshold, `_getAvailableMemoryForStreamer()` returns 0 (no available memory for new loads). This maintains headroom so new allocations can succeed without triggering synchronous eviction. The engine's normal LRU/priority eviction continues to operate within the budget.

- **New ConVar:** `str_resourceCachePressureThreshold` (default `0` = off, opt-in)
- **Recommended value:** `90` (~280 MiB headroom on 4 GB cards, ~700 MiB on 10 GB cards)
- **Valid range:** 1-100, persists via `ConVar_Archive`
- **Debug traces:** gated behind `#ifdef _DEBUG`

## Changes

1. **`code/components/gta-streaming-five/src/PatchExtendedBudgeting.cpp`** — Pressure threshold gate with ConVar
2. **`code/components/devtools-five/src/StreamingDebug.cpp`** — Enhanced `strmem` viewer: shows cache usage %, throttle status (active/idle/disabled) with color coding

## Testing

- Built and tested locally against localhost server
- Verified ConVar registers and persists correctly
- Confirmed throttle activates/deactivates at threshold boundary
- No regressions to existing streaming behavior when disabled (default)

Fixes #3874