### PR TITLE
fix(scripting-node): allow opt-in absolute-path filesystem reads

### DIFF
--- a/code/components/citizen-scripting-core/include/FilesystemPermissions.h
+++ b/code/components/citizen-scripting-core/include/FilesystemPermissions.h
@@ -10,6 +10,8 @@ class Resource;
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
 bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resourceOverride = nullptr);
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
+bool ScriptingFilesystemAllowAbsoluteRead(const std::string& absolutePath, fx::Resource* resourceOverride = nullptr);
+COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
 bool ScriptingWorkerAllowSpawn(fx::Resource* resourceOverride = nullptr);
 COMPONENT_EXPORT(CITIZEN_SCRIPTING_CORE)
 bool ScriptingChildProcessAllowSpawn(fx::Resource* resourceOverride = nullptr);

--- a/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
+++ b/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
@@ -50,6 +50,7 @@ g_permissions{};
 
 static std::unordered_set<std::string> g_workerPermissions{};
 static std::unordered_set<std::string> g_childProcessPermissions{};
+static std::unordered_map<std::string, std::vector<std::string>> g_filesystemAbsoluteReadPermissions{};
 
 static std::tuple<std::string, std::filesystem::path> GetResourcePath(const std::filesystem::path& path)
 {
@@ -164,6 +165,58 @@ bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resour
 	return false;
 }
 
