### PR TITLE
feat(client/graphics): add FPS limit convar

### DIFF
--- a/code/components/rage-graphics-five/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-five/src/RenderHooks.cpp
@@ -67,6 +67,8 @@ static void* g_lastBackbufTexture;
 static bool g_useFlipModel = false;
 
 static bool g_overrideVsync;
+static uint16_t g_fpsLimit = 0;
+static ConVar<uint16_t> gameFpsLimit("game_fpsLimit", ConVar_Archive, 0, &g_fpsLimit);
 
 static void CaptureBufferOutput();
 static void CaptureInternalScreenshot();
@@ -224,6 +226,16 @@ static auto LimitFrameTime(WaitableTimer& timer, size_t fpsLimit)
 	}
 
 	return ReturnToken{};
+}
+
+static size_t GetFpsLimit()
+{
+	if (g_fpsLimit <= 0) // ignore non-positive values, enforcing no fps limit
+	{
+		return 0;
+	}
+
+	return std::clamp<size_t>(g_fpsLimit, 30, 500);
 }
 
 class BufferBackedDXGISwapChain : public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom>, IDXGISwapChain>
@@ -1454,6 +1466,9 @@ void D3DPresent(int syncInterval, int flags)
 	}
 
 	RootCheckPresented(flags);
+
+	static WaitableTimer fpsLimitTimer{ NULL, TRUE, NULL };
+	auto fpsLimitToken = LimitFrameTime(fpsLimitTimer, GetFpsLimit());
 
 	if (IsWindows10OrGreater())
 	{


### PR DESCRIPTION
### Goal of this PR

Adds a native client-side FPS limit convar for FiveM.

This allows users to cap their game FPS without relying on external driver/game overlay limiters.

Use case: Some racing servers tell users to cap their FPS so it can still be a competetive environment (Higher FPS usually means more vehicle speed).
Having a simple console command is easier than telling users to change NVIDIA settings for example.


### How is this PR achieving the goal

Adds the archived `game_fpsLimit` convar, defaulting to `0` / disabled.

When set to a positive value, the DirectX present path uses the existing frame-time limiter to wait until the configured frame interval has elapsed before presenting the next frame.

Values are clamped to a sane range to avoid accidentally setting unusably low or excessively high limits.


### This PR applies to the following area(s)

FiveM, Client, Graphics


### Successfully tested on

**Game builds:** bXXXX

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

PS: Thanks to Gogsi for the hint