### PR TITLE
fix(server/resources): decode percent-encoded resource name from URI fragment

### DIFF
--- a/code/components/citizen-server-impl/src/ServerResourceMounter.cpp
+++ b/code/components/citizen-server-impl/src/ServerResourceMounter.cpp
@@ -29,7 +29,7 @@ public:
 		if (uriParsed)
 		{
 			auto pathRef = uriParsed->pathname();
-			auto fragRef = uriParsed->hash().substr(1);
+			auto fragRef = *skyr::percent_decode(uriParsed->hash().substr(1));
 
 			if (!pathRef.empty() && !fragRef.empty())
 			{


### PR DESCRIPTION
Resource names from URI fragments were not decoded back from
percent-encoding, causing non-ASCII resource names (e.g. Chinese)
to be registered as encoded strings like "%E8%B7%91%E9%85%B7".

This resulted in:
- `ensure <resource>` unable to find resources with non-ASCII names
- Garbled resource names in console warnings/errors

The path component already calls `skyr::percent_decode()`, but the
fragment (used as the resource name) was missing the same treatment.
Adding it makes the encode/decode cycle symmetric.
