### PR TITLE
fix(gta-core-five): correct original bike jump patch

### DIFF
--- a/code/components/gta-core-five/src/PatchBikeJump.cpp
+++ b/code/components/gta-core-five/src/PatchBikeJump.cpp
@@ -30,86 +30,52 @@ static HookFunction hookFunction([]()
 
 	static struct : jitasm::Frontend
 	{
-		uintptr_t m_origBikeJumpBoolLoc{ 0 };
-		uintptr_t m_defaultPathLoc{ 0 };
-		uintptr_t m_continueLoc{ 0 };
-		uintptr_t m_earlyOutLoc{ 0 };
-		uint8_t m_impulseVarStackOffset{ 0 };
+		uintptr_t m_boolLoc{ 0 };
+		uintptr_t m_jmpBackLoc{ 0 };
+		uint8_t m_impulseOffX{ 0 };
 
-		float m_origJumpImpulseVec[4]{ 0.0f, 0.0f, 1.0f, 0.0f };
-		float m_minBunnyHopTime{ 0.0f };
-
-		void Init(uintptr_t origBikeJumpBoolLoc, uintptr_t defaultPathLoc, uintptr_t continueLoc,
-		uintptr_t earlyOutLoc, uint8_t impulseVarStackOffset)
+		void Init(uintptr_t boolLoc, uintptr_t jmpBackLoc, uint8_t impulseOffX)
 		{
-			m_origBikeJumpBoolLoc = origBikeJumpBoolLoc;
-			m_defaultPathLoc = defaultPathLoc;
-			m_continueLoc = continueLoc;
-			m_earlyOutLoc = earlyOutLoc;
-			m_impulseVarStackOffset = impulseVarStackOffset;
+			m_boolLoc = boolLoc;
+			m_jmpBackLoc = jmpBackLoc;
+			m_impulseOffX = impulseOffX;
 		}
 
 		void InternalMain() override
 		{
-			constexpr uintptr_t kVec3ZWOffset{ sizeof(float) * 2 };
+			const uint8_t offX = m_impulseOffX;
+			const uint8_t offY = static_cast<uint8_t>(offX + sizeof(float));
+			const uint8_t offZ = static_cast<uint8_t>(offX + sizeof(float) * 2);
 
-			auto origJumpImpulseLoc = reinterpret_cast<uintptr_t>(m_origJumpImpulseVec);
-			auto minBunnyHopTimeLoc = reinterpret_cast<uintptr_t>(&m_minBunnyHopTime);
+			// Reproduce the original stores of the computed impulse
+			movss(dword_ptr[rsp + offX], xmm1); // impulse.X
+			movss(dword_ptr[rsp + offY], xmm2); // impulse.Y
+			movss(dword_ptr[rsp + offZ], xmm3); // impulse.Z
 
-			mov(rax, minBunnyHopTimeLoc);
-			comiss(xmm15, dword_ptr[rax]);
-			jbe("earlyOut");
+			mov(rax, m_boolLoc);
+			cmp(byte_ptr[rax], 0);
+			jz("done");
 
-			mov(rax, m_origBikeJumpBoolLoc);
-			mov(al, byte_ptr[rax]);
-			test(al, al);
-			jz("useDefaultPhysics");
+			// Restore the original world space unit Z impulse: (0, 0, 1)
+			mov(dword_ptr[rsp + offX], 0x00000000);
+			mov(dword_ptr[rsp + offY], 0x00000000);
+			mov(dword_ptr[rsp + offZ], 0x3F800000); // 1.0f
 
-			L("useOriginalPhysics");
-			// Load the original jump impulse.
-			mov(rax, origJumpImpulseLoc);
-			movlps(xmm9, qword_ptr[rax]); // Impulse XY -> XMM9.
-			movlps(xmm10, qword_ptr[rax + kVec3ZWOffset]); // Impulse ZW -> XMM10.
-
-			// Store the impulse value to the proper variable on the stack.
-			movlps(qword_ptr[rsp + m_impulseVarStackOffset], xmm9); // XMM9 -> impulse var XY.
-			movlps(qword_ptr[rsp + m_impulseVarStackOffset + kVec3ZWOffset], xmm10); // XMM10 -> impulse var ZW.
-
-			movsx(edx, byte_ptr[rbx + 0x0CA1]);
-			movsx(r9d, byte_ptr[rbx + 0x0CA0]);
-			mov(r8d, edx);
-
-			// Continue execution with the new impulse.
-			mov(rcx, m_continueLoc);
-			jmp(rcx);
-
-			L("useDefaultPhysics");
-			mov(rcx, m_defaultPathLoc);
-			jmp(rcx);
-
-			L("earlyOut");
-			mov(rcx, m_earlyOutLoc);
-			jmp(rcx);
+			L("done");
+			mov(rax, m_jmpBackLoc);
+			jmp(rax);
 		}
 	} patchStub;
 
-	auto patchLoc = hook::get_pattern<char>("44 0F 2F 3D ? ? ? ? 0F 86 ? ? ? ? 0F 28 7B");
+	auto patchLoc = hook::get_pattern<char>("F3 0F 11 4C 24 ? F3 0F 11 54 24 ? F3 0F 11 5C 24 ? 41 3B D1");
 
-	auto useOrigBikeJumpBoolPtr = reinterpret_cast<uintptr_t>(&g_useOrigBikeJump);
+	// The impulse X component stack offset is the imm8 of the first store.
+	uint8_t impulseOffX = *reinterpret_cast<uint8_t*>(patchLoc + 5);
 
-	auto defaultPathLoc = hook::get_pattern<char>("44 0F 2F 3D ? ? ? ? 0F 86 ? ? ? ? 0F 28 7B", 0x0E);
-	auto defaultPathLocPtr = reinterpret_cast<uintptr_t>(defaultPathLoc);
+	// Resume right after the three reproduced stores (3 * 6 = 18 bytes)
+	auto jmpBackLoc = reinterpret_cast<uintptr_t>(patchLoc + 18);
 
-	auto continueLoc = hook::get_pattern<char>("41 3B D1 73 ? 48 0F BE C2 48 8B 8C C3 ? ? ? ? EB ? 33 C9 48 85 C9 0F 84 ? ? ? ? 45 3B C1 73 ? 48 0F BE C2 48 8B 8C C3 ? ? ? ? EB ? 33 C9 8A 81");
-	auto continueLocPtr = reinterpret_cast<uintptr_t>(continueLoc);
-
-	auto earlyOutLoc = hook::get_pattern<char>("4C 8D 9C 24 ? ? ? ? 49 8B 5B ? 49 8B 73 ? 41 0F 28 73 ? 41 0F 28 7B ? 45 0F 28 43 ? 45 0F 28 4B ? 45 0F 28 53 ? 45 0F 28 5B ? 45 0F 28 63 ? 45 0F 28 6B ? 45 0F 28 B3 ? ? ? ? 45 0F 28 BB ? ? ? ? 49 8B E3 5D");
-	auto earlyOutLocPtr = reinterpret_cast<uintptr_t>(earlyOutLoc);
-
-	auto varOffset = hook::get_pattern("F3 0F 10 4C 24 ? F3 0F 10 54 24 ? 0F BE 93", 5);
-	uint8_t impulseVarOffset = *static_cast<uint8_t*>(varOffset);
-
-	patchStub.Init(useOrigBikeJumpBoolPtr, defaultPathLocPtr, continueLocPtr, earlyOutLocPtr, impulseVarOffset);
+	patchStub.Init(reinterpret_cast<uintptr_t>(&g_useOrigBikeJump), jmpBackLoc, impulseOffX);
 
 	hook::jump(patchLoc, patchStub.GetCode());
 });


### PR DESCRIPTION
### Goal of this PR
Fix `game_originalBikeJump` convar on build 3751. It was meant to restore the pre b3095 bike bunny-hop, a straight-up jump but instead the bike shot off horizontally and barely left the ground.

https://github.com/user-attachments/assets/c869d019-b104-4534-9fbe-17236cfbeac4

A better view of the issue can be also see here: https://www.youtube.com/watch?v=kfEQf1Kp5NQ


### How is this PR achieving the goal
The old patch injected too early and jumped over part of the game's own code, leaving the jump's rotation axes and lever-arm uninitialized and (on 3751) overwriting the register that holds the jump force.

The patch now injects later, after the game has finished building the impulse, and only overwrites the three values of the impulse vector with (0, 0, 1) (world up).

### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3407, 3751
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #3024 


