### PR TITLE
feat(extra-natives-five): Add COPY_TEXT_TO_CLIPBOARD

### DIFF
--- a/code/client/shared/ICoreGameInit.h
+++ b/code/client/shared/ICoreGameInit.h
@@ -36,7 +36,9 @@ public:
 	bool OneSyncBigIdEnabled = false;
 
 	bool SyncIsARQ = false;
-
+	
+	bool HasClipboardPermission = false;
+	
 	uint64_t BitVersion = 0;
 
 private:

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -394,7 +394,7 @@ static InitFunction initFunction([]()
 		auto pureVar = instance->AddVariable<int>("sv_pureLevel", ConVar_ServerInfo, 0);
 		auto shVar = instance->AddVariable<bool>("sv_scriptHookAllowed", ConVar_ServerInfo, false);
 		auto ehVar = instance->AddVariable<bool>("sv_enhancedHostSupport", ConVar_ServerInfo, false);
-		auto clipboardPermission = instance->AddVariable<bool>("sv_requiredClipboardPermission", ConVar_ServerInfo, false);
+		auto optionalUserPermissionClipboard = instance->AddVariable<bool>("sv_optionalUserPersmission_clipBoard", ConVar_ServerInfo, false);
 
 		// list of space-separated endpoints that can but don't have to include a port
 		// for example: sv_endpoints "123.123.123.123 124.124.124.124"
@@ -1284,7 +1284,10 @@ static InitFunction initFunction([]()
 		
 		instance->GetComponent<fx::ClientMethodRegistry>()->AddHandler("precheck", [=](const std::map<std::string, std::string>& postMap, const fwRefContainer<net::HttpRequest>& request, const std::function<void(const json&)>& cb)
 		{
-			cb(json::object({ {"result", "ok"}, {"requestClipboardPermission", clipboardPermission->GetValue()} }));
+			cb(json::object({ 
+				{"result", "ok"}, 
+				{"optionalUserPermissionClipboard", optionalUserPermissionClipboard->GetValue()} 
+			}));
 			cb(json(nullptr));
 		});
 	}, 50);

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -394,6 +394,7 @@ static InitFunction initFunction([]()
 		auto pureVar = instance->AddVariable<int>("sv_pureLevel", ConVar_ServerInfo, 0);
 		auto shVar = instance->AddVariable<bool>("sv_scriptHookAllowed", ConVar_ServerInfo, false);
 		auto ehVar = instance->AddVariable<bool>("sv_enhancedHostSupport", ConVar_ServerInfo, false);
+		auto clipboardPermission = instance->AddVariable<bool>("sv_requiredClipboardPermission", ConVar_ServerInfo, false);
 
 		// list of space-separated endpoints that can but don't have to include a port
 		// for example: sv_endpoints "123.123.123.123 124.124.124.124"
@@ -1278,6 +1279,12 @@ static InitFunction initFunction([]()
 			}
 
 			cb(json::object({ { "result", "ok" } }));
+			cb(json(nullptr));
+		});
+		
+		instance->GetComponent<fx::ClientMethodRegistry>()->AddHandler("precheck", [=](const std::map<std::string, std::string>& postMap, const fwRefContainer<net::HttpRequest>& request, const std::function<void(const json&)>& cb)
+		{
+			cb(json::object({ {"result", "ok"}, {"requestClipboardPermission", clipboardPermission->GetValue()} }));
 			cb(json(nullptr));
 		});
 	}, 50);

--- a/code/components/extra-natives-five/src/Clipboard.cpp
+++ b/code/components/extra-natives-five/src/Clipboard.cpp
@@ -2,10 +2,19 @@
 
 #include <ScriptEngine.h>
 
