### PR TITLE
fix(launcher/citicore): fall back to Win32 UI and downlevel SEH handling under Wine

### DIFF
--- a/code/client/citicore/SEHTableHandler.Win32.cpp
+++ b/code/client/citicore/SEHTableHandler.Win32.cpp
@@ -14,6 +14,8 @@
 
 #include <udis86.h>
 
+#include <LaunchMode.h>
+
 static void* FindCallFromAddress(void* methodPtr, ud_mnemonic_code mnemonic = UD_Icall, bool breakOnFirst = false)
 {
 	// return value holder
@@ -210,7 +212,8 @@ extern "C" void DLL_EXPORT CoreRT_SetupSEHHandler(void* moduleBase, void* module
 			if (!internalAddress)
 			{
 				// and 2k3 to 7 don't even _have_ Rtlpx - so we directly hook the Rtl* function
-				if (IsWindows8OrGreater())
+				// (Wine's ntdll doesn't match real ntdll's binary layout, so it never finds RtlpxLookupFunctionTable there either. Treat it like a downlevel OS)
+				if (IsWindows8OrGreater() && !CfxIsWine())
 				{
 					FatalError("Could not find RtlpxLookupFunctionTable - hooking RtlLookupFunctionTable directly. This will break on a Win8+ system since RtlpxLookupFunctionTable is supposed to exist!\n");
 				}

--- a/code/client/launcher/UpdaterUI.cpp
+++ b/code/client/launcher/UpdaterUI.cpp
@@ -15,6 +15,8 @@
 
 #include "launcher.rc.h"
 
+#include <../citicore/LaunchMode.h>
+
 #include <ShellScalingApi.h>
 
 #include <winrt/Windows.Storage.Streams.h>
@@ -1330,6 +1332,12 @@ std::unique_ptr<TenUIBase> UI_InitTen()
 
 	if (getenv("CitizenFX_NoTenUI"))
 	{
+		forceOff = true;
+	}
+
+	if (CfxIsWine())
+	{
+		// WinRT XAML Islands not implemented in Wine/Proton, fall back to the plain Win32 controls UI.
 		forceOff = true;
 	}
 


### PR DESCRIPTION
### Goal of this PR
Get the legacy FiveM client to a point where it can actually start under Wine/Proton on Linux. Right now it doesn't get past the launcher, two separate things kill it before you even see a window.

Let me know if there is any genuine issues with this code being merged.

...

### How is this PR achieving the goal
Two unrelated Wine-compat fixes, both gated behind the existing `CfxIsWine()` check in `LaunchMode.h` so native Windows behavior is untouched:

1. `client/launcher/UpdaterUI.cpp`

The update/patch splash screen is built with WinRT XAML Islands `DesktopWindowXamlSource`, which Wine doesn't implement. 

The code already has a working plain-Win32-controls fallback `g_uui.tenMode = false`, used for older Windows and safe mode. 

Added Wine to the existing `forceOff` checks in `UI_InitTen()` so it takes that path instead of trying to init XAML and dying.

4. `client/citicore/SEHTableHandler.Win32.cpp`

`CoreRT_SetupSEHHandler` disassembles `RtlLookupFunctionTable` in `ntdll.dll` to locate the internal `RtlpxLookupFunctionTable`. 

Wine's `ntdll` doesn't match real ntdll's binary layout, so the lookup never finds it, and since `IsWindows8OrGreater()` reports true under Wine, it was hitting a `FatalError()`. 

The code already has a fallback path for genuinely older/downlevel OS's that hooks `RtlLookupFunctionTable` directly instead, routed Wine into that same path instead of the fatal error.

...

### This PR applies to the following area(s)
FiveM, RedM

...

### Successfully tested on

**Platforms:** Windows, Linux

...

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.