### PR TITLE
fix(scripting/node): scope build task fs writes

### DIFF
--- a/code/components/citizen-scripting-core/include/FilesystemPermissions.h
+++ b/code/components/citizen-scripting-core/include/FilesystemPermissions.h
@@ -2,6 +2,10 @@
 
 #include "ComponentExport.h"
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 
 namespace fx
 {
@@ -9,6 +13,12 @@ class Resource;
 
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
 bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resourceOverride = nullptr);
+COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
+uint64_t ScriptingFilesystemPushBuildTaskPermission(const std::string& sourceResource, const std::string& targetResource, const std::vector<std::string>& allowedPaths);
+COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
+void ScriptingFilesystemPopBuildTaskPermission(uint64_t permissionId);
+COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
+bool ScriptingFilesystemIsBuildTaskPathSafe(const std::string& path);
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
 bool ScriptingWorkerAllowSpawn(fx::Resource* resourceOverride = nullptr);
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)

--- a/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
+++ b/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
@@ -156,19 +156,16 @@ static std::string NormalizeRelativeResourcePath(const std::filesystem::path& pa
 static std::optional<BuildTaskFilesystemPathPermission> NormalizeBuildTaskAllowedPath(const std::string& path)
 {
 	const std::filesystem::path permissionPath = path;
-	auto firstPart = permissionPath.begin();
-	if (firstPart != permissionPath.end())
-	{
-		const std::string firstPartString = firstPart->generic_string();
-		if (!firstPartString.empty() && firstPartString[0] == '@')
-		{
-			return {};
-		}
-	}
-
 	const bool isDirectory = HasTrailingDirectorySeparator(path);
 	const auto normalizedPath = NormalizeRelativeResourcePath(permissionPath);
 	if (normalizedPath.empty())
+	{
+		return {};
+	}
+
+	const auto firstSeparator = normalizedPath.find('/');
+	const auto firstPart = normalizedPath.substr(0, firstSeparator);
+	if (!firstPart.empty() && firstPart[0] == '@')
 	{
 		return {};
 	}

--- a/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
+++ b/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
@@ -11,6 +11,9 @@
 #include "Resource.h"
 
 #include <filesystem>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "ServerInstanceBase.h"
@@ -48,6 +51,24 @@ static bool g_permissionModifyAllowed{ true };
 static std::unordered_map<std::tuple<Source, Target>, FilesystemPermission, ResourceTupleHash, ResourceTupleEqual>
 g_permissions{};
 
+static std::recursive_mutex g_buildTaskPermissionMutex;
+
+struct BuildTaskFilesystemPathPermission
+{
+	std::string path;
+	bool isDirectory;
+};
+
+struct BuildTaskFilesystemPermission
+{
+	std::string sourceResource;
+	std::string targetResource;
+	std::vector<BuildTaskFilesystemPathPermission> allowedPaths;
+};
+
+static uint64_t g_nextBuildTaskPermissionId = 1;
+static std::unordered_map<uint64_t, BuildTaskFilesystemPermission> g_buildTaskPermissions{};
+
 static std::unordered_set<std::string> g_workerPermissions{};
 static std::unordered_set<std::string> g_childProcessPermissions{};
 
@@ -81,9 +102,183 @@ static std::tuple<std::string, std::filesystem::path> GetResourcePath(const std:
 	return { resourceName, remainingPath };
 }
 
+static bool HasTrailingDirectorySeparator(const std::string& path)
+{
+	return !path.empty() && (path.back() == '/' || path.back() == '\\');
+}
+
+static std::string NormalizeRelativeResourcePath(const std::filesystem::path& path)
+{
+	if (path.empty() || path.is_absolute() || path.has_root_name() || path.has_root_directory())
+	{
+		return {};
+	}
+
+	for (const auto& part : path)
+	{
+		if (part == "..")
+		{
+			return {};
+		}
+	}
+
+	const auto normalized = path.lexically_normal();
+	if (normalized.empty())
+	{
+		return {};
+	}
+
+	std::string result;
+	for (const auto& part : normalized)
+	{
+		const std::string partString = part.generic_string();
+		if (partString.empty() || partString == ".")
+		{
+			continue;
+		}
+
+		if (partString == "..")
+		{
+			return {};
+		}
+
+		if (!result.empty())
+		{
+			result += '/';
+		}
+
+		result += partString;
+	}
+
+	return result;
+}
+
+static std::optional<BuildTaskFilesystemPathPermission> NormalizeBuildTaskAllowedPath(const std::string& path)
+{
+	const std::filesystem::path permissionPath = path;
+	auto firstPart = permissionPath.begin();
+	if (firstPart != permissionPath.end())
+	{
+		const std::string firstPartString = firstPart->generic_string();
+		if (!firstPartString.empty() && firstPartString[0] == '@')
+		{
+			return {};
+		}
+	}
+
+	const bool isDirectory = HasTrailingDirectorySeparator(path);
+	const auto normalizedPath = NormalizeRelativeResourcePath(permissionPath);
+	if (normalizedPath.empty())
+	{
+		return {};
+	}
+
+	return BuildTaskFilesystemPathPermission{
+		normalizedPath,
+		isDirectory
+	};
+}
+
+bool ScriptingFilesystemIsBuildTaskPathSafe(const std::string& path)
+{
+	return NormalizeBuildTaskAllowedPath(path).has_value();
+}
+
+static bool IsBuildTaskPathAllowed(const std::string& requestedPath, const BuildTaskFilesystemPathPermission& allowedPath)
+{
+	if (requestedPath == allowedPath.path)
+	{
+		return true;
+	}
+
+	if (!allowedPath.isDirectory)
+	{
+		return false;
+	}
+
+	return requestedPath.rfind(allowedPath.path + '/', 0) == 0;
+}
+
+static bool ScriptingFilesystemHasBuildTaskPermission(const std::string& sourceResource, const std::string& targetResource, const std::filesystem::path& targetPath)
+{
+	std::lock_guard<std::recursive_mutex> lock(g_buildTaskPermissionMutex);
+
+	const auto normalizedTargetPath = NormalizeRelativeResourcePath(targetPath);
+	if (normalizedTargetPath.empty())
+	{
+		return false;
+	}
+
+	for (const auto& [_, permission] : g_buildTaskPermissions)
+	{
+		if (permission.sourceResource != sourceResource || permission.targetResource != targetResource)
+		{
+			continue;
+		}
+
+		for (const auto& allowedPath : permission.allowedPaths)
+		{
+			if (IsBuildTaskPathAllowed(normalizedTargetPath, allowedPath))
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+uint64_t ScriptingFilesystemPushBuildTaskPermission(const std::string& sourceResource, const std::string& targetResource, const std::vector<std::string>& allowedPaths)
+{
+	if (sourceResource.empty() || targetResource.empty() || sourceResource == targetResource)
+	{
+		return 0;
+	}
+
+	std::vector<BuildTaskFilesystemPathPermission> normalizedAllowedPaths;
+	for (const auto& path : allowedPaths)
+	{
+		if (const auto normalizedPath = NormalizeBuildTaskAllowedPath(path))
+		{
+			normalizedAllowedPaths.push_back(*normalizedPath);
+		}
+	}
+
+	if (normalizedAllowedPaths.empty())
+	{
+		return 0;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(g_buildTaskPermissionMutex);
+
+	const uint64_t permissionId = g_nextBuildTaskPermissionId++;
+	if (g_nextBuildTaskPermissionId == 0)
+	{
+		g_nextBuildTaskPermissionId = 1;
+	}
+
+	g_buildTaskPermissions[permissionId] = BuildTaskFilesystemPermission{
+		sourceResource,
+		targetResource,
+		std::move(normalizedAllowedPaths)
+	};
+
+	return permissionId;
+}
+
+void ScriptingFilesystemPopBuildTaskPermission(uint64_t permissionId)
+{
+	if (permissionId == 0)
+	{
+		return;
+	}
+
+	std::lock_guard<std::recursive_mutex> lock(g_buildTaskPermissionMutex);
+	g_buildTaskPermissions.erase(permissionId);
+}
+
 bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resourceOverride)
 {
-	std::filesystem::path filePath = path;
 	auto [resourceName, resourceFilePath] = GetResourcePath(path);
 	if (resourceName.empty() || resourceFilePath.empty())
 	{
@@ -109,11 +304,15 @@ bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resour
 		currentResource = static_cast<fx::Resource*>(runtime->GetParentObject());
 		currentResourceName = (currentResource) ? currentResource->GetName() : "";
 	}
-	
 
 	if (currentResourceName == resourceName)
 	{
 		// return true if the file is inside the same resource
+		return true;
+	}
+
+	if (ScriptingFilesystemHasBuildTaskPermission(currentResourceName, resourceName, resourceFilePath))
+	{
 		return true;
 	}
 
@@ -272,6 +471,20 @@ static InitFunction initFunction([]()
 namespace fx
 {
 bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resourceOverride)
+{
+	return true;
+}
+
+uint64_t ScriptingFilesystemPushBuildTaskPermission(const std::string& sourceResource, const std::string& targetResource, const std::vector<std::string>& allowedPaths)
+{
+	return 0;
+}
+
+void ScriptingFilesystemPopBuildTaskPermission(uint64_t permissionId)
+{
+}
+
+bool ScriptingFilesystemIsBuildTaskPathSafe(const std::string& path)
 {
 	return true;
 }

--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -113,7 +113,8 @@ const std::string_view& resource)
 		return true;
 	}
 
-	if (m_resourceName == "yarn" || m_resourceName == "webpack")
+	if ((m_resourceName == "yarn" || m_resourceName == "webpack") &&
+		(perm == permission::PermissionScope::kChildProcess || perm == permission::PermissionScope::kWorkerThreads))
 	{
 		return true;
 	}

--- a/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
+++ b/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
@@ -562,7 +562,8 @@ static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator 
 	if (first != last)
 	{
 		std::shared_ptr<BuildTaskProvider> provider = (*first);
-		provider->Build(resource->GetName(), [resource, first, last](bool success, const std::string& result)
+		const std::string resourceName = resource->GetName();
+		provider->Build(resourceName, [resource, resourceName, first, last](bool success, const std::string& result)
 		{
 			if (success)
 			{
@@ -571,7 +572,7 @@ static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator 
 			}
 			else
 			{
-				trace("Building resource %s failed.\n", resource->GetName());
+				trace("Building resource %s failed.\n", resourceName.c_str());
 				trace("Error data: %s\n", result);
 			}
 		});

--- a/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
+++ b/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
@@ -11,8 +11,50 @@
 #include <fxScripting.h>
 #include <ScriptEngine.h>
 
+#include <FilesystemPermissions.h>
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+
 namespace fx
 {
+static constexpr auto kBuildTaskFilesystemPermissionTimeout = std::chrono::minutes(30);
+static constexpr auto kBuildTaskFilesystemPermissionCleanupInterval = std::chrono::seconds(30);
+
+template<typename TCallback>
+class ScopeExit
+{
+public:
+	explicit ScopeExit(TCallback callback)
+		: m_callback(std::move(callback))
+	{
+	}
+
+	~ScopeExit()
+	{
+		if (m_active)
+		{
+			m_callback();
+		}
+	}
+
+	void Dismiss()
+	{
+		m_active = false;
+	}
+
+	ScopeExit(const ScopeExit&) = delete;
+	ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+	TCallback m_callback;
+	bool m_active = true;
+};
+
+template<typename TCallback>
+ScopeExit(TCallback) -> ScopeExit<TCallback>;
+
 class BuildTaskProvider
 {
 public:
@@ -21,10 +63,280 @@ public:
 	virtual void Build(const std::string& resourceName, const std::function<void(bool, const std::string&)>& completionCb) = 0;
 };
 
+class ScopedBuildTaskFilesystemPermission
+{
+public:
+	ScopedBuildTaskFilesystemPermission(const std::string& sourceResource, const std::string& targetResource, const std::vector<std::string>& allowedPaths)
+		: m_sourceResource(sourceResource), m_targetResource(targetResource)
+	{
+		if (!m_sourceResource.empty() && !m_targetResource.empty() && m_sourceResource != m_targetResource)
+		{
+			m_permissionId = fx::ScriptingFilesystemPushBuildTaskPermission(m_sourceResource, m_targetResource, allowedPaths);
+		}
+	}
+
+	~ScopedBuildTaskFilesystemPermission()
+	{
+		Release();
+	}
+
+	void Release()
+	{
+		std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+		if (m_permissionId == 0)
+		{
+			return;
+		}
+
+		fx::ScriptingFilesystemPopBuildTaskPermission(m_permissionId);
+		m_permissionId = 0;
+	}
+
+	bool IsSourceResource(const std::string& resourceName) const
+	{
+		return m_sourceResource == resourceName;
+	}
+
+	ScopedBuildTaskFilesystemPermission(const ScopedBuildTaskFilesystemPermission&) = delete;
+	ScopedBuildTaskFilesystemPermission& operator=(const ScopedBuildTaskFilesystemPermission&) = delete;
+
+private:
+	std::string m_sourceResource;
+	std::string m_targetResource;
+	std::recursive_mutex m_mutex;
+	uint64_t m_permissionId = 0;
+};
+
+struct BuildTaskCompletionState
+{
+	std::recursive_mutex mutex;
+	bool completed = false;
+};
+
+struct BuildMap : public fwRefCountable
+{
+	~BuildMap()
+	{
+		ClearActiveBuilds("Build task target resource was destroyed before invoking its completion callback.");
+	}
+
+	void AddActiveBuild(const std::shared_ptr<ScopedBuildTaskFilesystemPermission>& permission, const std::function<void(const std::string&)>& failureCb)
+	{
+		std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
+		activeBuilds.push_back({
+			permission,
+			std::chrono::steady_clock::now() + kBuildTaskFilesystemPermissionTimeout,
+			failureCb
+		});
+	}
+
+	void ReleaseActiveBuild(const std::shared_ptr<ScopedBuildTaskFilesystemPermission>& permission)
+	{
+		std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
+
+		for (auto it = activeBuilds.begin(); it != activeBuilds.end(); ++it)
+		{
+			if (it->permission == permission)
+			{
+				it->permission->Release();
+				activeBuilds.erase(it);
+				return;
+			}
+		}
+
+		permission->Release();
+	}
+
+	void ClearActiveBuilds(const std::string& failureReason)
+	{
+		std::vector<std::function<void(const std::string&)>> cleanupCallbacks;
+
+		{
+			std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
+
+			for (auto& activeBuild : activeBuilds)
+			{
+				activeBuild.permission->Release();
+				cleanupCallbacks.push_back(activeBuild.failureCb);
+			}
+
+			activeBuilds.clear();
+		}
+
+		for (const auto& cleanupCb : cleanupCallbacks)
+		{
+			cleanupCb(failureReason);
+		}
+	}
+
+	void ClearActiveBuildsForSource(const std::string& sourceResource)
+	{
+		std::vector<std::function<void(const std::string&)>> cleanupCallbacks;
+
+		{
+			std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
+
+			for (auto it = activeBuilds.begin(); it != activeBuilds.end();)
+			{
+				if (it->permission->IsSourceResource(sourceResource))
+				{
+					it->permission->Release();
+					cleanupCallbacks.push_back(it->failureCb);
+					it = activeBuilds.erase(it);
+					continue;
+				}
+
+				++it;
+			}
+		}
+
+		for (const auto& cleanupCb : cleanupCallbacks)
+		{
+			cleanupCb("Build task provider resource stopped before invoking its completion callback.");
+		}
+	}
+
+	void ReleaseExpiredBuilds(const std::string& targetResource)
+	{
+		std::vector<std::function<void(const std::string&)>> timeoutCallbacks;
+
+		{
+			std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
+
+			const auto now = std::chrono::steady_clock::now();
+			for (auto it = activeBuilds.begin(); it != activeBuilds.end();)
+			{
+				if (it->timeout <= now)
+				{
+					trace("Build task for resource %s expired after build timeout.\n", targetResource.c_str());
+					it->permission->Release();
+					timeoutCallbacks.push_back(it->failureCb);
+					it = activeBuilds.erase(it);
+					continue;
+				}
+
+				++it;
+			}
+		}
+
+		for (const auto& timeoutCb : timeoutCallbacks)
+		{
+			timeoutCb("Build task timed out before invoking its completion callback.");
+		}
+	}
+
+	std::vector<std::shared_ptr<BuildTaskProvider>> buildingProviders;
+
+private:
+	struct ActiveBuild
+	{
+		std::shared_ptr<ScopedBuildTaskFilesystemPermission> permission;
+		std::chrono::steady_clock::time_point timeout;
+		std::function<void(const std::string&)> failureCb;
+	};
+
+	std::recursive_mutex m_activeBuildsMutex;
+	std::vector<ActiveBuild> activeBuilds;
+};
+
+static std::string TrimBuildTaskPermissionEntry(const std::string& entry)
+{
+	const auto start = entry.find_first_not_of(" \t\r\n");
+	if (start == std::string::npos)
+	{
+		return {};
+	}
+
+	const auto end = entry.find_last_not_of(" \t\r\n");
+	return entry.substr(start, end - start + 1);
+}
+
+bool ParseBuildTaskPermissionEntry(const std::string& entry, const std::string& builderResourceName, std::string* allowedPath)
+{
+	if (!allowedPath)
+	{
+		return false;
+	}
+
+	const auto value = TrimBuildTaskPermissionEntry(entry);
+	if (value.empty())
+	{
+		return false;
+	}
+
+	const auto separator = value.find(':');
+	if (separator == std::string::npos)
+	{
+		return false;
+	}
+
+	const auto sourceResource = TrimBuildTaskPermissionEntry(value.substr(0, separator));
+	if (sourceResource != builderResourceName)
+	{
+		return false;
+	}
+
+	*allowedPath = TrimBuildTaskPermissionEntry(value.substr(separator + 1));
+	return !allowedPath->empty() && fx::ScriptingFilesystemIsBuildTaskPathSafe(*allowedPath);
+}
+
+static bool TryParseBuildTaskPermissionEntry(const std::string& entry, const std::string& builderResourceName, std::string* allowedPath)
+{
+	return ParseBuildTaskPermissionEntry(entry, builderResourceName, allowedPath);
+}
+
+static void AppendBuildTaskPermissionEntries(const fwRefContainer<ResourceMetaDataComponent>& metadata, const std::string& key, const std::string& builderResourceName, std::vector<std::string>* allowedPaths)
+{
+	if (!metadata.GetRef())
+	{
+		return;
+	}
+
+	for (const auto& entry : metadata->GetEntries(key))
+	{
+		std::string allowedPath;
+		if (TryParseBuildTaskPermissionEntry(entry.second, builderResourceName, &allowedPath))
+		{
+			allowedPaths->push_back(allowedPath);
+		}
+	}
+}
+
+static std::vector<std::string> GetBuildTaskAllowedPaths(Resource* targetResource, const std::string& builderResourceName)
+{
+	std::vector<std::string> allowedPaths;
+	if (!targetResource)
+	{
+		return allowedPaths;
+	}
+
+	const auto metadata = targetResource->GetComponent<ResourceMetaDataComponent>();
+	if (builderResourceName == "webpack")
+	{
+		// Compatibility for the built-in webpack provider. Custom providers require target opt-in.
+		allowedPaths.push_back("build/");
+		allowedPaths.push_back("dist/");
+	}
+	else if (builderResourceName == "yarn")
+	{
+		// Compatibility for the built-in yarn provider marker file and package output.
+		allowedPaths.push_back(".yarn.installed");
+		allowedPaths.push_back("node_modules/");
+		allowedPaths.push_back("yarn.lock");
+	}
+
+	// Manifest syntax: build_task_permission 'builder-resource:relative/path'
+	// Directory permissions must end in a slash, for example 'leap:build/'.
+	AppendBuildTaskPermissionEntries(metadata, "build_task_permission", builderResourceName, &allowedPaths);
+
+	return allowedPaths;
+}
+
 class ResourceBuildTaskProvider : public BuildTaskProvider
 {
 public:
-	ResourceBuildTaskProvider(fx::ResourceManager* resman, const std::map<std::string, msgpack::object>& map);
+	ResourceBuildTaskProvider(fx::ResourceManager* resman, const std::string& ownerResourceName, const std::map<std::string, msgpack::object>& map);
 
 	virtual bool ShouldBuild(const std::string& resourceName) override;
 
@@ -33,13 +345,16 @@ public:
 private:
 	fx::ResourceManager* m_resourceManager;
 
+	std::string m_ownerResourceName;
+
 	FunctionRef m_shouldBuildRef;
 
 	FunctionRef m_buildRef;
 };
 
-ResourceBuildTaskProvider::ResourceBuildTaskProvider(fx::ResourceManager* resman, const std::map<std::string, msgpack::object>& map)
+ResourceBuildTaskProvider::ResourceBuildTaskProvider(fx::ResourceManager* resman, const std::string& ownerResourceName, const std::map<std::string, msgpack::object>& map)
 	: m_resourceManager(resman)
+	, m_ownerResourceName(ownerResourceName)
 {
 	auto setCallback = [&](const std::string& cbId) -> FunctionRef
 	{
@@ -83,26 +398,129 @@ void ResourceBuildTaskProvider::Build(const std::string& resourceName, const std
 		return;
 	}
 
-	auto cbComponent = m_resourceManager->GetComponent<fx::ResourceCallbackComponent>();
-	auto cb = cbComponent->CreateCallback([completionCb](const msgpack::unpacked& unpacked)
-	{
-		auto obj = unpacked.get().as<std::vector<msgpack::object>>();
+	fwRefContainer<BuildMap> buildMap;
+	std::vector<std::string> allowedPaths;
 
-		if (!obj.empty())
+	const fwRefContainer<Resource> resource = m_resourceManager->GetResource(resourceName);
+	if (resource.GetRef())
+	{
+		buildMap = resource->GetComponent<BuildMap>();
+		allowedPaths = GetBuildTaskAllowedPaths(resource.GetRef(), m_ownerResourceName);
+	}
+
+	if (allowedPaths.empty())
+	{
+		trace("Build task provider %s has no filesystem write permissions for resource %s. Add build_task_permission '%s:build/' to the target resource manifest for build outputs, and additional build_task_permission entries for any extra paths.\n", m_ownerResourceName.c_str(), resourceName.c_str(), m_ownerResourceName.c_str());
+	}
+
+	auto permission = std::make_shared<ScopedBuildTaskFilesystemPermission>(m_ownerResourceName, resourceName, allowedPaths);
+	auto completionState = std::make_shared<BuildTaskCompletionState>();
+
+	auto markBuildCompleted = [completionState]()
+	{
+		std::lock_guard<std::recursive_mutex> lock(completionState->mutex);
+		if (completionState->completed)
 		{
-			bool success = obj[0].as<bool>();
-			std::string result = "";
-			
-			if (obj.size() >= 2)
+			return false;
+		}
+
+		completionState->completed = true;
+		return true;
+	};
+
+	auto releasePermission = [permission, buildMap]() mutable
+	{
+		if (buildMap.GetRef())
+		{
+			buildMap->ReleaseActiveBuild(permission);
+		}
+		else
+		{
+			permission->Release();
+		}
+	};
+
+	auto failBuild = [completionCb, markBuildCompleted](const std::string& result) mutable
+	{
+		if (!markBuildCompleted())
+		{
+			return;
+		}
+
+		completionCb(false, result);
+	};
+
+	auto completeBuild = [completionCb, releasePermission, markBuildCompleted](bool success, const std::string& result) mutable
+	{
+		if (!markBuildCompleted())
+		{
+			return;
+		}
+
+		releasePermission();
+		completionCb(success, result);
+	};
+
+	if (buildMap.GetRef())
+	{
+		buildMap->AddActiveBuild(permission, failBuild);
+	}
+
+	ScopeExit setupGuard(releasePermission);
+	try
+	{
+		auto cbComponent = m_resourceManager->GetComponent<fx::ResourceCallbackComponent>();
+		auto cb = cbComponent->CreateCallback([completeBuild](const msgpack::unpacked& unpacked) mutable
+		{
+			std::vector<msgpack::object> obj;
+			try
 			{
-				result = obj[1].as<std::string>();
+				obj = unpacked.get().as<std::vector<msgpack::object>>();
+			}
+			catch (const std::exception& e)
+			{
+				completeBuild(false, fmt::sprintf("Build task completion callback returned invalid data: %s", e.what()));
+				return;
 			}
 
-			completionCb(success, result);
-		}
-	});
+			if (obj.empty())
+			{
+				completeBuild(false, "Build task completion callback did not return a result.");
+				return;
+			}
 
-	m_resourceManager->CallReference<void>(m_buildRef.GetRef(), resourceName, cb);
+			bool success = false;
+			std::string result = "";
+
+			try
+			{
+				success = obj[0].as<bool>();
+
+				if (obj.size() >= 2)
+				{
+					result = obj[1].as<std::string>();
+				}
+			}
+			catch (const std::exception& e)
+			{
+				completeBuild(false, fmt::sprintf("Build task completion callback returned invalid data: %s", e.what()));
+				return;
+			}
+
+			completeBuild(success, result);
+		});
+
+		m_resourceManager->CallReference<void>(m_buildRef.GetRef(), resourceName, cb);
+		setupGuard.Dismiss();
+	}
+	catch (const std::exception& e)
+	{
+		completeBuild(false, fmt::sprintf("Build task setup failed: %s", e.what()));
+	}
+	catch (...)
+	{
+		completeBuild(false, "Build task setup failed.");
+	}
 }
 
 using TFactoryFn = std::function<std::shared_ptr<BuildTaskProvider>()>;
@@ -147,11 +565,6 @@ static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator 
 		resource->Start();
 	}
 }
-
-struct BuildMap : public fwRefCountable
-{
-	std::vector<std::shared_ptr<BuildTaskProvider>> buildingProviders;
-};
 
 static bool TriggerBuild(Resource* resource)
 {
@@ -220,22 +633,32 @@ static InitFunction initFunction([]()
 
 				auto resourceManager = resource->GetManager();
 
-				fx::RegisterBuildTaskFactory(fullFactoryId, [resourceManager, factoryRef]() -> std::shared_ptr<fx::ResourceBuildTaskProvider>
+				const std::string ownerResourceName = resource->GetName();
+				fx::RegisterBuildTaskFactory(fullFactoryId, [resourceManager, ownerResourceName, factoryRef]() -> std::shared_ptr<fx::ResourceBuildTaskProvider>
 				{
 					msgpack::unpacked unpacked;
 					auto factoryObject = resourceManager->CallReferenceUnpacked<std::map<std::string, msgpack::object>>(factoryRef, &unpacked);
 
 					if (!factoryObject.empty())
 					{
-						return std::make_shared<fx::ResourceBuildTaskProvider>(resourceManager, factoryObject);
+						return std::make_shared<fx::ResourceBuildTaskProvider>(resourceManager, ownerResourceName, factoryObject);
 					}
 
 					return {};
 				});
 
-				resource->OnStop.Connect([fullFactoryId]()
+				resource->OnStop.Connect([resourceManager, fullFactoryId, ownerResourceName]()
 				{
 					fx::UnregisterBuildTaskFactory(fullFactoryId);
+
+					resourceManager->ForAllResources([&](const fwRefContainer<fx::Resource>& targetResource)
+					{
+						auto buildMap = targetResource->GetComponent<fx::BuildMap>();
+						if (buildMap.GetRef())
+						{
+							buildMap->ClearActiveBuildsForSource(ownerResourceName);
+						}
+					});
 				});
 			}
 		}
@@ -243,9 +666,52 @@ static InitFunction initFunction([]()
 
 	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* resource)
 	{
+		resource->OnStop.Connect([resource]()
+		{
+			auto buildMap = resource->GetComponent<fx::BuildMap>();
+			if (buildMap.GetRef())
+			{
+				buildMap->ClearActiveBuilds("Build task target resource stopped before invoking its completion callback.");
+			}
+		});
+
+		resource->OnRemove.Connect([resource]()
+		{
+			auto buildMap = resource->GetComponent<fx::BuildMap>();
+			if (buildMap.GetRef())
+			{
+				buildMap->ClearActiveBuilds("Build task target resource was removed before invoking its completion callback.");
+			}
+		});
+
 		resource->OnBeforeStart.Connect([resource]()
 		{
 			return fx::TriggerBuild(resource);
 		}, 1000);
 	});
+
+	fx::ResourceManager::OnInitializeInstance.Connect([](fx::ResourceManager* manager)
+	{
+		auto nextPermissionCleanup = std::chrono::steady_clock::time_point{};
+		manager->OnTick.Connect([manager, nextPermissionCleanup]() mutable
+		{
+			const auto now = std::chrono::steady_clock::now();
+			if (now < nextPermissionCleanup)
+			{
+				return;
+			}
+
+			nextPermissionCleanup = now + kBuildTaskFilesystemPermissionCleanupInterval;
+
+			manager->ForAllResources([](const fwRefContainer<fx::Resource>& resource)
+			{
+				auto buildMap = resource->GetComponent<fx::BuildMap>();
+				if (buildMap.GetRef())
+				{
+					buildMap->ReleaseExpiredBuilds(resource->GetName());
+				}
+			});
+		});
+	});
+
 });

--- a/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
+++ b/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <mutex>
 
 namespace fx
@@ -322,6 +323,22 @@ static void AppendBuildTaskPermissionEntries(const fwRefContainer<ResourceMetaDa
 	}
 }
 
+static bool HasResourceMetadata(const fwRefContainer<ResourceMetaDataComponent>& metadata, const std::string& key)
+{
+	return metadata.GetRef() && !metadata->GetEntries(key).empty();
+}
+
+static bool ResourceHasFile(Resource* resource, const std::string& relativePath)
+{
+	if (!resource)
+	{
+		return false;
+	}
+
+	std::error_code ec;
+	return std::filesystem::exists(std::filesystem::path(resource->GetPath()) / relativePath, ec);
+}
+
 static std::vector<std::string> GetBuildTaskAllowedPaths(Resource* targetResource, const std::string& builderResourceName)
 {
 	std::vector<std::string> allowedPaths;
@@ -331,13 +348,13 @@ static std::vector<std::string> GetBuildTaskAllowedPaths(Resource* targetResourc
 	}
 
 	const auto metadata = targetResource->GetComponent<ResourceMetaDataComponent>();
-	if (builderResourceName == "webpack")
+	if (builderResourceName == "webpack" && HasResourceMetadata(metadata, "webpack_config"))
 	{
 		// Compatibility for the built-in webpack provider. Custom providers require target opt-in.
 		allowedPaths.push_back("build/");
 		allowedPaths.push_back("dist/");
 	}
-	else if (builderResourceName == "yarn")
+	else if (builderResourceName == "yarn" && ResourceHasFile(targetResource, "package.json"))
 	{
 		// Compatibility for the built-in yarn provider marker file and package output.
 		allowedPaths.push_back(".yarn.installed");

--- a/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
+++ b/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
@@ -121,12 +121,13 @@ struct BuildMap : public fwRefCountable
 		ClearActiveBuilds("Build task target resource was destroyed before invoking its completion callback.");
 	}
 
-	void AddActiveBuild(const std::shared_ptr<ScopedBuildTaskFilesystemPermission>& permission, const std::function<void(const std::string&)>& failureCb)
+	void AddActiveBuild(const std::shared_ptr<ScopedBuildTaskFilesystemPermission>& permission, const std::function<bool()>& cancelCb, const std::function<void(const std::string&)>& failureCb)
 	{
 		std::lock_guard<std::recursive_mutex> lock(m_activeBuildsMutex);
 		activeBuilds.push_back({
 			permission,
 			std::chrono::steady_clock::now() + kBuildTaskFilesystemPermissionTimeout,
+			cancelCb,
 			failureCb
 		});
 	}
@@ -157,6 +158,11 @@ struct BuildMap : public fwRefCountable
 
 			for (auto& activeBuild : activeBuilds)
 			{
+				if (!activeBuild.cancelCb())
+				{
+					continue;
+				}
+
 				activeBuild.permission->Release();
 				cleanupCallbacks.push_back(activeBuild.failureCb);
 			}
@@ -181,6 +187,12 @@ struct BuildMap : public fwRefCountable
 			{
 				if (it->permission->IsSourceResource(sourceResource))
 				{
+					if (!it->cancelCb())
+					{
+						it = activeBuilds.erase(it);
+						continue;
+					}
+
 					it->permission->Release();
 					cleanupCallbacks.push_back(it->failureCb);
 					it = activeBuilds.erase(it);
@@ -210,6 +222,12 @@ struct BuildMap : public fwRefCountable
 				if (it->timeout <= now)
 				{
 					trace("Build task for resource %s expired after build timeout.\n", targetResource.c_str());
+					if (!it->cancelCb())
+					{
+						it = activeBuilds.erase(it);
+						continue;
+					}
+
 					it->permission->Release();
 					timeoutCallbacks.push_back(it->failureCb);
 					it = activeBuilds.erase(it);
@@ -233,6 +251,7 @@ private:
 	{
 		std::shared_ptr<ScopedBuildTaskFilesystemPermission> permission;
 		std::chrono::steady_clock::time_point timeout;
+		std::function<bool()> cancelCb;
 		std::function<void(const std::string&)> failureCb;
 	};
 
@@ -440,14 +459,14 @@ void ResourceBuildTaskProvider::Build(const std::string& resourceName, const std
 		}
 	};
 
-	auto failBuild = [completionCb, markBuildCompleted](const std::string& result) mutable
+	auto failBuild = [completionCb](const std::string& result) mutable
 	{
-		if (!markBuildCompleted())
-		{
-			return;
-		}
-
 		completionCb(false, result);
+	};
+
+	auto cancelBuild = [markBuildCompleted]() mutable
+	{
+		return markBuildCompleted();
 	};
 
 	auto completeBuild = [completionCb, releasePermission, markBuildCompleted](bool success, const std::string& result) mutable
@@ -463,7 +482,7 @@ void ResourceBuildTaskProvider::Build(const std::string& resourceName, const std
 
 	if (buildMap.GetRef())
 	{
-		buildMap->AddActiveBuild(permission, failBuild);
+		buildMap->AddActiveBuild(permission, cancelBuild, failBuild);
 	}
 
 	ScopeExit setupGuard(releasePermission);

--- a/code/tests/server/TestLua.cpp
+++ b/code/tests/server/TestLua.cpp
@@ -264,7 +264,7 @@ TEST_CASE("build task filesystem permissions are scoped to the target resource")
 	REQUIRE(fx::ScriptingFilesystemAllowWrite("@builder/cache/target.json", &builder) == true);
 	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &builder) == false);
 
-	const uint64_t invalidPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "../outside", "build/../fxmanifest.lua", "@other/build/" });
+	const uint64_t invalidPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "../outside", "build/../fxmanifest.lua", "@other/build/", "./@other/build/" });
 	REQUIRE(invalidPermission == 0);
 
 	const uint64_t exactBuildPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "build" });
