### PR TITLE
fix: null-dereference in local manifest itydependencies fixup

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -2300,8 +2300,15 @@ void LoadManifest(const char* tagName)
 
 				CDataFileMgr::DataFile entry = { 0 };
 				strcpy_s(entry.name, name.c_str());
+				entry.type = DataFileType::DLC_ITYP_REQUEST;
 
-				mounter->UnloadDataFile(&entry);
+				__try
+				{
+					mounter->UnloadDataFile(&entry);
+				}
+				__except (FilterUnmountOperation(entry))
+				{
+				}
 			}
 		}
 
@@ -2344,8 +2351,15 @@ void LoadManifest(const char* tagName)
 
 					CDataFileMgr::DataFile entry = { 0 };
 					strcpy_s(entry.name, name.c_str());
+					entry.type = DataFileType::DLC_ITYP_REQUEST;
 
-					mounter->UnloadDataFile(&entry);
+					__try
+					{
+						mounter->UnloadDataFile(&entry);
+					}
+					__except (FilterUnmountOperation(entry))
+					{
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Goal of this PR


fixes https://github.com/citizenfx/fivem/issues/3943  in LoadManifest while processing itypDependencies a streamed resource's manifest contained #typ entries that hash-collided 


### How is this PR achieving the goal

field with DataFileType::DLC_ITYP_REQUEST before calling UnloadDataFile this field to correctly identify the resource type , 


### This PR applies to the following area(s)

FiveM, RedM, Streaming


### Successfully tested on

**Game builds:** 

2545+ (GTA V), 1436.28 (RDR3)

**Platforms:** 

Windows


### Checklist


- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

https://github.com/citizenfx/fivem/issues/3943


