### PR TITLE
fix(rage-input): don't move the OS cursor while the game window is inactive

### DIFF
--- a/code/components/rage-input-five/src/InputHook.cpp
+++ b/code/components/rage-input-five/src/InputHook.cpp
@@ -393,6 +393,14 @@ HKL WINAPI ActivateKeyboardLayoutWrap(IN HKL hkl, IN UINT flags)
 
 BOOL WINAPI SetCursorPosWrap(int X, int Y)
 {
+	// the game keeps running while its window is inactive (alt-tabbed or minimized), so anything
+	// moving the cursor from there - such as a script looping SET_CURSOR_LOCATION - would warp the
+	// cursor away from whatever application the user is actually looking at
+	if (!g_isFocused)
+	{
+		return TRUE;
+	}
+
 	if (!g_isFocusStolen || g_enableSetCursorPos)
 	{
 		return SetCursorPos(X, Y);

--- a/code/components/rage-input-rdr3/src/InputHook.cpp
+++ b/code/components/rage-input-rdr3/src/InputHook.cpp
@@ -346,6 +346,14 @@ HKL WINAPI ActivateKeyboardLayoutWrap(IN HKL hkl, IN UINT flags)
 
 BOOL WINAPI SetCursorPosWrap(int X, int Y)
 {
+	// the game keeps running while its window is inactive (alt-tabbed or minimized), so anything
+	// moving the cursor from there - such as a script looping SET_CURSOR_LOCATION - would warp the
+	// cursor away from whatever application the user is actually looking at
+	if (!g_isFocused)
+	{
+		return TRUE;
+	}
+
 	if (!g_isFocusStolen || g_enableSetCursorPos)
 	{
 		return SetCursorPos(X, Y);


### PR DESCRIPTION
### Goal of this PR

`SET_CURSOR_LOCATION` moves the *desktop* cursor even when the game window is minimized or alt-tabbed. The game keeps ticking while inactive, so a script calling the native in a loop — a common pattern for cursor handling in resources — keeps dragging the user's mouse pointer around while they are working in another application.

Fixes #3554.

### How is this PR achieving the goal

`rage-input` already tracks window activation through `WM_ACTIVATEAPP` (`g_isFocused`). This PR makes both `SetCursorPosWrap` IAT hooks (FiveM and RedM) return early while the window is inactive, so no in-process caller can move the OS cursor from a window the user isn't looking at.

Notes on the approach, compared to the existing #3581:

- The check sits where CFX already arbitrates who may move the OS cursor (the `SetCursorPos` IAT hook), so it covers every caller instead of only the native.
- The native still runs, so the game-side cursor position keeps updating and is applied to the OS again as soon as the window is active — skipping the native entirely leaves the game's own cursor state behind.
- No new inter-component dependency (`conhost:v2` into `gta-core-five`) and no `GetForegroundWindow()` syscall per native call. It also stays correct when the game window is not the foreground window itself (e.g. the FxDK game view, where the game window is a child window).
- `g_isFocused` defaults to `true` and only changes on `WM_ACTIVATEAPP`, so setups that never receive that message behave exactly as before.

The F8 console half of #3554 is intentionally not changed here: with the console open the game window is still active and the cursor stays inside it, so no other application is affected. Gating cursor control on console state would also silently change in-game cursor behaviour for every server whenever a player opens the console. Happy to add that on top if you'd prefer the issue covered in full.

### This PR applies to the following area(s)

FiveM, RedM, Natives

### Successfully tested on

**Game builds:** the bug reproduces on current live builds — we hit it in production, where a resource that keeps the cursor positioned every frame drags the player's desktop cursor around while they are alt-tabbed. The fix itself has not been verified in-game yet (no client build environment on hand); compilation is covered by this PR's CI build. Happy to follow up with in-game results if that's a blocker.

**Platforms:** Windows

### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

fixes #3554