+#include "ICoreGameInit.h"
+#include "ScriptWarnings.h"
+
 static InitFunction initFunction([]()
 {	
 	fx::ScriptEngine::RegisterNativeHandler("COPY_TEXT_TO_CLIPBOARD", [](fx::ScriptContext& context)
 	{
+		if (!Instance<ICoreGameInit>::Get()->HasClipboardPermission)
+		{
+			fx::scripting::Warningf("natives", "No Permission for clipboard");
+			return;
+		}
+		
 		std::string text = context.GetArgument<const char*>(0);
 		
 		if (text.empty())

--- a/code/components/extra-natives-five/src/Clipboard.cpp
+++ b/code/components/extra-natives-five/src/Clipboard.cpp
@@ -1,0 +1,44 @@
+#include "StdInc.h"
+
+#include <ScriptEngine.h>
+
+static InitFunction initFunction([]()
+{	
+	fx::ScriptEngine::RegisterNativeHandler("COPY_TEXT_TO_CLIPBOARD", [](fx::ScriptContext& context)
+	{
+		std::string text = context.GetArgument<const char*>(0);
+		
+		if (text.empty())
+		{
+			return;
+		}
+		
+		const size_t textSize = text.size() + 1;
+		
+		if (!OpenClipboard(nullptr))
+		{
+			return;
+		}
+		
+		EmptyClipboard();
+		
+		HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, textSize);
+		if (hMem)
+		{
+			char* ptr = static_cast<char*>(GlobalLock(hMem));
+
+			if (ptr)
+			{
+				memcpy(ptr, text.c_str(), textSize);
+
+				GlobalUnlock(hMem);
+				SetClipboardData(CF_TEXT, hMem);
+			}
+			else
+			{
+				GlobalFree(hMem);
+			}
+		}
+		CloseClipboard();
+	});
+});

--- a/code/components/glue/src/ConnectToNative.cpp
+++ b/code/components/glue/src/ConnectToNative.cpp
@@ -286,11 +286,11 @@ static void ConnectTo(const std::string& hostnameStr, bool fromUI = false, const
 
 	if (!hostnameStr.empty() && hostnameStr[0] == '-')
 	{
-		netLibrary->ConnectToServer("cfx.re/join/" + hostnameStr.substr(1));
+		netLibrary->PrecheckServer("cfx.re/join/" + hostnameStr.substr(1));
 	}
 	else
 	{
-		netLibrary->ConnectToServer(hostnameStr);
+		netLibrary->PrecheckServer(hostnameStr);
 	}
 }
 

--- a/code/components/net/include/NetLibrary.h
+++ b/code/components/net/include/NetLibrary.h
@@ -227,6 +227,8 @@ public:
 	virtual void SetBase(uint32_t base) override;
 
 	virtual void RunFrame() override;
+	
+	virtual concurrency::task<void> PrecheckServer(const std::string& rootUrl);
 
 	virtual concurrency::task<void> ConnectToServer(const std::string& rootUrl);
 

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -879,18 +879,22 @@ concurrency::task<void> NetLibrary::PrecheckServer(const std::string& rootUrl)
 			
 			if (response["result"] == "ok")
 			{
-				if (response["requestClipboardPermission"])
+				if (response["optionalUserPermissionClipboard"])
 				{					
 					json clipBoardCardJson = json::object({
 						{ "type", "AdaptiveCard" },
 						{ "version", "1.0" },
 						{ "body", json::array({
-							  {
+							  json::object({
+								  { "type", "TextBlock" },
+								  { "title", "Optional server permissions" }
+							  }),
+							  json::object({
 								  { "type", "Input.Toggle" },
 								  { "title", "Enables the server to copy text or media data directly to your clipboard to use." },
 								  { "id", "acceptedClipboardPermission" },
 								  { "value", "true" }
-							  }
+							  })
 							})
 						},
 						{ "actions", json::array({
@@ -905,7 +909,7 @@ concurrency::task<void> NetLibrary::PrecheckServer(const std::string& rootUrl)
 						}
 					});
 					
-					OnConnectionCardPresent(clipBoardCardJson.dump(), "requestClipboardPermission");
+					OnConnectionCardPresent(clipBoardCardJson.dump(), "optionalUserPermissionClipboard");
 				}
 				else
 				{

--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -840,6 +840,91 @@ void NetLibrary::OnConnectionError(const std::string& errorString, const std::st
 // hack for NetLibraryImplV2
 int g_serverVersion;
 
+concurrency::task<void> NetLibrary::PrecheckServer(const std::string& rootUrl)
+{
+	std::string ruRef = rootUrl;
+
+	auto urlRef = co_await ResolveUrl(ruRef);
+
+	if (!urlRef)
+	{
+		OnConnectionError(fmt::sprintf("Couldn't resolve URL %s.", ruRef), json::object({
+			{ "fault", "either" },
+			{ "status", true },
+			{ "action", "#ErrorAction_TryAgainCheckStatus" },
+		}).dump());
+
+		co_return;
+	}
+
+	auto url = *urlRef;
+	
+	m_cardResponseHandler = [this, rootUrl](const std::string& cardData, const std::string& token)
+	{
+		auto response = nlohmann::json::parse(cardData);
+
+		Instance<ICoreGameInit>::Get()->HasClipboardPermission = (!response["acceptedClipboardPermission"].is_null() && response["acceptedClipboardPermission"] == "true");
+		ConnectToServer(rootUrl);
+	};
+	
+	auto handlePrecheckResult = [this, rootUrl](bool result, const char* connDataStr, size_t size)
+	{
+		if (result)
+		{
+			console::PrintWarning(
+				_CFX_NAME_STRING(_CFX_COMPONENT_NAME),
+				connDataStr
+			);
+			auto response = nlohmann::json::parse(connDataStr, connDataStr + size);
+			
+			if (response["result"] == "ok")
+			{
+				if (response["requestClipboardPermission"])
+				{					
+					json clipBoardCardJson = json::object({
+						{ "type", "AdaptiveCard" },
+						{ "version", "1.0" },
+						{ "body", json::array({
+							  {
+								  { "type", "Input.Toggle" },
+								  { "title", "Enables the server to copy text or media data directly to your clipboard to use." },
+								  { "id", "acceptedClipboardPermission" },
+								  { "value", "true" }
+							  }
+							})
+						},
+						{ "actions", json::array({
+							  {
+								  { "type", "Action.Submit" },
+								  { "title", "Submit" },
+								  { "data", {
+										{ "action", "submitClipboardPermission" }
+									} }
+							  }
+						  }) 
+						}
+					});
+					
+					OnConnectionCardPresent(clipBoardCardJson.dump(), "requestClipboardPermission");
+				}
+				else
+				{
+					ConnectToServer(rootUrl);
+				}
+			}
+		}
+		else
+		{
+			ConnectToServer(rootUrl);
+		}
+	};
+	
+	m_handshakeRequest =  m_httpClient->DoPostRequest(fmt::sprintf("%sclient", url), m_httpClient->BuildPostString({
+			{ "method", "precheck" }
+		}), handlePrecheckResult);
+	
+}
+
 concurrency::task<void> NetLibrary::ConnectToServer(const std::string& rootUrl)
 {
 	m_disconnecting = false;

--- a/ext/native-decls/CopyTextToClipboard.md
+++ b/ext/native-decls/CopyTextToClipboard.md
@@ -1,0 +1,15 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## COPY_TEXT_TO_CLIPBOARD
+
+```c
+void COPY_TEXT_TO_CLIPBOARD(char* text);
+```
+
+Copy Text to ClipBoard
+
+## Parameters
+* **text**: The text for clipboard


### PR DESCRIPTION
### Goal of this PR
The possiblity to copy text into the clipboard of the player.

### How is this PR achieving the goal

By adding the native COPY_TEXT_TO_CLIPBOARD

### This PR applies to the following area(s)
FiveM



### Successfully tested on
Latest game build: 3258 but works for all

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



