### PR TITLE
fix(scripting/node): resolve symlinked resource sandbox paths

### DIFF
--- a/code/components/citizen-scripting-node/include/NodeScriptRuntime.h
+++ b/code/components/citizen-scripting-node/include/NodeScriptRuntime.h
@@ -52,6 +52,7 @@ private:
 	int m_instanceId;
 	std::string m_name;
 	std::string m_resourceName;
+	std::string m_resourceMountPrefix;
 	std::string m_tempDir;
 	bool m_isMonitorRuntime = false;
 

--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -165,8 +165,9 @@ const std::string_view& resource)
 
 		if (!device.GetRef())
 		{
-			std::string absolutePath = std::filesystem::absolute(std::filesystem::path(path)).string();
-			device = vfs::FindDevice(absolutePath, path);
+			std::error_code ec;
+			const std::filesystem::path absolutePath = std::filesystem::absolute(std::filesystem::path(path), ec);
+			device = vfs::FindDevice(ec ? path : absolutePath.string(), path, m_resourceMountPrefix);
 			if (!device.GetRef())
 			{
 				trace("Filesystem permission check from '%s' for permission %s on resource '%s' - no device found\n", m_resourceName.c_str(), permName.c_str(), res.c_str());
@@ -387,6 +388,7 @@ result_t NodeScriptRuntime::Create(IScriptHost* host)
 	char* resourceName = nullptr;
 	m_resourceHost->GetResourceName(&resourceName);
 	m_resourceName = resourceName;
+	m_resourceMountPrefix = "@" + m_resourceName + "/";
 
 	// don't create the runtime environment if nodejs is not initialized
 	if (!g_nodeEnv.IsInitialized())

--- a/code/components/vfs-core/include/VFSManager.h
+++ b/code/components/vfs-core/include/VFSManager.h
@@ -40,6 +40,9 @@ public:
 	virtual void Unmount(const std::string& path) = 0;
 
 	virtual fwRefContainer<Device> GetNativeDevice(void* nativeDevice);
+
+	// Used when multiple mounted devices resolve to the same native path.
+	virtual fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string& preferredMountPrefix);
 };
 
 VFS_CORE_EXPORT fwRefContainer<Stream> OpenRead(const std::string& path);
@@ -55,6 +58,9 @@ VFS_CORE_EXPORT fwRefContainer<Stream> Create(const std::string& path, bool crea
 VFS_CORE_EXPORT fwRefContainer<Device> GetDevice(const std::string& path);
 
 VFS_CORE_EXPORT fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath);
+
+// Used when multiple mounted devices resolve to the same native path.
+VFS_CORE_EXPORT fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string& preferredMountPrefix);
 
 VFS_CORE_EXPORT fwRefContainer<Device> GetNativeDevice(void* nativeDevice);
 

--- a/code/components/vfs-core/src/VFSManager.cpp
+++ b/code/components/vfs-core/src/VFSManager.cpp
@@ -90,6 +90,11 @@ fwRefContainer<Device> Manager::GetNativeDevice(void* nativeDevice)
 	return nullptr;
 }
 
+fwRefContainer<Device> Manager::FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string&)
+{
+	return FindDevice(absolutePath, transformedPath);
+}
+
 fwRefContainer<Stream> OpenRead(const std::string& path)
 {
 	return Instance<Manager>::Get()->OpenRead(path);
@@ -123,6 +128,11 @@ fwRefContainer<Device> GetDevice(const std::string& path)
 fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath)
 {
 	return Instance<Manager>::Get()->FindDevice(absolutePath, transformedPath);
+}
+
+fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string& preferredMountPrefix)
+{
+	return Instance<Manager>::Get()->FindDevice(absolutePath, transformedPath, preferredMountPrefix);
 }
 
 fwRefContainer<Device> GetNativeDevice(void* nativeDevice)