+bool ScriptingFilesystemAllowAbsoluteRead(const std::string& absolutePath, fx::Resource* resourceOverride)
+{
+	fx::Resource* currentResource = nullptr;
+	if (resourceOverride != nullptr)
+	{
+		currentResource = resourceOverride;
+	}
+	else
+	{
+		fx::OMPtr<IScriptRuntime> runtime;
+		if (!FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			return false;
+		}
+		currentResource = static_cast<fx::Resource*>(runtime->GetParentObject());
+	}
+
+	if (!currentResource)
+	{
+		return false;
+	}
+
+	auto it = g_filesystemAbsoluteReadPermissions.find(currentResource->GetName());
+	if (it == g_filesystemAbsoluteReadPermissions.end())
+	{
+		return false;
+	}
+
+	std::filesystem::path normalizedRequest = std::filesystem::path(absolutePath).lexically_normal();
+	std::string normalizedRequestStr = normalizedRequest.generic_string();
+
+	for (const auto& allowedPrefix : it->second)
+	{
+		std::filesystem::path normalizedAllowed = std::filesystem::path(allowedPrefix).lexically_normal();
+		std::string normalizedAllowedStr = normalizedAllowed.generic_string();
+
+		if (normalizedRequestStr == normalizedAllowedStr)
+		{
+			return true;
+		}
+
+		if (normalizedRequestStr.size() > normalizedAllowedStr.size()
+			&& normalizedRequestStr.rfind(normalizedAllowedStr, 0) == 0
+			&& normalizedRequestStr[normalizedAllowedStr.size()] == '/')
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool ScriptingWorkerAllowSpawn(fx::Resource* resourceOverride)
 {
 	fx::OMPtr<IScriptRuntime> runtime;
@@ -250,6 +303,25 @@ static InitFunction initFunction([]()
 			fx::g_workerPermissions.insert(sourceResource);
 		});
 
+		static ConsoleCommand addFSReadPermCmd("add_unsafe_filesystem_absolute_read_permission", [](const std::string& sourceResource, const std::string& absolutePath)
+		{
+			if (!fx::g_permissionModifyAllowed)
+			{
+				console::PrintWarning(_CFX_NAME_STRING(_CFX_COMPONENT_NAME),
+				"add_unsafe_filesystem_absolute_read_permission is only executable before the server finished execution.\n");
+				return;
+			}
+
+			if (absolutePath.empty() || !std::filesystem::path(absolutePath).is_absolute())
+			{
+				console::PrintWarning(_CFX_NAME_STRING(_CFX_COMPONENT_NAME),
+				"add_unsafe_filesystem_absolute_read_permission requires an absolute path, got '%s'.\n", absolutePath.c_str());
+				return;
+			}
+
+			fx::g_filesystemAbsoluteReadPermissions[sourceResource].push_back(absolutePath);
+		});
+
 		static ConsoleCommand addChildProcessPermCmd("add_unsafe_child_process_permission", [](const std::string& sourceResource)
 		{
 			if (!fx::g_permissionModifyAllowed)
@@ -274,6 +346,11 @@ namespace fx
 bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resourceOverride)
 {
 	return true;
+}
+
+bool ScriptingFilesystemAllowAbsoluteRead(const std::string& absolutePath, fx::Resource* resourceOverride)
+{
+	return false;
 }
 }
 #endif

--- a/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
+++ b/code/components/citizen-scripting-node/src/NodeScriptRuntime.cpp
@@ -169,6 +169,12 @@ const std::string_view& resource)
 			device = vfs::FindDevice(absolutePath, path);
 			if (!device.GetRef())
 			{
+				if (perm == permission::PermissionScope::kFileSystemRead
+					&& fx::ScriptingFilesystemAllowAbsoluteRead(absolutePath, m_parentObject))
+				{
+					return true;
+				}
+
 				trace("Filesystem permission check from '%s' for permission %s on resource '%s' - no device found\n", m_resourceName.c_str(), permName.c_str(), res.c_str());
 				return false;
 			}


### PR DESCRIPTION
## Goal of this PR
Fix #3978.

The Node.js scripting sandbox blocks every `fs.read` on an absolute path that is not inside a registered VFS device. This is the correct default, but it makes the MongoDB Node driver (and Mongoose) crash at construction time, because its internal `getContainerMetadata()` probes paths like `/.dockerenv`, `/proc/self/cgroup`, `/etc/os-release` to detect its runtime environment. Right now any resource using `mongodb` or `mongoose` throws `Error: Access to this API has been restricted` and dies before it can connect.

## How is this PR achieving the goal
Adds an admin opt-in allow-list for absolute reads, mirroring the existing `add_unsafe_worker_permission` / `add_unsafe_child_process_permission` pattern:

- New `fx::ScriptingFilesystemAllowAbsoluteRead(absolutePath, resource)` helper in `citizen-scripting-core`.
- New console command `add_unsafe_filesystem_absolute_read_permission <resource> <absolute-path>`, gated by the same `g_permissionModifyAllowed` startup-only flag as the other `_unsafe_*` commands. Path must be absolute, exact-or-directory-prefix match (no glob, no traversal).
- `NodePermissionCallback` consults the allow-list only for `kFileSystemRead`, only when no VFS device matches, and only after the existing `..` traversal guard. Writes are untouched.
- Default behaviour is unchanged: without an explicit `add_unsafe_filesystem_absolute_read_permission` entry, the sandbox blocks as before.

Admins write in `server.cfg`:

```
add_unsafe_filesystem_absolute_read_permission my_mongo_resource "C:\.dockerenv"
add_unsafe_filesystem_absolute_read_permission my_mongo_resource /proc/self/cgroup
```

## This PR applies to the following area(s)
FXServer, ScRT: JS

## Successfully tested on
**Game builds:** N/A (server-only change)
**Platforms:** Windows

Built FXServer locally and reproduced #3978 end-to-end with `mongodb@6` and `mongoose@8`.

Before:

```
[ c-scripting-node] Filesystem permission check from 'mongoose_test' for permission fs.read on resource 'C:\.dockerenv' - no device found
Error: Access to this API has been restricted. Use --allow-fs-read to manage permissions.
```

After (with matching `add_unsafe_filesystem_absolute_read_permission`):

```
[script:mongoose_test] MongoClient: connecting to mongodb://127.0.0.1:27017/fivem_test
[           resources] Started resource mongoose_test
```

Driver gets past `getContainerMetadata()` and continues normally.

## Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
