### PR TITLE
feat(server/state): expose attachment offset, bone and flags

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -2157,6 +2157,41 @@ static void Init()
 		return handle;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_ATTACHMENT_OFFSET", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		scrVector resultVec = { 0 };
+
+		auto attachment = entity->syncTree->GetAttachment();
+
+		if (attachment && attachment->attached && attachment->hasOffset)
+		{
+			resultVec.x = attachment->x;
+			resultVec.y = attachment->y;
+			resultVec.z = attachment->z;
+		}
+
+		return resultVec;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_ATTACHMENT_BONE_INDEX", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto attachment = entity->syncTree->GetAttachment();
+
+		if (attachment && attachment->attached && attachment->attachBone != 0xFFFF)
+		{
+			return (int)attachment->attachBone;
+		}
+
+		return -1;
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_ATTACHMENT_FLAGS", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
+	{
+		auto attachment = entity->syncTree->GetAttachment();
+
+		return (attachment && attachment->attached) ? (int)attachment->attachmentFlags : 0;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_HELI_MAIN_ROTOR_HEALTH", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		auto heliHealth = entity->syncTree->GetHeliHealth();

--- a/ext/native-decls/GetEntityAttachmentBoneIndex.md
+++ b/ext/native-decls/GetEntityAttachmentBoneIndex.md
@@ -1,0 +1,18 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_ENTITY_ATTACHMENT_BONE_INDEX
+
+```c
+int GET_ENTITY_ATTACHMENT_BONE_INDEX(Entity entity);
+```
+
+Gets the bone index of the entity the given entity is attached to.
+
+## Parameters
+* **entity**: The entity handle.
+
+## Return value
+The bone index, or -1 when the entity is not attached or is not attached to a bone.

--- a/ext/native-decls/GetEntityAttachmentFlags.md
+++ b/ext/native-decls/GetEntityAttachmentFlags.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_ENTITY_ATTACHMENT_FLAGS
+
+```c
+int GET_ENTITY_ATTACHMENT_FLAGS(Entity entity);
+```
+
+Gets the attachment flags for the entity, as they were synchronised by the client that owns it.
+
+Returns 0 when the entity is not attached.
+
+## Parameters
+* **entity**: The entity handle.
+
+## Return value
+The attachment flags.

--- a/ext/native-decls/GetEntityAttachmentOffset.md
+++ b/ext/native-decls/GetEntityAttachmentOffset.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: server
+game: gta5
+---
+## GET_ENTITY_ATTACHMENT_OFFSET
+
+```c
+Vector3 GET_ENTITY_ATTACHMENT_OFFSET(Entity entity);
+```
+
+Gets the offset the entity is attached at, relative to the entity it is attached to.
+
+Returns a zero vector when the entity is not attached, or when it is attached without an offset.
+
+## Parameters
+* **entity**: The entity handle.
+
+## Return value
+The attachment offset.


### PR DESCRIPTION
### Goal of this PR
Let a server see *how* an entity is attached, not just what it is attached to. `GET_ENTITY_ATTACHED_TO` gives you the parent entity, but the offset, bone and flags are already parsed and there is currently no way to read them.

### How is this PR achieving the goal
`CBaseAttachNodeData` already carries all of it, and both attach nodes fill it in. `CPhysicalAttachDataNode::Parse`:

```cpp
data.hasOffset = state.buffer.ReadBit();
if (data.hasOffset) // Divisor 0x42200000
{
	data.x = state.buffer.ReadSignedFloat(15, 40.f);
	...
```

```cpp
data.hasAttachBones = state.buffer.ReadBit();
if (data.hasAttachBones)
{
	data.otherAttachBone = state.buffer.Read<uint16_t>(8);
	data.attachBone = state.buffer.Read<uint16_t>(8);
}
else
{
	data.attachBone = 0xFFFF;
}

data.attachmentFlags = state.buffer.Read<uint32_t>(19);
```

with `CPedAttachDataNode::Serialize` writing the same base fields for peds and players. `GetAttachment()` already resolves whichever of the two the tree has, so this only adds the three getters on top:

| native | field |
| --- | --- |
| `GET_ENTITY_ATTACHMENT_OFFSET` | `x`, `y`, `z` |
| `GET_ENTITY_ATTACHMENT_BONE_INDEX` | `attachBone` |
| `GET_ENTITY_ATTACHMENT_FLAGS` | `attachmentFlags` |

Two details worth calling out, since the two parsers don't behave identically:

- The offset is gated on `hasOffset`. `CPedAttachDataNode` zeroes `x/y/z` in its else branch but `CPhysicalAttachDataNode` leaves them untouched, so reading them unconditionally would hand back whatever was last there.
- `attachBone` is returned as `-1` when it is `0xFFFF`, which is what `CPhysicalAttachDataNode` writes when there are no attach bones.

The flags are the same value the server already relies on for the parachute check in `ServerGameState.cpp`:

```cpp
allowed |= (base && ((attachment->attachmentFlags & 130) == 130)); // Parachute attachment flags.
```

so this is not new data being trusted, just data that scripts couldn't see.

I left the orientation out. It is stored as a quaternion (`qx`/`qy`/`qz`/`qw`) and there is no four component return type here, so it would mean picking a euler convention and converting, which felt like it deserved its own change rather than being guessed at in this one.

Marked `game: gta5` in the declarations: the natives are registered for both, but `SyncTrees_RDR3.h` returns `nullptr` from `GetAttachment()` and its attach nodes are empty stubs, so on RedM they would only ever return the defaults. `GetEntityAttachedTo.md` has no `game` line today even though it has the same limitation, so say the word if you would rather these matched it.

### This PR applies to the following area(s)
FXServer, OneSync, Natives

### Successfully tested on

**Game builds:** n/a, none of these fields are build gated

**Platforms:** Windows, Linux

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

I could not do a full server build locally so I left the first box unchecked. What I did check is that both attach parsers actually write these fields, which of them zero their outputs and which don't, that `GetAttachment()` resolves both node types, that RedM returns `nullptr` there so the null checks cover it, and that none of the three names collide with an existing native.
