### PR TITLE
fix(server/tcp): properly dispose of connections

### DIFF
--- a/code/components/net-tcp-server/src/UvTcpServer.cpp
+++ b/code/components/net-tcp-server/src/UvTcpServer.cpp
@@ -207,9 +207,7 @@ void UvTcpServer::OnConnection(int status)
 #endif
 
 	static char dummyMessage[] = { 1, 2, 3, 4 };
-	m_dispatchPipes[index]->write(*clientHandle, dummyMessage, sizeof(dummyMessage));
-
-	clientHandle->close();
+	m_dispatchPipes[index]->writeAndClose(clientHandle, dummyMessage, sizeof(dummyMessage));
 }
 
 UvTcpChildServer::UvTcpChildServer(UvTcpServer* parent, const std::string& pipeName, const std::array<uint8_t, 16>& pipeMessage, int idx)


### PR DESCRIPTION
This fixes issue #3931

I'm not entirely sure if this is the best approach (and hence I gated this to be only for Linux), but this fixes the life time issue that the TCP Server currently has for Linux.

It should be noted that this is a Linux specific bug, and the same thing cannot happen on Windows since it does direct IPC calls and is sync

On Linux this appends to a shared list and the actual write call gets done later, but because we close the client right after this its possible to hit it when the request handle is invalid and we will crash the server with

```
Assertion failed: fd_to_send >= 0 (../deps/uv/src/unix/stream.c: uv__try_write: 791)
```


### This PR applies to the following area(s)
Server


### Successfully tested on
**Platforms:**  Linux

Through much pain and suffering I got this to build on WSL


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Fixes #3931 


