### PR TITLE
feat(extra-natives/five): SET_WEATHER_INTERPOLATE

### DIFF
--- a/code/components/extra-natives-five/src/WeatherNatives.cpp
+++ b/code/components/extra-natives-five/src/WeatherNatives.cpp
@@ -35,6 +35,7 @@ struct CWeather
 	float changeCloundOnSameWeatherType;
 	uint32_t prevTypeIndex;
 	uint32_t nextTypeIndex;
+	float interp;
 	// and a bunch of other fields...
 
 	int32_t GetTypeIndex(const char* name)
@@ -68,6 +69,22 @@ static void AddStopCallback(T&& stopCb)
 template <int Build>
 static void RegisterExtraWeatherNatives()
 {
+	fx::ScriptEngine::RegisterNativeHandler("SET_WEATHER_INTERPOLATE", [](fx::ScriptContext& context)
+	{
+		const char* weatherNamePrev = context.CheckArgument<const char*>(0);
+		const char* weatherNameNext = context.CheckArgument<const char*>(1);
+		float interpVal = context.GetArgument<float>(2);
+
+		auto& weather = *g_weather<Build>;
+
+		int32_t typeIndexPrev = weather.GetTypeIndex(weatherNamePrev);
+		weather.prevTypeIndex = (uint32_t)typeIndexPrev;
+		int32_t typeIndexNext = weather.GetTypeIndex(weatherNameNext);
+		weather.nextTypeIndex = (uint32_t)typeIndexNext;
+
+		weather.interp = interpVal; 
+		weather.cycleTimer = (int)weather.currentMsPerCycle * weather.interp;
+	});
 	fx::ScriptEngine::RegisterNativeHandler("SET_WEATHER_CYCLE_ENTRY", [](fx::ScriptContext& context)
 	{
 		int index = context.GetArgument<int>(0);

--- a/ext/native-decls/SetWeatherInterpolate.md
+++ b/ext/native-decls/SetWeatherInterpolate.md
@@ -1,0 +1,35 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_WEATHER_INTERPOLATE
+
+```c
+void SET_WEATHER_INTERPOLATE(char* weatherTypePrev, char* weatherTypeNext, float interp);
+```
+## Examples
+
+Valid weather types are:
+* EXTRASUNNY
+* CLEAR
+* CLOUDS
+* SMOG
+* FOGGY
+* OVERCAST
+* RAIN
+* THUNDER
+* CLEARING
+* NEUTRAL
+* SNOW
+* BLIZZARD
+* SNOWLIGHT
+* XMAS
+* HALLOWEEN
+* RAIN_HALLOWEEN (added in 3258)
+* SNOW_HALLOWEEN (added in 3258)
+
+## Parameters
+* **weatherTypePrev**: any valid weather type
+* **weatherTypeNext**: any valid weather type
+* **interp**: float between 0.0-1.0


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

I recreated the SET_CURR_WEATHER_STATE native because it is disabled on network in the default game logic for it


### How is this PR achieving the goal

I recreated how the native functions and named it "SET_WEATHER_INTERPOLATE" which more accurately reflects its purpose


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3751 

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


