### PR TITLE
fix(nui): key media permissions by server identity

### DIFF
--- a/code/components/glue/src/NUIMediaAccess.cpp
+++ b/code/components/glue/src/NUIMediaAccess.cpp
@@ -2,6 +2,7 @@
 #include <CefOverlay.h>
 #include <json.hpp>
 #include <NetLibrary.h>
+#include <ICoreGameInit.h>
 
 #include <ConsoleHost.h>
 
@@ -19,12 +20,37 @@ static std::map<std::string, int> g_mediaSettings;
 
 extern NetLibrary* netLibrary;
 
+static std::string GetMediaPermissionServerKey()
+{
+	// Prefer a stable logical server identifier over the selected network peer.
+	// This avoids re-prompting for the same server when it is reached through
+	// different proxy/endpoint addresses.
+	if (auto gameInit = Instance<ICoreGameInit>::Get())
+	{
+		std::string serverId;
+
+		if (gameInit->GetData("serverId", &serverId) && !serverId.empty())
+		{
+			return "server:" + serverId;
+		}
+	}
+
+	// Fallback to the connect URL.
+	if (!netLibrary->GetCurrentServerUrl().empty())
+	{
+		return "url:" + netLibrary->GetCurrentServerUrl();
+	}
+
+	// Fallback: preserve old behavior.
+	return "peer:" + netLibrary->GetCurrentPeer().ToString();
+}
+
 static void ParseMediaSettings(const std::string& jsonStr)
 {
 	try
 	{
 		auto j = nlohmann::json::parse(jsonStr);
-		
+
 		for (auto& pair : j["origins"])
 		{
 			g_mediaSettings.emplace(pair[0].get<std::string>(), pair[1].get<int>());
@@ -32,7 +58,6 @@ static void ParseMediaSettings(const std::string& jsonStr)
 	}
 	catch (std::exception& e)
 	{
-
 	}
 }
 
@@ -97,7 +122,6 @@ void SavePermissionSettings()
 	}
 	catch (std::exception& e)
 	{
-	
 	}
 }
 
@@ -116,7 +140,7 @@ bool HandleMediaRequest(const std::string& frameOrigin, const std::string& url, 
 	permissions &= ~nui::NUI_MEDIA_PERMISSION_DESKTOP_VIDEO_CAPTURE;
 
 	// if this server+resource already has permission, keep it
-	auto origin = netLibrary->GetCurrentPeer().ToString() + ":" + frameOrigin;
+	auto origin = GetMediaPermissionServerKey() + ":" + frameOrigin;
 	int hadPermissions = 0;
 
 	if (auto it = g_mediaSettings.find(origin); it != g_mediaSettings.end())
@@ -156,7 +180,7 @@ bool HandleMediaRequest(const std::string& frameOrigin, const std::string& url, 
 	};
 	requestedPermissionMask = permissions & ~hadPermissions;
 	requestedPermissionOrigin = origin;
-	
+
 	permGrants[0] = true;
 	permGrants[1] = false;
 	permGrants[2] = false;
@@ -199,7 +223,7 @@ static InitFunction mediaRequestInit([]()
 			{
 				ImGui::Text("Permission request: %s", requestedPermissionResource.c_str());
 				ImGui::Separator();
-				
+
 				if (ConHost::IsConsoleOpen())
 				{
 					ImGui::Text("The resource %s at %s wants access to the following:", requestedPermissionResource.c_str(), requestedPermissionUrl.c_str());
@@ -258,7 +282,7 @@ static InitFunction mediaRequestInit([]()
 						requestedPermissionCallback(true, outcomeMask);
 						requestedPermissionCallback = {};
 					}
-					
+
 					ImGui::SameLine();
 
 					if (ImGui::Button("Deny"))


### PR DESCRIPTION
### Goal of this PR

Avoid repeated NUI media permission prompts when the same server is reached through different proxy endpoints.

Currently permissions are scoped using `GetCurrentPeer()`, which can change for servers using multiple or rotating game proxy IPs.

### How is this PR achieving the goal

This changes the media permission origin to prefer a stable server identifier:

1. `serverId`
2. `GetCurrentServerUrl()`
3. `GetCurrentPeer()` as fallback

`serverId` is already stored during connection setup:
https://github.com/citizenfx/fivem/blob/cc6032bec3569c48097f708419f0690ace0bbe14/code/components/net/src/NetLibrary.cpp#L1453

`m_currentServerUrl` is already set when connecting:
https://github.com/citizenfx/fivem/blob/cc6032bec3569c48097f708419f0690ace0bbe14/code/components/net/src/NetLibrary.cpp#L916

### This PR applies to the following area(s)

FiveM, NUI, Client

### Successfully tested on

**Game builds:** 3258

**Platforms:** Windows

### Checklist

* [x] Code compiles and has been tested successfully.
* [x] Code explains itself well and/or is documented.
* [x] My commit message explains what the changes do and what they are for.
* [x] No extra compilation warnings are added by these changes.

### Fixes issues

N/A

Removes media request prompt for same servers using different proxy ip addresses.

PS: I am aware of CEF update planned and it might already implemented this but I just want to be sure this gets added 🥲 

One slight annoyance: If this gets merged people on all servers might get prompted once again (should be fine imo)