### PR TITLE
feat(server/state): add train getters for already synced fields

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -1931,6 +1931,48 @@ static void Init()
 		return train ? train->direction : false;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_CONFIG_INDEX", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->trainConfigIndex : -1;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_TRAIN_DISTANCE_FROM_ENGINE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->distanceFromEngine : 0.0f;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_MISSION_TRAIN", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->isMissionTrain : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_TRAIN_HAVE_PASSENGER_CARRIAGES", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->hasPassengerCarriages : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("IS_TRAIN_RENDERED_DERAILED", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->renderDerailed : false;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("DOES_TRAIN_FORCE_DOORS_OPEN", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto train = entity->syncTree->GetTrainState();
+
+		return train ? train->forceDoorsOpen : false;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_FAKE_WANTED_LEVEL", MakePlayerEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto pn = entity->syncTree->GetPlayerWantedAndLOS();

--- a/ext/native-decls/DoesTrainForceDoorsOpen.md
+++ b/ext/native-decls/DoesTrainForceDoorsOpen.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## DOES_TRAIN_FORCE_DOORS_OPEN
+
+```c
+bool DOES_TRAIN_FORCE_DOORS_OPEN(Vehicle train);
+```
+
+Returns whether this train forces its doors open while a player is inside it.
+
+This reads the flag as it is synchronised for the given train. The client-side `SET_TRAINS_FORCE_DOORS_OPEN` sets this for all trains at once.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+Returns true if the train forces its doors open.

--- a/ext/native-decls/DoesTrainHavePassengerCarriages.md
+++ b/ext/native-decls/DoesTrainHavePassengerCarriages.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## DOES_TRAIN_HAVE_PASSENGER_CARRIAGES
+
+```c
+bool DOES_TRAIN_HAVE_PASSENGER_CARRIAGES(Vehicle train);
+```
+
+Returns whether the train has carriages that peds can ride in.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+Returns true if the train has passenger carriages.

--- a/ext/native-decls/GetTrainConfigIndex.md
+++ b/ext/native-decls/GetTrainConfigIndex.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_TRAIN_CONFIG_INDEX
+
+```c
+int GET_TRAIN_CONFIG_INDEX(Vehicle train);
+```
+
+Gets the index of the train configuration this train was created from, as defined in `traintracks.xml`.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The train's config index, or -1 if the entity is not a train.

--- a/ext/native-decls/GetTrainDistanceFromEngine.md
+++ b/ext/native-decls/GetTrainDistanceFromEngine.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_TRAIN_DISTANCE_FROM_ENGINE
+
+```c
+float GET_TRAIN_DISTANCE_FROM_ENGINE(Vehicle train);
+```
+
+Gets how far along the chain this carriage sits, measured from the engine carriage. Returns 0.0 for the engine itself.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+The distance from the engine carriage, or 0.0 if the entity is not a train.

--- a/ext/native-decls/IsMissionTrain.md
+++ b/ext/native-decls/IsMissionTrain.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## IS_MISSION_TRAIN
+
+```c
+bool IS_MISSION_TRAIN(Vehicle train);
+```
+
+Returns whether the train was created by a script rather than by the ambient train population.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+Returns true if the train is a mission train.

--- a/ext/native-decls/IsTrainRenderedDerailed.md
+++ b/ext/native-decls/IsTrainRenderedDerailed.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## IS_TRAIN_RENDERED_DERAILED
+
+```c
+bool IS_TRAIN_RENDERED_DERAILED(Vehicle train);
+```
+
+Returns whether the train is being rendered as derailed, as set by `SET_RENDER_TRAIN_AS_DERAILED`.
+
+## Parameters
+* **train**: The train handle
+
+## Return value
+Returns true if the train is rendered derailed.


### PR DESCRIPTION
### Goal of this PR
Read back a few more train fields server-side. The server already parses them out of the train sync node, there just aren't natives for them yet.

### How is this PR achieving the goal
`CTrainGameStateDataNode` fills in more of `CTrainGameStateDataNodeData` than the current getters expose. These six are all serialized unconditionally:

```cpp
s.SerializeSigned(32, 1000.0f, data.distanceFromEngine);

s.Serialize(8, data.trainConfigIndex);
...
s.Serialize(data.isMissionTrain);
s.Serialize(data.direction);
s.Serialize(data.hasPassengerCarriages);
s.Serialize(data.renderDerailed);

s.Serialize(data.forceDoorsOpen);
```

so this adds:

| native | field |
| --- | --- |
| `GET_TRAIN_CONFIG_INDEX` | `trainConfigIndex` |
| `GET_TRAIN_DISTANCE_FROM_ENGINE` | `distanceFromEngine` |
| `IS_MISSION_TRAIN` | `isMissionTrain` |
| `DOES_TRAIN_HAVE_PASSENGER_CARRIAGES` | `hasPassengerCarriages` |
| `IS_TRAIN_RENDERED_DERAILED` | `renderDerailed` |
| `DOES_TRAIN_FORCE_DOORS_OPEN` | `forceDoorsOpen` |

Each one is the same shape as the getters already there, e.g. `GET_TRAIN_STATE`:

```cpp
fx::ScriptEngine::RegisterNativeHandler("IS_MISSION_TRAIN", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
{
	auto train = entity->syncTree->GetTrainState();

	return train ? train->isMissionTrain : false;
}));
```

I left the build gated fields out on purpose. `carriageSpeed` and `isTrackDirectionForwards` are only serialized under `IsWinterUpdate25()`, and `allowRemovalByPopulation` / `highPrecisionBlending` only under `Is2372()`, so a getter for those would read an uninitialised member on older builds unless it carried the same gate. `stopAtStations` is in the same boat and is already handled by `DOES_TRAIN_STOP_AT_STATIONS`.

`DOES_TRAIN_FORCE_DOORS_OPEN` reads the per train synced flag, which isn't quite the same thing as the client side `SET_TRAINS_FORCE_DOORS_OPEN` that sets it globally, so I noted that in its page.

### This PR applies to the following area(s)
FXServer, OneSync, Natives

### Successfully tested on

**Game builds:** n/a for the gated fields since none are used; the six added are build independent

**Platforms:** Windows, Linux

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

I could not do a full server build locally so I left the first box unchecked. What I did check is that each field is actually written by the parser and not behind a build gate, and that none of the six names collide with an existing native in `ext/native-decls` or the natives stash.
