### PR TITLE
feat(net): add client-side ping, variance and packet loss natives

### DIFF
--- a/code/components/extra-natives-five/src/NetworkExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/NetworkExtraNatives.cpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <StdInc.h>
+#include <ScriptEngine.h>
+#include <NetLibrary.h>
+
+static HookFunction hookFunction([]()
+{
+	static NetLibrary* netLibrary;
+
+	NetLibrary::OnNetLibraryCreate.Connect([](NetLibrary* lib)
+	{
+		netLibrary = lib;
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_CLIENT_PING", [](fx::ScriptContext& context)
+	{
+		if (netLibrary)
+		{
+			context.SetResult<int>(netLibrary->GetPing());
+			return;
+		}
+
+		context.SetResult<int>(-1);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_CLIENT_PING_VARIANCE", [](fx::ScriptContext& context)
+	{
+		if (netLibrary)
+		{
+			context.SetResult<int>(netLibrary->GetVariance());
+			return;
+		}
+
+		context.SetResult<int>(-1);
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_CLIENT_PACKET_LOSS", [](fx::ScriptContext& context)
+	{
+		if (netLibrary)
+		{
+			context.SetResult<int>(netLibrary->GetPacketLoss());
+			return;
+		}
+
+		context.SetResult<int>(-1);
+	});
+});

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -394,6 +394,8 @@ public:
 
 	int32_t GetVariance();
 
+	int32_t GetPacketLoss();
+
 	void SetMetricSink(fwRefContainer<INetMetricSink>& sink);
 
 	virtual void AddReceiveTick() override;

--- a/code/components/net/include/NetLibraryImplBase.h
+++ b/code/components/net/include/NetLibraryImplBase.h
@@ -52,6 +52,8 @@ public:
 	virtual int32_t GetPing() = 0;
 
 	virtual int32_t GetVariance() = 0;
+
+	virtual int32_t GetPacketLoss() = 0;
 };
 
 class INetLibraryInherit

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -2159,6 +2159,16 @@ int32_t NetLibrary::GetVariance()
 	return -1;
 }
 
+int32_t NetLibrary::GetPacketLoss()
+{
+	if (auto impl = GetImpl())
+	{
+		return impl->GetPacketLoss();
+	}
+
+	return -1;
+}
+
 void NetLibrary::SetRichError(const std::string& data /* = "{}" */)
 {
 	m_richError = data;

--- a/code/components/net/src/NetLibraryImplV2.cpp
+++ b/code/components/net/src/NetLibraryImplV2.cpp
@@ -44,6 +44,8 @@ public:
 
 	virtual int32_t GetVariance() override;
 
+	virtual int32_t GetPacketLoss() override;
+
 private:
 	void ProcessPacket(const uint8_t* data, size_t size, NetPacketMetrics& metrics, ENetPacketFlag flags);
 
@@ -478,6 +480,16 @@ int32_t NetLibraryImplV2::GetVariance()
 	if (m_serverPeer)
 	{
 		return int32_t(m_serverPeer->roundTripTimeVariance);
+	}
+
+	return -1;
+}
+
+int32_t NetLibraryImplV2::GetPacketLoss()
+{
+	if (m_serverPeer)
+	{
+		return int32_t((m_serverPeer->packetLoss / (double)ENET_PEER_PACKET_LOSS_SCALE) * 100);
 	}
 
 	return -1;


### PR DESCRIPTION
## Summary
- Adds three new client-side natives: `GET_CLIENT_PING`, `GET_CLIENT_PING_VARIANCE`, and `GET_CLIENT_PACKET_LOSS`
- These values were already available internally via the ENet peer but not exposed to the scripting layer
- Adds `GetPacketLoss()` to the `NetLibrary` interface, following the same pattern as `GetPing()` and `GetVariance()`

## Usage

```lua
local ping = GetClientPing()             -- RTT in ms, -1 if not connected
local variance = GetClientPingVariance() -- RTT variance in ms, -1 if not connected
local loss = GetClientPacketLoss()       -- packet loss percentage, -1 if not connected
```

## Test plan
- [ ] Connect to a server and verify `GetClientPing()` returns a valid RTT in ms
- [ ] Verify `GetClientPingVariance()` returns RTT variance matching `netgraph 1` display
- [ ] Verify `GetClientPacketLoss()` returns packet loss percentage matching `cl_drawPacketLoss`
- [ ] Verify all three return `-1` when not connected to any server

Fixes #2233