### PR TITLE
fix(net-tcp-server): prevent use-after-free crash in UvLoopHolder destructor

### DIFF
--- a/code/components/net-tcp-server/src/UvLoopHolder.cpp
+++ b/code/components/net-tcp-server/src/UvLoopHolder.cpp
@@ -57,6 +57,12 @@ UvLoopHolder::UvLoopHolder(const std::string& loopTag)
 			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		}
 
+		// close the async handle from within the loop thread and run the
+		// loop one final time so libuv can process the close callback
+		// before the loop is destroyed
+		m_async->close();
+		m_loop->run<uvw::Loop::Mode::DEFAULT>();
+
 		// clean up the libuv loop
 		m_loop = {};
 	});
@@ -70,24 +76,15 @@ UvLoopHolder::~UvLoopHolder()
 	// stop the loop as soon as possible
 	m_loop->stop();
 
-	// signal the loop so it can get triggered
-	uv_async_t async;
-	
-	uv_async_init(m_loop->raw(), &async, [] (uv_async_t*)
-	{
-
-	});
-
-	uv_async_send(&async);
+	// wake the loop thread using the existing async handle so it can
+	// observe m_shouldExit and shut down cleanly
+	m_async->send();
 
 	// wait for the thread to exit cleanly
 	if (m_thread.joinable())
 	{
 		m_thread.join();
 	}
-
-	// clean up the async
-	uv_close(reinterpret_cast<uv_handle_t*>(&async), nullptr);
 }
 
 void UvLoopHolder::AssertThread()


### PR DESCRIPTION
## Summary

`UvLoopHolder::~UvLoopHolder()` can crash with `Assertion failed: 0 (../deps/uv/src/unix/core.c: uv_close: 234)` due to a race condition during shutdown.

### Root cause

The destructor creates a **stack-allocated** `uv_async_t`, registers it with the loop, sends a signal, then calls `m_thread.join()`. The loop thread sees `m_shouldExit == true`, destroys the loop (`m_loop = {}`), and exits. After `join()` returns, the destructor calls `uv_close()` on the stack-allocated handle — but the loop is already destroyed and the handle's internal type field is corrupt. libuv's `uv_close` hits the default branch in its type-switch and asserts.

```
Timeline:
  Destructor thread              Loop thread
  ──────────────────             ──────────────
  m_shouldExit = true
  m_loop->stop()
  uv_async_init(&async)
  uv_async_send(&async)
  m_thread.join() ───────────►   exits while loop
       (blocks)                  m_loop = {}  ← loop destroyed
       (returns) ◄──────────     thread exits
  uv_close(&async) ← CRASH
```

### Fix

- Reuse the existing `m_async` member to wake the loop thread — no stack-allocated handle needed.
- Close `m_async` from within the loop thread (where libuv requires handle closure to happen) and run the loop one final time to process the close callback.
- Remove the post-join `uv_close()` call that operated on a dead loop.

### Observed impact

This crash was observed on a production FXServer (Linux, 64-slot) running artifacts 27055 and 27722. The crash dump signature:
```
Assertion failed: 0 (../deps/uv/src/unix/core.c: uv_close: 234)
```
The bug exists in all current artifacts — the file has never been modified since creation.

### Testing

The fix is a minimal, targeted change (9 lines added, 12 removed) to a single file. The async handle lifecycle now follows libuv's threading rules: handles are closed from the thread that owns the loop, before the loop is destroyed.