### PR TITLE
fix(server/state): don't insert into the world grid map under a shared lock

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -1048,6 +1048,21 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 		auto slotId = client->GetSlotId();
 		auto netId = client->GetNetId();
 
+		// look up the world grid for the client's routing bucket once: grids are only created
+		// and erased in UpdateWorldGrid, which ran earlier in this tick on this thread, so the
+		// pointer stays valid for the whole pass and we don't need to lock per entity
+		const WorldGrid* worldGrid = nullptr;
+
+		if (playerEntity)
+		{
+			std::shared_lock _(m_worldGridsMutex);
+
+			if (auto gridIt = m_worldGrids.find(clientDataUnlocked->routingBucket); gridIt != m_worldGrids.end())
+			{
+				worldGrid = gridIt->second.get();
+			}
+		}
+
 		auto& currentSyncedEntities = clientDataUnlocked->syncedEntities;
 		decltype(clientDataUnlocked->syncedEntities) newSyncedEntities{};
 
@@ -1089,19 +1104,17 @@ void ServerGameState::Tick(fx::ServerInstanceBase* instance)
 					}
 
 					// are we owning the world grid in which this entity exists?
-					int sectorX = std::max(entityPos.x + 8192.0f, 0.0f) / 150;
-					int sectorY = std::max(entityPos.y + 8192.0f, 0.0f) / 150;
-
-					auto selfBucket = clientDataUnlocked->routingBucket;
-
-					std::shared_lock _(m_worldGridsMutex);
-					const auto& grid = m_worldGrids[selfBucket];
-
-					if (grid && sectorX >= 0 && sectorY >= 0 && sectorX < 256 && sectorY < 256)
+					if (worldGrid)
 					{
-						if (grid->accel.netIDs[sectorX][sectorY] == netId)
+						int sectorX = std::max(entityPos.x + 8192.0f, 0.0f) / 150;
+						int sectorY = std::max(entityPos.y + 8192.0f, 0.0f) / 150;
+
+						if (sectorX >= 0 && sectorY >= 0 && sectorX < 256 && sectorY < 256)
 						{
-							return true;
+							if (worldGrid->accel.netIDs[sectorX][sectorY] == netId)
+							{
+								return true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Goal of this PR

While reading the relevance pass in `ServerGameState::Tick` I noticed it resolves the world grid differently from every other place that touches `m_worldGrids`:

```cpp
std::shared_lock _(m_worldGridsMutex);
const auto& grid = m_worldGrids[selfBucket];
```

Everything else uses `find()`. `operator[]` on a `std::map` inserts when the key is missing, and here that happens while holding only the reader side of the lock, racing any concurrent reader of the map. The key can actually be missing: `UpdateWorldGrid` creates grids at the start of the tick, but a routing bucket change from another thread (or a player entity appearing mid tick) leaves the pass looking at a bucket that has no grid yet.

The inserted entry is also a default constructed null `unique_ptr`, and since `UpdateWorldGrid` only creates a grid when `find()` fails, it keeps finding the null entry and bailing on its `if (!grid)` check. From then on nobody in that bucket gets world grid ownership until the bucket empties out.

### How is this PR achieving the goal

Resolving the grid once per client with `find()` before the entity loop, like the other call sites do. This is safe because grids are only created and erased in `UpdateWorldGrid`, which runs earlier in the same tick on the same thread. A missing grid now just means no world grid relevance for that pass, which is what the next tick would produce anyway, instead of poisoning the bucket.

This also removes a `shared_mutex` acquisition and a map walk per entity per client from the pass.

### This PR applies to the following area(s)

Server, OneSync

### Successfully tested on

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues