### PR TITLE
fix(rage-input-five): track last host cursor state

### DIFF
--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -143,6 +143,8 @@ void InputHook::SetHostCursorEnabled(bool enabled)
 		DisableHostCursor();
 	}
 
+	lastEnabled = enabled;
+
 	g_useHostCursor = enabled;
 }
 


### PR DESCRIPTION
### Goal of this PR
Make the host cursor go away again after NUI stops asking for one, instead of leaving the OS cursor drawn over the game.

### How is this PR achieving the goal
`InputHook::SetHostCursorEnabled` is written to only do work when the state changes:

```cpp
void InputHook::SetHostCursorEnabled(bool enabled)
{
	static bool lastEnabled = false;

	if (!lastEnabled && enabled)
	{
		EnableHostCursor();
	}
	else if (lastEnabled && !enabled)
	{
		DisableHostCursor();
	}

	g_useHostCursor = enabled;
}
```

`lastEnabled` is never assigned though, so it is false forever. That means the first branch is taken on every call with `enabled` true, and the second branch can never be taken at all, so `DisableHostCursor` is dead code.

It matters because the call is per frame, from the NUI render callback:

```cpp
// are we in any situation where we need a cursor?
bool needsNuiCursor = (nui::HasCursor()) && !g_shouldHideCursor;
g_nuiGi->SetHostCursorEnabled(needsNuiCursor);
```

and because `EnableHostCursor` does not stop at "already visible":

```cpp
void EnableHostCursor()
{
	while (ShowCursor(TRUE) < 0)
		;
}
```

`ShowCursor` moves an internal display counter and returns the new value, and the cursor is shown while that counter is `>= 0`. Once the counter is already `0` a single `ShowCursor(TRUE)` returns `1`, which ends the loop, so every frame adds one to the counter. A NUI cursor that is up for five seconds at 60fps leaves it around 300.

When the cursor is no longer wanted `DisableHostCursor` never runs, so nothing brings that counter back down. `g_useHostCursor` does go false, which stops the `ShowCursor` hook swallowing the game's own calls:

```cpp
static INT HookShowCursor(BOOL show)
{
	if (g_useHostCursor)
	{
		return (show) ? 0 : -1;
	}

	return ShowCursor(show);
}
```

but the game only calls `ShowCursor(FALSE)` on its own state changes, so a handful of calls cannot undo a few hundred increments and the cursor stays on screen. The longer the NUI cursor was up the worse it gets.

Assigning `lastEnabled` restores the intended behaviour: `EnableHostCursor` once when the cursor is first needed, `DisableHostCursor` once when it stops being needed, and the counter stays where it belongs.

`rage-input-rdr3` has the same function with the same missing assignment. I left it out since RedM changes seem to go as their own PRs here, happy to add it or open a second one if you would prefer.

### This PR applies to the following area(s)
FiveM

### Successfully tested on

**Game builds:** n/a, this does not depend on a game build

**Platforms:** Windows

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

I could not do a full client build locally so I left the first box unchecked. What I did check is the counter arithmetic, by putting `SetHostCursorEnabled`, `EnableHostCursor`, `DisableHostCursor` and `HookShowCursor` next to a model of `ShowCursor` and running 300 frames of "cursor wanted" followed by "cursor no longer wanted". Without the assignment the counter ends at 299 and the cursor is still shown afterwards, with it the counter stays at 0 and the cursor is hidden again.
