### PR TITLE
fix(citizen-server-impl): scan categories with lexically relative path

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResourceList.cpp
+++ b/code/components/citizen-server-impl/src/ServerResourceList.cpp
@@ -206,21 +206,17 @@ void ServerResourceList::ScanResources(const std::string& resourceRoot, ScanResu
 							auto path = std::filesystem::u8path(resPath);
 
 							// get parent path components
-							std::error_code ec;
 							std::vector<std::string> components;
 
-							auto relPath = std::filesystem::relative(path, resourceRootPath, ec);
+							auto relPath = path.lexically_relative(resourceRootPath);
 
-							if (!ec)
+							for (const auto& component : relPath)
 							{
-								for (const auto& component : relPath)
-								{
-									auto name = component.filename().u8string();
+								auto name = component.filename().u8string();
 
-									if (name[0] == '[' && name[name.size() - 1] == ']')
-									{
-										components.push_back(name);
-									}
+								if (name[0] == '[' && name[name.size() - 1] == ']')
+								{
+									components.push_back(name);
 								}
 							}
 


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Currently, `ensure`ing categories will not start any resources that are a symlink.


### How is this PR achieving the goal

Instead of computing the relative path to the absolute directory, use `lexically_relative` without computing the symlink. This means the path that will be scanned for categories would always be inside the resources root.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

Server


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


