### PR TITLE
feat(gta-core-five): disable passive mode using convar

### DIFF
--- a/code/components/gta-core-five/src/PatchPassiveMode.cpp
+++ b/code/components/gta-core-five/src/PatchPassiveMode.cpp
@@ -1,0 +1,53 @@
+#include <StdInc.h>
+
+#include <CoreConsole.h>
+
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
+#include <jitasm.h>
+
+static bool g_DisablePassiveMode = false;
+
+static HookFunction hookFunction([]
+{
+	static ConVar<bool> enableVehicleHijackFix("game_disablePassiveMode", ConVar_Replicated, false, &g_DisablePassiveMode);
+
+	auto patchAllowedToDamagePassiveFlagLocation = hook::get_pattern("C1 E8 ? A8 ? 75 ? C1 E9 ? F6 C1 ? 75 ? 48 8B D3");
+	auto patchAllowedToDamageSkipLocation = hook::get_pattern("32 C0 E9 ? ? ? ? F7 83");
+
+	static struct : jitasm::Frontend
+	{
+		uintptr_t m_ContinueAddress;
+		uintptr_t m_SkipAddress;
+
+		void Init(uintptr_t continueAddress, uintptr_t skipAddress)
+		{
+			m_ContinueAddress = continueAddress;
+			m_SkipAddress = skipAddress;
+		}
+
+		void InternalMain() override
+		{
+			shr(eax, 7);
+			test(al, 1);
+			jz("Continue");
+
+			mov(r11, reinterpret_cast<uintptr_t>(&g_DisablePassiveMode));
+			cmp(byte_ptr[r11], 0);
+			jne("Continue");
+
+			mov(r11, m_SkipAddress);
+			jmp(r11);
+
+			L("Continue");
+			mov(r11, m_ContinueAddress);
+			jmp(r11);
+		}
+	} patchStub;
+
+	patchStub.Init((uintptr_t)patchAllowedToDamagePassiveFlagLocation + 7, (uintptr_t)patchAllowedToDamageSkipLocation);
+
+	hook::nop(patchAllowedToDamagePassiveFlagLocation, 7);
+	hook::jump_rcx(patchAllowedToDamagePassiveFlagLocation, patchStub.GetCode());
+});

--- a/code/components/gta-core-five/src/PatchPassiveMode.cpp
+++ b/code/components/gta-core-five/src/PatchPassiveMode.cpp
@@ -11,7 +11,7 @@ static bool g_DisablePassiveMode = false;
 
 static HookFunction hookFunction([]
 {
-	static ConVar<bool> enableVehicleHijackFix("game_disablePassiveMode", ConVar_Replicated, false, &g_DisablePassiveMode);
+	static ConVar<bool> convarDisablePassiveMode("game_disablePassiveMode", ConVar_Replicated, false, &g_DisablePassiveMode);
 
 	auto patchAllowedToDamagePassiveFlagLocation = hook::get_pattern("C1 E8 ? A8 ? 75 ? C1 E9 ? F6 C1 ? 75 ? 48 8B D3");
 	auto patchAllowedToDamageSkipLocation = hook::get_pattern("32 C0 E9 ? ? ? ? F7 83");


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Preventing abuse of the GTA:O friendly / passive mode sync which is being actively exploited and implemented in almost every cheat.

### How is this PR achieving the goal
Patch out the TreatAsFriendlyForTargetingAndDamage check inside CPed::IsAllowedToDamageEntity when the _**game_disablePassiveMode**_ convar is enabled.

### This PR applies to the following area(s)
FiveM

### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
Cheats abusing passive mode: https://www.youtube.com/watch?v=IXXxhkDEt6A

