### PR TITLE
fix(scripting/mono): Block clients from using Assembly.Load with a bytearray

### DIFF
--- a/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
+++ b/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
@@ -80,6 +80,9 @@ public:
 	// Print script messages
 	static void Print(MonoString* channel, MonoString* message);
 
+	// Callback when someone calls Assembly.Load with an bytearray
+	static void AssemblyLoadCallback(MonoAssembly* assembly, void* user_data);
+
 	// Print exception details
 	FX_API static void PrintException(MonoObject* exc, bool fatal = false);
 

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -9,6 +9,9 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/mono-gc.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/image.h>
 
 #ifndef IS_FXSERVER
 extern "C" {
@@ -137,7 +140,30 @@ void MonoComponentHostShared::Initialize()
 		mono_domain_set_config(rootDomain, (basePath + "cfg/mono/").c_str(), "cfx.config");
 
 		mono_install_unhandled_exception_hook(UnhandledException, nullptr);
+		mono_install_assembly_load_hook(AssemblyLoadCallback, nullptr);
 	}
+}
+
+void MonoComponentHostShared::AssemblyLoadCallback(MonoAssembly* assembly, void* user_data)
+{
+	MonoImage* image = mono_assembly_get_image(assembly);
+	if (!image)
+		return;
+
+	const char* filename = mono_image_get_filename(image);
+	const char* assembly_name = mono_assembly_get_name(assembly);
+
+   #ifndef IS_FXSERVER
+	// Just block Assembly.Load on client side if they try to load it from memory directly from an byte array
+	if (filename == NULL || strlen(filename) == 0 || strcmp(filename, assembly_name) == 0)
+	{
+		MonoDomain* currentDomain = mono_domain_get();
+		if (currentDomain)
+		{
+			mono_jit_cleanup(currentDomain);
+		}
+	}
+   #endif
 }
 
 void MonoComponentHostShared::PrintException(MonoObject* exc, bool fatal)

--- a/code/components/citizen-server-impl/include/ServerLicensingComponent.h
+++ b/code/components/citizen-server-impl/include/ServerLicensingComponent.h
@@ -3,15 +3,21 @@
 class ServerLicensingComponent : public fwRefCountable
 {
 public:
-	ServerLicensingComponent(const std::string& key, const std::string& listingToken)
+	ServerLicensingComponent(const std::string& key, const std::string& nucleusToken, const std::string& listingToken)
 	{
 		m_key = key;
+		m_nucleusToken = nucleusToken;
 		m_listingToken = listingToken;
 	}
 
 	inline std::string GetLicenseKey()
 	{
 		return m_key;
+	}
+
+	inline std::string GetNucleusToken()
+	{
+		return m_nucleusToken;
 	}
 
 	inline std::string GetListingToken()
@@ -21,6 +27,7 @@ public:
 
 private:
 	std::string m_key;
+	std::string m_nucleusToken;
 	std::string m_listingToken;
 };
 

