### PR TITLE
fix(handling-loader-five): handle m_acceleration and fAcceleration aliases

### DIFF
--- a/code/components/handling-loader-five/src/HandlingLoader.cpp
+++ b/code/components/handling-loader-five/src/HandlingLoader.cpp
@@ -276,6 +276,13 @@ static void setFloatField(char* handlingChar, uint32_t offset, float value, cons
 }
 
 atArray<CHandlingData*>* g_handlingData;
+static constexpr uint32_t CHandlingDataAccelerationOffset = 0x4C;
+
+static bool IsAccelerationFieldHash(uint32_t fieldHash)
+{
+	return (fieldHash == HashRageString("m_acceleration")
+		|| fieldHash == HashRageString("fAcceleration"));
+}
 
 static void SetHandlingDataInternal(fx::ScriptContext& context, CHandlingData* handlingData, const char* fromFunction)
 {
@@ -321,12 +328,23 @@ static void SetHandlingDataInternal(fx::ScriptContext& context, CHandlingData* h
 	if (isCHandling || isSubHandling)
 	{
 		uint32_t fieldHash = HashRageString(handlingField);
-
-		auto& members = parserStructure->m_members;
 		bool found = false;
 
+		if (isCHandling && IsAccelerationFieldHash(fieldHash))
+		{
+			setFloatField(handlingChar, CHandlingDataAccelerationOffset, context.GetArgument<float>(3), handlingField);
+			found = true;
+			context.SetResult(true);
+		}
+
+		auto& members = parserStructure->m_members;
 		for (rage::parMember* member : members)
 		{
+			if (found)
+			{
+				break;
+			}
+
 			if (member->m_definition->hash == fieldHash)
 			{
 				uint32_t offset = member->m_definition->offset;
@@ -449,12 +467,22 @@ void GetVehicleHandling(fx::ScriptContext& context, const char* fromFunction)
 		if (isCHandling || isSubHandling)
 		{
 			uint32_t fieldHash = HashRageString(handlingField);
-
-			auto& members = parserStructure->m_members;
 			bool found = false;
 
+			if (isCHandling && IsAccelerationFieldHash(fieldHash))
+			{
+				context.SetResult<T>((T)(getFloatField(handlingChar, CHandlingDataAccelerationOffset, handlingField)));
+				found = true;
+			}
+
+			auto& members = parserStructure->m_members;
 			for (rage::parMember* member : members)
 			{
+				if (found)
+				{
+					break;
+				}
+
 				if (member->m_definition->hash == fieldHash)
 				{
 					uint32_t offset = member->m_definition->offset;


### PR DESCRIPTION
## Summary
- add explicit `m_acceleration` and `fAcceleration` aliases for `CHandlingData`
- read and write those aliases through the existing acceleration float at offset `0x4C`
- stop scanning parser members once an alias has already been handled

## Why
`m_acceleration` and `fAcceleration` map to the same acceleration value in `CHandlingData`, but they are not exposed through the normal parser member lookup. As a result, handling getter/setter calls for those names fall through to `No such field` even though the backing field exists.

## Impact
Scripts can now read and write acceleration using either alias without breaking the existing conversion logic in `setFloatField` and `getFloatField`.

## Validation
- `git diff --check`
- verified the final one-file diff matches the requested patch

## Notes
- no full FiveM build was run in this environment