@@ -338,6 +338,7 @@ TEST_CASE("build task permission metadata entries are explicit")
 	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder=build/", "builder", &allowedPath) == false);
 	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder build/", "builder", &allowedPath) == false);
 	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:@other/build/", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:./@other/build/", "builder", &allowedPath) == false);
 	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:build/../fxmanifest.lua", "builder", &allowedPath) == false);
 	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:", "builder", &allowedPath) == false);
 }

--- a/code/tests/server/TestLua.cpp
+++ b/code/tests/server/TestLua.cpp
@@ -2,6 +2,7 @@
 
 #include <catch_amalgamated.hpp>
 #include <filesystem>
+#include <utility>
 
 #include <lua.hpp>
 #include <LuaFXLib.h>
@@ -9,6 +10,7 @@
 #include <lua_rapidjsonlib.h>
 
 #include "LuaScriptRuntime.h"
+#include "FilesystemPermissions.h"
 #include "RelativeDevice.h"
 #include "ResourceManager.h"
 #include "VFSManager.h"
@@ -16,6 +18,14 @@
 #ifdef IS_FXSERVER
 // vfs manager
 #include "Manager.h"
+#endif
+
+#ifdef IS_FXSERVER
+namespace fx
+{
+// Internal test hook from ResourceBuildTasks.cpp.
+bool ParseBuildTaskPermissionEntry(const std::string& entry, const std::string& builderResourceName, std::string* allowedPath);
+}
 #endif
 
 //#undef LuaScriptRuntime
