### PR TITLE
feat(extra-natives-five): Add DISABLE_INFLATED_MAP_DATA_RANGE

### DIFF
--- a/code/components/extra-natives-five/src/BoxStreamerNatives.cpp
+++ b/code/components/extra-natives-five/src/BoxStreamerNatives.cpp
@@ -1,0 +1,35 @@
+#include "StdInc.h"
+
+#include <ScriptEngine.h>
+#include <Hooking.h>
+#include <GameInit.h>
+#include <GameValueStub.h>
+
+static GameValueStub<float> MediumRange;
+
+static HookFunction initFunction([]()
+{
+	{
+		auto location = hook::get_pattern("F3 0F 10 3D ? ? ? ? 48 8D 55 ? 48 8D 0D", 0x04);
+		MediumRange.Init(*hook::get_address<float*>(location));
+		MediumRange.SetLocation(location);
+	}
+
+	OnKillNetworkDone.Connect([]()
+	{
+		MediumRange.Reset();
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("DISABLE_INFLATED_MAP_DATA_RANGE", [=](fx::ScriptContext& context)
+	{
+		const bool disabled = context.GetArgument<bool>(0);
+		if (disabled)
+		{
+			MediumRange.Set(0.0f);
+		}
+		else
+		{
+			MediumRange.Reset();
+		}
+	});
+});

--- a/ext/native-decls/DisableInflatedMapDataRange.md
+++ b/ext/native-decls/DisableInflatedMapDataRange.md
@@ -1,0 +1,16 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## DISABLE_INFLATED_MAP_DATA_RANGE
+
+```c
+void DISABLE_INFLATED_MAP_DATA_RANGE(BOOL state);
+```
+
+Disables the inflated map data range when extended distance scaling is enabled.
+Useful to reduce the number of registered archetypes when using a lot of custom maps.
+
+## Parameters
+* **state**: On/Off


### PR DESCRIPTION
### Goal of this PR
When using extended distance scaling with any value other than 0 the game increase the range in which medium mapdata are loaded by 500.0

This make the limit of 65k registered archetypes being reached very fast in Los Santos with few custom content

This change adds a native to disable the increased range while keeping the lod scaling.

This will allow users to have more custom content on their servers

### How is this PR achieving the goal

By adding the native DISABLE_INFLATED_MAP_DATA_RANGE


### This PR applies to the following area(s)
FiveM


### Successfully tested on
2699, 3095, 3258

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
workaround #3792


