### PR TITLE
Fix NUI backdrop-filter flicker

### DIFF
--- a/code/components/nui-core/src/NUIApp.cpp
+++ b/code/components/nui-core/src/NUIApp.cpp
@@ -169,6 +169,7 @@ void NUIApp::OnContextReleased(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame
 void NUIApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
 	static ConVar<bool> nuiUseInProcessGpu("nui_useInProcessGpu", ConVar_Archive, true);
+	static ConVar<bool> nuiDisableGpuDriverBugWorkarounds("nui_disableGpuDriverBugWorkarounds", ConVar_Archive, false);
 
 	static std::string defaultUiUrl = "https://nui-game-internal/ui/app/index.html";
 	static ConVar<std::string> uiUrlVar("ui_url", ConVar_None, defaultUiUrl);
@@ -194,13 +195,22 @@ void NUIApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRef
 	command_line->AppendSwitch("ignore-gpu-blacklist");
 	command_line->AppendSwitch("ignore-gpu-blocklist"); // future proofing for when Google disables the above
 	command_line->AppendSwitch("disable-direct-composition");
-	command_line->AppendSwitch("disable-gpu-driver-bug-workarounds");
+
+	if (nuiDisableGpuDriverBugWorkarounds.GetValue())
+	{
+		command_line->AppendSwitch("disable-gpu-driver-bug-workarounds");
+	}
+
 	command_line->AppendSwitchWithValue("default-encoding", "utf-8");
 	command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
 	command_line->AppendSwitchWithValue("disable-features", "HardwareMediaKeyHandling");
 
 #if !GTA_NY
-	command_line->AppendSwitch("enable-gpu-rasterization");
+	static ConVar<bool> nuiUseGpuRasterization("nui_useGpuRasterization", ConVar_Archive, false);
+	if (nuiUseGpuRasterization.GetValue())
+	{
+		command_line->AppendSwitch("enable-gpu-rasterization");
+	}
 #else
 	command_line->AppendSwitch("disable-gpu-vsync");
 #endif


### PR DESCRIPTION
### Goal of this PR

Fix or mitigate NUI `backdrop-filter: blur()` flickering in normal resource NUI.

### How is this PR achieving the goal

Normal resource NUI is rendered through the root raw NUI window and CEF shared-texture/compositor path. The previous shader approach affected DUI/runtime-texture windows only, so it has been reverted.

This PR changes CEF GPU compositor defaults for normal NUI:

- `disable-gpu-driver-bug-workarounds` is no longer forced by default.
- `enable-gpu-rasterization` is no longer forced by default.
- The old behavior remains available through convars:
  - `nui_disableGpuDriverBugWorkarounds`
  - `nui_useGpuRasterization`

This keeps the risky compositor settings available for diagnostics while avoiding them by default for NUI rendering.

### This PR applies to the following area(s)

FiveM, NUI

### Successfully tested on

**Game builds:** Not runtime-tested locally.

**Platforms:** Windows

Validation performed:
- Traced the normal NUI and DUI render paths.
- Confirmed normal NUI does not use the DUI `quadPS` shader path.
- Restored the DUI shader behavior.
- Confirmed the PR now only changes `code/components/nui-core/src/NUIApp.cpp`.
- Ran `git diff --check origin/master...HEAD`.

### Runtime validation needed

Test a normal resource NUI repro using:

```css
backdrop-filter: blur(10px);
```

Then compare:
- default settings
- `nui_useGpuRasterization 1`
- `nui_disableGpuDriverBugWorkarounds 1`
- both enabled
- `nui_useSharedResources 0`

### Fixes issues

Related to #3843