### PR TITLE
fix(gta-core-five): door auto-open framerate independent

### DIFF
--- a/code/components/gta-core-five/src/PatchDoorFrameRate.cpp
+++ b/code/components/gta-core-five/src/PatchDoorFrameRate.cpp
@@ -1,0 +1,31 @@
+#include "StdInc.h"
+#include "Hooking.Patterns.h"
+struct PatternPair
+{
+	std::string_view pattern;
+	int offset;
+};
+
+static HookFunction hookFunction([]()
+{
+	// Opening speed: divisor = Max(0.03, realDt) clamps to 0.03 above ~33 FPS
+	{
+		auto loc = hook::get_pattern("F3 44 0F 10 3D ? ? ? ? 41 0F 2F D7");
+		hook::nop(loc, 9);
+		hook::put<uint32_t>(loc, 0xFF570F45); // xorps xmm15, xmm15
+	}
+
+	// Wake the collider for ALL auto door types
+	{
+		std::initializer_list<PatternPair> doorTorqueLocs = {
+			{ "44 0F 2F 0D ? ? ? ? 76 ? 48 8B CB", 8 }, // BAR
+			{ "44 0F 2F C8 76 ? 48 8B CB", 4 }, // GRG
+			{ "0F 2F F9 76 ? 48 8B CB", 3 } // SLD
+		};
+
+		for (auto& entry : doorTorqueLocs)
+		{
+			hook::nop(hook::get_pattern(entry.pattern, entry.offset), 2);
+		}
+	}
+});


### PR DESCRIPTION
### Goal of this PR
Make automatic sliding doors, gates and barriers actually open at high framerates. On high-FPS PCs they get stuck and you have to push them, this fix it and now they open on their own like they're supposed to.

https://github.com/user-attachments/assets/826ba35d-7a49-422c-af3a-e55208a828ef


### How is this PR achieving the goal
Sliding doors divided their opening force by Max(0.03, timestep), so above ~33 FPS the force got scaled way down, with this I zero the 0.03 so it uses the real timestep. And every door type skipped ActivatePhysics() when the per-frame delta was under a fixed epsilon (which never happens at high FPS), so the collider never woke up.


### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3407

**Platforms:** Windows, Linux


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
https://forum.cfx.re/t/sliding-doors-and-gates-not-opening-unless-force-applied-to-them-first/