### PR TITLE
tweak(state-bags): skip msgpack unpack when no change handler matches

### DIFF
--- a/code/components/citizen-resources-core/include/StateBagComponent.h
+++ b/code/components/citizen-resources-core/include/StateBagComponent.h
@@ -185,7 +185,27 @@ public:
 	virtual void SetRole(StateBagRole role) = 0;
 
 	//
+	// A state bag change handler. Returning false will block the change.
+	//
+	using TStateBagChangeHandler = std::function<bool(int source, std::string_view bagName, std::string_view key, const msgpack::object& value, bool replicated)>;
+
+	//
+	// Adds a change handler with an associated (bagName, key) filter, where an empty
+	// filter part matches any value. Unlike direct OnStateBagChange connections, this
+	// allows SetKey to skip deserialization entirely when no filter matches a change.
+	// Returns a cookie to pass to RemoveChangeHandler.
+	//
+	virtual size_t AddChangeHandler(std::string_view bagFilter, std::string_view keyFilter, TStateBagChangeHandler handler) = 0;
+
+	//
+	// Removes a change handler added with AddChangeHandler.
+	//
+	virtual void RemoveChangeHandler(size_t cookie) = 0;
+
+	//
 	// An event handling a state bag value change.
+	// NOTE: prefer AddChangeHandler; any connection to this event forces *every*
+	// state bag change to be deserialized, whether it matches or not.
 	//
 	fwEvent<int, std::string_view, std::string_view, const msgpack::object&, bool> OnStateBagChange;
 

--- a/code/components/citizen-resources-core/src/StateBagComponent.cpp
+++ b/code/components/citizen-resources-core/src/StateBagComponent.cpp
@@ -45,6 +45,22 @@ public:
 
 	virtual void AddSafePreCreatePrefix(std::string_view idPrefix, bool useParentTargets) override;
 
+	virtual size_t AddChangeHandler(std::string_view bagFilter, std::string_view keyFilter, TStateBagChangeHandler handler) override;
+
+	virtual void RemoveChangeHandler(size_t cookie) override;
+
+	//
+	// Returns whether any change handler (filtered or legacy event) could observe a
+	// change to the given (bagName, key). Cheap: no deserialization involved.
+	//
+	bool HasChangeHandlerFor(std::string_view bagName, std::string_view key);
+
+	//
+	// Invokes the legacy change event and any matching filtered change handlers.
+	// Returns false if any handler blocked the change.
+	//
+	bool DispatchChangeHandlers(int source, std::string_view bagName, std::string_view key, const msgpack::object& value, bool replicated);
+
 	virtual StateBagRole GetRole() const override
 	{
 		return m_role;
@@ -107,6 +123,19 @@ private:
 	// *owning* pointers for pre-created bags
 	std::set<std::shared_ptr<StateBagImpl>> m_preCreatedStateBags;
 	std::shared_mutex m_preCreatedStateBagsMutex;
+
+	// filtered change handlers
+	struct ChangeHandler
+	{
+		std::string bagFilter;
+		std::string keyFilter;
+		TStateBagChangeHandler handler;
+	};
+
+	std::map<size_t, std::shared_ptr<ChangeHandler>> m_changeHandlers;
+	std::shared_mutex m_changeHandlersMutex;
+	size_t m_nextChangeHandlerCookie = 1;
+	std::atomic<size_t> m_changeHandlerCount{ 0 };
 };
 
 class StateBagImpl : public StateBag
@@ -215,12 +244,10 @@ void StateBagImpl::SetKey(int source, std::string_view key, std::string_view dat
 		static_cast<StateBagImpl*>(thisRef.get())->SetKeyInternal(source, key, data, replicated);
 	};
 
-	const auto& sbce = m_parent->OnStateBagChange;
-
-	if (sbce)
+	// only deserialize (and potentially marshal to the main thread) if any change
+	// handler could actually observe this change
+	if (m_parent->HasChangeHandlerFor(m_id, key))
 	{
-		// #TODOPERF: this will unconditionally unpack and call into svMain if *any* change handler is reg'd
-		// -> ideally we'd have a separate event so we can poll if there's a match for script filters before doing this
 		msgpack::unpacked up;
 
 		try
@@ -251,7 +278,7 @@ void StateBagImpl::SetKey(int source, std::string_view key, std::string_view dat
 				up = std::move(up)
 			]()
 			{
-				if (parent->OnStateBagChange(source, id, key, up.get(), replicated))
+				if (parent->DispatchChangeHandlers(source, id, key, up.get(), replicated))
 				{
 					continuation(key, data);
 				}
@@ -260,7 +287,7 @@ void StateBagImpl::SetKey(int source, std::string_view key, std::string_view dat
 			return;
 		}
 
-		if (!sbce(source, m_id, key, up.get(), replicated))
+		if (!m_parent->DispatchChangeHandlers(source, m_id, key, up.get(), replicated))
 		{
 			return;
 		}
@@ -602,6 +629,89 @@ void StateBagComponentImpl::UnregisterTarget(int id)
 			b->RemoveRoutingTarget(id);
 		}
 	}
+}
+
+size_t StateBagComponentImpl::AddChangeHandler(std::string_view bagFilter, std::string_view keyFilter, TStateBagChangeHandler handler)
+{
+	std::unique_lock lock(m_changeHandlersMutex);
+
+	auto cookie = m_nextChangeHandlerCookie++;
+	m_changeHandlers.emplace(cookie, std::make_shared<ChangeHandler>(ChangeHandler{ std::string{ bagFilter }, std::string{ keyFilter }, std::move(handler) }));
+	m_changeHandlerCount.fetch_add(1, std::memory_order_relaxed);
+
+	return cookie;
+}
+
+void StateBagComponentImpl::RemoveChangeHandler(size_t cookie)
+{
+	std::unique_lock lock(m_changeHandlersMutex);
+
+	if (m_changeHandlers.erase(cookie))
+	{
+		m_changeHandlerCount.fetch_sub(1, std::memory_order_relaxed);
+	}
+}
+
+bool StateBagComponentImpl::HasChangeHandlerFor(std::string_view bagName, std::string_view key)
+{
+	// a direct event connection can't be filtered, so it always matches
+	if (OnStateBagChange)
+	{
+		return true;
+	}
+
+	// common case: no handlers registered at all
+	if (m_changeHandlerCount.load(std::memory_order_relaxed) == 0)
+	{
+		return false;
+	}
+
+	std::shared_lock lock(m_changeHandlersMutex);
+
+	for (const auto& [cookie, handler] : m_changeHandlers)
+	{
+		if ((handler->keyFilter.empty() || key == handler->keyFilter) &&
+			(handler->bagFilter.empty() || bagName == handler->bagFilter))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool StateBagComponentImpl::DispatchChangeHandlers(int source, std::string_view bagName, std::string_view key, const msgpack::object& value, bool replicated)
+{
+	if (!OnStateBagChange(source, bagName, key, value, replicated))
+	{
+		return false;
+	}
+
+	// collect matching handlers first: a handler may add/remove handlers itself
+	eastl::fixed_vector<std::shared_ptr<ChangeHandler>, 16> matchingHandlers;
+
+	{
+		std::shared_lock lock(m_changeHandlersMutex);
+
+		for (const auto& [cookie, handler] : m_changeHandlers)
+		{
+			if ((handler->keyFilter.empty() || key == handler->keyFilter) &&
+				(handler->bagFilter.empty() || bagName == handler->bagFilter))
+			{
+				matchingHandlers.push_back(handler);
+			}
+		}
+	}
+
+	for (const auto& handler : matchingHandlers)
+	{
+		if (!handler->handler(source, bagName, key, value, replicated))
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 void StateBagComponentImpl::AddSafePreCreatePrefix(std::string_view idPrefix, bool useParentTargets)

--- a/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/ResourceScriptFunctions.cpp
@@ -420,22 +420,18 @@ static InitFunction initFunction([] ()
 		auto rm = fx::ResourceManager::GetCurrent();
 		auto sbac = rm->GetComponent<fx::StateBagComponent>();
 
-		auto cookie = sbac->OnStateBagChange.Connect(make_shared_function([rm, keyNameRef, bagNameRef, cbRef = std::move(cbRef)](int source, std::string_view bagName, std::string_view key, const msgpack::object& value, bool replicated)
+		// registering the filter with the component allows it to skip deserializing
+		// changes that no handler is interested in
+		auto cookie = sbac->AddChangeHandler(bagNameRef, keyNameRef, make_shared_function([rm, cbRef = std::move(cbRef)](int source, std::string_view bagName, std::string_view key, const msgpack::object& value, bool replicated)
 		{
-			if (keyNameRef.empty() || key == keyNameRef)
-			{
-				if (bagNameRef.empty() || bagName == bagNameRef)
-				{
-					rm->CallReference<void>(cbRef.GetRef(), std::string{ bagName }, std::string{ key }, value, source, replicated);
-				}
-			}
+			rm->CallReference<void>(cbRef.GetRef(), std::string{ bagName }, std::string{ key }, value, source, replicated);
 
 			return true;
 		}));
 
 		resource->OnStop.Connect([sbac, cookie]()
 		{
-			sbac->OnStateBagChange.Disconnect(cookie);
+			sbac->RemoveChangeHandler(cookie);
 		});
 
 		context.SetResult(cookie);
@@ -447,7 +443,7 @@ static InitFunction initFunction([] ()
 		auto rm = fx::ResourceManager::GetCurrent();
 		auto sbac = rm->GetComponent<fx::StateBagComponent>();
 
-		sbac->OnStateBagChange.Disconnect(size_t(cookie));
+		sbac->RemoveChangeHandler(size_t(cookie));
 	});
 
 	fx::ScriptEngine::RegisterNativeHandler("STATE_BAG_HAS_KEY", [](fx::ScriptContext& context)


### PR DESCRIPTION
## Goal of this PR

Resolve the `#TODOPERF` in `StateBagImpl::SetKey`: as soon as *any* change handler was registered, **every** state bag change was msgpack-deserialized and (on asynchronous game interfaces) allocated two `std::string`s plus a queued task  even when no handler's (bag, key) filter could possibly match the change. Entity state bags update at very high frequency, so this is a constant per-change cost on busy servers.

## How is this PR achieving the goal

Filtering is moved from the script-side callback into the state bag component itself:

- `StateBagComponent` gains `AddChangeHandler(bagFilter, keyFilter, handler)` / `RemoveChangeHandler(cookie)`. Handlers are stored with their filters (empty filter part = match all).
- `SetKey` now asks `HasChangeHandlerFor(bagName, key)` — a cheap filter check with an atomic zero-handler fast path before deserializing anything. If nothing matches, it goes straight to `SetKeyInternal`.
- Dispatch collects matching handlers under a shared lock and invokes them outside it, so handlers can safely add/remove handlers (e.g. `REMOVE_STATE_BAG_CHANGE_HANDLER` from inside a callback).
- `ADD_STATE_BAG_CHANGE_HANDLER` / `REMOVE_STATE_BAG_CHANGE_HANDLER` use the new API; the per-callback filter check is removed since the component now guarantees the match.
- The legacy `OnStateBagChange` event remains fully functional for direct consumers; any direct connection conservatively forces the old always-deserialize behavior.

No script-facing behavior change: handler cookies remain opaque `size_t`s, filter semantics (empty = wildcard) are identical.

## This PR applies to the following area(s)

FiveM, RedM, FXServer 

## Successfully tested on

**Game builds:** 3258

**Platforms:** Windows

## Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
