### PR TITLE
fix(gamestate/server): reimplementation of dd2e1c9

### DIFF
--- a/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Five.h
@@ -508,78 +508,105 @@ struct CVehicleScriptGameStateDataNode
 	}
 };
 
-struct CEntityScriptInfoDataNode
+struct CEntityScriptInfoDataNode : GenericSerializeDataNode<CEntityScriptInfoDataNode>
 {
 	uint32_t m_scriptHash;
 	uint32_t m_timestamp;
+	uint32_t m_positionHash;
+	uint32_t m_instanceId;
+	uint32_t m_scriptObjectId;
+	uint32_t m_hostToken;
 
-	bool Parse(SyncParseState& state)
+	template<typename Serializer>
+	bool Serialize(Serializer& s)
 	{
-		auto hasScript = state.buffer.ReadBit();
+		bool hasScript = m_scriptHash != 0;
+		s.Serialize(hasScript);
 
-		if (hasScript) // Has script info
+		if (hasScript)
 		{
-			// deserialize CGameScriptObjInfo
+			// -> CGameScriptObjInfo
 
-			// -> CGameScriptId
-
-			// ---> rage::scriptId
-			m_scriptHash = state.buffer.Read<uint32_t>(32);
-			// ---> end
-
-			m_timestamp = state.buffer.Read<uint32_t>(32);
-
-			if (state.buffer.ReadBit())
 			{
-				auto positionHash = state.buffer.Read<uint32_t>(32);
+				// -> CGameScriptId
+
+				{
+					// -> rage::scriptId
+					s.Serialize(32, m_scriptHash);
+				}
+
+				s.Serialize(32, m_timestamp);
+
+				bool hasPositionHash = m_positionHash != 0;
+				s.Serialize(hasPositionHash);
+
+				if (hasPositionHash)
+				{
+					s.Serialize(32, m_positionHash);
+				}
+				else if constexpr (Serializer::isReader)
+				{
+					m_positionHash = 0;
+				}
+
+				bool hasInstanceId = m_instanceId != 0;
+				s.Serialize(hasInstanceId);
+
+				if (hasInstanceId)
+				{
+					s.Serialize(8, m_instanceId);
+				}
+				else if constexpr (Serializer::isReader)
+				{
+					m_instanceId = 0;
+				}
 			}
 
-			if (state.buffer.ReadBit())
-			{
-				auto instanceId = state.buffer.Read<uint32_t>(7);
-			}
+			s.Serialize(32, m_scriptObjectId);
 
-			// -> end
+			bool longHostToken = m_hostToken >= (1 << 3);
+			s.Serialize(longHostToken);
 
-			auto scriptObjectId = state.buffer.Read<uint32_t>(32);
-
-			auto hostTokenLength = state.buffer.ReadBit() ? 16 : 3;
-			auto hostToken = state.buffer.Read<uint32_t>(hostTokenLength);
-
-			// end
+			auto hostTokenLength = longHostToken ? 16 : 3;
+			s.Serialize(hostTokenLength, m_hostToken);
 		}
-		else
+		else if constexpr (Serializer::isReader)
 		{
 			m_scriptHash = 0;
 		}
 
 		return true;
 	}
+};
 
-	bool Unparse(sync::SyncUnparseState& state)
+template<>
+struct NodeProcessor<CEntityScriptInfoDataNode>
+{
+	uint32_t lastScriptId = 0;
+
+	bool PreParse(CEntityScriptInfoDataNode& node, SyncParseState& state)
 	{
-		rl::MessageBuffer& buffer = state.buffer;
+		lastScriptId = node.m_scriptHash;
 
-		if (m_scriptHash)
+		return false;
+	}
+
+	bool PostParse(CEntityScriptInfoDataNode& node, SyncParseState& state)
+	{
+		if (lastScriptId && !node.m_scriptHash)
 		{
-			buffer.WriteBit(true);
-
-			buffer.Write<uint32_t>(32, m_scriptHash);
-			buffer.Write<uint32_t>(32, m_timestamp);
-
-			buffer.WriteBit(false);
-			buffer.WriteBit(false);
-
-			buffer.Write<uint32_t>(32, 12);
-
-			buffer.WriteBit(false);
-			buffer.Write<uint32_t>(3, 0);
-		}
-		else
-		{
-			buffer.WriteBit(false);
+			if (state.entity && state.entity->IsOwnedByServerScript())
+			{
+				node.m_scriptHash = lastScriptId;
+				return true;
+			}
 		}
 
+		return false;
+	}
+
+	constexpr bool IsHandled()
+	{
 		return true;
 	}
 };

--- a/code/components/citizen-server-impl/include/state/SyncTrees_Header.h
+++ b/code/components/citizen-server-impl/include/state/SyncTrees_Header.h
@@ -2,6 +2,28 @@
 
 namespace fx::sync
 {
+template<typename TNode>
+inline constexpr bool AffectsBlender();
+
+template<typename TNode>
+struct NodeProcessor
+{
+	bool PreParse(TNode& node, SyncParseState& state)
+	{
+		return false;
+	}
+
+	bool PostParse(TNode& node, SyncParseState& state)
+	{
+		return false;
+	}
+
+	constexpr bool IsHandled()
+	{
+		return false;
+	}
+};
+
 template<int Id1, int Id2, int Id3, bool CanSendOnFirst = true>
 struct NodeIds
 {
@@ -393,10 +415,39 @@ struct NodeWrapper : public NodeBase
 			// parse manual data
 			if constexpr (ShouldParseNode<TNode>(0))
 			{
-				state.buffer.SetCurrentBit(endBit);
-				node.Parse(state);
+				NodeProcessor<TNode> nodeProc;
 
-				state.buffer.SetCurrentBit(endBit + length);
+				auto doParse = [this, &state, endBit, length]()
+				{
+					state.buffer.SetCurrentBit(endBit);
+					node.Parse(state);
+
+					state.buffer.SetCurrentBit(endBit + length);
+				};
+
+				if constexpr (nodeProc.IsHandled())
+				{
+					bool needReparse = nodeProc.PreParse(node, state);
+
+					doParse();
+
+					needReparse |= nodeProc.PostParse(node, state);
+
+					if (needReparse)
+					{
+						rl::MessageBuffer mb(data.size());
+						sync::SyncUnparseState unparseState{ mb };
+						node.Unparse(unparseState);
+
+						memcpy(data.data(), mb.GetBuffer().data(), mb.GetBuffer().size());
+
+						this->length = mb.GetCurrentBit();
+					}
+				}
+				else
+				{
+					doParse();
+				}
 			}
 
 			frameIndex = state.frameIndex;

--- a/code/components/citizen-server-impl/src/state/ServerSetters.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerSetters.cpp
@@ -111,6 +111,8 @@ std::shared_ptr<sync::SyncTreeBase> MakeAutomobile(uint32_t model, float posX, f
 	{
 		cdn.m_scriptHash = resourceHash;
 		cdn.m_timestamp = msec().count();
+		cdn.m_instanceId = 12;
+		cdn.m_scriptObjectId = 12;
 	});
 
 	return tree;
@@ -151,6 +153,8 @@ std::shared_ptr<sync::SyncTreeBase> MakeVehicle(uint32_t model, float posX, floa
 	{
 		cdn.m_scriptHash = resourceHash;
 		cdn.m_timestamp = msec().count();
+		cdn.m_instanceId = 12;
+		cdn.m_scriptObjectId = 12;
 	});
 
 	return tree;
@@ -195,6 +199,8 @@ std::shared_ptr<sync::SyncTreeBase> MakePed(uint32_t model, float posX, float po
 	{
 		cdn.m_scriptHash = resourceHash;
 		cdn.m_timestamp = msec().count();
+		cdn.m_instanceId = 12;
+		cdn.m_scriptObjectId = 12;
 	});
 
 	return tree;
@@ -235,6 +241,8 @@ std::shared_ptr<sync::SyncTreeBase> MakeObject(uint32_t model, float posX, float
 	{
 		cdn.m_scriptHash = resourceHash;
 		cdn.m_timestamp = msec().count();
+		cdn.m_instanceId = 12;
+		cdn.m_scriptObjectId = 12;
 	});
 
 	return tree;


### PR DESCRIPTION
### Goal of this PR
Reimplementation of the commit https://github.com/citizenfx/fivem/commit/dd2e1c9235fb00b9b908929a896d769613aab94e
The commit was quickly reverted due to crash issues with peds.

After doing some checks i found out the instance id was wrongly serialized (wrong value)
See screenshots:
<img width="991" height="546" alt="image" src="https://github.com/user-attachments/assets/b043ab63-78f2-4e58-aa4c-baab2287450d" />
<img width="1842" height="635" alt="image" src="https://github.com/user-attachments/assets/530008fa-4f74-49ac-b67b-884ef16da195" />

The value was checked on dump 1604 & 3258 and it's still 8


### How is this PR achieving the goal

By reimplementing the commit and fixing the wrong value


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
Wasn't tested yet, needs to be tested

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [ ] Code compiles and has been tested successfully.
- [ ] Code explains itself well and/or is documented.
- [ ] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


