### PR TITLE
feat(extra-natives-five): add IS_CONSOLE_OPEN and client-side GET_CONSOLE_BUFFER

### DIFF
--- a/code/components/conhost-v2/include/ConsoleHost.h
+++ b/code/components/conhost-v2/include/ConsoleHost.h
@@ -22,8 +22,10 @@ namespace ConHost
 	extern CONHOST_EXPORT fwEvent<bool*> OnShouldDrawGui;
 
 	CONHOST_EXPORT bool IsConsoleOpen();
-	
+
 	CONHOST_EXPORT void Print(const std::string& channel, const std::string& message);
 
 	CONHOST_EXPORT void SetCursorMode(bool mode);
+
+	CONHOST_EXPORT std::string GetBufferText(size_t maxLines = 0);
 }

--- a/code/components/conhost-v2/src/ConsoleHostGui.cpp
+++ b/code/components/conhost-v2/src/ConsoleHostGui.cpp
@@ -1021,6 +1021,49 @@ static void EnsureConsoles()
 	}
 }
 
+namespace ConHost
+{
+	std::string GetBufferText(size_t maxLines)
+	{
+		std::string result;
+
+		std::unique_lock consolesLock(g_consolesMutex);
+		auto* console = g_consoles[0].get();
+		if (!console)
+		{
+			return result;
+		}
+
+		std::unique_lock<std::recursive_mutex> itemsLock(console->ItemsMutex);
+		const size_t total = console->Items.size();
+		const size_t count = (maxLines == 0 || maxLines > total) ? total : maxLines;
+		const size_t startIdx = total - count;
+		for (size_t i = startIdx; i < total; ++i)
+		{
+			std::string line = console->Items[i];
+			while (!line.empty() && (line.back() == '\n' || line.back() == '\r'))
+			{
+				line.pop_back();
+			}
+
+			if (i > startIdx)
+			{
+				result += '\n';
+			}
+
+			const std::string& key = console->ItemKeys[i];
+			if (!key.empty())
+			{
+				result += '[';
+				result += key;
+				result += "] ";
+			}
+			result += line;
+		}
+		return result;
+	}
+}
+
 bool IsNonProduction()
 {
 #if (!defined(GTA_FIVE) && !defined(IS_RDR3)) || defined(_DEBUG)

--- a/code/components/extra-natives-five/component.json
+++ b/code/components/extra-natives-five/component.json
@@ -15,7 +15,8 @@
 		"net",
 		"voip:mumble",
 		"vendor:directxtex",
-		"vendor:im3d"
+		"vendor:im3d",
+		"conhost:v2"
 	],
 	"provides": []
 }

--- a/code/components/extra-natives-five/src/ConsoleBufferNatives.cpp
+++ b/code/components/extra-natives-five/src/ConsoleBufferNatives.cpp
@@ -1,0 +1,22 @@
+#include "StdInc.h"
+
+#include <ScriptEngine.h>
+#include <ConsoleHost.h>
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_CONSOLE_BUFFER", [](fx::ScriptContext& context)
+	{
+		const int requested = context.GetArgument<int>(0);
+		const size_t maxLines = (requested <= 0) ? 0 : static_cast<size_t>(requested);
+
+		static thread_local std::string buffer;
+		buffer = ConHost::GetBufferText(maxLines);
+		context.SetResult<const char*>(buffer.c_str());
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_CONSOLE_OPEN", [](fx::ScriptContext& context)
+	{
+		context.SetResult<bool>(ConHost::IsConsoleOpen());
+	});
+});

--- a/ext/native-decls/GetConsoleBuffer.md
+++ b/ext/native-decls/GetConsoleBuffer.md
@@ -1,14 +1,22 @@
 ---
 ns: CFX
-apiset: server
+apiset: shared
 ---
 ## GET_CONSOLE_BUFFER
 
 ```c
-char* GET_CONSOLE_BUFFER();
+char* GET_CONSOLE_BUFFER(int maxLines);
 ```
 
 Returns the current console output buffer.
+
+On the **server** this returns the recent stdout/stderr text. On the **client**
+this returns the contents of the in-game F8 console (lines joined by newlines,
+each line prefixed with `[channel] ` when the channel is set — typically
+`[script:resource_name]` for resource prints).
+
+## Parameters
+- **maxLines**: Maximum number of trailing lines to return. Pass `0` (or any non-positive value) to retrieve the entire buffer.
 
 ## Return value
 The most recent game console output, as a string.

--- a/ext/native-decls/IsConsoleOpen.md
+++ b/ext/native-decls/IsConsoleOpen.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+---
+## IS_CONSOLE_OPEN
+
+```c
+BOOL IS_CONSOLE_OPEN();
+```
+
+Returns whether the in-game F8 console is currently open.
+
+## Return value
+
+`true` if the F8 console is open, `false` otherwise.
+
+## Examples
+
+```lua
+RegisterCommand("checkconsole", function()
+    if IsConsoleOpen() then
+        print("F8 is open")
+    else
+        print("F8 is closed")
+    end
+end)
+```


### PR DESCRIPTION
 ## Goal of this PR
  Allow client-side resource scripts to inspect the in-game F8 console state. The server-side
  `GET_CONSOLE_BUFFER` native already exists; this PR adds the client equivalent and a new
  `IS_CONSOLE_OPEN` native.

  ## How is this PR achieving the goal
  - Promote the `GET_CONSOLE_BUFFER` declaration from `apiset: server` to `apiset: shared` and add an
  `int maxLines` parameter to optionally limit the result to the most recent N entries (`0` = whole
  buffer).
  - Add `ConHost::GetBufferText(maxLines)` to `conhost-v2` that walks the existing `g_consoles[0]`
  items buffer under its `ItemsMutex`, prefixes each entry with its channel (e.g.
  `[script:resource_name]`) and joins them with newlines.
  - Register both natives from `extra-natives-five` so they are exposed to Lua/JS/C# resources.
  `IS_CONSOLE_OPEN` is a thin wrapper over the existing `ConHost::IsConsoleOpen()` helper.
  - Add `conhost:v2` as a dependency of `extra-natives-five` so the new export is reachable.

  Reading the buffer is done under the existing recursive_mutex protecting the console items, so
  concurrent prints from other threads remain safe.

  ## This PR applies to the following area(s)
  FiveM, Natives

  ## Successfully tested on
  **Game builds:** 3258
  **Platforms:** Windows

  ## Checklist
  - [x] Code compiles and testing was successful
  - [x] Code is properly commented and documented
  - [x] Commit message is clear and explains the change
  - [x] No additional compilation warnings introduced