### PR TITLE
feat(citizen-server-impl): add prevent_restart metadata to protect resources from console commands

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -670,6 +670,21 @@ static InitFunction initFunction([]()
 			return resources;
 		};
 
+		static auto isPreventRestart = [resman](const std::string& resourceName) -> bool
+		{
+			auto resource = resman->GetResource(resourceName);
+
+			if (!resource.GetRef())
+			{
+				return false;
+			}
+
+			auto metaData = resource->GetComponent<fx::ResourceMetaDataComponent>();
+			auto iv = metaData->GetEntries("prevent_restart");
+
+			return iv.begin() != iv.end();
+		};
+
 		static auto commandRef = instance->AddCommand("start", [=](const std::string& resourceName)
 		{
 			if (resourceName.empty())
@@ -693,6 +708,12 @@ static InitFunction initFunction([]()
 			if (!resource.GetRef())
 			{
 				trace("^3Couldn't find resource %s.^7\n", resourceName);
+				return;
+			}
+
+			if (isPreventRestart(resourceName))
+			{
+				trace("^3Resource %s has prevent_restart set and cannot be started via console commands.^7\n", resourceName);
 				return;
 			}
 
@@ -732,6 +753,12 @@ static InitFunction initFunction([]()
 				return;
 			}
 
+			if (isPreventRestart(resourceName))
+			{
+				trace("^3Resource %s has prevent_restart set and cannot be stopped via console commands.^7\n", resourceName);
+				return;
+			}
+
 			if (!resource->Stop())
 			{
 				if (resource->GetState() != fx::ResourceState::Stopped)
@@ -749,6 +776,12 @@ static InitFunction initFunction([]()
 			if (!resource.GetRef())
 			{
 				trace("^3Couldn't find resource %s.^7\n", resourceName);
+				return;
+			}
+
+			if (isPreventRestart(resourceName))
+			{
+				trace("^3Resource %s has prevent_restart set and cannot be restarted via console commands.^7\n", resourceName);
 				return;
 			}
 
@@ -789,6 +822,12 @@ static InitFunction initFunction([]()
 				if (!resource.GetRef())
 				{
 					trace("^3Couldn't find resource %s.^7\n", resourceName);
+					return false;
+				}
+
+				if (isPreventRestart(resourceName))
+				{
+					trace("^3Resource %s has prevent_restart set and cannot be managed via console commands.^7\n", resourceName);
 					return false;
 				}
 


### PR DESCRIPTION
### Goal of this PR

Allow resource authors to protect their resources from being stopped, started, restarted, or re-ensured via server console commands. This is useful for critical resources such as anti-cheat systems, core framework scripts, or any resource that should remain running without interference from console access.

### How is this PR achieving the goal

A new `prevent_restart` metadata key is introduced. When set in `fxmanifest.lua`, the `start`, `stop`, `restart`, and `ensure` console commands will refuse to operate on that resource and emit a warning trace instead.

The implementation follows the existing pattern used by `server_only` metadata, reading entries via `ResourceMetaDataComponent::GetEntries`.

**Usage in `fxmanifest.lua`:**
```lua
fx_version 'cerulean'
game 'gta5'

prevent_restart 'yes'
```

**Console output when blocked:**
```
^3Resource my_anticheat has prevent_restart set and cannot be managed via console commands.^7
```

Note: this only blocks console commands. Programmatic lifecycle control via resource events is unaffected.

### This PR applies to the following area(s)

Server

### Successfully tested on

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] The code follows the existing patterns in the codebase (`server_only` metadata pattern).
- [x] No breaking changes to existing resources that do not use this metadata.