@@ -180,9 +190,158 @@ void LoadAndRunCode(fx::LuaStateHolder& state, const std::string&& fileName, con
 		REQUIRE(!expectExecutionError);
 	}
 }
+
+#ifdef IS_FXSERVER
+class TestFilesystemPermissionResource final : public fx::Resource
+{
+public:
+	explicit TestFilesystemPermissionResource(std::string name)
+		: m_name(std::move(name))
+	{
+	}
+
+	virtual const std::string& GetName() override
+	{
+		return m_name;
+	}
+
+	virtual const std::string& GetIdentifier() override
+	{
+		return m_name;
+	}
+
+	virtual const std::string& GetPath() override
+	{
+		return m_path;
+	}
+
+	virtual fx::ResourceState GetState() override
+	{
+		return fx::ResourceState::Stopped;
+	}
+
+	virtual bool LoadFrom(const std::string& rootPath, std::string* errorResult) override
+	{
+		m_path = rootPath;
+		return true;
+	}
+
+	virtual bool Start() override
+	{
+		return false;
+	}
+
+	virtual bool Stop() override
+	{
+		return false;
+	}
+
+	virtual void Run(std::function<void()>&& func) override
+	{
+	}
+
+	virtual fx::ResourceManager* GetManager() override
+	{
+		return nullptr;
+	}
+
+private:
+	std::string m_name;
+	std::string m_path;
+};
+#endif
 }
 
 // todo: emulate threading
