### PR TITLE
fix(server/state): update last occupant for given seat index even if was taken

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -2178,14 +2178,19 @@ void ServerGameState::UpdateEntities()
 						lastVehicleData->playerOccupants.reset(vehicleData->lastVehicleSeat);
 					}
 
-					if (curVehicleData && curVehicleData->occupants[vehicleData->curVehicleSeat] == 0)
+					if (curVehicleData)
 					{
-						curVehicleData->occupants[vehicleData->curVehicleSeat] = pedHandle;
+						//set the last occupant even if the seat was not free
+						//will help to check for seat ejection
 						curVehicleData->lastOccupant[vehicleData->curVehicleSeat] = pedHandle;
-
-						if (entity->type == sync::NetObjEntityType::Player)
+						if (curVehicleData->occupants[vehicleData->curVehicleSeat] == 0)
 						{
-							curVehicleData->playerOccupants.set(vehicleData->curVehicleSeat);
+							curVehicleData->occupants[vehicleData->curVehicleSeat] = pedHandle;
+
+							if (entity->type == sync::NetObjEntityType::Player)
+							{
+								curVehicleData->playerOccupants.set(vehicleData->curVehicleSeat);
+							}
 						}
 					}
 


### PR DESCRIPTION
### Goal of this PR
There are a lot of seat ejection happening. Cheater able to force out already seated players in given vehicles. The problem is that `GetLastPedInVehicleSeat` wouldn't return the cheater ped, because there is an if check if the seat is free and won't modify the last occupant array for the vehicle.


### How is this PR achieving the goal
Current occupants for the vehicle would be the same, last occupants skip the if check.


### This PR applies to the following area(s)
Server


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


