### PR TITLE
fix(citizen-server-impl): expose ETag and Cache-Control headers on /files endpoint

### DIFF
--- a/code/components/citizen-server-impl/src/FilesHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/FilesHttpHandler.cpp
@@ -126,6 +126,27 @@ namespace fx
 				}
 			}
 
+			// Get ETag from existing file hash
+			std::string etag = "";
+			auto hashIt = filePairs.find(fileName);
+			if (hashIt != filePairs.end())
+			{
+				etag = "\"" + hashIt->second + "\"";
+			}
+
+			// Return 304 Not Modified if client already has this version
+			if (!etag.empty())
+			{
+				auto ifNoneMatch = request->GetHeader("if-none-match");
+				if (ifNoneMatch == etag)
+				{
+					response->SetHeader("ETag", etag);
+					response->WriteHead(304);
+					response->End();
+					return;
+				}
+			}
+
 			auto filter = filesComponent->CreateFilesFilter(fileName, request);
 
 			std::string reason;
@@ -191,7 +212,11 @@ namespace fx
 					// write header information and a 200 OK
 					response->SetHeader("content-length", std::to_string(size));
 					response->SetHeader("transfer-encoding", "identity");
-
+					if (!etag.empty())
+					{
+						response->SetHeader("ETag", etag);
+						response->SetHeader("Cache-Control", "public, max-age=0, must-revalidate");
+					}
 					response->WriteHead(200);
 
 					// read buffer and file handle


### PR DESCRIPTION
Add standard HTTP cache validation headers to the `/files` endpoint so that CDN and caching proxies can correctly revalidate file changes instead of serving stale content.

### Goal of this PR
The `/files` endpoint currently returns `200 OK` with only `content-length` and `transfer-encoding` headers, with no cache validation support. When placed behind a CDN or caching proxy, this causes updated resource files to remain stale until the cache is manually purged, since the proxy has no way to know the file has changed.

### How is this PR achieving the goal
- Reads the existing file hash from `ResourceFilesComponent::GetFileHashPairs()` and exposes it as an `ETag` response header — no new data is computed, the hash was already being retrieved but unused in the response path
- Handles incoming `If-None-Match` request headers — if the client's ETag matches the current file hash, returns `304 Not Modified` instead of transferring the full file, saving bandwidth
- Adds `Cache-Control: public, max-age=0, must-revalidate` to ensure proxies and CDNs always revalidate before serving cached files, preventing stale content from being served after resource updates

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
fixes #3918