+
+#ifdef IS_FXSERVER
+TEST_CASE("build task filesystem permissions are scoped to the target resource")
+{
+	TestFilesystemPermissionResource builder("builder");
+	TestFilesystemPermissionResource otherBuilder("other-builder");
+	TestFilesystemPermissionResource target("target");
+
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@builder/cache/target.json", &builder) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &builder) == false);
+
+	const uint64_t invalidPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "../outside", "build/../fxmanifest.lua", "@other/build/" });
+	REQUIRE(invalidPermission == 0);
+
+	const uint64_t exactBuildPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "build" });
+	REQUIRE(exactBuildPermission != 0);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build", &builder) == true);
+	// Directory grants are explicit: use "build/" when children should be writable.
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &builder) == false);
+	fx::ScriptingFilesystemPopBuildTaskPermission(exactBuildPermission);
+
+	const uint64_t buildPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "build/" });
+	REQUIRE(buildPermission != 0);
+
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &builder) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/nested/main.lua", &builder) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/@scope/pkg.js", &builder) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/../fxmanifest.lua", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &otherBuilder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build-other/main.lua", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/fxmanifest.lua", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@other/build/main.lua", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &target) == true);
+
+	const uint64_t manifestPermission = fx::ScriptingFilesystemPushBuildTaskPermission("builder", "target", { "fxmanifest.lua" });
+	REQUIRE(manifestPermission != 0);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/fxmanifest.lua", &builder) == true);
+
+	fx::ScriptingFilesystemPopBuildTaskPermission(buildPermission);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/build/main.lua", &builder) == false);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/fxmanifest.lua", &builder) == true);
+
+	fx::ScriptingFilesystemPopBuildTaskPermission(manifestPermission);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/fxmanifest.lua", &builder) == false);
+
+	const uint64_t webpackPermission = fx::ScriptingFilesystemPushBuildTaskPermission("webpack", "target", { "build/", "dist/" });
+	REQUIRE(webpackPermission != 0);
+	TestFilesystemPermissionResource webpack("webpack");
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/dist/chat.js", &webpack) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/dist/ui.html", &webpack) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/dist-other/chat.js", &webpack) == false);
+	fx::ScriptingFilesystemPopBuildTaskPermission(webpackPermission);
+
+	const uint64_t yarnPermission = fx::ScriptingFilesystemPushBuildTaskPermission("yarn", "target", { ".yarn.installed", "node_modules/", "yarn.lock" });
+	REQUIRE(yarnPermission != 0);
+	TestFilesystemPermissionResource yarn("yarn");
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/.yarn.installed", &yarn) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/node_modules/package/index.js", &yarn) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/yarn.lock", &yarn) == true);
+	REQUIRE(fx::ScriptingFilesystemAllowWrite("@target/package.json", &yarn) == false);
+	fx::ScriptingFilesystemPopBuildTaskPermission(yarnPermission);
+}
+
+TEST_CASE("build task permission metadata entries are explicit")
+{
+	std::string allowedPath;
+
+	// Target resources explicitly opt in to build writes. Directory permissions use a trailing slash.
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:build/", "builder", &allowedPath) == true);
+	REQUIRE(allowedPath == "build/");
+
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("  builder  :  fxmanifest.lua  ", "builder", &allowedPath) == true);
+	REQUIRE(allowedPath == "fxmanifest.lua");
+
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:build", "builder", &allowedPath) == true);
+	REQUIRE(allowedPath == "build");
+
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:build/@scope/pkg.js", "builder", &allowedPath) == true);
+	REQUIRE(allowedPath == "build/@scope/pkg.js");
+
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("other:build/", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder=build/", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder build/", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:@other/build/", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:build/../fxmanifest.lua", "builder", &allowedPath) == false);
+	REQUIRE(fx::ParseBuildTaskPermissionEntry("builder:", "builder", &allowedPath) == false);
+}
+#endif
 
 TEST_CASE("lua run")
 {


### PR DESCRIPTION
## Goal of this PR

Fix `RegisterResourceBuildTaskFactory` providers being unable to write build outputs to target resources under the Node.js filesystem sandbox.

Build task providers are meant to let resources run build steps such as bundling, dependency installation, or generated file output before the target resource starts. After the sandbox restrictions, custom providers could still decide that a resource should build, but their `fs.write` calls into the target resource were denied unless the server used broad filesystem permissions.

This PR keeps the sandbox strict while making build tasks usable again through temporary, scoped write permissions.

## How is this PR achieving the goal

The fix adds a build-task-specific filesystem permission path instead of restoring a global `fs.write` bypass.

Build task writes are now granted only for the active build and only for the matching:

* build provider resource
* target resource
* explicitly allowed relative path(s)

For custom build providers, the target resource opts in from its manifest with:

```lua
build_task_permission 'builder-resource:build/'
```

The path is relative to the target resource. Directory grants must end with a slash, so `build/` allows files under `build`, while `build` only allows the exact `build` path.

The permission handling also:

* normalizes relative paths before matching
* rejects absolute paths, `..`, and cross-resource `@resource` path entries
* releases permissions on build completion
* cancels and releases permissions on provider stop, target stop/remove/destruction, and timeout
* prevents late callbacks from restarting a resource after cancellation
* keeps compatibility for built-in `webpack` and `yarn` build resources without keeping the old global filesystem write bypass

The old special Node sandbox path for `webpack`/`yarn` is narrowed to child process and worker thread permissions only. Filesystem writes now go through the scoped build task permission check.

## This PR applies to the following area(s)

FiveM server resource build tasks and Node.js filesystem sandboxing.

## Successfully tested on

* Verified path-scoped build task filesystem permissions for `sourceResource -> targetResource`
* Verified directory grants and exact-file grants behave differently
* Verified writes outside the allowed target path are denied
* Verified writes from another builder resource are denied
* Verified path traversal attempts using `..` are denied
* Verified normalized `@resource` permission entries such as `./@other/build/` are denied
* Verified built-in `webpack` compatibility paths such as `dist/`
* Verified built-in `yarn` compatibility paths such as `.yarn.installed`, `node_modules/`, and `yarn.lock`
* Verified `git diff --check upstream/master...HEAD` passes

I could not run the full C++ test suite locally because this checkout does not have a generated build directory/toolchain available.

## Checklist

* Code compiles and has been tested successfully.
* Code explains itself well and/or is documented.
* My commit message explains what the changes do and what they are for.
* No extra compilation warnings are added by these changes.

## Fixes issues

Fixes #3928