### PR TITLE
fix(server/state): lock syncedEntities in the client tick loop

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -662,6 +662,10 @@ ServerGameState::ServerGameState()
 
 fx::sync::SyncEntityPtr ServerGameState::GetEntity(uint8_t playerId, uint16_t objectId)
 {
+	// .size() needs to be read under the lock too - m_entitiesById can be resized by another thread between
+	// this check and the shared_lock below otherwise.
+	std::shared_lock _lock(m_entitiesByIdMutex);
+
 	if (objectId >= m_entitiesById.size() || objectId < 0)
 	{
 		return {};
@@ -670,7 +674,6 @@ fx::sync::SyncEntityPtr ServerGameState::GetEntity(uint8_t playerId, uint16_t ob
 	uint16_t objIdAlias = objectId;
 	debug::Alias(&objIdAlias);
 
-	std::shared_lock _lock(m_entitiesByIdMutex);
 	return m_entitiesById[objectId].lock();
 }
 
@@ -1444,22 +1447,28 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 		const auto& clientRegistry = m_instance->GetComponent<fx::ClientRegistry>();
 		
 		// if any relevant entities are getting deleted, add them to our removal list and remove them from the relevancy list.
+		// ReassignEntityInner writes into this same syncedEntities map (under selfMutex, via GetClientData) whenever
+		// another client's tick task reassigns an entity we're relevant to, so our own walk/erase here needs the
+		// same lock or the two can hit this eastl::fixed_map from two different TBB threads at once.
 		auto& syncedEntities = clientDataUnlocked->syncedEntities;
 		auto& entitiesToDestroy = clientDataUnlocked->entitiesToDestroy;
-		for (auto entityIt = syncedEntities.begin(), entityEnd = syncedEntities.end(); entityIt != entityEnd;)
 		{
-			auto [identPair, syncData] = *entityIt;
-			auto oldIt = entityIt;
-
-			++entityIt;
-
-			auto& entity = syncData.entity;
-
-			if (entity->deleting)
+			std::unique_lock _(clientDataUnlocked->selfMutex);
+			for (auto entityIt = syncedEntities.begin(), entityEnd = syncedEntities.end(); entityIt != entityEnd;)
 			{
-				GS_LOG("deleting [obj:%d:%d] because it's deleting\n", entity->handle, entity->uniqifier);
-				entitiesToDestroy[identPair] = { entity, { false, false } };
-				syncedEntities.erase(oldIt);
+				auto [identPair, syncData] = *entityIt;
+				auto oldIt = entityIt;
+
+				++entityIt;
+
+				auto& entity = syncData.entity;
+
+				if (entity->deleting)
+				{
+					GS_LOG("deleting [obj:%d:%d] because it's deleting\n", entity->handle, entity->uniqifier);
+					entitiesToDestroy[identPair] = { entity, { false, false } };
+					syncedEntities.erase(oldIt);
+				}
 			}
 		}
 
@@ -1622,6 +1631,12 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 			auto& entity = syncData.entity;
 			auto& forceUpdate = syncData.forceUpdate;
 
+			// same syncedEntities map as the deletion scan above - needs the same selfMutex ReassignEntityInner
+			// already takes via GetClientData when another client's tick task reaches in. dropped below around
+			// calls that can loop back into GetClientData(this, client) for this exact client, since selfMutex
+			// isn't recursive and self-relocking it would deadlock this tick thread against itself.
+			std::unique_lock selfLock(clientDataUnlocked->selfMutex);
+
 			// relevant entity owned by nobody, or wants a reassign? try to yoink it
 			// (abuse clientMutex for wantsReassign safety)
 			{
@@ -1630,13 +1645,23 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 				if (!cl || (entity->wantsReassign && cl->GetNetId() != client->GetNetId()))
 				{
 					entity->wantsReassign = false;
+
+					// ReassignEntity -> ReassignEntityInner notifies every client relevant to this entity,
+					// which includes us if we're relevant - that path calls GetClientData(this, client) for us.
+					selfLock.unlock();
 					ReassignEntity(entity->handle, client, std::move(_)); // transfer the lock inside
+					selfLock.lock();
 				}
 			}
 
 			if (!syncData.hasCreated)
 			{
 				bool canCreate = true;
+
+				// GetClientData(this, client) a few lines down (BigMode player-scope bookkeeping) targets this
+				// same client - same self-relock risk as the reassign above.
+				selfLock.unlock();
+
 				if (fx::IsBigMode())
 				{
 					if (entity->type == sync::NetObjEntityType::Player)
@@ -1724,6 +1749,8 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 						}
 					}
 				}
+
+				selfLock.lock();
 
 				if (!canCreate)
 				{
@@ -4186,12 +4213,10 @@ void ServerGameState::SendArrayData(const fx::ClientSharedPtr& client)
 {
 	auto data = GetClientDataUnlocked(this, client);
 
-	decltype(m_arrayHandlers)::iterator arrayRef;
-
-	{
-		std::shared_lock s(m_arrayHandlersMutex);
-		arrayRef = m_arrayHandlers.find(data->routingBucket);
-	}
+	// m_arrayHandlers holds unique_ptrs, so we can't copy a handler out and unlock early - keep the shared_lock
+	// held for as long as we're using arrayRef, otherwise a concurrent erase (2340) can free it out from under us.
+	std::shared_lock s(m_arrayHandlersMutex);
+	auto arrayRef = m_arrayHandlers.find(data->routingBucket);
 
 	if (arrayRef != m_arrayHandlers.end())
 	{


### PR DESCRIPTION
### Goal of this PR
GameStateClientData::syncedEntities gets read and erased unlocked in Tick()'s
per-client loop, but ReassignEntityInner takes selfMutex on it when a
different client's tick task forces an update on an entity we're both
relevant to. parallel_for_each runs one TBB task per client, so this is two
threads touching the same eastl::fixed_map, one of them without a lock.

Traced the history on this: 638a776170 (2020) replaced an always-locked,
per-entity notification mechanism with a direct write into the target
client's own map, locked through GetClientData. The home side of the loop
kept using the old unlocked convention and nobody went back to fix it up.
5fa2ae542 added selfMutex to two other mutation points in the same function
a month later but missed this one.

### How is this PR achieving the goal
Wrapped the loop's direct touches of syncedEntities (the delete-scan pass
and the main sync pass) in selfMutex, same as ReassignEntityInner already
does.

The one thing that made this not a one-line fix: GetClientData(this, client)
and ReassignEntity/ReassignEntityInner can both call back into this exact
client's own selfMutex (ReassignEntityInner notifies every client relevant
to the reassigned entity, and that includes us). selfMutex is a plain
std::mutex, not recursive, so holding it across those calls would deadlock
the tick thread against itself. The lock gets dropped right before both
call sites and reacquired right after, everything else in the loop stays
covered.

While in there I also fixed two smaller, unrelated locking gaps in the same
file that were easy to close without touching anything else:
- SendArrayData looked up an iterator under m_arrayHandlersMutex, released
  the lock, then dereferenced the iterator. m_arrayHandlers erases happen
  elsewhere under a unique lock, so that's a use-after-free window. Now the
  shared_lock just stays held for the lookup and the dereference.
- GetEntity(uint8_t, uint16_t) checked m_entitiesById.size() before taking
  m_entitiesByIdMutex. Moved the whole bounds check under the lock.

### This PR applies to the following area(s)
Server (OneSync)

### Successfully tested on
Not build/soak tested yet, flagging this explicitly rather than checking
the box below. This needs a real build and some load (ideally something
that exercises entity reassignment, trains/vehicles changing hands a lot)
before merging.

### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [ ] No extra compilation warnings are added by these changes.

### Fixes issues
No linked issue, found during a concurrency audit of ServerGameState.cpp
(see docs/threading-map.md in this branch for the full trace).
