### PR TITLE
tweak(core/five): Fix additional vehicle trailer crash

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.TrailerAttachment.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.TrailerAttachment.cpp
@@ -2,6 +2,27 @@
 
 #include <jitasm.h>
 #include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <Hooking.FlexStruct.h>
+#include <EntitySystem.h>
+
+static rage::fwModelId* (*orig_CVehicleModelInfo_GetTrailer)(hook::FlexStruct*, rage::fwModelId*, uint32_t, void**);
+static rage::fwModelId* CVehicleModelInfo_GetTrailer(hook::FlexStruct* self, rage::fwModelId* result, uint32_t idx, void** vmi)
+{
+	if (!self || !self->Get<void*>(0x2E0))
+	{
+		if (result)
+		{
+			*result = rage::fwModelId{};
+		}
+		if (vmi)
+		{
+			*vmi = nullptr;
+		}
+		return result;
+	}
+	return orig_CVehicleModelInfo_GetTrailer(self, result, idx, vmi);
+}
 
 static HookFunction hookFunction([]
 {
@@ -41,4 +62,6 @@ static HookFunction hookFunction([]
 	patchStub.Init(reinterpret_cast<intptr_t>(location));
 	hook::nop(location, 6);
 	hook::jump(location, patchStub.GetCode());
+
+	orig_CVehicleModelInfo_GetTrailer = hook::trampoline(hook::get_pattern("48 89 5C 24 ? 48 89 7C 24 ? 55 48 8B EC 48 83 EC 30 8B 45 ? 49 8B F9 41 B9 FF FF 00 00"), &CVehicleModelInfo_GetTrailer);
 });


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix crash related to vehicle trailers
...


### How is this PR achieving the goal

...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3095, 3258
**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


