### PR TITLE
fix(gta/streaming): don't resolve game packfile handles when unregistering streamed files

### DIFF
--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -2619,18 +2619,29 @@ void DLL_EXPORT CfxCollection_RemoveStreamingTag(const std::string& tag)
 				// erase existing stack entry
 				auto& handleData = g_handleStack[strId + strModule->baseIdx];
 
-				for (auto it = handleData.begin(); it != handleData.end(); ++it)
+				for (auto it = handleData.begin(); it != handleData.end(); )
 				{
+					bool matches = false;
+
 #ifdef GTA_FIVE
-					auto rawStreamer = streaming::GetRawStreamerByIndex(streaming::GetCollectionIndex(*it));
-					auto entryName = rawStreamer->GetEntryName(streaming::GetEntryIndex(*it));
-					if (entryName && strcmp(file.c_str(), entryName) == 0)
-#elif IS_RDR3
-					if (*it == idx)
-#endif
+					// Only handles owned by a cfx raw streamer can refer to this resource
+					// file: `file` is a resource cache path, which game packfile entry
+					// names never match. More importantly, saved handles for an asset we
+					// overrode point at game packfile collections, and during session
+					// shutdown (e.g. Rockstar Editor activation forcing a disconnect)
+					// those collections are already destroyed - resolving their entry
+					// names dereferences freed collection state and crashes.
+					if (streaming::IsRawHandle(*it))
 					{
-						it = handleData.erase(it);
+						auto rawStreamer = streaming::GetRawStreamerByIndex(streaming::GetCollectionIndex(*it));
+						auto entryName = rawStreamer ? rawStreamer->GetEntryName(streaming::GetEntryIndex(*it)) : nullptr;
+						matches = entryName && strcmp(file.c_str(), entryName) == 0;
 					}
+#elif IS_RDR3
+					matches = (*it == idx);
+#endif
+
+					it = matches ? handleData.erase(it) : std::next(it);
 				}
 
 				// if not empty, set the handle to the current stack entry


### PR DESCRIPTION
### Goal of this PR

Fix a reliably reproducible client crash when entering the Rockstar Editor while connected to
any server that streams a file overriding a base-game asset (occlusion ymaps, `v_int_*` ytyps
and similar — very common on roleplay servers).

Crash signature: `EXCEPTION_ACCESS_VIOLATION` reading `0x10` at `GTA5_b3570.exe+1357D4F`,
called from `gta-streaming-five.dll+440AD`, legacy hash `summer-football-princess`.

This is very likely the mechanism behind the long-standing scattered reports of "the Rockstar
Editor always crashes on server X but works on server Y" — whether a server happens to stream
a base-asset override decides it.

### How is this PR achieving the goal

When a streamed file overrides an asset that is already registered, `LoadStreamingFile.cpp`
pushes the **original game packfile handle** (collection index >= 2) onto `g_handleStack`
before overwriting the entry, then pushes the new cfx raw handle on top:

```cpp
// LoadStreamingFile.cpp:1934-1948 — registration, override branch
// if no old handle was saved, save the old handle
auto& hs = g_handleStack[strId + strModule->baseIdx];

if (hs.empty())
{
    hs.push_front(entry.handle);          // ORIGINAL game handle
}

entry.handle = (collectionId << 16) | idx;
g_handlesToTag[entry.handle] = tag;

// save the new handle
hs.push_front(entry.handle);              // cfx raw handle
```

The handle stack therefore legitimately contains handles the cfx raw streamers do not own.
The registration path already accounts for this and guards raw streamer access:

```cpp
// LoadStreamingFile.cpp:1965
// only for 'real' rawStreamer (mod variant likely won't reregister)
if (streaming::IsRawHandle(entry.handle))
```

The matching unregistration path in `CfxCollection_RemoveStreamingTag` has no such guard —
it walks the whole stack and unconditionally does:

```cpp
// LoadStreamingFile.cpp:2622-2634
auto rawStreamer = streaming::GetRawStreamerByIndex(streaming::GetCollectionIndex(*it));
auto entryName = rawStreamer->GetEntryName(streaming::GetEntryIndex(*it));
```

Rockstar Editor activation forces a disconnect whose session shutdown destroys the base
packfile collections **before** resources unmount. By the time the unregister loop runs,
resolving a saved game handle dereferences freed collection state.

This PR applies the same ownership check the registration side already uses, and null-checks
the returned streamer. No behaviour is lost by skipping non-raw handles: `file` is a resource
cache path, so it can never string-compare equal to a game packfile entry name — those
compares were dead in healthy runs and fatal during teardown.

The loop rewrite also fixes a pre-existing iterator bug, independent of the crash: the
original `it = handleData.erase(it)` inside a `for (...; ++it)` header skipped the element
following each erasure, and incremented past `end()` when the erased element was the last one.
The RDR3 branch is behaviourally unchanged.

<details>
<summary>Crash evidence (4 minidumps, one client, one server)</summary>

- 3 dumps: RIP `GTA5_b3570.exe+1357D4F`, called from `gta-streaming-five.dll+440AD`; the
  crashing frame's locals contain `cs6_occl_00` (an occlusion ymap override).
- 1 dump: RIP `GTA5_b3570.exe+1357D38` (same function), locals contain `v_int_1.ytyp`
  (a base interior ytyp override) — different session, different first override in unmount
  order.
- Exception context in all four: `RAX = 0`, AV read at `0x10`.
- R* gamelog at crash time: 0 vehicles, 0 objects, 1 ped, streaming idle. All local entities
  had been deleted before activation as a mitigation attempt and the crash reproduced
  identically, so world entity state is not a factor.
- Stopping the same resources *mid-session* does not crash, consistent with the collections
  still being alive at that point.

Dumps available on request.

</details>

**Repro:** connect to a server streaming any file whose name collides with a base-game asset
(a `*_occl_*.ymap` from any free MLO is the easiest source), then trigger
`ACTIVATE_ROCKSTAR_EDITOR`. The client crashes during the resource unmount following
`HS_FORCE_DISCONNECT`, before the editor appears.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

**Game builds:** 3570

**Platforms:** Windows

**Testing status — please read.** This compiles clean with no new warnings, and the root cause
is established from four minidumps plus source analysis. I have **not** been able to complete
a runtime before/after run: a locally built `gta-streaming-five.dll` is rejected when dropped
into a retail client — the component loader deletes `content_index.xml` on the failed load and
the launcher's updater then restores the stock DLL on next start — so I could not get a
self-built component to load in a stock install to do the comparison.

If a maintainer with a dev-signed client can run it, the repro above is deterministic and
takes under a minute. Stock crashes every time; the patched build should enter the editor
cleanly. Happy to provide the dumps, the server-side repro setup, or to make any changes
requested.

### Checklist

- [ ] Code compiles and has been tested successfully. *(compiles clean; runtime testing blocked — see above)*
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.
