### PR TITLE
fix(gta-core-five): crash exploit non vehicle flag

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.NonVehicleFlag.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.NonVehicleFlag.cpp
@@ -1,0 +1,45 @@
+#include "StdInc.h"
+#include <jitasm.h>
+#include "Hooking.Patterns.h"
+
+static HookFunction hookFunction([]()
+{
+	// CDynamicEntityDrawHandler::AddFragmentToDrawList
+	// This function renders fragment entities that have a cloth component attached
+	//
+	// The code assumes that any entity whose model type is MI_TYPE_VEHICLE is an
+	// actual vehicle, and unconditionally sets isVehicleCloth = true. This causes
+	// the draw handler to be cast to CVehicleDrawHandler* without verification.
+	auto location = hook::get_pattern<char>("C6 85 ? ? ? ? ? E9 ? ? ? ? B9");
+	auto flagOffset = *(uint32_t*)(location + 0x2);
+
+	static struct : jitasm::Frontend
+	{
+		uintptr_t continueLoc;
+		uint32_t flagOffset;
+
+		void Init(uintptr_t loc, uint32_t flagOff)
+		{
+			continueLoc = loc;
+			flagOffset = flagOff;
+		}
+		
+		virtual void InternalMain() override
+		{
+			mov(al, byte_ptr[r15+0x28]); // entity->Type
+			cmp(al, 0x3);                // ENTITY_TYPE_VEHICLE
+			jne("skipFlagSet");
+			
+			mov(byte_ptr[rbp+flagOffset], 1);
+			L("skipFlagSet");
+			
+			mov(rax, continueLoc);
+			jmp(rax);
+		}
+	} stub;
+	
+	stub.Init((uintptr_t)location + 7, flagOffset);
+	
+	hook::nop(location, 7);
+	hook::jump(location, stub.GetCode());
+});


### PR DESCRIPTION
### Goal of this PR
`CDynamicEntityDrawHandler::AddFragmentToDrawList` renders fragment entities that have a cloth component attached
The code assumes that any entity whose model type is MI_TYPE_VEHICLE is an actual vehicle, and unconditionally sets isVehicleCloth = true. This causes the draw handler to be cast to CVehicleDrawHandler* without verification.

Thanks to @Gogsi for helping to analize the crash & testing.


### How is this PR achieving the goal
Validate that the entity type it's also a vehicle, the game already verifies the model type.


### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 1604, 3258, 3570
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Cfx Engineering Discord: https://discordapp.com/channels/779705925577080842/779739477642838036/1512591047480578268