### PR TITLE
fix(fxdk): prevent path traversal in remote resources

### DIFF
--- a/ext/sdk/resources/sdk-root/shell/src/backend/fxcode/fxcode-service.ts
+++ b/ext/sdk/resources/sdk-root/shell/src/backend/fxcode/fxcode-service.ts
@@ -9,6 +9,7 @@ import { concurrently } from "utils/concurrently";
 import { ShellBackend } from 'backend/shell-backend';
 import { URL } from 'url';
 import { NotificationService } from "backend/notification/notification-service";
+import * as path from 'path';
 
 interface FXCode {
   getRootPath(): string;
@@ -68,7 +69,12 @@ export class FXCodeService implements AppContribution {
 
     this.shellBackend.expressApp.get('/vscode-remote-resource', (req, res) => {
       if (this.fxcode) {
-        res.sendFile(this.fxcode.getRemoteResourcePath(getUrlQuery(req.url)));
+        const resourcePath = this.fxcode.getRemoteResourcePath(getUrlQuery(req.url));
+        if (!resourcePath || !isPathInside(resourcePath, this.configService.sdkRootFXCode)) {
+          res.status(400).send('Invalid resource path');
+          return;
+        }
+        res.sendFile(resourcePath);
       } else {
         res.send('FXCode not started it seems, rip');
       }
@@ -166,4 +172,12 @@ function getUrlQuery(url: string): Record<string, string> {
 
     return acc;
   }, {});
+}
+
+function isPathInside(candidate: string, root: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  const relativePath = path.relative(resolvedRoot, resolvedCandidate);
+
+  return relativePath === '' || (!!relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }


### PR DESCRIPTION
## Summary

Fixes the FxDK `/vscode-remote-resource` path traversal reported in #2209.

The shell backend previously passed the user-controlled `path` query through `getRemoteResourcePath()` and directly into `res.sendFile()`. Since `sendFile()` accepts absolute paths, a request such as `?path=C:/Windows/win.ini` could read files outside the FxDK install.

## Changes

- Resolve and validate the FxCode resource path before serving it.
- Reject empty resource paths.
- Reject any resource path that resolves outside `sdkRootFXCode` using `path.relative()` and an absolute-path check.
- Return HTTP 400 for invalid paths instead of passing them to Express `sendFile()`.

This keeps the remote resource endpoint limited to the same SDK root already exposed by `/fxcode-static`, while blocking arbitrary absolute-path reads and `..` traversal out of the FxCode root.

## Validation

- Reviewed the original issue and local path traversal analysis.
- Verified the committed diff is limited to `ext/sdk/resources/sdk-root/shell/src/backend/fxcode/fxcode-service.ts`.
- Checked path-boundary behavior for in-root FxCode paths, sibling-prefix paths, Windows system paths, and `..` traversal.

Full package build was not run because this checkout does not have `node_modules`, and `yarn` is not installed locally.