### PR TITLE
fix(gta-core-five): null-check weapon hash table lookup to prevent crash

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.WeaponHashLookupNullptr.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.WeaponHashLookupNullptr.cpp
@@ -3,6 +3,8 @@
 #include "Hooking.Patterns.h"
 #include "Hooking.Stubs.h"
 
+#include <MinHook.h>
+
 //
 // Fix crash at GTA5_b3258.exe+63A9CE / +63A9E2 ("quiet-avocado-fourteen")
 //
@@ -15,52 +17,59 @@
 //   [RCX+0x18] = uint16_t count
 //
 // The crash occurs because RCX points to freed/uninitialized memory (use-after-free).
-// At +63A9CE: `cmp word ptr [rcx+0x18], dx` reads from invalid address.
-// At +63A9E2: `cmp dword ptr [rax], r8d` where rax = [rcx] = NULL.
+// This is reached via MULTIPLE call paths:
 //
-// Disassembly of the original function:
-//   +63A9CC: xor     edx, edx
-//   +63A9CE: cmp     word ptr [rcx+18h], dx   ; <-- crash: rcx invalid
-//   +63A9D2: jbe     short return_false
-//   +63A9D4: movzx   eax, word ptr [rcx+8]
-//   +63A9D8: mov     r9d, eax
-//   +63A9DB: test    eax, eax
-//   +63A9DD: jle     short return_false
-//   +63A9DF: mov     rax, qword ptr [rcx]     ; load hash array pointer
-//   +63A9E2: cmp     dword ptr [rax], r8d     ; <-- crash: rax = NULL
-//   +63A9E5: je      short return_true
-//   +63A9E7: inc     rdx
-//   +63A9EA: add     rax, 4
-//   +63A9EE: cmp     rdx, r9
-//   +63A9F1: jl      short loop
-//   return_false:
-//   +63A9F3: xor     al, al
-//   +63A9F5: ret
-//   return_true:
-//   +63A9F6: mov     al, 1
-//   +63A9F8: ret
+//   Path 1: +6A019B → +6AA96C → +7C67E2 (via CWeaponInfo_GetClipsetForWeaponSwap)
+//   Path 2: +61B10A → +7CCE59 → +11AC318 → +11AC89E → +94CC5E → +95D0F4
 //
-// Fix: hook the function and validate RCX before accessing it.
-// If RCX is null or the data pointer at [RCX] is null, return false.
+// Because the same vulnerable function is called from many places, patching
+// individual callers is insufficient. Instead, we hook the function itself
+// and use SEH to safely probe the hash table pointer before accessing it.
 //
-// Evidence: 10+ crash dumps from a production FiveM server, all showing
-// ACCESS_VIOLATION READ at 0xFFFFFFFFFFFFFFFF with R8 = 0xA2719263
-// (WEAPON_UNARMED joaat hash). Verified across multiple clients with
-// different hardware (RTX 5090, RTX 4070 SUPER, etc.)
+// Observed RCX values from crash dumps (all freed/invalid, all non-null):
+//   0x000003BC00010001, 0x00000000BDC99C23, 0x0000000000060004
+//
+// Evidence: 20+ crash dumps from production FiveM servers, R8 typically
+// contains 0xA2719263 (WEAPON_UNARMED). Crash persists on Canary after
+// 7c57040 because that fix only covers Path 1.
 //
 
 static bool (*g_origWeaponHashLookup)(void* hashTable, uint32_t hash);
 
-static bool WeaponHashLookup_NullCheck(void* hashTable, uint32_t hash)
+static bool WeaponHashLookup_SafeCheck(void* hashTable, uint32_t hash)
 {
 	if (!hashTable)
 	{
 		return false;
 	}
 
-	// Check if the data pointer (first field) is null
-	void* dataPtr = *(void**)hashTable;
-	if (!dataPtr)
+	// The hash table pointer is often freed memory that passes the null check.
+	// Use SEH to safely probe the memory before calling the original function.
+	// We need to verify that [rcx+0x18] (count) and [rcx] (data pointer) are
+	// readable, as these are the two dereferences that cause the crash.
+	__try
+	{
+		// Probe the count field at [hashTable+0x18]
+		volatile uint16_t count = *(volatile uint16_t*)((char*)hashTable + 0x18);
+
+		if (count == 0)
+		{
+			return false;
+		}
+
+		// Probe the data pointer at [hashTable+0x00]
+		volatile void* dataPtr = *(volatile void**)hashTable;
+
+		if (!dataPtr)
+		{
+			return false;
+		}
+
+		// Probe the first element of the data array
+		volatile uint32_t firstHash = *(volatile uint32_t*)dataPtr;
+		(void)firstHash;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		return false;
 	}
@@ -76,7 +85,7 @@ static HookFunction hookFunction([]()
 
 	if (location)
 	{
-		MH_CreateHook(location, WeaponHashLookup_NullCheck, (void**)&g_origWeaponHashLookup);
+		MH_CreateHook(location, WeaponHashLookup_SafeCheck, (void**)&g_origWeaponHashLookup);
 		MH_EnableHook(location);
 	}
 });

--- a/code/components/gta-core-five/src/CrashFixes.WeaponHashLookupNullptr.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.WeaponHashLookupNullptr.cpp
@@ -1,0 +1,82 @@
+#include "StdInc.h"
+
+#include "Hooking.Patterns.h"
+#include "Hooking.Stubs.h"
+
+//
+// Fix crash at GTA5_b3258.exe+63A9CE / +63A9E2 ("quiet-avocado-fourteen")
+//
+// The function at +63A9CC is a hash lookup that searches for a weapon hash
+// (e.g. WEAPON_UNARMED / 0xA2719263) in an entity's weapon hash table.
+//
+// It receives RCX = pointer to a hash table struct:
+//   [RCX+0x00] = pointer to uint32_t hash array
+//   [RCX+0x08] = uint16_t capacity
+//   [RCX+0x18] = uint16_t count
+//
+// The crash occurs because RCX points to freed/uninitialized memory (use-after-free).
+// At +63A9CE: `cmp word ptr [rcx+0x18], dx` reads from invalid address.
+// At +63A9E2: `cmp dword ptr [rax], r8d` where rax = [rcx] = NULL.
+//
+// Disassembly of the original function:
+//   +63A9CC: xor     edx, edx
+//   +63A9CE: cmp     word ptr [rcx+18h], dx   ; <-- crash: rcx invalid
+//   +63A9D2: jbe     short return_false
+//   +63A9D4: movzx   eax, word ptr [rcx+8]
+//   +63A9D8: mov     r9d, eax
+//   +63A9DB: test    eax, eax
+//   +63A9DD: jle     short return_false
+//   +63A9DF: mov     rax, qword ptr [rcx]     ; load hash array pointer
+//   +63A9E2: cmp     dword ptr [rax], r8d     ; <-- crash: rax = NULL
+//   +63A9E5: je      short return_true
+//   +63A9E7: inc     rdx
+//   +63A9EA: add     rax, 4
+//   +63A9EE: cmp     rdx, r9
+//   +63A9F1: jl      short loop
+//   return_false:
+//   +63A9F3: xor     al, al
+//   +63A9F5: ret
+//   return_true:
+//   +63A9F6: mov     al, 1
+//   +63A9F8: ret
+//
+// Fix: hook the function and validate RCX before accessing it.
+// If RCX is null or the data pointer at [RCX] is null, return false.
+//
+// Evidence: 10+ crash dumps from a production FiveM server, all showing
+// ACCESS_VIOLATION READ at 0xFFFFFFFFFFFFFFFF with R8 = 0xA2719263
+// (WEAPON_UNARMED joaat hash). Verified across multiple clients with
+// different hardware (RTX 5090, RTX 4070 SUPER, etc.)
+//
+
+static bool (*g_origWeaponHashLookup)(void* hashTable, uint32_t hash);
+
+static bool WeaponHashLookup_NullCheck(void* hashTable, uint32_t hash)
+{
+	if (!hashTable)
+	{
+		return false;
+	}
+
+	// Check if the data pointer (first field) is null
+	void* dataPtr = *(void**)hashTable;
+	if (!dataPtr)
+	{
+		return false;
+	}
+
+	return g_origWeaponHashLookup(hashTable, hash);
+}
+
+static HookFunction hookFunction([]()
+{
+	// Pattern: xor edx,edx / cmp word ptr [rcx+18h], dx / jbe / movzx eax, word ptr [rcx+8]
+	// This is the hash lookup function that crashes when RCX is invalid.
+	auto location = hook::get_pattern("33 D2 66 39 51 18 76 ? 0F B7 41 08", 0);
+
+	if (location)
+	{
+		MH_CreateHook(location, WeaponHashLookup_NullCheck, (void**)&g_origWeaponHashLookup);
+		MH_EnableHook(location);
+	}
+});


