### PR TITLE
fix(mono): remove RELAX_REFLECTION to block filesystem side-channel v…

### DIFF
--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -98,7 +98,10 @@ void MonoComponentHostShared::Initialize()
 
 #ifndef IS_FXSERVER
 		mono_security_enable_core_clr();
-		mono_security_core_clr_set_options((MonoSecurityCoreCLROptions)(MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_DELEGATE | MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_REFLECTION));
+		// MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_REFLECTION removed: it allowed transparent
+		// code to invoke SecurityCritical methods (e.g. Assembly.LoadFrom) via MethodInfo.Invoke,
+		// enabling arbitrary filesystem probing from untrusted resource scripts.
+		mono_security_core_clr_set_options((MonoSecurityCoreCLROptions)(MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_DELEGATE));
 		mono_security_set_core_clr_platform_callback(CoreCLRIsTrustedCode);
 
 		mono_profiler_install(&s_monoProfiler, ProfilerShutDown);


### PR DESCRIPTION
### Goal of this PR
Remove `MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_REFLECTION` from the CoreCLR security options to prevent untrusted client-side resource scripts from probing the player's filesystem via a reflection-based side-channel.

### How is this PR achieving the goal
With `RELAX_REFLECTION` enabled, a client-side C# resource script could call `MethodInfo.Invoke` to invoke `Assembly.LoadFrom(path)` on arbitrary paths. Since `MethodInfo.Invoke` is `[SecuritySafeCritical]`, it bypasses the JIT-time verifier check that would otherwise block the call from transparent code. The exception type thrown by `Assembly.LoadFrom` reveals whether a file exists on the client's disk (`BadImageFormatException` = file exists, `FileNotFoundException` = does not exist), allowing any server to silently probe the filesystem of connecting players.

Removing `RELAX_REFLECTION` causes Mono to enforce the CoreCLR trust boundary: transparent code can no longer use reflection to invoke Critical/SafeCritical methods it cannot call directly. `RELAX_DELEGATE` is kept as it is required for legitimate event handler and export bridging between trusted and transparent code.

### This PR applies to the following area(s)
ScRT: C#, FiveM (client)

### Successfully tested on
**Game builds:** ..

**Platforms:** Windows

### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues