### PR TITLE
fix(streaming/five): add missing lock in GetStreamingIndexForLocalHashKey

### DIFF
--- a/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
+++ b/code/components/gta-streaming-five/src/StreamingFreeTests.cpp
@@ -247,6 +247,8 @@ namespace streaming
 
 	uint32_t GetStreamingIndexForLocalHashKey(streaming::strStreamingModule* module, uint32_t hash)
 	{
+		std::shared_lock _(g_streamingMapMutex);
+
 		auto entry = g_streamingHashStoresToIndices.find({ module, hash });
 
 		if (entry != g_streamingHashStoresToIndices.end())


### PR DESCRIPTION
## Goal of this PR

Fix a data race in `streaming::GetStreamingIndexForLocalHashKey`.

The function reads `g_streamingHashStoresToIndices` without acquiring `g_streamingMapMutex`, while `AddStreamingFileWrap` writes to the same map under a `std::unique_lock`. The three sibling accessors (`GetStreamingIndexForName`, `GetStreamingNameForIndex`, `GetStreamingBaseNameForHash`) all correctly take a `std::shared_lock`; this one was missing it.

A concurrent `find()` on a `std::map` while another thread inserts (rebalancing the tree) is undefined behavior and can cause intermittent crashes/corruption while custom streaming assets are being registered.

## How is this PR achieving the goal

Acquire `std::shared_lock _(g_streamingMapMutex);` at the top of the function, matching the other accessors in the same file.

## This PR applies to the following area(s)

FiveM

## Successfully tested on

**Game builds:** n/a (adds a missing lock, no functional change)

**Platforms:** Windows

## Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
