### PR TITLE
fix(server/state): scope our access to the client properly to prevent deadlock

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1628,8 +1628,14 @@ static void Init()
 		// get the server's game state
 		auto gameState = instance->GetComponent<fx::ServerGameState>();
 
-		auto [lock, clientData] = gameState->ExternalGetClientData(client);
-		return int(clientData->routingBucket);
+		uint32_t routingBucket = 0;
+
+		{
+			auto [lock, clientData] = gameState->ExternalGetClientData(client);
+			routingBucket = clientData->routingBucket;
+		}
+
+		return int(routingBucket);
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_ROUTING_BUCKET", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
@@ -1650,24 +1656,29 @@ static void Init()
 				// get the server's game state
 				auto gameState = instance->GetComponent<fx::ServerGameState>();
 
-				auto [lock, clientData] = gameState->ExternalGetClientData(client);
-
-				 // store old bucket for event
-				const auto oldBucket = clientData->routingBucket;
-
-				gameState->ClearClientFromWorldGrid(client);
-				clientData->routingBucket = bucket;
 				
-				fx::sync::SyncEntityPtr playerEntity;
+				uint32_t oldBucket = 0;
 
 				{
-					std::shared_lock _lock(clientData->playerEntityMutex);
-					playerEntity = clientData->playerEntity.lock();
-				}
+					auto [lock, clientData] = gameState->ExternalGetClientData(client);
 
-				if (playerEntity)
-				{
-					playerEntity->routingBucket = bucket;
+					 // store old bucket for event
+					oldBucket = clientData->routingBucket;
+
+					gameState->ClearClientFromWorldGrid(client);
+					clientData->routingBucket = bucket;
+					
+					fx::sync::SyncEntityPtr playerEntity;
+
+					{
+						std::shared_lock _lock(clientData->playerEntityMutex);
+						playerEntity = clientData->playerEntity.lock();
+					}
+
+					if (playerEntity)
+					{
+						playerEntity->routingBucket = bucket;
+					}
 				}
 
 				


### PR DESCRIPTION
If you listened to onPlayerBucketChange you would deadlock if you called GetPlayerRoutingBucket, while someone shouldn't do this since the argument is already provided in the event, we should also not deadlock.


### This PR applies to the following area(s)
Server

### Successfully tested on

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


