### PR TITLE
fix(gta-core-five): prevent invalid weapon info exploit in weapon swap task

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.TaskSwapWeapon.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.TaskSwapWeapon.cpp
@@ -1,0 +1,31 @@
+#include <StdInc.h>
+
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
+static uint32_t* (*g_CWeaponInfo_GetClipsetForWeaponSwap)(hook::FlexStruct*, uint32_t*, hook::FlexStruct*, uint32_t);
+
+static uint32_t* CWeaponInfo_GetClipsetForWeaponSwap(hook::FlexStruct* thisPtr, uint32_t* outClipSet, hook::FlexStruct* ped, uint32_t unkEnum)
+{
+	// NOTE: thisPtr (rcx) is nullptr when CClonedTaskWeaponInfo->m_Weapon is not a valid weapon
+	if (!thisPtr)
+	{
+		*outClipSet = 0;
+		return outClipSet;	
+	}
+
+	return g_CWeaponInfo_GetClipsetForWeaponSwap(thisPtr, outClipSet, ped, unkEnum);
+}
+
+static HookFunction hookFunction([]()
+{
+	// A null pointer dereference occurs during processing of a synchronized weapon swap task.
+	// If a serialized weapon is invalid, this ends up with the weapon info being nullptr.
+	// 
+	// When the nullptr is passed to CWeaponInfo_GetClipsetForWeaponSwap,
+	// the game attempts to access thisPtr->m_Name (0x10) without validation, causing a crash.
+	//
+	// This hook prevents the crash by checking if thisPtr is nullptr and returning a safe fallback value.
+
+	g_CWeaponInfo_GetClipsetForWeaponSwap = hook::trampoline(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 41 8B E9 49 8B F8 48 8B DA 48 8B F1 4D 85 C0 0F 84 ? ? ? ? 41 F7 80"), CWeaponInfo_GetClipsetForWeaponSwap);
+});


### PR DESCRIPTION
### Goal of this PR
Prevent a crash that can be caused by cheaters sending invalid weapon hashes that are serialized and synchronized in weapon swap tasks.

### How is this PR achieving the goal
This PR validates the weapon info before the task gets the clipset for the weapon swap task.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
https://www.youtube.com/watch?v=YNlbCgdpqtE