--- a/code/components/citizen-server-impl/src/ResourceHttpHandler.cpp
+++ b/code/components/citizen-server-impl/src/ResourceHttpHandler.cpp
@@ -323,6 +323,34 @@ static InitFunction initFunction([]()
 	{
 		instance->GetComponent<fx::HttpServerManager>()->AddEndpoint("/", [=](const fwRefContainer<net::HttpRequest>& request, fwRefContainer<net::HttpResponse> response)
 		{
+			auto webVar = instance->GetComponent<console::Context>()->GetVariableManager()->FindEntryRaw("web_baseUrl");
+
+			if (webVar)
+			{
+				auto wvv = webVar->GetValue();
+				std::string_view wvvv{
+					wvv
+				};
+
+				auto endPos = wvvv.find(".users.cfx.re");
+
+				if (endPos != std::string::npos)
+				{
+					auto startPos = wvvv.rfind("-", endPos);
+
+					if (startPos != std::string::npos)
+					{
+						auto webUrl = fmt::sprintf("https://cfx.re/join/%s", wvvv.substr(startPos + 1, endPos - (startPos + 1)));
+
+						response->SetStatusCode(302);
+						response->SetHeader("Location", webUrl);
+
+						response->End("Redirecting...");
+						return;
+					}
+				}
+			}
+
 			auto data = nlohmann::json::object(
 				{
 					{ "version", "FXServer-" GIT_DESCRIPTION }

--- a/code/components/citizen-server-impl/src/ServerNucleusMock.cpp
+++ b/code/components/citizen-server-impl/src/ServerNucleusMock.cpp
@@ -1,0 +1,127 @@
+#include <StdInc.h>
+
+#include <CoreConsole.h>
+
+#include <GameServer.h>
+#include <HttpClient.h>
+
+#include <ResourceEventComponent.h>
+#include <ResourceManager.h>
+
+#include <ServerInstanceBase.h>
+#include <ServerLicensingComponent.h>
+
+#include <StructuredTrace.h>
+
+#include <TcpListenManager.h>
+
+#include <chrono>
+
+static InitFunction initFunction([]()
+{
+	static auto httpClient = new HttpClient();
+
+	fx::ServerInstanceBase::OnServerCreate.Connect([](fx::ServerInstanceBase* instance)
+	{
+		using namespace std::chrono_literals;
+
+		static bool registerSent = false;
+		static bool registerSuccess = false;
+		static std::chrono::milliseconds registerTimeout{};
+		static auto registerDelay = 15s;
+
+		instance->GetComponent<fx::GameServer>()->OnTick.Connect([instance]()
+		{
+			if (registerSuccess)
+			{
+				return;
+			}
+
+			if (registerSent && msec() < registerTimeout)
+			{
+				return;
+			}
+
+			auto licenseTokenVar = instance->GetComponent<console::Context>()->GetVariableManager()->FindEntryRaw("sv_licenseKeyToken");
+
+			if (!licenseTokenVar || licenseTokenVar->GetValue().empty())
+			{
+				return;
+			}
+
+			auto licensingComponent = instance->GetComponent<ServerLicensingComponent>();
+			auto nucleusToken = licensingComponent->GetNucleusToken();
+
+			if (nucleusToken.empty())
+			{
+				return;
+			}
+
+			auto tlm = instance->GetComponent<fx::TcpListenManager>();
+
+			auto reqJson = nlohmann::json::object({
+				{ "token", nucleusToken },
+				{ "port", fmt::sprintf("%d", tlm->GetPrimaryPort()) },
+				{ "ipOverride", instance->GetComponent<fx::GameServer>()->GetIpOverrideVar()->GetValue() },
+			});
+
+			registerTimeout = msec() + registerDelay;
+			registerSent = true;
+
+			HttpRequestOptions opts;
+			opts.ipv4 = true;
+
+			httpClient->DoPostRequest("https://cfx.re/api/register/?v=2", reqJson.dump(), opts, [instance](bool success, const char* data, size_t length)
+			{
+				auto backoff = [&]()
+				{
+					if (registerDelay < 15min)
+					{
+						registerDelay *= 2;
+					}
+					registerTimeout = msec() + registerDelay;
+				};
+
+				if (!success)
+				{
+					backoff();
+					return;
+				}
+
+				std::string host;
+				try
+				{
+					auto resp = nlohmann::json::parse(std::string(data, length));
+					host = resp.value("host", "");
+				}
+				catch (const std::exception&)
+				{
+					backoff();
+					return;
+				}
+
+				if (host.empty())
+				{
+					backoff();
+					return;
+				}
+
+				auto url = fmt::sprintf("https://%s/", host);
+
+				instance->GetComponent<fx::ResourceManager>()
+					->GetComponent<fx::ResourceEventManagerComponent>()
+					->QueueEvent2(
+						"_cfx_internal:nucleusConnected",
+						{},
+						url
+					);
+
+				StructuredTrace({ "type", "nucleus_connected" }, { "url", url });
+
+				static auto webVar = instance->AddVariable<std::string>("web_baseUrl", ConVar_None, host);
+
+				registerSuccess = true;
+			});
+		});
+	}, INT32_MAX);
+});

--- a/code/components/citizen-server-monitor/src/MonitorNucleusMock.cpp
+++ b/code/components/citizen-server-monitor/src/MonitorNucleusMock.cpp
@@ -1,0 +1,147 @@
+#include <StdInc.h>
+
+#include <CoreConsole.h>
+
+#include <HttpClient.h>
+
+#include <ResourceEventComponent.h>
+#include <ResourceManager.h>
+
+#include <MonitorInstance.h>
+#include <TcpListenManager.h>
+
+#include <json.hpp>
+
+#include <boost/random/random_device.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <chrono>
+
+extern fwEvent<fx::MonitorInstance*> OnMonitorTick;
+
+inline auto msec()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+}
+
+static InitFunction initFunction([]()
+{
+	static auto httpClient = new HttpClient();
+
+	using namespace std::chrono_literals;
+
+	static bool registerSent = false;
+	static bool registerSuccess = false;
+	static std::chrono::milliseconds registerTimeout{};
+	static auto registerDelay = 15s;
+
+	OnMonitorTick.Connect([](fx::MonitorInstance* instance)
+	{
+		if (registerSuccess)
+		{
+			return;
+		}
+
+		if (registerSent && msec() < registerTimeout)
+		{
+			return;
+		}
+
+		std::string extToken;
+		{
+			char tokenData[64] = { 0 };
+			fwPlatformString tokenPath = MakeRelativeCitPath("server-monitor-token.key");
+
+			if (auto f = _pfopen(tokenPath.c_str(), _P("rb")))
+			{
+				fgets(tokenData, std::size(tokenData), f);
+				fclose(f);
+			}
+
+			if (!tokenData[0])
+			{
+				std::string token = boost::uuids::to_string(boost::uuids::basic_random_generator<boost::random_device>()());
+
+				if (auto f = _pfopen(tokenPath.c_str(), _P("wb")))
+				{
+					fmt::fprintf(f, "%s", token);
+					fclose(f);
+				}
+
+				extToken = token;
+			}
+			else
+			{
+				extToken = tokenData;
+			}
+		}
+
+		static ConVar<std::string> serverProfile("serverProfile", ConVar_None, "default");
+		extToken += "_" + serverProfile.GetValue();
+
+		auto tlm = instance->GetComponent<fx::TcpListenManager>();
+
+		auto reqJson = nlohmann::json::object({
+			{ "token", "anonymous" },
+			{ "tokenEx", extToken },
+			{ "port", fmt::sprintf("%d", tlm->GetPrimaryPort()) },
+		});
+
+		registerTimeout = msec() + registerDelay;
+		registerSent = true;
+
+		HttpRequestOptions opts;
+		opts.ipv4 = true;
+
+		httpClient->DoPostRequest("https://cfx.re/api/register/?v=2", reqJson.dump(), opts, [instance](bool success, const char* data, size_t length)
+		{
+			auto backoff = [&]()
+			{
+				if (registerDelay < 15min)
+				{
+					registerDelay *= 2;
+				}
+				registerTimeout = msec() + registerDelay;
+			};
+
+			if (!success)
+			{
+				backoff();
+				return;
+			}
+
+			std::string host;
+			try
+			{
+				auto resp = nlohmann::json::parse(std::string(data, length));
+				host = resp.value("host", "");
+			}
+			catch (const std::exception&)
+			{
+				backoff();
+				return;
+			}
+
+			if (host.empty())
+			{
+				backoff();
+				return;
+			}
+
+			auto url = fmt::sprintf("https://%s/", host);
+
+			instance->GetComponent<fx::ResourceManager>()
+				->GetComponent<fx::ResourceEventManagerComponent>()
+				->QueueEvent2(
+					"_cfx_internal:nucleusConnected",
+					{},
+					url
+				);
+
+			static auto webVar = instance->AddVariable<std::string>("web_baseUrl", ConVar_None, host);
+
+			registerSuccess = true;
+		});
+	});
+});


### PR DESCRIPTION
### Goal of this PR
So basically people can load Assembly directly into the memory using Assembly.Load(bytearray) this is a very serious concern for the security and i don't think any resource should need to be able to do this

...


### How is this PR achieving the goal
my pr adds an hook into the assembly loading and checks if the caller is loading from a bytearray or not and cancel it out and allows the server to do this with no issues
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Fivem,RedM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 3258 but works for all

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.



