### PR TITLE
Fix to the native SetBlipShowCone

### DIFF
--- a/ext/native-decls/SetBlipShowCone.md
+++ b/ext/native-decls/SetBlipShowCone.md
@@ -1,0 +1,17 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_BLIP_SHOW_CONE
+
+```c
+void SET_BLIP_SHOW_CONE(Blip blip, Bool toggle, Int hudColorIndex);
+```
+
+This function show or hide the cone of a blip, you can also set the cone color by using the last parameter "hudColorIndex"
+
+## Parameters
+* **blip**: The blip handle.
+* **toggle**: "true" to show, "false" to hide.
+* **hudColorIndex**: use the hud colors listed here : https://docs.fivem.net/docs/game-references/hud-colors/.


### PR DESCRIPTION
### Goal of this PR
The goal of this PR is to fix the "SetBlipShowCone" native function which has a missing parameter called "hudColorIndex". 

This parameter isn't present on the API class of the latest C# library and is also absent from the fivem documentation about native functions here : https://docs.fivem.net/natives/?_0x13127EC3665E8EE1

### How is this PR achieving the goal
The problem is solved by adding the new parameter like i did here : https://github.com/citizenfx/fivem/pull/4112/changes/d2fa5fb50ca924a204d53682d9fc92d4e542bb93

### This PR applies to the following area(s)
Five M

### Successfully tested on
Game : **GTA 5**

Game Build : **3258**

Platform : **Windows**




