### PR TITLE
feat(graphics/rdr3): graphics improvements v3

### DIFF
--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -608,6 +608,9 @@ int RealMain()
 	loadSystemDll(L"\\d3d11.dll");
 
 #ifdef IS_RDR3
+	// D3D12/RedM equivilant of the code above.
+	loadSystemDll(L"\\d3d12.dll");
+
 	// RedM attempts to load vulkan bundled with CEF first which on some systems leads to various issues
 	loadSystemDll(L"\\vulkan-1.dll");
 #endif

--- a/code/components/glue/src/ConnectToNative.cpp
+++ b/code/components/glue/src/ConnectToNative.cpp
@@ -964,7 +964,6 @@ static InitFunction initFunction([] ()
 		{
 			static bool done = ([]
 			{
-#ifdef GTA_FIVE
 				std::thread([]
 				{
 					UiDone();
@@ -977,7 +976,6 @@ static InitFunction initFunction([] ()
 					SetForegroundWindow(hWnd);
 				})
 				.detach();
-#endif
 
 				MarkNuiLoaded();
 

--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -628,18 +628,12 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 		// meanwhile in Vulkan, this is infinitely annoying
 		return new GtaNuiTexture([shareHandle, width, height](GtaNuiTexture* texture)
 		{
-			std::vector<uint8_t> pixelData(size_t(width) * size_t(height) * 4);
+			rage::grcManualTextureDef textureDef;
+			memset(&textureDef, 0, sizeof(textureDef));
+			textureDef.isStaging = 0;
+			textureDef.arraySize = 1;
 
-			rage::grcTextureReference reference;
-			memset(&reference, 0, sizeof(reference));
-			reference.width = width;
-			reference.height = height;
-			reference.depth = 1;
-			reference.stride = width * 4;
-			reference.format = 11;
-			reference.pixelData = (uint8_t*)pixelData.data();
-
-			auto texRef = (rage::sga::TextureVK*)rage::grcTextureFactory::getInstance()->createImage(&reference, nullptr);
+			auto texRef = (rage::sga::TextureVK*)rage::grcTextureFactory::getInstance()->createManualTexture(width, height, 2, nullptr, true, &textureDef);
 
 			if (texRef)
 			{
@@ -647,79 +641,20 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 
 				// Vulkan API magic time (copy/pasted from samples on GH)
 				VkDevice device = (VkDevice)GetGraphicsDriverHandle();
-				
-				VkExtent3D Extent = { width, height, 1 };
-
-				VkExternalMemoryImageCreateInfo ExternalMemoryImageCreateInfo = { VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO };
-				ExternalMemoryImageCreateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
-				VkImageCreateInfo ImageCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-				ImageCreateInfo.pNext = &ExternalMemoryImageCreateInfo;
-				ImageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-				ImageCreateInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
-				ImageCreateInfo.extent = Extent;
-				ImageCreateInfo.mipLevels = 1;
-				ImageCreateInfo.arrayLayers = 1;
-				ImageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-				ImageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-				ImageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-				ImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-				ImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+				VkPhysicalDevice physicalDevice = GetVulkanPhysicalHandle();
 
 				VkImage Image;
-				VkResult result = vkCreateImage(device, &ImageCreateInfo, nullptr, &Image);
-
-				if (result != VK_SUCCESS)
-				{
-					FatalError("Failed to create a Vulkan image. VkResult: %s", ResultToString(result));
-				}
-
-				VkMemoryRequirements MemoryRequirements;
-				vkGetImageMemoryRequirements(device, Image, &MemoryRequirements);
-
-				VkMemoryDedicatedAllocateInfo MemoryDedicatedAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO };
-				MemoryDedicatedAllocateInfo.image = Image;
-				VkImportMemoryWin32HandleInfoKHR ImportMemoryWin32HandleInfo = { VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR };
-				ImportMemoryWin32HandleInfo.pNext = &MemoryDedicatedAllocateInfo;
-				ImportMemoryWin32HandleInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
-				ImportMemoryWin32HandleInfo.handle = shareHandle;
-				VkMemoryAllocateInfo MemoryAllocateInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
-				MemoryAllocateInfo.pNext = &ImportMemoryWin32HandleInfo;
-				MemoryAllocateInfo.allocationSize = MemoryRequirements.size;
-
-				unsigned long typeIndex;
-				_BitScanForward(&typeIndex, MemoryRequirements.memoryTypeBits);
-				MemoryAllocateInfo.memoryTypeIndex = typeIndex;
-
-				static auto _vkBindImageMemory2 = (PFN_vkBindImageMemory2)vkGetDeviceProcAddr(device, "vkBindImageMemory2");
-
-				VkDeviceMemory ImageMemory;
-				result = vkAllocateMemory(device, &MemoryAllocateInfo, nullptr, &ImageMemory);
-
-				if (result != VK_SUCCESS)
-				{
-					FatalErrorNoReport("Failed to allocate memory for Vulkan. VkResult: %s", ResultToString(result));
-				}
-
-				VkBindImageMemoryInfo BindImageMemoryInfo = { VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO };
-				BindImageMemoryInfo.image = Image;
-				BindImageMemoryInfo.memory = ImageMemory;
-
-				result = _vkBindImageMemory2(device, 1, &BindImageMemoryInfo);
-
-				if (result != VK_SUCCESS)
-				{
-					FatalErrorNoReport("Failed to bind Vulkan image memory. VkResult: %s", ResultToString(result));
-				}
+				VkDeviceMemory DeviceMemory;
+				CreateVKImageFromShareHandle(device, shareHandle, width, height, Image, DeviceMemory);
 
 				auto newImage = new rage::sga::TextureVK::ImageData;
-				//memcpy(newImage, texRef->image, sizeof(*newImage));
 				memset(newImage, 0, sizeof(*newImage));
-				// these come from a fast allocator(?)
-				//delete texRef->image;
 				texRef->image = newImage;
 
 				texRef->image->image = Image;
-				texRef->image->memory = ImageMemory;
+				texRef->image->memory = DeviceMemory;
+				texRef->width = width;
+				texRef->height = height;
 
 				rage::sga::TextureViewDesc srvDesc;
 				srvDesc.mipLevels = 1;

--- a/code/components/glue/src/GtaNui.cpp
+++ b/code/components/glue/src/GtaNui.cpp
@@ -206,6 +206,21 @@ public:
 				texture->srv = NULL;
 			}
 		}
+#elif IS_RDR3
+		// Destroy SRV/ImageView as the game doesn't clean this up
+		g_onRenderQueue.push([texture]()
+		{
+			if (GetCurrentGraphicsAPI() == GraphicsAPI::Vulkan)
+			{
+				auto texRef = (rage::sga::TextureVK*)texture;
+				vkDestroyImageView((VkDevice)GetGraphicsDriverHandle(), texRef->data->imageView, nullptr);
+				texRef->data->imageView = VK_NULL_HANDLE;
+			}
+			else
+			{
+				rage::sga::Driver_Destroy_ShaderResourceView((rage::sga::TextureD3D12*)texture);
+			}
+		});
 #endif
 
 		g_onRenderQueue.push([texture]()
@@ -625,7 +640,6 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 	}
 	else if (GetCurrentGraphicsAPI() == GraphicsAPI::Vulkan)
 	{
-		// meanwhile in Vulkan, this is infinitely annoying
 		return new GtaNuiTexture([shareHandle, width, height](GtaNuiTexture* texture)
 		{
 			rage::grcManualTextureDef textureDef;
@@ -638,8 +652,6 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 			if (texRef)
 			{
 				rage::sga::Driver_Destroy_Texture(texRef);
-
-				// Vulkan API magic time (copy/pasted from samples on GH)
 				VkDevice device = (VkDevice)GetGraphicsDriverHandle();
 				VkPhysicalDevice physicalDevice = GetVulkanPhysicalHandle();
 
@@ -662,7 +674,33 @@ fwRefContainer<GITexture> GtaNuiInterface::CreateTextureFromShareHandle(HANDLE s
 				srvDesc.dimension = 4;
 				srvDesc.arraySize = 1;
 
-				rage::sga::Driver_Create_ShaderResourceView(texRef, srvDesc);
+				// Manually create VkImageView.
+				// Doing so allows us to create it immediately. As the sgaDriver call will defer it to another frame.
+				// DX12 requires a lot more work to achieve this.
+				{
+					VkImageViewCreateInfo viewInfo{};
+					viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+					viewInfo.image = Image;
+					viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+					viewInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
+					viewInfo.components = {
+						VK_COMPONENT_SWIZZLE_IDENTITY,
+						VK_COMPONENT_SWIZZLE_IDENTITY,
+						VK_COMPONENT_SWIZZLE_IDENTITY,
+						VK_COMPONENT_SWIZZLE_IDENTITY
+					};
+					viewInfo.subresourceRange = {
+						VK_IMAGE_ASPECT_COLOR_BIT,
+						0, 1,
+						0, 1
+					};
+
+					VkImageView view;
+					vkCreateImageView((VkDevice)GetGraphicsDriverHandle(), &viewInfo, nullptr, &view);
+
+					texRef->data->imageView = view;
+					texRef->data->imageViewType = 2;
+				}
 
 				CloseHandle(shareHandle);
 			}

--- a/code/components/rage-graphics-five/src/ReShadeFixups.cpp
+++ b/code/components/rage-graphics-five/src/ReShadeFixups.cpp
@@ -202,6 +202,10 @@ void ScanForReshades()
 		L"d3d10.dll",
 		L"d3d10_1.dll",
 		L"d3d11.dll",
+#ifdef IS_RDR3
+		L"d3d12.dll",
+		L"vulkan-1.dll"
+#endif
 		L"dxgi.dll" };
 
 	// try loading all dll files *from plugins/*

--- a/code/components/rage-graphics-rdr3/component.lua
+++ b/code/components/rage-graphics-rdr3/component.lua
@@ -1,1 +1,14 @@
-includedirs { '../../../vendor/vulkan-headers/include/' }
+includedirs { 
+    '../../../vendor/vulkan-headers/include/',
+    '../rage-graphics-five/include'
+}
+
+return function()
+    filter {}
+
+    files {
+        'components/rage-graphics-five/include/dxerr.h',
+        'components/rage-graphics-five/src/dxerr.cpp',
+        'components/rage-graphics-five/src/ReShadeFixups.cpp'
+    }
+end

--- a/code/components/rage-graphics-rdr3/include/DrawCommands.h
+++ b/code/components/rage-graphics-rdr3/include/DrawCommands.h
@@ -75,6 +75,11 @@ extern GFX_EXPORT GraphicsAPI GetCurrentGraphicsAPI();
 // VK context or D3D12 device
 extern GFX_EXPORT void* GetGraphicsDriverHandle();
 
+// VK physicalDevice
+extern GFX_EXPORT VkPhysicalDevice GetVulkanPhysicalHandle();
+
+extern GFX_EXPORT VkInstance GetVulkanInstance();
+
 namespace rage::sga
 {
 class GFX_EXPORT GraphicsContext

--- a/code/components/rage-graphics-rdr3/include/VulkanHelper.h
+++ b/code/components/rage-graphics-rdr3/include/VulkanHelper.h
@@ -3,8 +3,14 @@
 #if IS_RDR3
 #include <string_view>
 #include <vulkan/vulkan_core.h>
+#include <vulkan/vulkan_win32.h>
+#include <DrawCommands.h>
 
-inline std::string_view ResultToString(VkResult result)
+static PFN_vkBindImageMemory2 _vkBindImageMemory2 = nullptr;
+static PFN_vkGetPhysicalDeviceMemoryProperties2 _vkGetPhysicalDeviceMemoryProperties2 = nullptr;
+static PFN_vkGetImageMemoryRequirements2 _vkGetImageMemoryRequirements2 = nullptr;
+
+inline std::string ResultToString(VkResult result)
 {
 	switch (result)
 	{
@@ -69,7 +75,189 @@ inline std::string_view ResultToString(VkResult result)
 		case VK_ERROR_INVALID_DEVICE_ADDRESS_EXT:
 			return "VK_ERROR_INVALID_DEVICE_ADDRESS_EXT A buffer creation failed because the requested address is not available.";
 		default:
-			return std::to_string(static_cast<uint32_t>(result));
+			return std::to_string(static_cast<int32_t>(result));
+	}
+}
+
+static uint32_t FindExternalMemoryType(VkDevice device, VkPhysicalDevice physicalDevice, HANDLE handle, uint32_t typeFilter, VkMemoryPropertyFlags properties)
+{
+	static auto _vkGetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR");
+
+	VkPhysicalDeviceMemoryProperties memProps;
+	vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+
+	for (uint32_t i = 0; i < memProps.memoryTypeCount; i++)
+	{
+		if (!(typeFilter & (1 << i)))
+		{
+			continue;
+		}
+
+		if ((memProps.memoryTypes[i].propertyFlags & properties) != properties)
+		{
+			continue;
+		}
+
+        VkMemoryWin32HandlePropertiesKHR handleProps = {
+			VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR
+		};
+
+		// Finding the first 'VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT' memory type wasn't good enough on some system configurations.
+		// Check the handle properties against vkGetMemoryWin32HandlePropertiesKHR and 'VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT' if its good enough
+		static auto _vkGetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR");
+		if (_vkGetMemoryWin32HandlePropertiesKHR(device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT, handle, &handleProps) != VK_SUCCESS)
+		{
+			continue;
+		}
+
+		if (handleProps.memoryTypeBits & (1 << i))
+		{
+			return i;
+		}
+	}
+
+	trace("Failed to find suitable Vulkan external memory type.\n");
+	return UINT32_MAX;
+}
+
+static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsigned int width, unsigned int height, VkImage& outImage, VkDeviceMemory& outMemory)
+{
+	outImage = VK_NULL_HANDLE;
+	outMemory = VK_NULL_HANDLE;
+
+	if (!_vkBindImageMemory2)
+	{
+		_vkBindImageMemory2 = (PFN_vkBindImageMemory2)vkGetDeviceProcAddr(device, "vkBindImageMemory2");
+		if (!_vkBindImageMemory2)
+		{
+			FatalError("Unable to find 'vkBindImageMemory2' in vulkan.");
+		}
+	}
+
+	if (!_vkGetPhysicalDeviceMemoryProperties2)
+	{
+		_vkGetPhysicalDeviceMemoryProperties2 = (PFN_vkGetPhysicalDeviceMemoryProperties2)vkGetInstanceProcAddr((VkInstance)GetVulkanInstance(), "vkGetPhysicalDeviceMemoryProperties2");
+		if (!_vkGetPhysicalDeviceMemoryProperties2)
+		{
+			FatalError("Unable to find 'vkGetPhysicalDeviceMemoryProperties2' in vulkan.");
+		}
+	}
+
+	if (!_vkGetImageMemoryRequirements2)
+	{
+		_vkGetImageMemoryRequirements2 = (PFN_vkGetImageMemoryRequirements2)vkGetDeviceProcAddr(device, "vkGetImageMemoryRequirements2");
+		if (!_vkGetImageMemoryRequirements2)
+		{
+			FatalError("Unable to find 'vkGetImageMemoryRequirements2' in vulkan.");
+		}
+	}
+
+	VkExternalMemoryImageCreateInfo externalMemoryInfo = {};
+	externalMemoryInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+	externalMemoryInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+
+	VkImageCreateInfo imageInfo = {};
+	imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+	imageInfo.pNext = &externalMemoryInfo;
+	imageInfo.imageType = VK_IMAGE_TYPE_2D;
+	imageInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
+	imageInfo.extent = { width, height, 1 };
+	imageInfo.mipLevels = 1;
+	imageInfo.arrayLayers = 1;
+	imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+	imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+	imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+	imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+	VkResult result = vkCreateImage(device, &imageInfo, nullptr, &outImage);
+
+	if (result != VK_SUCCESS)
+	{
+		FatalError("Failed to create a Vulkan image. VkResult: %s", ResultToString(result));
+		outImage = VK_NULL_HANDLE;
+		outMemory = VK_NULL_HANDLE;
+		return;
+	}
+
+	VkMemoryDedicatedRequirements dedicatedReqs = {};
+	dedicatedReqs.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
+
+	VkMemoryRequirements2 memReqs2 = {};
+	memReqs2.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+	memReqs2.pNext = &dedicatedReqs;
+
+	VkImageMemoryRequirementsInfo2 memReqsInfo = {};
+	memReqsInfo.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2;
+	memReqsInfo.image = outImage;
+
+	_vkGetImageMemoryRequirements2(device, &memReqsInfo, &memReqs2);
+
+	if (dedicatedReqs.requiresDedicatedAllocation == VK_FALSE && dedicatedReqs.prefersDedicatedAllocation == VK_FALSE)
+	{
+		// Dedicated allocation should either be required or preferred.
+		FatalError("Vulkan cannot allocate D3D11 Shared texture.");
+		vkDestroyImage(device, outImage, nullptr);
+		outImage = VK_NULL_HANDLE;
+		outMemory = VK_NULL_HANDLE;
+		return;
+	}
+
+	VkMemoryDedicatedAllocateInfo dedicatedInfo = {};
+	dedicatedInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+	dedicatedInfo.image = outImage;
+
+	VkImportMemoryWin32HandleInfoKHR importInfo = {};
+	importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+	importInfo.pNext = &dedicatedInfo;
+	importInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+	importInfo.handle = handle;
+
+	uint32_t memTypeIndex = FindExternalMemoryType(
+		device,
+		(VkPhysicalDevice)GetVulkanPhysicalHandle(),
+		handle,
+		memReqs2.memoryRequirements.memoryTypeBits,
+		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+	if (memTypeIndex == UINT32_MAX)
+	{
+		// Fallback to old behaviour.
+		unsigned long typeIndex;
+		_BitScanForward(&typeIndex, memReqs2.memoryRequirements.memoryTypeBits);
+		memTypeIndex = (uint32_t)typeIndex;
+	}
+
+	VkMemoryAllocateInfo allocInfo = {};
+	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+	allocInfo.pNext = &importInfo;
+	allocInfo.allocationSize = memReqs2.memoryRequirements.size;
+	allocInfo.memoryTypeIndex = memTypeIndex;
+
+	result = vkAllocateMemory(device, &allocInfo, nullptr, &outMemory);
+	if (result != VK_SUCCESS)
+	{
+		FatalError("Failed to allocate memory for Vulkan shared texture. VkResult: %s", ResultToString(result));
+		vkDestroyImage(device, outImage, nullptr);
+		outImage = VK_NULL_HANDLE;
+		outMemory = VK_NULL_HANDLE;
+		return;
+	}
+
+	VkBindImageMemoryInfo bindInfo = {};
+	bindInfo.sType = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
+	bindInfo.image = outImage;
+	bindInfo.memory = outMemory;
+	bindInfo.memoryOffset = 0;
+
+	result = _vkBindImageMemory2(device, 1, &bindInfo);
+	if (result != VK_SUCCESS)
+	{
+		FatalError("Failed to bind Vulkan image memory. VkResult: %s", ResultToString(result));
+		vkFreeMemory(device, outMemory, nullptr);
+		vkDestroyImage(device, outImage, nullptr);
+		outMemory = VK_NULL_HANDLE;
+		outImage = VK_NULL_HANDLE;
 	}
 }
 #endif

--- a/code/components/rage-graphics-rdr3/include/VulkanHelper.h
+++ b/code/components/rage-graphics-rdr3/include/VulkanHelper.h
@@ -98,21 +98,23 @@ static uint32_t FindExternalMemoryType(VkDevice device, VkPhysicalDevice physica
 			continue;
 		}
 
-        VkMemoryWin32HandlePropertiesKHR handleProps = {
-			VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR
-		};
-
-		// Finding the first 'VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT' memory type wasn't good enough on some system configurations.
-		// Check the handle properties against vkGetMemoryWin32HandlePropertiesKHR and 'VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT' if its good enough
-		static auto _vkGetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandlePropertiesKHR");
-		if (_vkGetMemoryWin32HandlePropertiesKHR(device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT, handle, &handleProps) != VK_SUCCESS)
+		if (_vkGetMemoryWin32HandlePropertiesKHR)
 		{
-			continue;
-		}
+			VkMemoryWin32HandlePropertiesKHR handleProps = {
+				VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR
+			};
 
-		if (handleProps.memoryTypeBits & (1 << i))
-		{
-			return i;
+			// Finding the first 'VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT' memory type wasn't good enough on some system configurations.
+			// Check the handle properties against vkGetMemoryWin32HandlePropertiesKHR and 'VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT' if its good enough
+			if (_vkGetMemoryWin32HandlePropertiesKHR(device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT, handle, &handleProps) != VK_SUCCESS)
+			{
+				continue;
+			}
+
+			if (handleProps.memoryTypeBits & (1 << i))
+			{
+				return i;
+			}
 		}
 	}
 
@@ -130,7 +132,7 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 		_vkBindImageMemory2 = (PFN_vkBindImageMemory2)vkGetDeviceProcAddr(device, "vkBindImageMemory2");
 		if (!_vkBindImageMemory2)
 		{
-			FatalError("Unable to find 'vkBindImageMemory2' in vulkan.");
+			FatalError("Unable to find 'vkBindImageMemory2.\nIf this issue persists try updating your GPU Drivers or switching to DirectX12.");
 		}
 	}
 
@@ -139,7 +141,7 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 		_vkGetPhysicalDeviceMemoryProperties2 = (PFN_vkGetPhysicalDeviceMemoryProperties2)vkGetInstanceProcAddr((VkInstance)GetVulkanInstance(), "vkGetPhysicalDeviceMemoryProperties2");
 		if (!_vkGetPhysicalDeviceMemoryProperties2)
 		{
-			FatalError("Unable to find 'vkGetPhysicalDeviceMemoryProperties2' in vulkan.");
+			FatalError("Unable to find 'vkGetPhysicalDeviceMemoryProperties2'.\nIf this issue persists try updating your GPU Drivers or switching to DirectX12.");
 		}
 	}
 
@@ -148,7 +150,7 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 		_vkGetImageMemoryRequirements2 = (PFN_vkGetImageMemoryRequirements2)vkGetDeviceProcAddr(device, "vkGetImageMemoryRequirements2");
 		if (!_vkGetImageMemoryRequirements2)
 		{
-			FatalError("Unable to find 'vkGetImageMemoryRequirements2' in vulkan.");
+			FatalError("Unable to find 'vkGetImageMemoryRequirements2'.\nIf this issue persists try updating your GPU Drivers or switching to DirectX12.");
 		}
 	}
 
@@ -196,7 +198,7 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 	if (dedicatedReqs.requiresDedicatedAllocation == VK_FALSE && dedicatedReqs.prefersDedicatedAllocation == VK_FALSE)
 	{
 		// Dedicated allocation should either be required or preferred.
-		FatalError("Vulkan cannot allocate D3D11 Shared texture.");
+		FatalError("Unable to allocate memory for D3D11 Texture.\nIf this issue persists try updating your GPU Drivers or switching to DirectX12.");
 		vkDestroyImage(device, outImage, nullptr);
 		outImage = VK_NULL_HANDLE;
 		outMemory = VK_NULL_HANDLE;
@@ -237,7 +239,7 @@ static void CreateVKImageFromShareHandle(VkDevice& device, HANDLE handle, unsign
 	result = vkAllocateMemory(device, &allocInfo, nullptr, &outMemory);
 	if (result != VK_SUCCESS)
 	{
-		FatalError("Failed to allocate memory for Vulkan shared texture. VkResult: %s", ResultToString(result));
+		FatalError("Failed to allocate memory for Vulkan shared texture. VkResult: %s\nIf this issue persists try upgrading your GPU drivers, disabling any intergrated GPU's or switching to DirectX12", ResultToString(result));
 		vkDestroyImage(device, outImage, nullptr);
 		outImage = VK_NULL_HANDLE;
 		outMemory = VK_NULL_HANDLE;

--- a/code/components/rage-graphics-rdr3/include/grcTexture.h
+++ b/code/components/rage-graphics-rdr3/include/grcTexture.h
@@ -177,7 +177,10 @@ namespace rage
 				uint32_t pad[24];
 			};
 
-			char pad[64];
+			char pad[0x10];
+			uint16_t width;
+			uint16_t height;
+			char pad2[44];
 			ImageData* image;
 		};
 

--- a/code/components/rage-graphics-rdr3/include/grcTexture.h
+++ b/code/components/rage-graphics-rdr3/include/grcTexture.h
@@ -170,6 +170,14 @@ namespace rage
 		class TextureVK : public Texture
 		{
 		public:
+			struct TextureData : public sysUseAllocator
+			{
+				char pad0[0x11];
+				uint8_t imageViewType;
+				char pad1[6];
+				VkImageView imageView;
+			};
+
 			struct ImageData : public sysUseAllocator
 			{
 				VkDeviceMemory memory;
@@ -180,7 +188,9 @@ namespace rage
 			char pad[0x10];
 			uint16_t width;
 			uint16_t height;
-			char pad2[44];
+			char pad2[20];
+			TextureData* data;
+			char pad3[16];
 			ImageData* image;
 		};
 
@@ -215,7 +225,9 @@ namespace rage
 			}
 		};
 
-		void GFX_EXPORT Driver_Create_ShaderResourceView(Texture* texture, const TextureViewDesc& desc);
+		bool GFX_EXPORT Driver_Create_ShaderResourceView(Texture* texture, const TextureViewDesc& desc);
+
+		void GFX_EXPORT Driver_Destroy_ShaderResourceView(Texture* texture);
 
 		void GFX_EXPORT Driver_Destroy_Texture(Texture* texture);
 	}

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -579,9 +579,14 @@ GFX_EXPORT VkInstance GetVulkanInstance()
 
 namespace rage::sga
 {
-	void Driver_Create_ShaderResourceView(rage::sga::Texture* texture, const rage::sga::TextureViewDesc& desc)
+	bool Driver_Create_ShaderResourceView(rage::sga::Texture* texture, const rage::sga::TextureViewDesc& desc)
 	{
-		(*(void(__fastcall**)(__int64, void*, void*, const void*))(**(uint64_t**)sgaDriver + 256i64))(*(uint64_t*)sgaDriver, *(char**)((char*)texture + 48), texture, &desc);
+		return (*(bool(__fastcall**)(__int64, void*, void*, const void*))(**(uint64_t**)sgaDriver + 256i64))(*(uint64_t*)sgaDriver, *(char**)((char*)texture + 48), texture, &desc);
+	}
+
+	void Driver_Destroy_ShaderResourceView(rage::sga::Texture* texture)
+	{
+		(*(void(__fastcall**)(__int64, void*))(**(uint64_t**)sgaDriver + 432i64))(*(uint64_t*)sgaDriver, *(char**)((char*)texture + 48));
 	}
 
 	void Driver_Destroy_Texture(rage::sga::Texture* texture)

--- a/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
+++ b/code/components/rage-graphics-rdr3/src/GfxSpec.cpp
@@ -522,19 +522,6 @@ static void WrapEndDraw(void* cxt)
 	origEndDraw(cxt);
 }
 
-static LPWSTR GetCommandLineWHook()
-{
-	static wchar_t str[8192];
-	wcscpy(str, GetCommandLineW());
-
-	if (!wcsstr(str, L"sgadriver"))
-	{
-		wcscat(str, L" -sgadriver=d3d12");
-	}
-
-	return str;
-}
-
 static void* g_d3d12Driver;
 static void* g_vkDriver;
 
@@ -555,6 +542,8 @@ GraphicsAPI GetCurrentGraphicsAPI()
 void** g_d3d12Device;
 VkDevice* g_vkHandle;
 
+VkPhysicalDevice* g_vkPhysicalHandle;
+
 void* GetGraphicsDriverHandle()
 {
 	switch (GetCurrentGraphicsAPI())
@@ -566,6 +555,26 @@ void* GetGraphicsDriverHandle()
 	default:
 		return nullptr;
 	}
+}
+
+GFX_EXPORT VkPhysicalDevice GetVulkanPhysicalHandle()
+{
+	if (GetCurrentGraphicsAPI() == GraphicsAPI::Vulkan)
+	{
+		return *g_vkPhysicalHandle;
+	}
+}
+
+extern VkInstance g_vkInstance;
+
+GFX_EXPORT VkInstance GetVulkanInstance()
+{
+	if (GetCurrentGraphicsAPI() == GraphicsAPI::Vulkan)
+	{
+		return g_vkInstance;
+	}
+
+	return VK_NULL_HANDLE;
 }
 
 namespace rage::sga
@@ -680,9 +689,16 @@ void DynamicTexture2::UnmapInternal(GraphicsContext* context, const MapData& map
 
 static bool ShouldUsePipelineCache(const char* pipelineCachePrefix)
 {
-	// #TODO: check for ERR_GFX_STATE or similar failures last launch?
+	// This file is created on any hooked graphics related crashes (currently ERR_GFX_STATE)
+	std::wstring path = MakeRelativeCitPath("data\\cache\\clearPipelineCache");
+	if (_waccess(path.c_str(), 0))
+	{
+		_wunlink(path.c_str());
+		return false;
+	}
+
 	return true;
-}
+} 
 
 static HookFunction hookFunction([]()
 {
@@ -722,15 +738,13 @@ static HookFunction hookFunction([]()
 
 	g_d3d12Device = hook::get_address<decltype(g_d3d12Device)>(hook::get_pattern("48 8B 01 FF 50 78 48 8B 0B 48 8D", -7));
 	g_vkHandle = hook::get_address<decltype(g_vkHandle)>(hook::get_pattern("8D 50 41 8B CA 44 8B C2 F3 48 AB 48 8B 0D", 14));
+	g_vkPhysicalHandle = hook::get_address<decltype(g_vkPhysicalHandle)>(hook::get_pattern("FF 15 ? ? ? ? 33 D2 48 8D 4C 24 ? 41 B8", 27));
 
 	{
 		auto location = hook::get_pattern<char>("83 25 ? ? ? ? 00 83 25 ? ? ? ? 00 D1 F8 89 05", -0x26);
 		rage::g_WindowWidth = hook::get_address<int*>(location + 6);
 		rage::g_WindowHeight = hook::get_address<int*>(location + 0x3E);
 	}
-
-	// #TODORDR: badly force d3d12 sga driver (vulkan crashes on older Windows 10?)
-	hook::iat("kernel32.dll", GetCommandLineWHook, "GetCommandLineW");
 
 	MH_EnableHook(MH_ALL_HOOKS);
 });

--- a/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
@@ -322,7 +322,7 @@ static inline void SetVulkanCrashometry(const VkPhysicalDevice physicalDevice)
 	isInitialized = true;
 }
 
-static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
+static VkResult vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDevice* pDevice)
 {
 	// we keep the data here, to ensure the data does not go out of scope
 	std::vector<const char*> originalLayers(pCreateInfo->enabledLayerCount);
@@ -396,6 +396,14 @@ static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreat
 	{
 		trace("Unable to use vulkan driver: Vulkan driver does not include 'vkGetPhysicalDeviceImageFormatProperties2'\n");
 		return VK_ERROR_FEATURE_NOT_PRESENT;
+	}
+
+	// Even if the GPU claims to support 'VK_KHR_external_memory_win32' it can not support 'vkGetMemoryWin32HandlePropertiesKHR' which we expect for finding the right memory handle
+	// Since we can fallback to the legacy logic we don't want to fallback to DX12 for this but make a note to aid debugging should the user have issues with external memory.
+	static auto _vkGetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)vkGetDeviceProcAddr(*pDevice, "vkGetMemoryWin32HandlePropertiesKHR");
+	if (!_vkGetMemoryWin32HandlePropertiesKHR)
+	{
+		AddCrashometry("vk_partial_external_memory_support", "1");
 	}
 
 	VkPhysicalDeviceExternalImageFormatInfo externalImageInfo{};

--- a/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
+++ b/code/components/rage-graphics-rdr3/src/RenderHooks.cpp
@@ -1,19 +1,95 @@
 #include "StdInc.h"
 
 #include <vulkan/vulkan.h>
+#include <d3dcommon.h>
+#include <d3d12.h>
+
+#include <dxgi1_4.h>
+#include <dxgi1_5.h>
+#include <dxgi1_6.h>
+#include <wrl.h>
+
+#include <CL2LaunchMode.h>
+#include <ICoreGameInit.h>
+#include <HostSharedData.h>
 
 #include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <dxerr.h>
 #include <Error.h>
 
 #include <CoreConsole.h>
 
 #include <VulkanHelper.h>
 #include <CrossBuildRuntime.h>
+#include <CfxState.h>
+#include <DrawCommands.h>
 
 #pragma comment(lib, "vulkan-1.lib")
 
-static VkInstance g_vkInstance = nullptr;
+VkInstance g_vkInstance = nullptr;
 static bool g_enableVulkanValidation = false;
+
+#pragma comment(lib, "d3d12.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "dxguid.lib")
+
+namespace WRL = Microsoft::WRL;
+
+static void DXGIGetHighPerfAdapter(IDXGIAdapter** ppAdapter)
+{
+	{
+		WRL::ComPtr<IDXGIFactory1> dxgiFactory;
+		CreateDXGIFactory1(IID_IDXGIFactory1, &dxgiFactory);
+
+		WRL::ComPtr<IDXGIAdapter1> adapter;
+		WRL::ComPtr<IDXGIFactory6> factory6;
+		HRESULT hr = dxgiFactory.As(&factory6);
+		if (SUCCEEDED(hr))
+		{
+			for (UINT adapterIndex = 0;
+			DXGI_ERROR_NOT_FOUND != factory6->EnumAdapterByGpuPreference(adapterIndex, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(adapter.ReleaseAndGetAddressOf()));
+			adapterIndex++)
+			{
+				DXGI_ADAPTER_DESC1 desc;
+				adapter->GetDesc1(&desc);
+
+				if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)
+				{
+					// Don't select the Basic Render Driver adapter.
+					continue;
+				}
+
+				AddCrashometry("gpu_name", "%s", ToNarrow(desc.Description));
+				AddCrashometry("gpu_id", "%04x:%04x", desc.VendorId, desc.DeviceId);
+
+				adapter.CopyTo(ppAdapter);
+				break;
+			}
+		}
+	}
+}
+
+static HANDLE g_gameWindowEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+void DLL_EXPORT UiDone()
+{
+	static HostSharedData<CfxState> initState("CfxInitState");
+	WaitForSingleObject(g_gameWindowEvent, INFINITE);
+
+	auto uiExitEvent = CreateEventW(NULL, TRUE, FALSE, va(L"CitizenFX_PreUIExit%s", IsCL2() ? L"CL2" : L""));
+	auto uiDoneEvent = CreateEventW(NULL, FALSE, FALSE, va(L"CitizenFX_PreUIDone%s", IsCL2() ? L"CL2" : L""));
+
+	if (uiExitEvent)
+	{
+		SetEvent(uiExitEvent);
+	}
+
+	if (uiDoneEvent)
+	{
+		WaitForSingleObject(uiDoneEvent, INFINITE);
+	}
+}
 
 // Function to print the output of the validation layers
 VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessageCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
@@ -206,7 +282,9 @@ static inline void SetVulkanCrashometry(const VkPhysicalDevice physicalDevice)
 	static bool isInitialized = false;
 
 	if (isInitialized)
+	{
 		return;
+	}
 
 	VkPhysicalDeviceProperties props = {};
 
@@ -279,7 +357,178 @@ static HRESULT vkCreateDeviceHook(VkPhysicalDevice physicalDevice, VkDeviceCreat
 		trace("Vulkan device creation returned: %s\n", ResultToString(result));
 	}
 
+	// Check if we can use Vulkan with NUI
+    const char* requiredExtensions[] = {
+		"VK_KHR_external_memory",
+		"VK_KHR_external_memory_win32",
+		"VK_KHR_dedicated_allocation",
+	};
+
+	uint32_t extCount = 0;
+    vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, nullptr);
+
+	std::vector<VkExtensionProperties> extensions(extCount);
+	vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extCount, extensions.data());
+
+	for (const char* reqExt : requiredExtensions)
+	{
+		bool found = false;
+		for (auto& ext : extensions)
+		{
+			if (strcmp(ext.extensionName, reqExt) == 0)
+			{
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+		{
+			trace("Unable to use Vulkan driver: Missing required extension %s\n", reqExt);
+
+			// Fallback to D3D12.
+			return VK_ERROR_EXTENSION_NOT_PRESENT;
+		}
+	}
+
+	static auto _vkGetPhysicalDeviceImageFormatProperties2 = (PFN_vkGetPhysicalDeviceImageFormatProperties2)vkGetInstanceProcAddr(g_vkInstance, "vkGetPhysicalDeviceImageFormatProperties2");
+	if (!_vkGetPhysicalDeviceImageFormatProperties2)
+	{
+		trace("Unable to use vulkan driver: Vulkan driver does not include 'vkGetPhysicalDeviceImageFormatProperties2'\n");
+		return VK_ERROR_FEATURE_NOT_PRESENT;
+	}
+
+	VkPhysicalDeviceExternalImageFormatInfo externalImageInfo{};
+	externalImageInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+	externalImageInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
+
+	VkPhysicalDeviceImageFormatInfo2 formatInfo2{};
+	formatInfo2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+	formatInfo2.pNext = &externalImageInfo;
+	formatInfo2.format = VK_FORMAT_B8G8R8A8_UNORM;
+	formatInfo2.type = VK_IMAGE_TYPE_2D;
+	formatInfo2.tiling = VK_IMAGE_TILING_OPTIMAL;
+	formatInfo2.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+
+	VkExternalImageFormatProperties externalProps{};
+	externalProps.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+	VkImageFormatProperties2 formatProperties2{};
+	formatProperties2.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+	formatProperties2.pNext = &externalProps;
+
+	if (result = _vkGetPhysicalDeviceImageFormatProperties2(physicalDevice, &formatInfo2, &formatProperties2); result != VK_SUCCESS)
+	{
+		trace("Unable to use vulkan driver: 'vkGetPhysicalDeviceImageFormatProperties2' returned VkResult: %s\n", ResultToString(result));
+		return VK_ERROR_FEATURE_NOT_PRESENT;
+	}
+
+	// 'VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT' is required by NUI to import D3D11 textures from CEF.
+	if (!(externalProps.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT))
+	{
+		trace("Unable to use vulkan driver: GPU does not support 'VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT' which is required by NUI\n");
+		return VK_ERROR_FEATURE_NOT_PRESENT;
+	}
+
+	if (result == VK_SUCCESS)
+	{
+		SetEvent(g_gameWindowEvent);
+	}
+
 	return result;
+}
+
+static HRESULT D3D12CreateDeviceWrap(IDXGIAdapter* pAdapter, D3D_FEATURE_LEVEL MinimumFeatureLevel, REFIID riid, void** ppDevice)
+{
+    WRL::ComPtr<IDXGIAdapter> adapter(pAdapter);
+	DXGIGetHighPerfAdapter(adapter.ReleaseAndGetAddressOf());
+
+	if (!adapter)
+	{
+		return E_FAIL;
+	}
+
+	HRESULT hr = D3D12CreateDevice(adapter.Get(), MinimumFeatureLevel, riid, ppDevice);
+	if (SUCCEEDED(hr))
+	{
+		SetEvent(g_gameWindowEvent);
+	}
+
+	return hr;
+}
+
+static void SetCrashometryData(const char* type, const char* details, int unk)
+{
+	if (!strcmp(type,"d3d12_error") || !strcmp(type, "vulkan_last_error") || !strcmp(type, "pc_last_error"))
+	{
+		AddCrashometry(type, details);
+	}
+}
+
+// Creates a temp file to communicate to RedM on next restart to invalidate pipeline cache
+// Helps resolves issues where bad pipeline cache data causes an infinite loop of D3D12/Vulkan Crashes.
+static void InvalidatePipelineCache()
+{
+	FILE* f = _wfopen(MakeRelativeCitPath("data\\cache\\clearPipelineCache").c_str(), L"wb");
+	if (f)
+	{
+		fclose(f);
+	}
+}
+
+// the game only checks if VK_ERROR_DEVICE_LOST for certain calls. For consistentcy sake we do the same
+// just providing the user with the real error code rather then ERR_GFX_STATE
+static VkResult VulkanDeviceLost(VkResult result)
+{
+	InvalidatePipelineCache();
+	FatalError("Vulkan call failed with VK_ERROR_DEVICE_LOST: The logical or physical device has been lost.");
+	return result;
+}
+
+static VkResult VulkanFailed(VkResult result)
+{
+	if (result != VK_SUCCESS)
+	{
+		InvalidatePipelineCache();
+		FatalError("Vulkan Call failed with %s", ResultToString(result));
+		return result;
+	}
+
+	return result;
+}
+
+static void D3D12ResultFailed(HRESULT hr)
+{
+	constexpr auto errorBufferCount = 4096;
+	std::wstring errorDescription(errorBufferCount, L'\0');
+	DXGetErrorDescriptionW(hr, errorDescription.data(), errorBufferCount);
+
+	std::wstring errorString = DXGetErrorStringW(hr);
+	if (errorString.empty())
+	{
+		errorString = va(L"0x%08x", hr);
+	}
+
+	std::string removedError;
+	if (hr == DXGI_ERROR_DEVICE_REMOVED)
+	{
+		HRESULT removedReason = static_cast<ID3D12Device*>(GetGraphicsDriverHandle())->GetDeviceRemovedReason();
+
+		std::wstring removedDescription(2048, L'\0');
+		DXGetErrorDescriptionW(removedReason, removedDescription.data(), 2048);
+		removedDescription.resize(wcslen(removedDescription.c_str()));
+
+		std::wstring removedString = DXGetErrorStringW(removedReason);
+
+		if (removedString.empty())
+		{
+			removedString = va(L"0x%08x", removedReason);
+		}
+
+		removedError = ToNarrow(fmt::sprintf(L"\nGetDeviceRemovedReason returned %s - %s", removedString, removedDescription));
+	}
+
+	InvalidatePipelineCache();
+	FatalError("DirectX encountered an unrecoverable error: %s - %s%s", ToNarrow(errorString).c_str(), ToNarrow(errorDescription).c_str(), removedError.c_str());
 }
 
 static HookFunction hookFunction([]()
@@ -300,4 +549,89 @@ static HookFunction hookFunction([]()
 		hook::nop(location, 6);
 		hook::call(location, vkCreateDeviceHook);
 	}
+
+	// D3D12 CreateDevice Hook
+	// 1491.50 calls D3D12CreateDevice up to 4 times when creating the real D3D12Device
+	{
+		auto p = hook::pattern("48 8B CB FF 15 ? ? ? ? 8B C8").count(4);
+
+		for (int i = 0; i < p.size(); i++)
+		{
+			auto location = p.get(i).get<char>(3);
+			hook::nop(location, 6);
+			hook::call(location, D3D12CreateDeviceWrap);
+		}
+	}
+
+	// no ShowWindow early
+	{
+		auto location = hook::get_pattern<char>("48 85 C0 0F 45 D1", 9);
+		// ShowWindow
+		hook::nop(location, 6);
+		// UpdateWindow
+		hook::nop(location + 9, 6);
+		// SetFocus
+		hook::nop(location + 18, 6);
+	}
+	
+	// Hook crashometry call that has useful information passed to it related to graphics
+	{
+		auto location = hook::get_pattern("48 89 54 24 ? 48 89 4C 24 ? 55 56 57 41 54 41 56");
+		hook::jump(location, SetCrashometryData);
+	}
+
+	// D3D12: Catch FAILED calls and provide an error from DXErr instead of a generic ERR_GFX_STATE error
+	{
+		auto location = hook::get_pattern("C1 FB ? BA");
+		hook::nop(location, 0x1c);
+		hook::put<uint32_t>(location, 0xCB8B48); // mov rcx, rbx
+		hook::call((uintptr_t)location + 3, D3D12ResultFailed);
+	}
+
+	// Same for Vulkan, Vulkan has three ERR_GFX_STATE errors, one for VK_ERROR_DEVICE_LOST, one for Swapchain Creation and an unknown one.
+	// VK_ERROR_DEVICE_LOST exclusively, called after most vk functions.
+	{
+		auto location = hook::get_pattern("FF 90 ? ? ? ? BA ? ? ? ? B9 ? ? ? ? 41 B8");
+		hook::nop(location, 27);
+		hook::put<uint32_t>(location, 0xCB8B48); // mov rcx, rbx
+		hook::call((uintptr_t)location + 3, VulkanDeviceLost);
+	}
+
+	// Vulkan Swapchain creation. (VK_NOT_READY, VK_TIMEOUT, VK_ERROR_SURFACE_LOST_KHR etc falsely reported this as a D3D crash)
+	{
+		auto location = hook::get_pattern<char>("E8 ? ? ? ? 85 C0 0F 85 ? ? ? ? 41 8A 87");
+		hook::nop(location, 5);
+		hook::call(location, VulkanFailed);
+	}
+});
+
+// Create D3D12 device to load the UMD early.
+// Vulkan originally was loaded here but it appeared to have some side-effects and from testing didn't yield a significant speedup.
+static InitFunction initFunction([]()
+{
+	{
+		auto state = CfxState::Get();
+		if (!state->IsGameProcess())
+		{
+			return;
+		}
+	}
+
+	std::thread([]()
+	{
+		IDXGIAdapter* adapter = nullptr;
+		DXGIGetHighPerfAdapter(&adapter);
+
+		WRL::ComPtr<ID3D12Device> device;
+		HRESULT hr = D3D12CreateDevice(
+		adapter,
+		D3D_FEATURE_LEVEL_11_0,
+		IID_PPV_ARGS(&device));
+
+		if (adapter)
+		{
+			adapter->Release();
+		}
+		Sleep(20000);
+	}).detach();
 });


### PR DESCRIPTION
### Goal of this PR

third time's a charm. Reapplies #4033 with additional fixes to combat issues that were reported with the previous iteration of these changes. 

- Introduce fallback logic for cases where the GPU claims to support 'VK_KHR_external_memory_win32' but then doesn't implement/support 'vkGetMemoryWin32HandlePropertiesKHR' (thanks nvidia)
- Clean-up SRV's created for NUI. These SRV's weren't being properly released/recycled back into a pool in the case of DX12.

### How is this PR achieving the goal


### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:**  1491

**Platforms:** Windows, Linux


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


