### PR TITLE
feat(server-impl): compress /client getConfiguration responses

### DIFF
--- a/code/components/citizen-server-impl/component.json
+++ b/code/components/citizen-server-impl/component.json
@@ -24,6 +24,7 @@
 		"vendor:eastl",
 		"vendor:thread-pool-cpp",
 		"vendor:utfcpp",
+		"vendor:zlib",
 		"vendor:breakpad",
 		"vendor:prometheus-cpp",
 		"vendor:folly",

--- a/code/components/citizen-server-impl/src/ClientHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/ClientHttpHandler.cpp
@@ -11,10 +11,61 @@
 
 #include <FormData.h>
 
+#include <zlib.h>
+
 using json = nlohmann::json;
 
 static std::shared_ptr<ConVar<bool>> g_threadedHttpVar;
 static std::shared_ptr<ConVar<int>> g_maxClientEndpointRequestSize;
+
+namespace
+{
+bool ClientAcceptsGzip(const fwRefContainer<net::HttpRequest>& request)
+{
+	const auto header = request->GetHeader("accept-encoding");
+
+	for (size_t i = 0; i + 4 <= header.size(); ++i)
+	{
+		if ((header[i] | 0x20) == 'g' && (header[i + 1] | 0x20) == 'z' &&
+			(header[i + 2] | 0x20) == 'i' && (header[i + 3] | 0x20) == 'p')
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+std::optional<std::string> GzipCompress(std::string_view input)
+{
+	z_stream zs{};
+
+	// MAX_WBITS + 16 for the gzip wrapper format
+	if (deflateInit2(&zs, Z_BEST_SPEED, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+	{
+		return std::nullopt;
+	}
+
+	std::string output;
+	output.resize(deflateBound(&zs, static_cast<uLong>(input.size())));
+
+	zs.next_in = reinterpret_cast<z_const Bytef*>(const_cast<char*>(input.data()));
+	zs.avail_in = static_cast<uInt>(input.size());
+	zs.next_out = reinterpret_cast<Bytef*>(output.data());
+	zs.avail_out = static_cast<uInt>(output.size());
+
+	const int rc = deflate(&zs, Z_FINISH);
+	if (rc != Z_STREAM_END)
+	{
+		deflateEnd(&zs);
+		return std::nullopt;
+	}
+
+	output.resize(zs.total_out);
+	deflateEnd(&zs);
+	return output;
+}
+}
 
 namespace fx
 {
@@ -90,7 +141,7 @@ namespace fx
 					}
 					else if (handler->index() == 1)
 					{
-						(std::get<1>(*handler))(postMap, request, [response](const rapidjson::Document& data)
+						(std::get<1>(*handler))(postMap, request, [request, response](const rapidjson::Document& data)
 						{
 							if (data.IsNull())
 							{
@@ -110,12 +161,30 @@ namespace fx
 							sb.Put('\r');
 							sb.Put('\n');
 
+							// Compress with gzip when client supports it
+							constexpr size_t kGzipMinSize = 1024;
+
+							std::string compressedHolder;
+							std::string_view bodyView{ sb.GetString(), sb.GetSize() };
+
+							if (bodyView.size() >= kGzipMinSize && ClientAcceptsGzip(request))
+							{
+								if (auto compressed = GzipCompress(bodyView))
+								{
+									compressedHolder = std::move(*compressed);
+									bodyView = compressedHolder;
+									response->SetHeader(net::HeaderString{ "content-encoding" },
+										net::HeaderString{ "gzip" });
+								}
+							}
+
 							// for TCP write timeout bits, write this in chunks
 							constexpr size_t kChunkSize = 16384;
 
-							for (size_t i = 0; i < sb.GetLength(); i += kChunkSize)
+							for (size_t i = 0; i < bodyView.size(); i += kChunkSize)
 							{
-								response->Write(std::string{ sb.GetString() + i, std::min(kChunkSize, sb.GetLength() - i) });
+								response->Write(std::string{ bodyView.data() + i,
+									std::min(kChunkSize, bodyView.size() - i) });
 							}
 						});
 					}

--- a/code/components/http-client/src/HttpClient.cpp
+++ b/code/components/http-client/src/HttpClient.cpp
@@ -557,7 +557,8 @@ static std::shared_ptr<CurlData> SetupCURLHandle(const std::unique_ptr<HttpClien
 	curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYHOST, 0);
 	curl_easy_setopt(curlHandle, CURLOPT_STREAM_WEIGHT, long(options.weight));
-	
+	curl_easy_setopt(curlHandle, CURLOPT_ACCEPT_ENCODING, "");
+
 	if (options.responseHeaders)
 	{
 		curl_easy_setopt(curlHandle, CURLOPT_HEADERFUNCTION, CurlHeaderInfo);

--- a/code/vendor/curl-crt.lua
+++ b/code/vendor/curl-crt.lua
@@ -58,10 +58,18 @@ return {
 			add_dependencies 'vendor:nghttp2-crt'
 		end
 
+		-- zlib
+		if not isCrt then
+			add_dependencies 'vendor:zlib'
+		else
+			add_dependencies 'vendor:zlib-crt'
+		end
+
 		-- all the disables except http/file
 		defines { 'BUILDING_LIBCURL', 'USE_IPV6', 'CURL_DISABLE_TFTP', 'CURL_DISABLE_FTP', 'CURL_DISABLE_LDAP', 'CURL_DISABLE_TELNET',
 				  'CURL_DISABLE_DICT', 'CURL_DISABLE_RTSP', 'CURL_DISABLE_POP3', 'CURL_DISABLE_IMAP', 'CURL_DISABLE_SMTP',
-				  'CURL_DISABLE_RTMP', 'CURL_DISABLE_GOPHER', 'CURL_DISABLE_SMB', 'USE_IPV6', 'USE_NGHTTP2' }
+				  'CURL_DISABLE_RTMP', 'CURL_DISABLE_GOPHER', 'CURL_DISABLE_SMB', 'USE_IPV6', 'USE_NGHTTP2',
+				  'HAVE_LIBZ', 'HAVE_ZLIB_H' }
 
 		if os.istarget('windows') then
 			defines { 'USE_WINDOWS_SSPI' }


### PR DESCRIPTION
### Goal of this PR
Reduce the bandwidth used by `POST /client method=getConfiguration` endpoint. The server currently sends the response as JSON to every connecting client. On some servers the response can exceeds 10 Mb per client.

This can be an issue with 100 clients connecting at the same time on server restarts this make the server sends a spike of 1 Gbps. With 500+ players this is problematic and requires better bandwidth just for the connection of clients.

### How is this PR achieving the goal
- **Server**: the `/client` handler now gzips the JSON body when the client supports it.
- **Client**: handles decompression transparently.

Measured on a test server:
- From **2.51 Mb** to **156 Kb** (-94 %) per response adding a 30ms compression delay, although results may vary it guarantees an average minimum of -80%.

It should not introduce any breaking changes except if some power users MITM the getConfiguration response 😐

### This PR applies to the following area(s)
Server, FiveM, RedM

### Successfully tested on
**Game builds:** Not concerned.
**Platforms:** Windows.

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