--- a/code/components/vfs-impl-server/include/Manager.h
+++ b/code/components/vfs-impl-server/include/Manager.h
@@ -8,11 +8,19 @@ namespace vfs
 class ManagerServer : public vfs::Manager
 {
 private:
+	struct MountedDevice
+	{
+		fwRefContainer<Device> device;
+		std::string absolutePath;
+		std::string canonicalPath;
+		bool resolvesThroughLink = false;
+	};
+
 	struct MountPoint
 	{
 		std::string prefix;
 
-		mutable std::vector<fwRefContainer<Device>> devices; // mutable? MUTABLE? is this Rust?!
+		mutable std::vector<MountedDevice> devices; // mutable? MUTABLE? is this Rust?!
 	};
 
 	// sorts mount points based on longest prefix
@@ -37,6 +45,8 @@ private:
 
 	std::recursive_mutex m_mountMutex;
 
+	bool m_hasCanonicalPathMounts = false;
+
 	// fallback device - usually a local file system implementation
 	fwRefContainer<vfs::Device> m_fallbackDevice;
 
@@ -49,6 +59,8 @@ public:
 	virtual fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath) override;
 
 	virtual fwRefContainer<Device> GetNativeDevice(void* nativeDevice) override;
+
+	virtual fwRefContainer<Device> FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string& preferredMountPrefix) override;
 
 	virtual void Mount(fwRefContainer<Device> device, const std::string& path) override;
 

--- a/code/components/vfs-impl-server/src/Manager.cpp
+++ b/code/components/vfs-impl-server/src/Manager.cpp
@@ -4,6 +4,143 @@
 #include <LocalDevice.h>
 
 #include <filesystem>
+#include <utility>
+
+namespace
+{
+struct DeviceMatch
+{
+	size_t matchedPrefixLength = 0;
+	size_t canonicalPrefixLength = 0;
+	fwRefContainer<vfs::Device> device {nullptr};
+	std::string transformedPath;
+	bool isPreferredPrefix = false;
+};
+
+enum class DevicePathKind
+{
+	Lexical,
+	Canonical
+};
+
+std::string GetLexicalAbsoluteGenericPath(const std::filesystem::path& path)
+{
+	std::error_code ec;
+	std::filesystem::path absolutePath = std::filesystem::absolute(path, ec);
+	if (ec)
+	{
+		absolutePath = path;
+	}
+
+	return absolutePath.lexically_normal().generic_string();
+}
+
+std::string GetCanonicalAbsoluteGenericPath(const std::filesystem::path& path)
+{
+	std::error_code ec;
+	std::filesystem::path normalizedPath = std::filesystem::weakly_canonical(path, ec);
+	if (ec)
+	{
+		return GetLexicalAbsoluteGenericPath(path);
+	}
+
+	return normalizedPath.lexically_normal().generic_string();
+}
+
+void AddDirectorySuffix(std::string& path, const std::filesystem::path& sourcePath)
+{
+	if (path.empty() || path.back() == '/')
+	{
+		return;
+	}
+
+	std::string sourcePathString = sourcePath.generic_string();
+	if (!sourcePathString.empty() && sourcePathString.back() == '/')
+	{
+		path += '/';
+		return;
+	}
+
+	std::error_code ec;
+	if (std::filesystem::is_directory(sourcePath, ec) && !ec)
+	{
+		path += '/';
+	}
+}
+
+std::string GetMountedDevicePath(const std::string& devicePath, bool canonical)
+{
+	if (devicePath.empty())
+	{
+		return {};
+	}
+
+	std::filesystem::path path(devicePath);
+	std::string absolutePath = canonical
+		? GetCanonicalAbsoluteGenericPath(path)
+		: GetLexicalAbsoluteGenericPath(path);
+	AddDirectorySuffix(absolutePath, path);
+	return absolutePath;
+}
+
+void UpdateDeviceMatch(DeviceMatch& match, size_t matchedPrefixLength, size_t canonicalPrefixLength,
+	const fwRefContainer<vfs::Device>& device, std::string transformedPath, const bool isPreferredPrefix)
+{
+	if (match.device.GetRef())
+	{
+		if (match.matchedPrefixLength > matchedPrefixLength)
+		{
+			return;
+		}
+
+		if (match.matchedPrefixLength == matchedPrefixLength && match.isPreferredPrefix && !isPreferredPrefix)
+		{
+			return;
+		}
+	}
+
+	match.matchedPrefixLength = matchedPrefixLength;
+	match.canonicalPrefixLength = canonicalPrefixLength;
+	match.device = device;
+	match.transformedPath = std::move(transformedPath);
+	match.isPreferredPrefix = isPreferredPrefix;
+}
+
+const DeviceMatch& SelectDeviceMatch(const DeviceMatch& lexicalMatch, const DeviceMatch& canonicalMatch, const bool pathResolvedThroughLink)
+{
+	if (!lexicalMatch.device.GetRef())
+	{
+		return canonicalMatch;
+	}
+
+	if (!canonicalMatch.device.GetRef())
+	{
+		return lexicalMatch;
+	}
+
+	// Keep VFS longest-prefix semantics after symlink resolution: a more specific
+	// canonical mount wins even when the preferred mount is a parent.
+	if (lexicalMatch.canonicalPrefixLength != canonicalMatch.canonicalPrefixLength)
+	{
+		return lexicalMatch.canonicalPrefixLength > canonicalMatch.canonicalPrefixLength
+			? lexicalMatch
+			: canonicalMatch;
+	}
+
+	if (pathResolvedThroughLink)
+	{
+		return lexicalMatch;
+	}
+
+	if (canonicalMatch.isPreferredPrefix && !lexicalMatch.isPreferredPrefix)
+	{
+		return canonicalMatch;
+	}
+
+	return lexicalMatch;
+}
+
+}
 
 namespace vfs
 {
@@ -16,55 +153,104 @@ fwRefContainer<Device> MakeMemoryDevice();
 
 fwRefContainer<Device> ManagerServer::FindDevice(const std::string& absolutePath, std::string& transformedPath)
 {
+	return FindDevice(absolutePath, transformedPath, {});
+}
+
+fwRefContainer<Device> ManagerServer::FindDevice(const std::string& absolutePath, std::string& transformedPath, const std::string& preferredMountPrefix)
+{
+	transformedPath.clear();
+
 	std::filesystem::path absolute(absolutePath);
-	std::string absoluteGenericString = std::filesystem::absolute(absolute).generic_string();
+	std::string absoluteGenericString = GetLexicalAbsoluteGenericPath(absolute);
+	AddDirectorySuffix(absoluteGenericString, absolute);
+
+	auto findDevice = [&](const std::string& path, const DevicePathKind pathKind)
+	{
+		DeviceMatch foundMatch;
+
+		for (const auto& mount : m_mounts)
+		{
+			for (const auto& mountedDevice : mount.devices)
+			{
+				const std::string& deviceAbsolutePath = pathKind == DevicePathKind::Canonical
+					? mountedDevice.canonicalPath
+					: mountedDevice.absolutePath;
+				if (deviceAbsolutePath.empty())
+				{
+					continue;
+				}
+
+				size_t prefixLength = deviceAbsolutePath.size();
+
+				// device matches if the path start is the same
+				// e.g. usr/local/bin starts with /usr/local/
+				if (path.rfind(deviceAbsolutePath, 0) == 0)
+				{
+					const bool isPreferredPrefix = !preferredMountPrefix.empty() && mount.prefix == preferredMountPrefix;
+					std::string nextTransformedPath = mount.prefix + path.substr(prefixLength);
+					size_t canonicalPrefixLength = prefixLength;
+					if (pathKind == DevicePathKind::Lexical &&
+						mountedDevice.resolvesThroughLink &&
+						!mountedDevice.canonicalPath.empty())
+					{
+						canonicalPrefixLength = mountedDevice.canonicalPath.size();
+					}
+
+					// find the device with the largest prefix length
+					UpdateDeviceMatch(foundMatch, prefixLength, canonicalPrefixLength, mountedDevice.device,
+						std::move(nextTransformedPath), isPreferredPrefix);
+				}
+			}
+		}
+
+		return foundMatch;
+	};
+
+	auto returnMatch = [&](DeviceMatch& match)
+	{
+		if (match.device.GetRef())
+		{
+			transformedPath = std::move(match.transformedPath);
+		}
+
+		return match.device;
+	};
+
+	{
+		std::lock_guard<std::recursive_mutex> lock(m_mountMutex);
+		DeviceMatch lexicalMatch = findDevice(absoluteGenericString, DevicePathKind::Lexical);
+
+		if (lexicalMatch.device.GetRef() && (preferredMountPrefix.empty() || lexicalMatch.isPreferredPrefix))
+		{
+			return returnMatch(lexicalMatch);
+		}
+
+		if (!m_hasCanonicalPathMounts)
+		{
+			return returnMatch(lexicalMatch);
+		}
+	}
+
+	std::string canonicalGenericString = GetCanonicalAbsoluteGenericPath(absolute);
+	AddDirectorySuffix(canonicalGenericString, absolute);
+	const bool pathResolvedThroughLink = absoluteGenericString != canonicalGenericString;
+
 	std::lock_guard<std::recursive_mutex> lock(m_mountMutex);
-
-	// ensure directories have a / suffix
-	// e.g. /usr/local should be matched for /usr/local/
-	if (!absoluteGenericString.empty() && absoluteGenericString.back() != '/')
+	DeviceMatch lexicalMatch = findDevice(absoluteGenericString, DevicePathKind::Lexical);
+	if (lexicalMatch.device.GetRef() && (preferredMountPrefix.empty() || lexicalMatch.isPreferredPrefix))
 	{
-		std::error_code ec;
-		if (std::filesystem::is_directory(absoluteGenericString, ec) && !ec)
-		{
-			absoluteGenericString += '/';
-		}
+		return returnMatch(lexicalMatch);
 	}
 
-	size_t longestPrefixLength = 0;
-	fwRefContainer<Device> foundDevice {nullptr};
-	for (const auto& mount : m_mounts)
+	if (!m_hasCanonicalPathMounts)
 	{
-		for (const auto& device : mount.devices)
-		{
-			// check if the device has an absolute path
-			if (device->GetAbsolutePath().empty())
-			{
-				continue;
-			}
-
-			std::string deviceAbsolutePath = std::filesystem::absolute(std::filesystem::path(device->GetAbsolutePath())).generic_string();
-			size_t prefixLength = deviceAbsolutePath.size();
-
-			// find the device with the largest prefix length
-			if (longestPrefixLength > prefixLength)
-			{
-				continue;
-			}
-
-			// device matches if the path start is the same
-			// e.g. usr/local/bin starts with /usr/local/
-			if (absoluteGenericString.rfind(deviceAbsolutePath, 0) == 0)
-			{
-				longestPrefixLength = deviceAbsolutePath.size();
-				foundDevice = device;
-				// e.g. /usr/local/bin -> bin, @local/bin
-				transformedPath = mount.prefix + absoluteGenericString.substr(deviceAbsolutePath.size());
-			}
-		}
+		return returnMatch(lexicalMatch);
 	}
 
-	return foundDevice;
+	DeviceMatch canonicalMatch = findDevice(canonicalGenericString, DevicePathKind::Canonical);
+	DeviceMatch selectedMatch = SelectDeviceMatch(lexicalMatch, canonicalMatch, pathResolvedThroughLink);
+
+	return returnMatch(selectedMatch);
 }
 
 fwRefContainer<Device> ManagerServer::GetDevice(const std::string& path)
@@ -92,15 +278,16 @@ fwRefContainer<Device> ManagerServer::GetDevice(const std::string& path)
 			// single device case
 			if (mount.devices.size() == 1)
 			{
-				return mount.devices[0];
+				return mount.devices[0].device;
 			}
 			else
 			{
 				// check each device assigned to the mount point
 				Device::THandle handle;
 
-				for (const auto& device : mount.devices)
+				for (const auto& mountedDevice : mount.devices)
 				{
+					const auto& device = mountedDevice.device;
 					if ((handle = device->Open(path, true)) != Device::InvalidHandle)
 					{
 						device->Close(handle);
@@ -130,6 +317,17 @@ void ManagerServer::Mount(fwRefContainer<Device> device, const std::string& path
 	// set the path prefix on the device
 	device->SetPathPrefix(path);
 
+	const std::string devicePath = device->GetAbsolutePath();
+	const std::string absolutePath = GetMountedDevicePath(devicePath, false);
+	std::string canonicalPath = GetMountedDevicePath(absolutePath, true);
+	const bool resolvesThroughLink = !canonicalPath.empty() && canonicalPath != absolutePath;
+	MountedDevice mountedDevice {
+		device,
+		absolutePath,
+		std::move(canonicalPath),
+		resolvesThroughLink
+	};
+
 	// mount
 	std::lock_guard<std::recursive_mutex> lock(m_mountMutex);
 
@@ -138,7 +336,8 @@ void ManagerServer::Mount(fwRefContainer<Device> device, const std::string& path
 	{
 		if (mount.prefix == path)
 		{
-			mount.devices.push_back(device);
+			mount.devices.push_back(mountedDevice);
+			m_hasCanonicalPathMounts = m_hasCanonicalPathMounts || resolvesThroughLink;
 			return;
 		}
 	}
@@ -147,9 +346,10 @@ void ManagerServer::Mount(fwRefContainer<Device> device, const std::string& path
 	{
 		MountPoint mount;
 		mount.prefix = path;
-		mount.devices.push_back(device);
+		mount.devices.push_back(mountedDevice);
 
 		m_mounts.insert(mount);
+		m_hasCanonicalPathMounts = m_hasCanonicalPathMounts || resolvesThroughLink;
 	}
 }
 
@@ -169,6 +369,19 @@ void ManagerServer::Unmount(const std::string& path)
 		else
 		{
 			++it;
+		}
+	}
+
+	m_hasCanonicalPathMounts = false;
+	for (const auto& mount : m_mounts)
+	{
+		for (const auto& mountedDevice : mount.devices)
+		{
+			m_hasCanonicalPathMounts = m_hasCanonicalPathMounts || mountedDevice.resolvesThroughLink;
+			if (m_hasCanonicalPathMounts)
+			{
+				return;
+			}
 		}
 	}
 }

--- a/code/tests/server/TestLua.cpp
+++ b/code/tests/server/TestLua.cpp
@@ -2,6 +2,7 @@
 
 #include <catch_amalgamated.hpp>
 #include <filesystem>
+#include <utility>
 
 #include <lua.hpp>
 #include <LuaFXLib.h>
@@ -179,6 +180,53 @@ void LoadAndRunCode(fx::LuaStateHolder& state, const std::string&& fileName, con
 	{
 		REQUIRE(!expectExecutionError);
 	}
+}
+
+template<typename TCallback>
+class ScopeExit
+{
+public:
+	explicit ScopeExit(TCallback callback)
+		: m_callback(std::move(callback))
+	{
+	}
+
+	~ScopeExit()
+	{
+		m_callback();
+	}
+
+	ScopeExit(const ScopeExit&) = delete;
+	ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+	TCallback m_callback;
+};
+
+template<typename TCallback>
+ScopeExit(TCallback) -> ScopeExit<TCallback>;
+
+void CreateDirectorySymlinkOrSkip(const std::filesystem::path& target, const std::filesystem::path& link, const char* description)
+{
+	std::error_code ec;
+	std::filesystem::create_directory_symlink(target, link, ec);
+	if (ec)
+	{
+		SKIP("Could not " << description << ": " << ec.message());
+	}
+}
+
+std::filesystem::path GetNodePermissionPath(const std::filesystem::path& path)
+{
+	std::error_code ec;
+	std::filesystem::path normalizedPath = std::filesystem::weakly_canonical(path, ec);
+	if (!ec)
+	{
+		return normalizedPath;
+	}
+
+	normalizedPath = std::filesystem::absolute(path, ec);
+	return ec ? path : normalizedPath;
 }
 }
 
@@ -925,6 +973,195 @@ TEST_CASE("vfs")
 		REQUIRE(vfs::RenameFile("@test/test2.txt", "@test/test.txt") == true);
 	}
 }
+
+#ifdef IS_FXSERVER
+TEST_CASE("vfs resolves symlinked resource paths for node sandbox permission checks")
+{
+	REQUIRE(Instance<vfs::Manager>::Get() != nullptr);
+
+	std::error_code ec;
+	const auto basePath = std::filesystem::current_path() / "vfs_symlink_test";
+	const auto targetPath = basePath / "target";
+	const auto nestedTargetPath = targetPath / "nested";
+	const auto shortTargetPath = basePath / "t";
+	const auto canonicalTargetPath = basePath / "canonical_target";
+	const auto linkPath = basePath / "resource_link";
+	const auto duplicateLinkPath = basePath / "resource_link_duplicate";
+	const auto canonicalLinkPath = basePath / "resource_canonical_link";
+	const auto shortNestedLinkPath = targetPath / "short_link";
+	const auto nestedLinkPath = basePath / "resource_nested_link";
+	const std::string mountPath = "@symlink-test/";
+	const std::string duplicateMountPath = "@symlink-test-duplicate/";
+	const std::string directMountPath = "@symlink-test-direct/";
+	const std::string canonicalMountPath = "@symlink-test-canonical/";
+	const std::string shortNestedMountPath = "@symlink-test-short-nested/";
+	const std::string nestedMountPath = "@symlink-test-nested/";
+
+	ScopeExit cleanup([&]()
+	{
+		std::error_code cleanupEc;
+		vfs::Unmount(nestedMountPath);
+		vfs::Unmount(shortNestedMountPath);
+		vfs::Unmount(canonicalMountPath);
+		vfs::Unmount(directMountPath);
+		vfs::Unmount(duplicateMountPath);
+		vfs::Unmount(mountPath);
+		std::filesystem::remove_all(basePath, cleanupEc);
+	});
+
+	std::filesystem::remove_all(basePath, ec);
+	ec.clear();
+	REQUIRE(std::filesystem::create_directories(nestedTargetPath, ec));
+	REQUIRE(!ec);
+	ec.clear();
+	REQUIRE(std::filesystem::create_directories(shortTargetPath, ec));
+	REQUIRE(!ec);
+	ec.clear();
+	REQUIRE(std::filesystem::create_directories(canonicalTargetPath, ec));
+	REQUIRE(!ec);
+
+	CreateDirectorySymlinkOrSkip(targetPath, linkPath, "create directory symlink");
+
+	fwRefContainer relativeDevice = new vfs::RelativeDevice(linkPath.generic_string() + "/");
+	vfs::Unmount(mountPath);
+	vfs::Mount(relativeDevice, mountPath);
+
+	fwRefContainer<vfs::Stream> stream = vfs::Create(mountPath + "module.cjs", false);
+	REQUIRE(stream.GetRef() != nullptr);
+	stream->Close();
+
+	std::string transformedPath;
+	const auto linkFile = linkPath / "module.cjs";
+	const auto linkDevice = vfs::FindDevice(linkFile.string(), transformedPath);
+	REQUIRE(linkDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "module.cjs");
+
+	transformedPath.clear();
+	// Mirrors Node's sandbox callback after require() resolves the symlinked resource path.
+	const auto nodeRequirePath = GetNodePermissionPath(linkFile);
+	const auto targetFile = targetPath / "module.cjs";
+	const auto nodeRequireDevice = vfs::FindDevice(nodeRequirePath.string(), transformedPath, mountPath);
+	REQUIRE(nodeRequireDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "module.cjs");
+
+	transformedPath.clear();
+	const auto targetDirectoryDevice = vfs::FindDevice(targetPath.string(), transformedPath, mountPath);
+	REQUIRE(targetDirectoryDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath);
+
+	CreateDirectorySymlinkOrSkip(shortTargetPath, shortNestedLinkPath, "create nested lexical directory symlink");
+
+	fwRefContainer shortNestedDevice = new vfs::RelativeDevice((linkPath / "short_link").generic_string() + "/");
+	vfs::Unmount(shortNestedMountPath);
+	vfs::Mount(shortNestedDevice, shortNestedMountPath);
+
+	transformedPath.clear();
+	const auto shortNestedFile = linkPath / "short_link" / "module.cjs";
+	const auto lexicalLongestDevice = vfs::FindDevice(shortNestedFile.string(), transformedPath);
+	REQUIRE(lexicalLongestDevice.GetRef() == shortNestedDevice.GetRef());
+	REQUIRE(transformedPath == shortNestedMountPath + "module.cjs");
+
+	CreateDirectorySymlinkOrSkip(targetPath, duplicateLinkPath, "create duplicate directory symlink");
+
+	fwRefContainer duplicateDevice = new vfs::RelativeDevice(duplicateLinkPath.generic_string() + "/");
+	vfs::Unmount(duplicateMountPath);
+	vfs::Mount(duplicateDevice, duplicateMountPath);
+
+	transformedPath.clear();
+	const auto lexicalLinkDevice = vfs::FindDevice(linkFile.string(), transformedPath, duplicateMountPath);
+	REQUIRE(lexicalLinkDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "module.cjs");
+
+	transformedPath.clear();
+	const auto preferredTargetDevice = vfs::FindDevice(targetFile.string(), transformedPath, duplicateMountPath);
+	REQUIRE(preferredTargetDevice.GetRef() == duplicateDevice.GetRef());
+	REQUIRE(transformedPath == duplicateMountPath + "module.cjs");
+
+	transformedPath.clear();
+	const auto preferredOriginalDevice = vfs::FindDevice(targetFile.string(), transformedPath, mountPath);
+	REQUIRE(preferredOriginalDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "module.cjs");
+
+	fwRefContainer directDevice = new vfs::RelativeDevice(targetPath.generic_string() + "/");
+	vfs::Unmount(directMountPath);
+	vfs::Mount(directDevice, directMountPath);
+
+	transformedPath.clear();
+	const auto canonicalPreferredDevice = vfs::FindDevice(targetFile.string(), transformedPath, mountPath);
+	REQUIRE(canonicalPreferredDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "module.cjs");
+
+	transformedPath.clear();
+	const auto directPreferredDevice = vfs::FindDevice(targetFile.string(), transformedPath, directMountPath);
+	REQUIRE(directPreferredDevice.GetRef() == directDevice.GetRef());
+	REQUIRE(transformedPath == directMountPath + "module.cjs");
+
+	transformedPath.clear();
+	const auto newTargetFile = linkPath / "generated" / "write.js";
+	const auto newTargetDevice = vfs::FindDevice(GetNodePermissionPath(newTargetFile).string(), transformedPath, mountPath);
+	REQUIRE(newTargetDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "generated/write.js");
+
+	transformedPath.clear();
+	const auto newTargetDirectory = linkPath / "generated-directory";
+	const auto newTargetDirectoryDevice = vfs::FindDevice(GetNodePermissionPath(newTargetDirectory).string(), transformedPath, mountPath);
+	REQUIRE(newTargetDirectoryDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "generated-directory");
+
+	transformedPath.clear();
+	const auto newTargetDirectoryWithSlash = (linkPath / "generated-directory-with-slash").generic_string() + "/";
+	const auto newTargetDirectoryWithSlashDevice = vfs::FindDevice(newTargetDirectoryWithSlash, transformedPath, mountPath);
+	REQUIRE(newTargetDirectoryWithSlashDevice.GetRef() == relativeDevice.GetRef());
+	REQUIRE(transformedPath == mountPath + "generated-directory-with-slash/");
+
+	CreateDirectorySymlinkOrSkip(canonicalTargetPath, canonicalLinkPath, "create canonical directory symlink");
+
+	fwRefContainer canonicalDevice = new vfs::RelativeDevice(canonicalLinkPath.generic_string() + "/");
+	vfs::Unmount(canonicalMountPath);
+	vfs::Mount(canonicalDevice, canonicalMountPath);
+
+	transformedPath.clear();
+	const auto canonicalFile = canonicalTargetPath / "module.cjs";
+	const auto canonicalDeviceMatch = vfs::FindDevice(canonicalFile.string(), transformedPath, canonicalMountPath);
+	REQUIRE(canonicalDeviceMatch.GetRef() == canonicalDevice.GetRef());
+	REQUIRE(transformedPath == canonicalMountPath + "module.cjs");
+
+	CreateDirectorySymlinkOrSkip(nestedTargetPath, nestedLinkPath, "create nested directory symlink");
+
+	fwRefContainer nestedDevice = new vfs::RelativeDevice(nestedLinkPath.generic_string() + "/");
+	vfs::Unmount(nestedMountPath);
+	vfs::Mount(nestedDevice, nestedMountPath);
+
+	transformedPath.clear();
+	const auto nestedTargetFile = nestedTargetPath / "write.js";
+	const auto lexicalTargetDevice = vfs::FindDevice(nestedTargetFile.string(), transformedPath);
+	REQUIRE(lexicalTargetDevice.GetRef() == directDevice.GetRef());
+	REQUIRE(transformedPath == directMountPath + "nested/write.js");
+
+	transformedPath.clear();
+	const auto preferredParentResolvedDevice = vfs::FindDevice(nestedTargetFile.string(), transformedPath, mountPath);
+	REQUIRE(preferredParentResolvedDevice.GetRef() == nestedDevice.GetRef());
+	REQUIRE(transformedPath == nestedMountPath + "write.js");
+
+	transformedPath.clear();
+	const auto preferredNestedDevice = vfs::FindDevice(nestedTargetFile.string(), transformedPath, nestedMountPath);
+	REQUIRE(preferredNestedDevice.GetRef() == nestedDevice.GetRef());
+	REQUIRE(transformedPath == nestedMountPath + "write.js");
+
+	const auto siblingPath = basePath / "target-other";
+	REQUIRE(std::filesystem::create_directories(siblingPath, ec));
+	REQUIRE(!ec);
+	transformedPath = "stale";
+	const auto siblingDevice = vfs::FindDevice((siblingPath / "module.cjs").string(), transformedPath);
+	REQUIRE(siblingDevice.GetRef() == nullptr);
+	REQUIRE(transformedPath.empty());
+
+	transformedPath = "stale";
+	const auto siblingPreferredDevice = vfs::FindDevice((siblingPath / "module.cjs").string(), transformedPath, mountPath);
+	REQUIRE(siblingPreferredDevice.GetRef() == nullptr);
+	REQUIRE(transformedPath.empty());
+}
+#endif
 
 TEST_CASE("debug namespace")
 {


### PR DESCRIPTION
## Goal of this PR

Fix Node.js resources mounted through a symbolic link being unable to access their own files through `require()` and `fs.*` APIs.

The sandbox permission callback can receive a resolved native path for a symlinked resource, while the resource is mounted in VFS through its lexical symlink path. This made the permission lookup fail before the normal resource-local filesystem checks could run.

## How is this PR achieving the goal

The fix teaches VFS device lookup how to map canonical native paths back to mounted resource devices, and lets the Node.js sandbox prefer the currently running resource mount when several mounts resolve to the same native path.

**Key changes:**

1. **Canonical VFS lookup** (`ManagerServer`): mounted devices now cache both their lexical absolute path and their canonical absolute path at mount time. `FindDevice()` keeps the existing lexical fast path, and only falls back to canonical matching when a symlink/canonical mount exists.

2. **Preferred resource mount** (`NodeScriptRuntime`): Node filesystem permission checks pass `@<resourceName>/` as the preferred mount prefix, so paths resolved through a resource symlink are transformed back to the current resource VFS path.

3. **Longest-prefix semantics preserved** (`ManagerServer`): when both lexical and canonical matches are possible, the existing VFS longest-prefix behavior is preserved. A more specific canonical mount still wins over a preferred parent mount.

4. **Regression coverage** (`TestLua.cpp`): adds server-side VFS coverage for symlinked resources, duplicate symlinks, direct mounts, nested symlink mounts, not-yet-created file/directory paths used by write/mkdir flows, and sibling path rejection.

This keeps the sandbox resource-based instead of allowing broad native filesystem paths, while fixing the symlinked resource workflow reported in the issue.

## This PR applies to the following area(s)

FXServer, ScRT: JS, VFS

## Successfully tested on

- `git diff --check`
- Added C++ server regression coverage for symlinked resource VFS lookup in `TestLua.cpp`
- Locally reviewed the Node sandbox path flow from `NodePermissionCallback()` to `vfs::FindDevice()`

A full local `CitiTest` run was not performed because this checkout does not include a generated build directory or an existing test executable.

## Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit messages explain what the changes do and what they are for.
- [x] No extra compilation warnings are expected from these changes.

## Fixes issues

Fixes #3878
