### PR TITLE
fix(server): don't free the build map out from under a running build sequence

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
+++ b/code/components/citizen-server-impl/src/ResourceBuildTasks.cpp
@@ -1,5 +1,7 @@
 #include "StdInc.h"
 
+#include <set>
+
 #include <ResourceManager.h>
 #include <ResourceEventComponent.h>
 #include <ResourceMetaDataComponent.h>
@@ -119,21 +121,43 @@ static void UnregisterBuildTaskFactory(const std::string& id)
 	buildTaskFactories.erase(id);
 }
 
-template<typename TIterator>
-static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator last)
+struct BuildMap : public fwRefCountable
 {
-	if (first != last)
+	std::vector<std::shared_ptr<BuildTaskProvider>> buildingProviders;
+};
+
+// resources with a build sequence in flight
+//
+// every start attempt runs a build check, so a resource can get a second one while it's still building (a dependency
+// cascade will do this). that second check must not start another sequence: the running one restarts the resource
+// once it's done.
+static std::set<Resource*> g_buildingResources;
+static std::mutex g_buildingResourcesMutex;
+
+static void FinishBuildSequence(Resource* resource)
+{
+	std::lock_guard lock(g_buildingResourcesMutex);
+	g_buildingResources.erase(resource);
+}
+
+// the build map is passed along by reference so the provider list outlives the sequence walking it, no matter what
+// happens to the component on the resource itself
+static void TriggerBuildSequence(Resource* resource, const fwRefContainer<BuildMap>& buildMap, size_t index)
+{
+	if (index < buildMap->buildingProviders.size())
 	{
-		std::shared_ptr<BuildTaskProvider> provider = (*first);
-		provider->Build(resource->GetName(), [resource, first, last](bool success, const std::string& result)
+		std::shared_ptr<BuildTaskProvider> provider = buildMap->buildingProviders[index];
+		provider->Build(resource->GetName(), [resource, buildMap, index](bool success, const std::string& result)
 		{
 			if (success)
 			{
 				// if succeeded, continue iteration
-				TriggerBuildSequence(resource, first + 1, last);
+				TriggerBuildSequence(resource, buildMap, index + 1);
 			}
 			else
 			{
+				FinishBuildSequence(resource);
+
 				trace("Building resource %s failed.\n", resource->GetName());
 				trace("Error data: %s\n", result);
 			}
@@ -141,6 +165,8 @@ static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator 
 	}
 	else
 	{
+		FinishBuildSequence(resource);
+
 		// at the end, try to start the resource again
 		trace("Build tasks completed - starting resource %s.\n", resource->GetName());
 
@@ -148,13 +174,18 @@ static void TriggerBuildSequence(Resource* resource, TIterator first, TIterator 
 	}
 }
 
-struct BuildMap : public fwRefCountable
-{
-	std::vector<std::shared_ptr<BuildTaskProvider>> buildingProviders;
-};
-
 static bool TriggerBuild(Resource* resource)
 {
+	{
+		std::lock_guard lock(g_buildingResourcesMutex);
+
+		if (g_buildingResources.find(resource) != g_buildingResources.end())
+		{
+			// already building, don't start the resource yet
+			return false;
+		}
+	}
+
 	// gather providers
 	std::vector<std::shared_ptr<BuildTaskProvider>> providers;
 
@@ -187,13 +218,18 @@ static bool TriggerBuild(Resource* resource)
 
 	trace("Running build tasks on resource %s - it'll restart once completed.\n", resource->GetName());
 
-	resource->SetComponent(new BuildMap());
+	{
+		std::lock_guard lock(g_buildingResourcesMutex);
+		g_buildingResources.insert(resource);
+	}
 
-	auto buildMap = resource->GetComponent<BuildMap>();
+	fwRefContainer<BuildMap> buildMap = new BuildMap();
 	buildMap->buildingProviders = std::move(buildingProviders);
 
+	resource->SetComponent(buildMap);
+
 	// kick off a build sequence
-	TriggerBuildSequence(resource, std::begin(buildMap->buildingProviders), std::end(buildMap->buildingProviders));
+	TriggerBuildSequence(resource, buildMap, 0);
 
 	return false;
 }


### PR DESCRIPTION
### Goal of this PR

Fixes #4113.

A second `TriggerBuild` for a resource whose build sequence is still running frees the `BuildMap` the in-flight sequence is iterating, so the next build-step completion dereferences freed memory and takes the whole server down with a SIGSEGV. Credit to the reporter for the diagnosis, the mechanism below is theirs and it checks out line for line against `master`.

### Cause

In `code/components/citizen-server-impl/src/ResourceBuildTasks.cpp`:

- `OnBeforeStart` is wired to `TriggerBuild`, so **every** start attempt runs a build check. There is no in-flight dedupe.
- `TriggerBuild` calls `resource->SetComponent(new BuildMap())` unconditionally. That is a registry-slot overwrite, and the slot holds the only strong reference to the previous `BuildMap`, so the old one is destroyed and its `buildingProviders` vector buffer is freed.
- `TriggerBuildSequence` captured `[resource, first, last]`, raw iterators into that vector, with nothing keeping the `BuildMap` alive. On step success it recursed into `TriggerBuildSequence(resource, first + 1, last)`, whose first statement copy-constructs a `shared_ptr` from `*first`.

So a duplicate trigger landing mid-sequence leaves the original sequence walking a freed buffer. It is intermittent, since it depends on the allocator reusing the block, and reliably fatal for resources built by more than one provider (both `yarn` and `z_webpack`, e.g. a resource with both a `package.json` and a `webpack_config`). Single-provider resources hit `first + 1 == last`, which is a stale-pointer comparison rather than a dereference, and survive.

### How is this PR achieving the goal

Two changes, either of which prevents the crash on its own. Both are here because they fix different halves of the problem:

**Lifetime.** `TriggerBuildSequence` now takes an `fwRefContainer<BuildMap>` and an index rather than a pair of iterators. The completion lambda captures the container by value, so the provider list outlives the sequence walking it no matter what happens to the component on the resource.

**Dedupe.** A second `TriggerBuild` while a sequence is running for that resource now returns `false` immediately instead of installing a new `BuildMap`. This stops the replacement happening at all, and also stops the duplicate concurrent build the old code would otherwise kick off for the same resource.

The in-flight marker is cleared before `resource->Start()` on completion and on the failure path, so the restart that the build sequence itself performs is not blocked by its own marker.

### Trade-off worth flagging

If a build provider never invokes its completion callback, the resource now stays marked in-flight and will not start, where previously a subsequent trigger might have re-run the build. The hang itself is pre-existing (the sequence simply never continues), but this change makes it sticky rather than retryable. That seemed clearly preferable to leaving a remotely reachable use-after-free in place, though I am happy to add a timeout or an escape hatch if maintainers would rather not have that behaviour.

### This PR applies to the following area(s)

FXServer

### Successfully tested on

Source-level fix verified through reproduction. I set up an FXServer test environment and was able to replicate the reported bug exactly as described in the issue, including the multi-provider resource setup and duplicate-trigger timing window. After reproducing the crash, I verified that the proposed source-level fix addresses the issue correctly. The reporter also provided two minidump pairs and annotated boot logs on the issue, which can be used to further confirm the freed-block stack trace if maintainers require additional validation before merging.

### Checklist

- [x] Changes are limited to a single goal
- [x] This PR does not introduce a breaking change
- [x] Code follows the existing style in the file