### PR TITLE
fix(devtools-five): guard hook behind debug & removed ComputeSceneNodeIndex

### DIFF
--- a/code/components/devtools-five/src/SceneGraphPoolsDebug.cpp
+++ b/code/components/devtools-five/src/SceneGraphPoolsDebug.cpp
@@ -261,17 +261,8 @@ static void FwBasePool(rage::fwBasePool* pool, int poolSize, uint8_t* storage, u
 	g_origFwBasePool(pool, poolSize, storage, scratchBuffer, name, classSize, flags);
 }
 
-static int16_t (*g_origComputeSceneNodeIndex)(const void* sceneNode);
-static int16_t ComputeSceneNodeIndex(const void* sceneNode)
-{
-	auto result = g_origComputeSceneNodeIndex(sceneNode);
-	trace("Scene Node Index: %d\n", result);
-	return result;
-}
-
 static HookFunction hookFunction([]()
 {
-	g_origComputeSceneNodeIndex = hook::trampoline(hook::get_pattern("4C 8B C1 0F B6 49 ? 85 C9"), ComputeSceneNodeIndex);
 	g_origFwBasePool = hook::trampoline(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 89 1D ? ? ? ? EB ? 48 89 35 ? ? ? ? 48 8B 0D")), FwBasePool);
 	// Visibility Being
 	{
@@ -323,6 +314,7 @@ static HookFunction hookFunction([]()
 	}
 
 	// Asset scratch buffer guard
+	#ifdef _DEBUG
 	{
 		auto location = hook::get_pattern<char>("48 8D 4C 24 ? E8 ? ? ? ? B0 ? 48 81 C4 ? ? ? ? 5D");
 
@@ -345,6 +337,7 @@ static HookFunction hookFunction([]()
 		hook::nop(location, 5);
 		hook::jump_rcx(location, stub.GetCode());
 	}
+	#endif
 });
 
 static InitFunction initFunction([]()


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Remove unnecessary runtime debug logging from `ComputeSceneNodeIndex` to reduce console spam and avoid potential performance overhead. Debug output is retained only when `_DEBUG` builds are active.

### How is this PR achieving the goal

- Removes the `trace` call.
- Wraps debug-related code with #ifdef `_DEBUG` to ensure it only runs in debug builds.

### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** -

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

<img width="535" height="580" alt="{722724C3-7AB7-4950-B946-AF4DE78186E1}" src="https://github.com/user-attachments/assets/6cc7dbd7-f3ad-497b-9d5e-ac17d05e5bdd" />