### PR TITLE
fix(scripting-core): let LoadResourceFile read through symlinks again

### DIFF
--- a/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
@@ -35,48 +35,24 @@ static inline auto GetGameBuild()
 #endif
 
 #ifdef IS_FXSERVER
-static bool IsPathWithinResourceRoot(const std::filesystem::path& rootPath, const std::filesystem::path& candidatePath)
+// checks whether a resource-relative path contains anything that'd climb out of the resource directory
+//
+// this is deliberately a lexical check: resolving the path on disk would also resolve symbolic links, and links inside
+// a resource are put there by the server owner rather than by the script asking for the file, so they're expected to
+// keep working. a script can't create them either, as there's no native to do so.
+static bool IsPathEscapingResourceRoot(const std::filesystem::path& relativePath)
 {
-#ifdef _WIN32
-	auto equalsPathPart = [](const std::filesystem::path& lhs, const std::filesystem::path& rhs)
+	static const std::filesystem::path parentDirectory{ ".." };
+
+	for (const auto& part : relativePath)
 	{
-		auto lhsString = lhs.wstring();
-		auto rhsString = rhs.wstring();
-
-		if (lhsString.size() != rhsString.size())
+		if (part == parentDirectory)
 		{
-			return false;
-		}
-
-		for (size_t i = 0; i < lhsString.size(); ++i)
-		{
-			if (towlower(lhsString[i]) != towlower(rhsString[i]))
-			{
-				return false;
-			}
-		}
-
-		return true;
-	};
-#else
-	auto equalsPathPart = [](const std::filesystem::path& lhs, const std::filesystem::path& rhs)
-	{
-		return lhs == rhs;
-	};
-#endif
-
-	auto rootIt = rootPath.begin();
-	auto candidateIt = candidatePath.begin();
-
-	for (; rootIt != rootPath.end(); ++rootIt, ++candidateIt)
-	{
-		if (candidateIt == candidatePath.end() || !equalsPathPart(*rootIt, *candidateIt))
-		{
-			return false;
+			return true;
 		}
 	}
 
-	return true;
+	return false;
 }
 #endif
 
@@ -176,8 +152,6 @@ static InitFunction initFunction([] ()
 #else
 		try
 		{
-			const std::filesystem::path resourceRoot = std::filesystem::weakly_canonical(std::filesystem::absolute(std::filesystem::u8path(rootPath)));
-
 			std::string sanitizedFileName = requestedFileName;
 			while (!sanitizedFileName.empty() && (sanitizedFileName[0] == '/' || sanitizedFileName[0] == '\\'))
 			{
@@ -186,15 +160,7 @@ static InitFunction initFunction([] ()
 
 			const std::filesystem::path requestedPath = std::filesystem::u8path(sanitizedFileName);
 
-			if (requestedPath.is_absolute() || requestedPath.has_root_name())
-			{
-				context.SetResult(nullptr);
-				return;
-			}
-
-			const std::filesystem::path absoluteRequestedPath = std::filesystem::weakly_canonical(std::filesystem::absolute(resourceRoot / requestedPath));
-
-			if (!IsPathWithinResourceRoot(resourceRoot, absoluteRequestedPath))
+			if (requestedPath.is_absolute() || requestedPath.has_root_name() || IsPathEscapingResourceRoot(requestedPath))
 			{
 				context.SetResult(nullptr);
 				return;


### PR DESCRIPTION
### Goal of this PR

Fixes #4071.

`LoadResourceFile` stopped being able to read files that live behind a symbolic link inside a resource directory, a regression between artifacts 30819 and 30863. Symlinked subfolders inside a resource are placed there deliberately by the server owner and used to work.

### Cause

The containment check added in bef45f2c8 (`tweak(scripting/core): restrict LoadResourceFile`) builds both sides of the comparison with `std::filesystem::weakly_canonical`:

```cpp
const std::filesystem::path resourceRoot = weakly_canonical(absolute(u8path(rootPath)));
...
const std::filesystem::path absoluteRequestedPath = weakly_canonical(absolute(resourceRoot / requestedPath));

if (!IsPathWithinResourceRoot(resourceRoot, absoluteRequestedPath))
```

`weakly_canonical` resolves symbolic links. For the layout in the issue:

```
resourceA/
  fxmanifest.lua
  main.lua
  locales -> /srv/shared/locales
```

`LoadResourceFile(resourceA, locales/en.json)` canonicalizes to `/srv/shared/locales/en.json`, which is not a prefix match against the resource root, so the native returns `nil`. The file is inside the resource as far as the resource is concerned; only link resolution moves it out.

### How is this PR achieving the goal

Validates the requested path lexically instead of resolving it on disk. A path is rejected if it is absolute, has a root name, or contains any parent-directory (`..`) component. Nothing touches the filesystem, so links are never followed during validation and the sandbox no longer depends on what the path happens to point at.

This keeps the protection the original change was added for. `../../server.cfg`, `..`, `../x`, `a/../../b`, `C:/Windows/win.ini` and `C:file.txt` are all still rejected, and the existing leading-slash stripping from c858b0ebe is untouched.

The rule is slightly stricter than before in one spot: `sub/../file.json` used to normalize back into the root and pass, and is now rejected. That is intentional. Once links are in play, `..` after a linked directory does not lead back to the resource root, so a path containing `..` cannot be reasoned about lexically and is not worth allowing. A resource has no reason to ask for one.

Worth noting that scripts cannot create symbolic links in the first place, there is no native for it, so a link inside a resource is always operator intent rather than something a resource can arrange for itself.

### This PR applies to the following area(s)

FXServer, Natives

### Successfully tested on

The path predicate was extracted and run standalone against the cases above (allowed: `locales/en.json`, `en.json`, `./data/x.json`, `sub/dir/file.txt`, `..foo.json`, `a..b/c.json`; rejected: `../../server.cfg`, `..`, `../x`, `a/../../b`, `sub/../file.json`, `C:/Windows/win.ini`, `C:file.txt`, `data\..\..\x`). I do not have a full server build environment set up, so this has not been exercised end to end against a live server.

### Checklist

- [x] Changes are limited to a single goal
- [x] This PR does not introduce a breaking change
- [x] Code follows the existing style in the file