### PR TITLE
fix(server): check `inVehicle` in `GET_VEHICLE_PED_IS_IN` for RedM

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1280,7 +1280,7 @@ static void Init()
 		 if (!pedVehicleData)
 			 return (uint32_t)0;
 
-		 if ((lastVehicleArg == true && pedVehicleData->lastVehiclePedWasIn == 0) || (lastVehicleArg == false && pedVehicleData->curVehicle == 0))
+		 if ((lastVehicleArg == true && pedVehicleData->lastVehiclePedWasIn == 0) || (lastVehicleArg == false && (!pedVehicleData->inVehicle || pedVehicleData->curVehicle == 0)))
 			 return (uint32_t)0;
 
 		 lastVeh = pedVehicleData->lastVehiclePedWasIn;


### PR DESCRIPTION
### Goal of this PR
Make server-side `GetVehiclePedIsIn(ped, false)` return `0` on RedM when the ped is not sitting in a vehicle, instead of returning the last vehicle it was in.

Right now both `GetVehiclePedIsIn(ped, false)` and `GetVehiclePedIsIn(ped, true)` return the same handle once the ped is on foot, so there is no way to tell the two apart.

### How is this PR achieving the goal
On RDR3 `CPedVehicleNodeData` splits this over two fields. `curVehicle` holds the vehicle id and keeps it after the ped gets out, it is only cleared when the vehicle slot stops being sent at all. `inVehicle` is the one that says whether the ped is seated right now.

This is already how the neighbouring natives in the same file work:

- `IS_PED_IN_ANY_VEHICLE` returns `pedVehicleData->inVehicle`
- `IS_PED_IN_VEHICLE` bails out on `if (!vehicleId || !inVehicle)`
- `GET_MOUNT` bails out on `if (!onHorse || !horseId)`

`GET_VEHICLE_PED_IS_IN` only checked `curVehicle == 0`, which is why it kept returning the stale handle. It now checks `inVehicle` as well for the current vehicle case:

```cpp
if ((lastVehicleArg == true && pedVehicleData->lastVehiclePedWasIn == 0) || (lastVehicleArg == false && (!pedVehicleData->inVehicle || pedVehicleData->curVehicle == 0)))
	 return (uint32_t)0;
```

The `lastVehicle == true` path is untouched, `lastVehiclePedWasIn` is kept up to date by `CPedVehicleDataNode::Serialize` and still works.

This is RedM only, the `#else` branch for FiveM already handles it because `CPedGameStateDataNode` writes `data.curVehicle = -1` when the ped leaves.

### This PR applies to the following area(s)
RedM, FXServer, OneSync, Natives

### Successfully tested on

**Game builds:** n/a, server-side only

**Platforms:** Windows, Linux

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

I could not do a full server build locally, so I left the first box unchecked. What I did check is that the changed condition compiles clean against the real `CPedVehicleNodeData`, and I stepped the real `CPedVehicleDataNode::Serialize` through enter vehicle -> exit -> re-enter -> swap vehicle to confirm `curVehicle` holds the old id while `inVehicle` is false, that the old condition returns the stale handle there, and that the new one returns `0` without changing any of the other cases. Happy to adjust if maintainers would rather this be shaped differently.

### Fixes issues
fixes #4006
