### PR TITLE
feat(core/five): Crash fix for grcProgramResource vtable

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.ProgramResourceVtable.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.ProgramResourceVtable.cpp
@@ -1,0 +1,43 @@
+#include <StdInc.h>
+
+#include <jitasm.h>
+#include <Hooking.h>
+
+static void* SafeGetSrvFromResource(void* resource)
+{
+	__try
+	{
+		void** vtable = *(void***)resource;
+		using GetSrvFn = void* (__fastcall*)(void*);
+		return ((GetSrvFn)vtable[22])(resource); // 0xB0 / sizeof(void*)
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		static bool warned = false;
+		if (!warned)
+		{
+			warned = true;
+			trace("WARNING: SetTextureResourcesUsingVectorDXAPICall: skipped freed grcProgramResource (vtable AV)\n");
+		}
+		return nullptr;
+	}
+}
+
+static HookFunction hookFunction([]
+{
+	static struct : jitasm::Frontend
+	{
+		void InternalMain() override
+		{
+			sub(rsp, 0x28);
+			mov(rax, reinterpret_cast<uintptr_t>(&SafeGetSrvFromResource));
+			call(rax);
+			add(rsp, 0x28);
+			ret();
+		}
+	} safeSrvStub;
+
+	auto location = hook::get_pattern<char>("48 8B 01 FF 90 ? ? ? ? 4C 8D 05 ? ? ? ? EB");
+	hook::nop(location, 9);
+	hook::call(location, safeSrvStub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Fix crash related to broken assets
...


### How is this PR achieving the goal
guarding the internal function call
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3095, 3258
**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


<img width="534" height="489" alt="image" src="https://github.com/user-attachments/assets/ad0e7c58-da0a-41c9-a502-221521a9c2bf" />

[CfxCrashDump_2026_05_20_01_15_04.zip](https://github.com/user-attachments/files/28039294/CfxCrashDump_2026_05_20_01_15_04.zip)
