### PR TITLE
fix(server): use signed int32 for weaponType in CWeaponDamageEvent

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -5046,7 +5046,7 @@ struct CWeaponDamageEvent
 	}
 
 	uint8_t damageType;
-	uint32_t weaponType; // weaponHash
+	int32_t weaponType; // weaponHash
 
 	bool overrideDefaultDamage;
 	bool hitEntityWeapon;
@@ -6308,7 +6308,7 @@ struct CWeaponDamageEvent
 	}
 
 	uint8_t damageType;
-	uint32_t weaponType; // weaponHash
+	int32_t weaponType; // weaponHash
 	uint32_t f92;
 
 	bool overrideDefaultDamage;


### PR DESCRIPTION
## Summary
`weaponDamageEvent` exposes `weaponType` as `uint32_t`, which causes script-side comparisons against `GetHashKey()` to fail due to signedness mismatch.

For example, `GetHashKey('weapon_rpg')` returns `-1312131151` (signed) while `data.weaponType` from the event returns `2982836145` (unsigned). These are the same 32-bit pattern (`0xB1CA77B1`) interpreted differently.

`CStartProjectileEvent` already stores its `weaponHash` as a signed `int` and does not have this issue.

## Changes
- Changed `weaponType` from `uint32_t` to `int32_t` in both the GTA5 and RDR3 `CWeaponDamageEvent` structs

The network read (`buffer.Read<uint32_t>(32)`) remains unchanged — the implicit conversion to `int32_t` reinterprets the bit pattern as signed, matching how `CStartProjectileEvent` already works.

## Test Plan
- Verify `data.weaponType` in `weaponDamageEvent` handler now returns signed hashes matching `GetHashKey()`
- Confirm existing weapon damage detection scripts continue to function

Fixes #3827