### PR TITLE
feat(extra-natives-five): add a global vehicle audio volume control

### DIFF
--- a/code/components/conhost-v2/src/DevGui.cpp
+++ b/code/components/conhost-v2/src/DevGui.cpp
@@ -69,6 +69,10 @@ struct DevGuiNode
 	std::string name;
 	std::string commandOrConVar;
 
+	float sliderMin = 0.0f;
+	float sliderMax = 0.0f;
+	float sliderStep = 0.0f;
+
 	std::list<std::unique_ptr<DevGuiNode>> children;
 
 	inline DevGuiNode* RegisterMenu(const std::string& name)
@@ -185,11 +189,59 @@ static void DevGui_Draw(const DevGuiNode* node)
 				auto value = intEntry->GetRawValue();
 				auto initialValue = value;
 
-				ImGui::InputScalar(node->name.c_str(), ImGuiDataType_S32, &value);
+				bool useSlider = node->sliderMax > node->sliderMin;
+
+				if (useSlider)
+				{
+					ImGui::SetNextItemWidth(160.0f);
+					ImGui::SliderInt(node->name.c_str(), &value, (int)node->sliderMin, (int)node->sliderMax);
+
+					if (node->sliderStep > 0.0f)
+					{
+						int step = (int)node->sliderStep;
+						value = (int)node->sliderMin + (int)std::round((value - (int)node->sliderMin) / (float)step) * step;
+					}
+				}
+				else
+				{
+					ImGui::InputScalar(node->name.c_str(), ImGuiDataType_S32, &value);
+				}
 
 				if (initialValue != value)
 				{
 					intEntry->SetRawValue(value);
+				}
+
+				return;
+			}
+
+			auto floatEntry = std::dynamic_pointer_cast<internal::ConsoleVariableEntry<float>>(entry);
+
+			if (floatEntry)
+			{
+				auto value = floatEntry->GetRawValue();
+				auto initialValue = value;
+
+				bool useSlider = node->sliderMax > node->sliderMin;
+
+				if (useSlider)
+				{
+					ImGui::SetNextItemWidth(160.0f);
+					ImGui::SliderFloat(node->name.c_str(), &value, node->sliderMin, node->sliderMax, "%.2f");
+
+					if (node->sliderStep > 0.0f)
+					{
+						value = node->sliderMin + std::round((value - node->sliderMin) / node->sliderStep) * node->sliderStep;
+					}
+				}
+				else
+				{
+					ImGui::InputScalar(node->name.c_str(), ImGuiDataType_Float, &value);
+				}
+
+				if (initialValue != value)
+				{
+					floatEntry->SetRawValue(value);
 				}
 
 				return;
@@ -246,6 +298,28 @@ static InitFunction initFunction([]()
 		node->commandOrConVar = convarName;
 	});
 
+	// devgui_convar with an explicit slider range: devgui_convar_slider "path" convar min max [step]
+	static ConsoleCommand devguiAddConVarSlider("devgui_convar_slider", [](const DevGuiPath& path, const std::string& convarName, float min, float max)
+	{
+		auto node = DevGui_InstantiatePath(path);
+
+		node->type = DevGuiNode::DevGuiNode_ConVar;
+		node->commandOrConVar = convarName;
+		node->sliderMin = min;
+		node->sliderMax = max;
+	});
+
+	static ConsoleCommand devguiAddConVarSliderStep("devgui_convar_slider", [](const DevGuiPath& path, const std::string& convarName, float min, float max, float step)
+	{
+		auto node = DevGui_InstantiatePath(path);
+
+		node->type = DevGuiNode::DevGuiNode_ConVar;
+		node->commandOrConVar = convarName;
+		node->sliderMin = min;
+		node->sliderMax = max;
+		node->sliderStep = step;
+	});
+
 #ifndef IS_FXSERVER
 	static ConVar<std::string> uiConnectHost("uiConnectHost", ConVar_Archive | ConVar_UserPref, "");
 
@@ -277,13 +351,19 @@ devgui_convar "Tools/Windowed Console" con_winConsole
 set "game_mute" "profile_sfxVolume 0; profile_musicVolumeInMp 0; profile_musicVolume 0"
 set "game_unmute" "profile_sfxVolume 25; profile_musicVolumeInMp 10; profile_musicVolume 10"
 
-devgui_convar "Game/SFX Volume" profile_sfxVolume
+devgui_convar_slider "Game/SFX Volume" profile_sfxVolume 0 25
 devgui_cmd "Game/Mute" "vstr game_mute"
 devgui_cmd "Game/Unmute" "vstr game_unmute"
 
 devgui_convar "Overlays/Performance/Draw Performance" cl_drawPerf
 devgui_cmd    "Overlays/Performance/--------------------" "wait 1"
 )");
