### PR TITLE
feat(gta-streaming-five): give each resource its own pgRawStreamer

### DIFF
--- a/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
+++ b/code/components/citizen-devtools/src/ResourceTimeWarnings.cpp
@@ -972,14 +972,81 @@ static InitFunction initFunction([]()
 
 		if (ImGui::Begin("Loaded pgRawStreamer assets", &m_enabledPgRawStreamerStats))
 		{
+			auto streamers = streaming::GetRawStreamerInfos();
+
+			// with bucket streamers, add a summary + selector
+			static int selectedStreamer = 0;
+			bool multiStreamer = streamers.size() > 1;
+
+			if (multiStreamer)
+			{
+				uint32_t grandTotal = 0;
+				for (auto& s : streamers)
+				{
+					grandTotal += s.count;
+				}
+				ImGui::LabelText("Assets total", "%u across %d streamer(s)", grandTotal, (int)streamers.size());
+
+				ImGuiTableFlags summaryFlags = ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY;
+				if (ImGui::BeginTable("Streamers", 3, summaryFlags, ImVec2(0, 120)))
+				{
+					ImGui::TableSetupColumn("#", ImGuiTableColumnFlags_WidthFixed, 40);
+					ImGui::TableSetupColumn("Streamer", ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableSetupColumn("Assets", ImGuiTableColumnFlags_WidthFixed, 120);
+					ImGui::TableHeadersRow();
+
+					for (auto& s : streamers)
+					{
+						ImGui::TableNextRow();
+						ImGui::TableNextColumn();
+						ImGui::Text("%d", s.index);
+						ImGui::TableNextColumn();
+						ImGui::Text("%s", s.label.c_str());
+						ImGui::TableNextColumn();
+						ImGui::Text("%u/65535", s.count);
+					}
+
+					ImGui::EndTable();
+				}
+
+				std::string preview = "streamer 0";
+				for (auto& s : streamers)
+				{
+					if (s.index == selectedStreamer)
+					{
+						preview = fmt::sprintf("streamer %d (%s)", s.index, s.label);
+						break;
+					}
+				}
+
+				if (ImGui::BeginCombo("Show streamer", preview.c_str()))
+				{
+					for (auto& s : streamers)
+					{
+						std::string item = fmt::sprintf("streamer %d (%s) - %u", s.index, s.label, s.count);
+						if (ImGui::Selectable(item.c_str(), s.index == selectedStreamer))
+						{
+							selectedStreamer = s.index;
+						}
+					}
+					ImGui::EndCombo();
+				}
+			}
+			else
+			{
+				selectedStreamer = 0;
+			}
+
 			static char search[100] = "";
 			ImGui::InputText("Search", search, IM_ARRAYSIZE(search));
-			auto assets = rage::GetPgRawStreamerEntries();
+			auto assets = rage::GetPgRawStreamerEntriesByIndex((uint16_t)selectedStreamer);
 			ImGui::LabelText("Assets total", "%d/65535", assets.GetCount());
 
-			ImGuiTableFlags tableFlags = ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable;
-			if (ImGui::BeginTable("Assets", 2, tableFlags))
+			// list fills the remaining space and scrolls
+			ImGuiTableFlags tableFlags = ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY;
+			if (ImGui::BeginTable("Assets", 2, tableFlags, ImVec2(0, 0)))
 			{
+				ImGui::TableSetupScrollFreeze(0, 1);
 				ImGui::TableSetupColumn("Asset path", ImGuiTableColumnFlags_WidthStretch);
 				ImGui::TableSetupColumn("Add timestamp", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_PreferSortDescending, 200);
 				ImGui::TableHeadersRow();

--- a/code/components/extra-natives-five/src/GamePrimitives_MapData.cpp
+++ b/code/components/extra-natives-five/src/GamePrimitives_MapData.cpp
@@ -46,7 +46,7 @@ static auto IsMapDataFromRawStreamer(int localIdx)
 	auto strIdx = mapDataStore->baseIdx + localIdx;
 
 	const auto& strEntry = streaming::Manager::GetInstance()->Entries[strIdx];
-	return streaming::GetCollectionIndex(strEntry.handle) < 3;
+	return streaming::IsRawStreamerCollection(streaming::GetCollectionIndex(strEntry.handle));
 }
 
 class MapDataOwnerExtension : public rage::fwExtension

--- a/code/components/gta-streaming-five/include/Streaming.h
+++ b/code/components/gta-streaming-five/include/Streaming.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <atArray.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 #if defined(COMPILING_GTA_STREAMING_FIVE) || defined(COMPILING_GTA_STREAMING_RDR3)
 #define STREAMING_EXPORT DLL_EXPORT
@@ -272,6 +275,8 @@ public:
 
 	STREAMING_EXPORT uint32_t* RegisterRawStreamingFile(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed);
 
+	STREAMING_EXPORT uint32_t* RegisterRawStreamingFileWithTag(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed, const std::string& tag);
+
 	STREAMING_EXPORT StreamingPackfileEntry* GetStreamingPackfileForEntry(StreamingDataEntry* entry);
 
 	// are we trying to shut down?
@@ -280,7 +285,19 @@ public:
 	atArray<StreamingPackfileEntry>& GetStreamingPackfileArray();
 
 	STREAMING_EXPORT int GetRawStreamerForFile(const char* fileName, rage::fiCollection** collection);
+	STREAMING_EXPORT int GetRawStreamerForFileWithTag(const char* fileName, const std::string& tag, rage::fiCollection** collection);
 	STREAMING_EXPORT rage::fiCollection* GetRawStreamerByIndex(uint16_t idx);
+
+	STREAMING_EXPORT std::vector<std::pair<std::string, int>> GetRawStreamerTagMap();
+
+	struct RawStreamerInfo
+	{
+		int index;
+		std::string label; // "game" or a bucket summary
+		uint32_t count;
+	};
+
+	STREAMING_EXPORT std::vector<RawStreamerInfo> GetRawStreamerInfos();
 
 	inline uint16_t GetCollectionIndex(uint32_t handle)
 	{
@@ -292,9 +309,11 @@ public:
 		return handle & 0xFFFF;
 	}
 
+	STREAMING_EXPORT bool IsRawStreamerCollection(uint16_t idx);
+
 	inline bool IsRawHandle(uint32_t handle)
 	{
-		return GetCollectionIndex(handle) < 2;
+		return IsRawStreamerCollection(GetCollectionIndex(handle));
 	}
 }
 
@@ -310,6 +329,7 @@ namespace rage
 namespace rage
 {
 	STREAMING_EXPORT const chunkyArray<rage::fiCollection::RawEntry, 1024, 64>& GetPgRawStreamerEntries();
+	STREAMING_EXPORT const chunkyArray<rage::fiCollection::RawEntry, 1024, 64>& GetPgRawStreamerEntriesByIndex(uint16_t idx);
 }
 
 #if 0

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1913,7 +1913,7 @@ static void LoadStreamingFiles(LoadType loadType)
 			int collectionId = 0;
 
 #ifdef GTA_FIVE
-			if (auto idx = streaming::GetRawStreamerForFile(file.c_str(), &rawStreamer))
+			if (auto idx = streaming::GetRawStreamerForFileWithTag(file.c_str(), tag, &rawStreamer))
 			{
 				collectionId = idx;
 			}
@@ -1954,7 +1954,7 @@ static void LoadStreamingFiles(LoadType loadType)
 			else
 			{
 				fileId = -1;
-				streaming::RegisterRawStreamingFile(&fileId, file.c_str(), true, baseName.c_str(), false);
+				streaming::RegisterRawStreamingFileWithTag(&fileId, file.c_str(), true, baseName.c_str(), false, tag);
 
 				if (fileId != -1)
 				{
@@ -3302,11 +3302,7 @@ void* chunkyArrayAppend(hook::FlexStruct* self)
 		AddCrashometry("asset_stats", ss.str());
 
 		AddCrashometry("pgRawStreamer", std::to_string(g_GetRawStreamer()->m_entries.count));
-#ifdef GTA_FIVE
-		AddCrashometry("pgRawStreamer(ytd)", std::to_string(streaming::GetRawStreamerByIndex(1)->m_entries.count));
-		AddCrashometry("pgRawStreamer(mod)", std::to_string(streaming::GetRawStreamerByIndex(2)->m_entries.count));
-#endif
-		
+
 		FatalError("ERR_STR_FAILURE: trying to add more assets to pgRawStreamer when it's already full (65535).");
 	}
 
@@ -3324,14 +3320,27 @@ static ConsoleCommand pgRawStreamer_AssetsCountCmd("assetscount", []()
 	trace("Total loaded assets in pgRawStreamer - %d/65535\n", g_GetRawStreamer()->m_entries.count);
 
 #ifdef GTA_FIVE
-	trace("Total loaded assets in pgRawStreamer(ytd) - %d/65535\n", streaming::GetRawStreamerByIndex(1)->m_entries.count);
-	trace("Total loaded assets in pgRawStreamer(mod) - %d/65535\n", streaming::GetRawStreamerByIndex(2)->m_entries.count);
+	for (const auto& [tag, idx] : streaming::GetRawStreamerTagMap())
+	{
+		trace("  pgRawStreamer(%d) [%s] - %d/65535\n", idx, tag.c_str(), streaming::GetRawStreamerByIndex((uint16_t)idx)->m_entries.count);
+	}
 #endif
 });
 
 const rage::chunkyArray<rage::fiCollection::RawEntry, 1024, 64>& rage::GetPgRawStreamerEntries()
 {
 	return g_GetRawStreamer()->m_entries;
+}
+
+const rage::chunkyArray<rage::fiCollection::RawEntry, 1024, 64>& rage::GetPgRawStreamerEntriesByIndex(uint16_t idx)
+{
+	// fall back to the game streamer if the slot isn't a streamer
+	auto streamer = streaming::GetRawStreamerByIndex(idx);
+	if (!streamer)
+	{
+		return g_GetRawStreamer()->m_entries;
+	}
+	return streamer->m_entries;
 }
 
 #endif

--- a/code/components/gta-streaming-five/src/Streaming.cpp
+++ b/code/components/gta-streaming-five/src/Streaming.cpp
@@ -3,6 +3,13 @@
 #include <Hooking.Stubs.h>
 #include <Streaming.h>
 
+#include <algorithm>
+#include <bitset>
+#include <cctype>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 static void* g_storeMgr;
 
 static hook::cdecl_stub<void(bool)> g_loadObjectsNow([]()
@@ -97,9 +104,38 @@ namespace rage
 
 rage::fiCollection** g_fiCollections;
 static void* (*g_orig_rage_pgStreamer_ctor)(void*);
-int currentIdx = 1;
 
-void AddRawStreamer()
+// slots 0-2 are the stock raw streamers (0 = base game, 1 = ytd mods, 2 = user mods)
+static const int kBaseRawStreamers = 3;
+
+static int g_maxPackfiles = 3928; // limit taken from b3258
+static const int kPackfileReserve = 512;
+static const uint16_t kStreamerRolloverEntries = 65535 - 1;
+static const uint8_t kMaxExtraStreamers = 16;
+
+static bool HasDedicatedStreamer(const std::string& ext)
+{
+	return ext == "ytd" || ext == "ybn" || ext == "yft" || ext == "ydd" || ext == "ydr" || ext == "ymap";
+}
+
+static std::unordered_map<std::string, int> g_streamerByExt;
+static std::unordered_map<int, std::string> g_extBySlot;
+
+static constexpr int kMaxCollections = 8192;
+static std::bitset<kMaxCollections> g_isRawStreamerSlot;
+static std::vector<int> g_bucketSlots;
+static int g_nextFreeSlotHint = kBaseRawStreamers;
+
+namespace streaming
+{
+	STREAMING_EXPORT bool IsRawStreamerCollection(uint16_t idx)
+	{
+		return idx < g_isRawStreamerSlot.size() && g_isRawStreamerSlot.test(idx);
+	}
+}
+
+// the game ctor writes itself into sm_Collections[0]; move it to `slot`
+static void MakeRawStreamerAt(int slot)
 {
 	auto alloc8ed = rage::GetAllocator()->Allocate(2048, 16, 0);
 
@@ -107,21 +143,70 @@ void AddRawStreamer()
 	g_orig_rage_pgStreamer_ctor(alloc8ed);
 	g_fiCollections[0] = swap;
 
-	g_fiCollections[currentIdx++] = static_cast<rage::fiCollection*>(alloc8ed);
+	g_fiCollections[slot] = static_cast<rage::fiCollection*>(alloc8ed);
+
+	if (slot >= 0 && slot < kMaxCollections)
+	{
+		g_isRawStreamerSlot.set(slot);
+	}
 }
 
 void* rage_pgStreamer_ctor(void* self)
 {
-	// the game's own raw streamer
 	auto ret = g_orig_rage_pgStreamer_ctor(self);
 
-	// for fivem
-	AddRawStreamer();
+	g_isRawStreamerSlot.set(0);
 
-	// for mod loader
-	AddRawStreamer();
+	MakeRawStreamerAt(1);
+	MakeRawStreamerAt(2);
 
 	return ret;
+}
+
+namespace streaming
+{
+	int GetOrCreateRawStreamerForExt(const std::string& ext)
+	{
+		if (auto it = g_streamerByExt.find(ext); it != g_streamerByExt.end())
+		{
+			int slot = it->second;
+			if (g_fiCollections[slot]->m_entries.count < kStreamerRolloverEntries)
+			{
+				return slot;
+			}
+
+			// full; the type moves to a fresh streamer (existing handles stay valid)
+			g_streamerByExt.erase(it);
+		}
+
+		if ((int)g_bucketSlots.size() < kMaxExtraStreamers)
+		{
+			int freeSlots = 0;
+			for (int slot = kBaseRawStreamers; slot < g_maxPackfiles; slot++)
+			{
+				freeSlots += (g_fiCollections[slot] == nullptr) ? 1 : 0;
+			}
+
+			if (freeSlots > kPackfileReserve)
+			{
+				for (int slot = g_nextFreeSlotHint; slot < g_maxPackfiles; slot++)
+				{
+					if (g_fiCollections[slot] == nullptr)
+					{
+						MakeRawStreamerAt(slot);
+						g_nextFreeSlotHint = slot + 1;
+						g_bucketSlots.push_back(slot);
+						g_streamerByExt.emplace(ext, slot);
+						g_extBySlot.emplace(slot, ext);
+						return slot;
+					}
+				}
+			}
+		}
+
+		// out of per-asset streamers; fall back to the ytd mod streamer
+		return 1;
+	}
 }
 
 namespace streaming
@@ -205,12 +290,14 @@ namespace streaming
 		return (Manager*)g_storeMgr;
 	}
 
-	uint32_t* RegisterRawStreamingFile(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed)
-	{
-		rage::fiCollection* rawStreamer = nullptr;
+	int GetOrCreateRawStreamerForExt(const std::string& ext);
 
-		if (auto collectionIdx = GetRawStreamerForFile(fileName, &rawStreamer))
+	static uint32_t* RegisterRawStreamingFileInto(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed, int collectionIdx)
+	{
+		if (collectionIdx)
 		{
+			rage::fiCollection* rawStreamer = g_fiCollections[collectionIdx];
+
 			auto fileIdx = rawStreamer->GetEntryByName(fileName);
 			if (fileIdx != uint16_t(-1))
 			{
@@ -231,14 +318,26 @@ namespace streaming
 		return g_registerRawStreamingFile(fileId, fileName, unkTrue, registerAs, errorIfFailed);
 	}
 
-	int GetCollectionIndexForFileName(const char* fileName)
+	uint32_t* RegisterRawStreamingFile(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed)
 	{
-		// anything related to mods installed by the users themselves
+		rage::fiCollection* rawStreamer = nullptr;
+		return RegisterRawStreamingFileInto(fileId, fileName, unkTrue, registerAs, errorIfFailed, GetRawStreamerForFile(fileName, &rawStreamer));
+	}
+
+	uint32_t* RegisterRawStreamingFileWithTag(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed, const std::string& tag)
+	{
+		rage::fiCollection* rawStreamer = nullptr;
+		return RegisterRawStreamingFileInto(fileId, fileName, unkTrue, registerAs, errorIfFailed, GetRawStreamerForFileWithTag(fileName, tag, &rawStreamer));
+	}
+
+	// stock routing: base game -> 0, ytd mods -> 1, user mods -> 2
+	static int GetCollectionIndexForFileName(const char* fileName)
+	{
 		if (strncmp(fileName, "faux_pack", 9) == 0 || strncmp(fileName, "addons:/", 8) == 0)
 		{
 			return 2;
 		}
-		// for now, only texture dictionaries have a custom streamer as its the most used
+
 		auto len = strlen(fileName);
 		if (len > 4 && strcmp(fileName + len - 3, "ytd") == 0)
 		{
@@ -250,14 +349,73 @@ namespace streaming
 
 	STREAMING_EXPORT int GetRawStreamerForFile(const char* fileName, rage::fiCollection** collection)
 	{
-		auto idx = GetCollectionIndexForFileName(fileName);
+		int idx = GetCollectionIndexForFileName(fileName);
 		*collection = g_fiCollections[idx];
 		return idx;
 	}
 
+	STREAMING_EXPORT int GetRawStreamerForFileWithTag(const char* fileName, const std::string& tag, rage::fiCollection** collection)
+	{
+		if (!tag.empty())
+		{
+			if (const char* extPos = strrchr(fileName, '.'))
+			{
+				std::string ext = extPos + 1;
+				std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) { return std::tolower(c); });
+
+				if (HasDedicatedStreamer(ext))
+				{
+					int idx = GetOrCreateRawStreamerForExt(ext);
+					*collection = g_fiCollections[idx];
+					return idx;
+				}
+			}
+		}
+
+		return GetRawStreamerForFile(fileName, collection);
+	}
+
 	STREAMING_EXPORT rage::fiCollection* GetRawStreamerByIndex(uint16_t idx)
 	{
+		if (!g_fiCollections || idx >= g_maxPackfiles)
+		{
+			return nullptr;
+		}
 		return g_fiCollections[idx];
+	}
+
+	// for the devtools window
+	STREAMING_EXPORT std::vector<std::pair<std::string, int>> GetRawStreamerTagMap()
+	{
+		std::vector<std::pair<std::string, int>> out;
+		out.reserve(g_extBySlot.size());
+		for (const auto& [idx, ext] : g_extBySlot)
+		{
+			out.emplace_back(ext, idx);
+		}
+		return out;
+	}
+
+	// for the devtools window
+	STREAMING_EXPORT std::vector<RawStreamerInfo> GetRawStreamerInfos()
+	{
+		std::vector<RawStreamerInfo> out;
+		for (int idx = 0; idx < g_maxPackfiles; idx++)
+		{
+			if (!g_isRawStreamerSlot.test(idx) || !g_fiCollections || g_fiCollections[idx] == nullptr)
+			{
+				continue;
+			}
+
+			std::string label;
+			if (idx == 0) { label = "game"; }
+			else if (idx == 1) { label = "ytd mods"; }
+			else if (idx == 2) { label = "user mods"; }
+			else if (auto it = g_extBySlot.find(idx); it != g_extBySlot.end()) { label = "." + it->second; }
+
+			out.push_back({ idx, std::move(label), g_fiCollections[idx]->m_entries.count });
+		}
+		return out;
 	}
 }
 
@@ -268,9 +426,13 @@ static HookFunction hookFunction([] ()
 
 	g_orig_rage_pgStreamer_ctor = hook::trampoline(hook::get_pattern("48 8B CB 33 D2 41 B8 00 02 00 00 E8", -0x29), rage_pgStreamer_ctor);
 
-	// the first 3 indexes are for rawstreamers, rest is for packfiles
+	// packfile slot scan starts at 2, keeping low slots for raw streamers
 	auto addr = hook::get_pattern<char>("41 0F B7 D2 4C 8D");
 	hook::put<uint32_t>(addr, 0x02528D41); // lea    edx,[r10+0x2]
 
 	g_fiCollections = hook::get_address<rage::fiCollection**>(addr + 7);
+
+	// MaxPackfiles
+	uint32_t maxPackfiles = *hook::get_pattern<uint32_t>("B8 ? ? ? ? 66 3B D0 72", 1);
+	g_maxPackfiles = std::min<uint32_t>(maxPackfiles, kMaxCollections);
 });

--- a/code/components/gta-streaming-five/src/UnkStuff.cpp
+++ b/code/components/gta-streaming-five/src/UnkStuff.cpp
@@ -61,7 +61,7 @@ static void ErrorInflateFailure(char* ioData, char* requestData, int zlibError, 
 	auto spf = streaming::GetStreamingPackfileByIndex(collectionIndex);
 	auto collection = (rage::fiCollection*)(spf ? spf->packfile : nullptr);
 
-	if (!collection && collectionIndex < 2)
+	if (!collection && streaming::IsRawStreamerCollection(collectionIndex))
 	{
 		collection = streaming::GetRawStreamerByIndex(collectionIndex);
 	}
@@ -79,7 +79,7 @@ static void ErrorInflateFailure(char* ioData, char* requestData, int zlibError, 
 	{
 		name = collection->GetEntryName(fileIndex);
 
-		if (collectionIndex < 2)
+		if (streaming::IsRawStreamerCollection(collectionIndex))
 		{
 			// get the _raw_ file name
 			char fileNameBuffer[1024];

--- a/code/components/gta-streaming-rdr3/src/Streaming.cpp
+++ b/code/components/gta-streaming-rdr3/src/Streaming.cpp
@@ -137,6 +137,38 @@ namespace streaming
 	{
 		return g_registerRawStreamingFile(fileId, fileName, unkTrue, registerAs, errorIfFailed, true);
 	}
+
+	// stubs for the shared Streaming.h exports; raw streamer buckets are FiveM-only
+	uint32_t* RegisterRawStreamingFileWithTag(uint32_t* fileId, const char* fileName, bool unkTrue, const char* registerAs, bool errorIfFailed, const std::string& tag)
+	{
+		return RegisterRawStreamingFile(fileId, fileName, unkTrue, registerAs, errorIfFailed);
+	}
+
+	int GetRawStreamerForFileWithTag(const char* fileName, const std::string& tag, rage::fiCollection** collection)
+	{
+		*collection = nullptr;
+		return 0;
+	}
+
+	rage::fiCollection* GetRawStreamerByIndex(uint16_t idx)
+	{
+		return nullptr;
+	}
+
+	bool IsRawStreamerCollection(uint16_t idx)
+	{
+		return idx < 2;
+	}
+
+	std::vector<std::pair<std::string, int>> GetRawStreamerTagMap()
+	{
+		return {};
+	}
+
+	std::vector<RawStreamerInfo> GetRawStreamerInfos()
+	{
+		return {};
+	}
 }
 
 static HookFunction hookFunction([]()


### PR DESCRIPTION
### Goal of this PR

Raise the raw-streaming file limit so large servers stop hitting
"pgRawStreamer is full".

A `pgRawStreamer` addresses its entries with a 16-bit file index, so a single
raw streamer fills up at 65535 files. Servers that register a lot of loose
stream assets overflow that shared streamer, after which streaming breaks.

### How is this PR achieving the goal

Each resource gets its own `pgRawStreamer`, allocated lazily on the first
stream file it registers, so the 65535 limit becomes per-resource instead of
shared across the whole server.

1. Stream files are routed to their owning resource's streamer via the tag
   already available at registration time
   (`GetRawStreamerForFileWithTag` / `RegisterRawStreamingFileWithTag` in
   `Streaming.cpp`). Files that would otherwise land in the shared game (0) or
   ytd (1) streamer are diverted; `faux_pack`/`addons:` and untagged files
   keep the existing shared streamers.
2. The streaming handle already reserves the upper 16 bits for the collection
   index, so per-resource streamers just occupy their own collection slots and
   total capacity scales with the number of streaming resources.
3. Per-resource streamers take free `sm_Collections` slots (packfiles already
   claim some by the time resources load, so a free slot is searched for rather
   than assumed). `MaxPackfiles` is read from the game's packfile
   slot-allocation loop so the bound follows the game across builds.
4. A reserve of slots is kept for real packfiles, and once the budget is spent
   further resources bucket into streamers already allocated, so packfiles are
   never starved - this should ensure that nothing can cause crashes in the future.
5. `IsRawHandle` is now a membership test (per-resource streamers sit at
   non-contiguous collection indices), and the "Loaded pgRawStreamer assets"
   devtools window lists every streamer with its owning resource and fill level.

### This PR applies to the following area(s)

FiveM, Streaming

### Successfully tested on

Game builds: **3258**
Platforms: **Windows**
Pattern `B8 ? ? ? ? 66 3B D0 72` has been found in all game builds up to 3788
Tested locally with a bunch of copied .ytd files
<img width="894" height="307" alt="image" src="https://github.com/user-attachments/assets/290dd210-96f1-44ba-b830-30b2780d28f5" />
<img width="906" height="455" alt="image" src="https://github.com/user-attachments/assets/94076262-0186-46d9-a49e-c1d580db8253" />


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.

### Fixes issues

Fixes the "pgRawStreamer is full" (65535 raw file) limit on large servers.

PS: This idea was taken from prikolium 
Note: You can't have infinite pgRawStreamers, there's an upper limit (which should increase every gamebuild)
For 3258: MaxPackfiles (3928) − reserve (512) ≈ 3,416 ressources, so unless you have 3400 ressources on your server you should be golden.