### PR TITLE
feat(gta-core-five): add more vehicle pools

### DIFF
--- a/code/components/gta-core-five/src/PoolManagement.cpp
+++ b/code/components/gta-core-five/src/PoolManagement.cpp
@@ -166,6 +166,8 @@ static const char* poolEntriesTable[] = {
 	"CTask",
 	"OcclusionPathNode",
 	"OcclusionPortalInfo",
+	"CNetObjVehicle",
+	"CVehicleSyncData",
 #include "gta_vtables.h"
 	"Decorator",
 	"StreamPed req data",


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Add more Vehicle pools to fivem for allowing server owners to adjust these pools, because on large servers a full vehicle pool can cause invisible vehicles and client crashes.

I also suggest adding the pools `CNetObjVehicle` and `CVehicleSyncData` to the https://content.cfx.re/mirrors/client/pool-size-limits/fivem.json and set the max allowed limit for `CNetObjVehicle` to 500 and for `CVehicleSyncData` to 510. 


### How is this PR achieving the goal
Added the pools to the poolEntriesTable.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3751

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
resolves #3883

