### PR TITLE
fix(server/state): ignore stale frame acknowledgements

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -4397,9 +4397,14 @@ void ServerGameState::HandleGameStateAck(fx::ServerInstanceBase* instance, const
 	}
 
 	auto [lock, clientData] = GetClientData(sgs.GetRef(), client);
-			
-	const auto& ref = clientData->frameStates[frameIndex];
-	const ClientEntityState& clientEntityState = ref;
+
+	auto frameIt = clientData->frameStates.find(frameIndex);
+	if (frameIt == clientData->frameStates.end())
+	{
+		return;
+	}
+
+	const ClientEntityState& clientEntityState = frameIt->second;
 
 	{
 		for (const uint16_t objectId : packet.GetRecreateList())


### PR DESCRIPTION
### Goal of this PR
Avoid creating an empty client frame state when an acknowledgement arrives after its frame has already been removed.

### How is this PR achieving the goal
`frameStates[frameIndex]` inserts a default `ClientEntityState` when the ACK is for a frame that is no longer tracked.

Using `find()` lets us ignore those late ACKs without mutating the map. Existing frames still follow the same ACK path as before :p

### This PR applies to the following area(s)
Server

### Successfully tested on
**Game builds:** 3258

**Platforms:** Windows

Verified by replaying an ACK after its frame had already been removed.

### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
No linked issue.