+
+#ifdef GTA_FIVE
+	console::GetDefaultContext()->AddToBuffer(R"(
+devgui_convar_slider "Game/Vehicle Volume" profile_vehicleVolume 0.0 1.0 0.05
+)");
+#endif
 
 	if (IsNonProduction())
 	{

--- a/code/components/extra-natives-five/src/VehicleAudioVolume.cpp
+++ b/code/components/extra-natives-five/src/VehicleAudioVolume.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the Cfx project - https://cfx.re/
+ *
+ * See LICENSE in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include "StdInc.h"
+
+#include <ScriptEngine.h>
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+#include <CoreConsole.h>
+#include <nutsnbolts.h>
+
+#include <algorithm>
+
+static float g_vehicleVolume = 1.0f;
+
+// "VEHICLES" - parent category of every vehicle sound
+static constexpr uint32_t kVehiclesCategory = 0x74B31BE3;
+
+namespace
+{
+	void** g_audCategoryControllerManager = nullptr;
+
+	hook::thiscall_stub<char*(void*, uint32_t)> _createController([]()
+	{
+		return hook::get_call(hook::get_pattern("45 33 C0 BA 90 1C E2 44 E8", 8));
+	});
+
+	char* CreateVehicleController()
+	{
+		auto mgr = g_audCategoryControllerManager ? *g_audCategoryControllerManager : nullptr;
+		if (!mgr)
+		{
+			return nullptr;
+		}
+
+		return _createController(mgr, kVehiclesCategory);
+	}
+}
+
+static char* GetVehicleController()
+{
+	static char* controller = nullptr;
+	if (!controller)
+	{
+		controller = CreateVehicleController();
+	}
+	return controller;
+}
+
+static void ApplyVehicleVolume()
+{
+	if (auto controller = reinterpret_cast<hook::FlexStruct*>(GetVehicleController()))
+	{
+		controller->Set<float>(0, g_vehicleVolume);
+		controller->Set<float>(4, 0.0f);
+	}
+}
+
+static HookFunction hookFunction([]()
+{
+	g_audCategoryControllerManager = hook::get_address<void**>(hook::get_pattern("45 33 C0 BA 90 1C E2 44 E8", -4));
+
+	OnMainGameFrame.Connect([]()
+	{
+		static bool applied = false;
+		if (!applied && GetVehicleController())
+		{
+			ApplyVehicleVolume();
+			applied = true;
+		}
+	});
+});
+
+static InitFunction initFunction([]()
+{
+	static ConVar<float> vehicleVolumeVar("profile_vehicleVolume", ConVar_Archive, 1.0f, &g_vehicleVolume);
+
+	OnMainGameFrame.Connect([]()
+	{
+		static float last = -1.0f;
+		if (g_vehicleVolume != last)
+		{
+			g_vehicleVolume = std::clamp(g_vehicleVolume, 0.0f, 1.0f);
+			ApplyVehicleVolume();
+			last = g_vehicleVolume;
+		}
+	});
+
+	// no new natives will be added as of now but here they are in case that changes.
+
+	// global vehicle audio volume: 0.0 silent .. 1.0 normal
+	// kept disabled - gen8 is in feature freeze, no new natives for now
+	// fx::ScriptEngine::RegisterNativeHandler("SET_AUDIO_VEHICLE_VOLUME", [](fx::ScriptContext& context)
+	// {
+	// 	g_vehicleVolume = std::clamp(context.GetArgument<float>(0), 0.0f, 1.0f);
+	// 	ApplyVehicleVolume();
+	// });
+
+	// fx::ScriptEngine::RegisterNativeHandler("GET_AUDIO_VEHICLE_VOLUME", [](fx::ScriptContext& context)
+	// {
+	// 	context.SetResult<float>(g_vehicleVolume);
+	// });
+});


### PR DESCRIPTION
### Goal of this PR

Let players lower (or fully mute) **only** vehicle sounds - engine, exhaust,
tyres, horns, alarms, collisions - without affecting weapons, footsteps,
ambience or music.

https://github.com/user-attachments/assets/412f5500-076b-4371-bbcc-1403898cdb0e

### How is this PR achieving the goal

Vehicle audio all descends from the RAGE `VEHICLES` audio category
(`0x74B31BE3`). The feature creates an `audCategoryControllerManager` controller
on that category and sets its linear volume - the same mechanism the game uses
for its own SFX/Music sliders. Setting the parent category scales every child
vehicle sound in one place.

1. The controller wrappers (`GetInstance` / `CreateController`) already exist in
   [`NuiAudioSink.cpp`](https://github.com/citizenfx/fivem/blob/25c937b1451be564e66afabab09b47a30d095385/code/components/extra-natives-five/src/NuiAudioSink.cpp#L2941-L2959)
   for the Mumble voice-volume feature; this reuses the same pattern on the
   `VEHICLES` category.
2. Exposed as the convar `profile_vehicleVolume` (archive convar)
3. The F8 menu previously rendered numeric convars as text
   inputs. I've added a slider for volumes which is easier to use in my opinion.

`SET_/GET_AUDIO_VEHICLE_VOLUME` native handlers are present but commented out
while gen8 is in feature freeze.


### This PR applies to the following area(s)

FiveM, Audio

### Successfully tested on

Game builds: **3258**
Platforms: **Windows**


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.

### Fixes issues

Ears hurting from driving modded vehicles that have obnoxiously loud modded engine sounds

PS: I've tried implementing this functionality using existing natives, but I wasn't successful—hence the PR.