### PR TITLE
feat(native): new native to remove a key mapping in runtime

### DIFF
--- a/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/GameInputFunctions.cpp
@@ -27,6 +27,20 @@ static InitFunction initFunction([]()
 		}
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("UNREGISTER_KEY_MAPPING", [](fx::ScriptContext& context)
+	{
+		std::string commandString = context.CheckArgument<const char*>(0);
+
+		fx::OMPtr<IScriptRuntime> runtime;
+
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+			game::UnregisterBindingForTag(resource->GetName(), commandString);
+		}
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_KEY_MAPPING_HIDE_RESOURCES", [](fx::ScriptContext& context)
 	{
 		bool hide = context.GetArgument<bool>(0);

--- a/code/components/gta-core-five/include/GameInput.h
+++ b/code/components/gta-core-five/include/GameInput.h
@@ -12,6 +12,8 @@ namespace game
 
 	GAMEINPUT_EXPORT void RegisterBindingForTag(const std::string& tag, const std::string& command, const std::string& languageDesc, const std::string& ioms, const std::string& ioParam);
 
+	GAMEINPUT_EXPORT void UnregisterBindingForTag(const std::string& tag, const std::string& command);
+
 	GAMEINPUT_EXPORT bool IsControlKeyDown(int control);
 
 	GAMEINPUT_EXPORT void SetKeyMappingHideResources(bool hide);

--- a/code/components/gta-core-five/src/GameInput.cpp
+++ b/code/components/gta-core-five/src/GameInput.cpp
@@ -1125,6 +1125,67 @@ namespace game
 		}
 	}
 
+	void UnregisterBindingForTag(const std::string& tag, const std::string& command)
+	{
+		bindingManager.QueueOnFrame([tag, command]()
+		{
+			if (auto it = g_registeredBindings.find(command); it != g_registeredBindings.end())
+			{
+				if (std::get<0>(it->second) == tag)
+				{
+					g_registeredBindings.erase(it);
+				}
+				else
+				{
+					return; // not owned by this resource
+				}
+			}
+
+			auto textKey = fmt::sprintf("INPUT_%08X", HashString(command.c_str()));
+			game::RemoveCustomText(HashString(textKey.c_str()));
+
+			// Remove primary & alternate
+			std::string altCommand = "~!" + command;
+			auto& bindings = bindingManager.GetBindings();
+
+			for (auto it = bindings.begin(); it != bindings.end(); )
+			{
+				if (it->second->GetTag() == tag &&
+					(it->second->GetCommand() == command || it->second->GetCommand() == altCommand))
+				{
+					std::string_view cmd = it->second->GetCommand();
+					if (cmd.size() > 1 && cmd[0] == '+')
+					{
+						std::string_view baseCmd = cmd;
+						if (baseCmd.find("~!") == 0)
+						{
+							baseCmd = baseCmd.substr(2);
+						}
+						std::string plusCmd(baseCmd);
+
+						if (auto dsIt = g_downSet.find(plusCmd); dsIt != g_downSet.end())
+						{
+							g_downSet.erase(dsIt);
+
+							if (g_downSet.find(plusCmd) == g_downSet.end())
+							{
+								console::GetDefaultContext()->AddToBuffer("-" + plusCmd.substr(1) + "\n");
+							}
+						}
+					}
+
+					it = bindings.erase(it);
+				}
+				else
+				{
+					++it;
+				}
+			}
+
+			console::GetDefaultContext()->SetVariableModifiedFlags(ConVar_Archive);
+		});
+	}
+
 	bool IsInputSourceDown(const rage::ioInputSource& controlData)
 	{
 		// mouse?

--- a/ext/native-decls/UnregisterKeyMapping.md
+++ b/ext/native-decls/UnregisterKeyMapping.md
@@ -1,0 +1,35 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## UNREGISTER_KEY_MAPPING
+
+```c
+void UNREGISTER_KEY_MAPPING(char* commandString);
+```
+
+Unregisters a key mapping for the current resource that was previously registered with [REGISTER_KEY_MAPPING](#_0xD7664FD1).
+
+The key mapping will be removed from the settings menu and the associated binding will be unmapped. This only affects key mappings registered by the calling resource.
+
+If the command has an alternate key binding (prefixed with `~!`), it will also be removed automatically.
+
+## Parameters
+* **commandString**: The command that was used when registering the key mapping, e.g. `+handsup`.
+
+## Examples
+
+```lua
+RegisterKeyMapping('+handsup', 'Hands Up', 'keyboard', 'i')
+RegisterKeyMapping('~!+handsup', 'Hands Up - Alternate Key', 'keyboard', 'o')
+
+UnregisterKeyMapping('+handsup')
+```
+
+```js
+RegisterKeyMapping('+handsup', 'Hands Up', 'keyboard', 'i');
+RegisterKeyMapping('~!+handsup', 'Hands Up - Alternate Key', 'keyboard', 'o');
+
+UnregisterKeyMapping('+handsup');
+```


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Being able to delete a registered keymapping in runtime


### How is this PR achieving the goal
By adding a new native `UNREGISTER_KEY_MAPPING` to remove a registered keymapping in runtime, please note this native can only be used by the resource who created the keymapping

### This PR applies to the following area(s)
FiveM


### Successfully tested on

**Game builds:** 9095

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.