### PR TITLE
fix(gta-core-five): gfx set to image exploit

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.GfxImage.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.GfxImage.cpp
@@ -1,0 +1,22 @@
+#include "StdInc.h"
+#include "Hooking.Patterns.h"
+#include "Hooking.Stubs.h"
+
+static char imageInfoOffset;
+
+static void (*g_origGfxShapeSetToImage)(void* self, hook::FlexStruct* image, bool bilinear);
+static void GfxShapeSetToImage(void* self, hook::FlexStruct* image, bool bilinear)
+{
+	if (!image || !image->Get<void*>(imageInfoOffset))
+	{
+		return;
+	}
+
+	g_origGfxShapeSetToImage(self, image, bilinear);
+}
+
+static HookFunction hookFunction([]()
+{
+	imageInfoOffset = *(char*)hook::get_pattern("48 8B 4A ? 0F 29 78 ? 48 8B 01", 0x3);
+	g_origGfxShapeSetToImage = hook::trampoline(hook::get_call(hook::get_pattern("E8 ? ? ? ? 48 39 7D ? 74 ? 48 85 FF")), GfxShapeSetToImage);
+});


### PR DESCRIPTION
### Goal of this PR
Fix a crash exploit. Somehow they made `ImageInfo` nullptr.

Also I'll try to check tomorrow how they could be doing this, because it may crash in other place.


### How is this PR achieving the goal
Validating Image and ImageInfo.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3952 