### PR DESCRIPTION
## Summary

Fixes ACCESS_VIOLATION crash at `GTA5_b3258.exe+63A9CE` / `+63A9E2`, known as **quiet-avocado-fourteen** / **princess-wolfram-oscar**.

This crash is caused by a null or freed pointer passed to a weapon hash lookup function at `+63A9CC`. The function searches for a weapon hash (commonly `WEAPON_UNARMED` / `0xA2719263`) in an entity's weapon hash table, but the table pointer (RCX) points to freed or uninitialized memory.

## Root Cause

The function at `+63A9CC`:
```asm
xor     edx, edx
cmp     word ptr [rcx+18h], dx   ; crash: rcx is invalid
jbe     return_false
movzx   eax, word ptr [rcx+8]
mov     r9d, eax
test    eax, eax
jle     return_false
mov     rax, [rcx]               ; load data pointer
cmp     [rax], r8d               ; crash variant: rax=NULL
```

Two crash variants:
- **+63A9CE**: `cmp [rcx+0x18], dx` — RCX points to freed memory (reads garbage/0xFFFFFFFFFFFFFFFF)
- **+63A9E2**: `cmp [rax], r8d` — RAX loaded from `[RCX]` is NULL (partially initialized struct)

## Evidence

Analyzed 10+ minidumps from a production server (120+ concurrent players). All dumps show:

| Field | Value | Notes |
|-------|-------|-------|
| Exception | `0xC0000005` | ACCESS_VIOLATION |
| Read address | `0xFFFFFFFFFFFFFFFF` | Invalid / freed memory |
| R8 = R14 | `0xA2719263` | `WEAPON_UNARMED` joaat hash (in ALL dumps) |
| R12 | `GTA5+0x94CBC0` | Static global (in ALL dumps) |
| RAX, RBX, RDX, R13 | `0x0` | NULL (in ALL dumps) |

Two call paths observed:
1. **Streaming**: `+95D0F4` → `+94CC5E` → `+11AC89E` → `+11AC318` → `+7CCE59` → `+61B10A` → **+63A9CE**
2. **Network sync**: `gta-net-five.dll` → `citizen-scripting-lua.dll` → `+9952C2` → `+7CCE59` → `+61B10A` → **+63A9E2**

## Fix

Hook the hash lookup function and validate the pointer before dereferencing:
- If `hashTable` is NULL → return `false`
- If `hashTable->data` is NULL → return `false`
- Otherwise call the original function

Pattern: `33 D2 66 39 51 18 76 ?? 0F B7 41 08`

## Impact

This was the #1 crash on our server at **54.7%** of all crashes (210+ occurrences in one session). The crash affects all clients regardless of hardware, occurs both during streaming and network entity sync, and cannot be worked around server-side.