### PR TITLE
fix(extra-natives/rdr3): graphic natives flickering

### DIFF
--- a/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
@@ -55,7 +55,6 @@ static void RenderScriptIm()
 	{
 		g_scriptImRenderBuffer.clear();
 		std::swap(g_scriptImRequests, g_scriptImRenderBuffer);
-		g_scriptImReady.store(false, std::memory_order_relaxed);
 	}
 
 	if (g_scriptImRenderBuffer.empty())
@@ -99,12 +98,13 @@ struct DrawOriginStore
 	char pad_404[12];
 };
 
-static bool (*isGamePaused)();
-
 static int* g_renderBufferIndex;
 static int* g_updateBufferIndex;
 static DrawOriginStore* g_drawOriginStore;
 static uint32_t* g_scriptDrawOriginIndex;
+
+static int g_updateDrawOriginCount = 0;
+static DrawOriginData g_updateDrawOrigin[32];
 
 struct WorldhorizonManager
 {
@@ -138,8 +138,6 @@ static HookFunction hookFunction([]()
 		g_renderBufferIndex = hook::get_address<int*>(location - 20);
 		g_updateBufferIndex = hook::get_address<int*>(location - 7);
 		g_drawOriginStore = hook::get_address<DrawOriginStore*>(location + 10);
-
-		hook::set_call(&isGamePaused, location - 27);
 	}
 
 	{
@@ -174,14 +172,18 @@ static HookFunction hookFunction([]()
 	OnPostFrontendRender.Connect([]()
 	{
 		g_scriptImReady.store(true, std::memory_order_release);
+		if (g_updateDrawOriginCount)
+		{
+			auto drawIndex = *g_updateBufferIndex;
+			std::move(g_updateDrawOrigin, g_updateDrawOrigin + g_updateDrawOriginCount, g_drawOriginStore[drawIndex].m_items);
+			g_drawOriginStore[drawIndex].m_count = g_updateDrawOriginCount;
+			g_updateDrawOriginCount = 0;
+		}
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("SET_DRAW_ORIGIN", [](fx::ScriptContext& context)
 	{
-		auto& store = g_drawOriginStore[*g_renderBufferIndex];
-		const auto index = store.m_count;
-
-		if (index >= 32)
+		if (g_updateDrawOriginCount >= 32)
 		{
 			return;
 		}
@@ -192,10 +194,9 @@ static HookFunction hookFunction([]()
 		data.m_pos.z = context.GetArgument<float>(2);
 		data.m_is2d = context.GetArgument<bool>(3);
 
-		store.m_items[index] = data;
-		store.m_count += 1;
-
-		*g_scriptDrawOriginIndex = index;
+		g_updateDrawOrigin[g_updateDrawOriginCount] = data;
+		*g_scriptDrawOriginIndex = g_updateDrawOriginCount;
+		g_updateDrawOriginCount += 1;
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("CLEAR_DRAW_ORIGIN", [](fx::ScriptContext& context)

--- a/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/GraphicsNatives.cpp
@@ -6,6 +6,8 @@
 #include "Hooking.Stubs.h"
 #include "GamePrimitives.h"
 #include "scrEngine.h"
+#include <nutsnbolts.h>
+#include <DrawCommands.h>
 
 enum ScriptImDrawType : uint32_t
 {
@@ -28,6 +30,9 @@ struct ScriptImRequest
 
 static constexpr int kMaxScriptImRequests = 1024;
 static std::vector<ScriptImRequest> g_scriptImRequests{};
+static std::vector<ScriptImRequest> g_scriptImRenderBuffer{};
+
+static std::atomic<bool> g_scriptImReady{false};
 
 static ScriptImRequest** g_scriptImBuffer;
 static uint16_t* g_scriptImEntriesCount;
@@ -45,12 +50,20 @@ static void RenderScriptIm()
 	// Like if something allocate script im buffer before us, we would need to resize it
 	// and not just rewrite everything without custom stuff.
 
-	if (g_scriptImRequests.empty())
+	// Wait until the main thread is done for this frame before pushing new requests
+	if (g_scriptImReady.load(std::memory_order_acquire))
+	{
+		g_scriptImRenderBuffer.clear();
+		std::swap(g_scriptImRequests, g_scriptImRenderBuffer);
+		g_scriptImReady.store(false, std::memory_order_relaxed);
+	}
+
+	if (g_scriptImRenderBuffer.empty())
 	{
 		return;
 	}
 
-	*g_scriptImEntriesCount = g_scriptImRequests.size();
+	*g_scriptImEntriesCount = g_scriptImRenderBuffer.size();
 
 	// If the buffer isn't allocated, let's do it.
 	if (!*g_scriptImBuffer)
@@ -66,11 +79,9 @@ static void RenderScriptIm()
 	}
 
 	// Move stuff from our temp vector to the in-game buffer.
-	std::move(g_scriptImRequests.begin(), g_scriptImRequests.end(), *g_scriptImBuffer);
+	std::copy(g_scriptImRenderBuffer.begin(), g_scriptImRenderBuffer.end(), *g_scriptImBuffer);
 
 	g_origRenderScriptIm();
-
-	g_scriptImRequests.clear();
 	*g_scriptImEntriesCount = 0;
 }
 
@@ -90,8 +101,8 @@ struct DrawOriginStore
 
 static bool (*isGamePaused)();
 
-static int* g_frameDrawIndex1;
-static int* g_frameDrawIndex2;
+static int* g_renderBufferIndex;
+static int* g_updateBufferIndex;
 static DrawOriginStore* g_drawOriginStore;
 static uint32_t* g_scriptDrawOriginIndex;
 
@@ -124,8 +135,8 @@ static HookFunction hookFunction([]()
 	{
 		auto location = hook::get_pattern<char>("48 69 D0 10 04 00 00 48 8D 05 ? ? ? ? 48 03");
 
-		g_frameDrawIndex1 = hook::get_address<int*>(location - 20);
-		g_frameDrawIndex2 = hook::get_address<int*>(location - 7);
+		g_renderBufferIndex = hook::get_address<int*>(location - 20);
+		g_updateBufferIndex = hook::get_address<int*>(location - 7);
 		g_drawOriginStore = hook::get_address<DrawOriginStore*>(location + 10);
 
 		hook::set_call(&isGamePaused, location - 27);
@@ -155,11 +166,19 @@ static HookFunction hookFunction([]()
 		g_screenHeight = hook::get_address<int*>(location + 8);
 	}
 
+	OnMainGameFrame.Connect([]()
+	{
+		g_scriptImReady.store(false, std::memory_order_relaxed);
+	});
+
+	OnPostFrontendRender.Connect([]()
+	{
+		g_scriptImReady.store(true, std::memory_order_release);
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("SET_DRAW_ORIGIN", [](fx::ScriptContext& context)
 	{
-		auto drawIndex = *(isGamePaused() ? g_frameDrawIndex2 : g_frameDrawIndex1);
-
-		auto& store = g_drawOriginStore[drawIndex];
+		auto& store = g_drawOriginStore[*g_renderBufferIndex];
 		const auto index = store.m_count;
 
 		if (index >= 32)


### PR DESCRIPTION
### Goal of this PR

Resolves flickering within several graphic natives (DRAW_BOX/DRAW_POLY/DRAW_LINE) caused by a race condition. This should also resolve several crashes tied to these natives but these crashes were unable to be reproduced. SET_DRAW_ORIGIN has been changed to fix https://github.com/citizenfx/fivem/issues/2450 and the flickering regression reported in https://github.com/citizenfx/fivem/issues/3082

### How is this PR achieving the goal

Only allow the game to read imRequests when the main thread has finished for this frame.

### This PR applies to the following area(s)

RedM

### Successfully tested on
Tested with snippet provided from https://github.com/citizenfx/fivem/issues/4019 

Tested with the following settings with/without the changes to confirm it works
- 5 lines
- 400 lines
- 1024 lines

SET_DRAW_ORIGIN issue was tested with snippet provided from https://forum.cfx.re/t/draworigin-single-frame-positional-issue/5223033 and https://github.com/citizenfx/fivem/issues/3082#issuecomment-2601015894

**Game builds:**  1491

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

fixes https://github.com/citizenfx/fivem/issues/4019 
fixes https://github.com/citizenfx/fivem/issues/2450
https://forum.cfx.re/t/draworigin-single-frame-positional-issue/5223033