### PR TITLE
fix(scripting/mono): fixed the trusted code check to be actually call…

### DIFF
--- a/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
+++ b/code/components/citizen-scripting-mono/include/MonoComponentHostShared.h
@@ -86,6 +86,8 @@ public:
 #if COMPILE_MONO_RUNTIME_METHODS
 	// Hook to handle unhandled exceptions
 	static void UnhandledException(MonoObject* exc, void* userData);
+	// Hook to assembly Load
+	static void AssemblyLoadCallback(MonoAssembly* assembly, void* user_data);
 
 private:
 	// Hook to that determines if the loading of an image/assembly is trusted/platform or untrusted/UGC code

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -9,6 +9,8 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/mono-gc.h>
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/image.h>
 
 #ifndef IS_FXSERVER
 extern "C" {
@@ -137,8 +139,11 @@ void MonoComponentHostShared::Initialize()
 		mono_domain_set_config(rootDomain, (basePath + "cfg/mono/").c_str(), "cfx.config");
 
 		mono_install_unhandled_exception_hook(UnhandledException, nullptr);
+		mono_install_assembly_load_hook(AssemblyLoadCallback, nullptr);
 	}
 }
+
+
 
 void MonoComponentHostShared::PrintException(MonoObject* exc, bool fatal)
 {
@@ -176,6 +181,29 @@ void MonoComponentHostShared::PrintException(MonoObject* exc, bool fatal)
 		mono_free(msg2CStr);
 	}
 }
+
+#if COMPILE_MONO_RUNTIME_METHODS
+void MonoComponentHostShared::AssemblyLoadCallback(MonoAssembly* assembly, void* user_data)
+{
+	MonoImage* image = mono_assembly_get_image(assembly);
+	if (!image)
+		return;
+
+	const char* filename = mono_image_get_filename(image);
+
+   #ifndef IS_FXSERVER
+	// block if the code is not trusted
+	if (MonoComponentHostShared::CoreCLRIsTrustedCode(filename) == 0)
+	{
+		MonoDomain* currentDomain = mono_domain_get();
+		if (currentDomain)
+		{
+			mono_jit_cleanup(currentDomain);
+		}
+	}
+   #endif
+}
+#endif
 
 #if COMPILE_MONO_RUNTIME_METHODS
 #ifndef IS_FXSERVER


### PR DESCRIPTION
### Goal of this PR
the trusted code check was never properly implemented and people could load any image using Assembly.Load(bytearray) so i have added a hook to the image load and implemented the check this is very dengerous as bad actors could load anything with this method

...


### How is this PR achieving the goal
added a hook which would then call MonoComponentHostShared::CoreCLRIsTrustedCode to check if the image should be loaded from the right path
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
Fivem/RedM
ScRt: C#
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 3258 but should work on all

**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.