### PR TITLE
fix(net): prefer TLS for getConfiguration requests

### DIFF
--- a/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
+++ b/code/components/citizen-legacy-net-resources/src/ResourceNetBindings.cpp
@@ -293,8 +293,13 @@ void NetLibraryResourcesComponent::UpdateResources(const std::string& updateList
 
 	auto curServerUrl = fmt::sprintf("https://%s/", m_netLibrary->GetCurrentPeer().ToString());
 
-	// #TODO: remove this once server version with `18d5259f60dd203b5705130491ddda4e95665171` becomes mandatory
+	// fallback only: servers that needed this (pre-`18d5259f6`, h2 stalling on large `/client` responses)
+	// can't connect anymore, and plaintext to a bare IP gets dropped by some ISP middleboxes
 	auto curServerUrlNonTls = fmt::sprintf("http://%s/", m_netLibrary->GetCurrentPeer().ToString());
+
+	// curl only writes this once a response arrived, telling a transport failure apart from an HTTP error
+	auto responseCode = std::make_shared<int>(0);
+	options.responseCode = responseCode;
 
 	options.progressCallback = [](const ProgressInfo& progress)
 	{
@@ -314,8 +319,10 @@ void NetLibraryResourcesComponent::UpdateResources(const std::string& updateList
 
 	ThrottledConnectionProgress("Downloading content manifest...", 0, 1, false);
 
-	httpClient->DoPostRequest(fmt::sprintf("%sclient", curServerUrlNonTls), httpClient->BuildPostString(postMap), options,
-		[this, httpClient, address, curServerUrl, updateList, doneCb](bool result, const char* data, size_t size)
+	auto postData = httpClient->BuildPostString(postMap);
+
+	// completion handler shared by both attempts below
+	auto handleConfiguration = [this, httpClient, address, curServerUrl, updateList, doneCb](const std::string& extraErrorInfo, bool result, const char* data, size_t size)
 	{
 		// keep a reference to the HTTP client
 		auto httpClientRef = httpClient;
@@ -331,7 +338,7 @@ void NetLibraryResourcesComponent::UpdateResources(const std::string& updateList
 									 .dump());
 
 			static ConVar<bool> streamerMode("ui_streamerMode", ConVar_UserPref, false);
-			std::string errorData = fmt::sprintf(" Error state: %s", std::string{ data, size });
+			std::string errorData = fmt::sprintf(" Error state: %s%s", std::string{ data, size }, extraErrorInfo);
 
 			if (streamerMode.GetValue())
 			{
@@ -627,6 +634,27 @@ void NetLibraryResourcesComponent::UpdateResources(const std::string& updateList
 			doneCb();
 		},
 		cts.get_token());
+	};
+
+	// TLS first, retrying in plaintext at most once and only if no HTTP response arrived at all:
+	// falling back on a real 4xx/5xx would mask a server-side error
+	httpClient->DoPostRequest(fmt::sprintf("%sclient", curServerUrl), postData, options,
+		[httpClient, options, postData, curServerUrlNonTls, responseCode, handleConfiguration](bool result, const char* data, size_t size)
+	{
+		if (result || *responseCode != 0)
+		{
+			handleConfiguration("", result, data, size);
+			return;
+		}
+
+		std::string tlsError{ data, size };
+		trace("Content manifest request over TLS failed (%s), retrying without TLS.\n", tlsError);
+
+		httpClient->DoPostRequest(fmt::sprintf("%sclient", curServerUrlNonTls), postData, options,
+			[handleConfiguration, tlsError](bool result, const char* data, size_t size)
+		{
+			handleConfiguration(result ? "" : fmt::sprintf(" TLS attempt: %s", tlsError), result, data, size);
+		});
 	});
 }
 


### PR DESCRIPTION
### Goal of this PR

Make `getConfiguration` prefer HTTPS instead of always using plaintext HTTP when connecting to the game endpoint.

This removes the mandatory plaintext path for the configuration request while preserving compatibility with servers that may still require the legacy HTTP behavior.


### How is this PR achieving the goal

- Attempts to fetch `getConfiguration` over HTTPS first.
- Falls back to the existing HTTP path only when the TLS request fails at the transport level.
- Preserves the existing request payload and response handling.
- Avoids masking valid HTTP responses or server-side errors by only retrying when no HTTP response was received.


### This PR applies to the following area(s)

- FiveM
- Networking
- Client connection flow


### Successfully tested on

**Game builds:** Not tested

**Platforms:** Not tested


### Checklist

- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

Addresses #4064