### PR TITLE
tweak(chat): optimize client resource start

### DIFF
--- a/ext/system-resources/resources/chat/cl_chat.lua
+++ b/ext/system-resources/resources/chat/cl_chat.lua
@@ -163,22 +163,22 @@ RegisterRawNuiCallback('chatResult', function(requestData, cb)
 end)
 
 local function refreshCommands()
-  if GetRegisteredCommands then
-    local registeredCommands = GetRegisteredCommands()
+  local registeredCommands = GetRegisteredCommands()
+  if not next(registeredCommands) then return end
 
-    local suggestions = {}
+  local suggestions = {}
 
-    for _, command in ipairs(registeredCommands) do
-        if IsAceAllowed(('command.%s'):format(command.name)) and command.name ~= 'toggleChat' then
-            table.insert(suggestions, {
-                name = '/' .. command.name,
-                help = ''
-            })
-        end
+  for i = 1, #registeredCommands do
+    local command = registeredCommands[i]
+    if IsAceAllowed(('command.%s'):format(command.name)) and command.name ~= 'openChat' then
+      suggestions[#suggestions + 1] = {
+        name = '/' .. command.name,
+        help = ''
+      }
     end
-
-    TriggerEvent('chat:addSuggestions', suggestions)
   end
+
+  TriggerEvent('chat:addSuggestions', suggestions)
 end
 
 local function refreshThemes()
@@ -208,18 +208,26 @@ local function refreshThemes()
   })
 end
 
-AddEventHandler('onClientResourceStart', function(resName)
-  Wait(500)
+local commandsRefreshScheduled = false
 
-  refreshCommands()
-  refreshThemes()
+local function scheduleCommandsRefresh()
+  if commandsRefreshScheduled then return end
+
+  commandsRefreshScheduled = true
+
+  SetTimeout(500, function()
+    commandsRefreshScheduled = false
+    refreshCommands()
+    refreshThemes()
+  end)
+end
+
+AddEventHandler('onClientResourceStart', function(_)
+  scheduleCommandsRefresh()
 end)
 
-AddEventHandler('onClientResourceStop', function(resName)
-  Wait(500)
-
-  refreshCommands()
-  refreshThemes()
+AddEventHandler('onClientResourceStop', function(_)
+  scheduleCommandsRefresh()
 end)
 
 RegisterNUICallback('loaded', function(data, cb)


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Optimize chat resource for servers with large resource counts.


### How is this PR achieving the goal

1. Removal of table.insert (slow)
2. Preventing every resource start from refreshing commands instead opting to refresh at most every 500ms during resource starts
3. Eliminates one extra call to GetRegisteredCommands()
4. Use numeric iterator instead of pairs/ipairs for looping through registered commands.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM/RedM
system-resources/chat


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->
n/a


