### PR TITLE
fix(nui): make <input type="file"> file upload work

### DIFF
--- a/code/client/launcher/GameSelect.cpp
+++ b/code/client/launcher/GameSelect.cpp
@@ -447,4 +447,405 @@ std::optional<int> EnsureGamePath()
 
 	return {};
 }
+
+// Out-of-process file dialog server for the game process.
+//
+// The game process cannot show IFileDialog itself: shell extension creation deadlocks on
+// the shell's own worker pool inside the hooked/hand-mapped game process (see
+// nui-core/src/NUIFileDialog.cpp). nui-core spawns a clean copy of this exe with
+// "-filedialog:<mappingHandle>:<eventHandle>" (inherited-handle-as-integer convention,
+// like -dumpserver/-switchcl) and reads the result back from the mapping. A helper that
+// hangs is simply killed by the game - that containment is the point of the design.
+//
+// Lives in GameSelect.cpp because this file is already main-personality-only and already
+// hosts the launcher's other IFileDialog use.
+
+#include <FileDialogIPC.h>
+
+namespace
+{
+class FileDialogServerEvents : public IFileDialogEvents
+{
+public:
+	explicit FileDialogServerEvents(fdipc::Response* response)
+		: m_response(response)
+	{
+	}
+
+	// IUnknown
+	IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) override
+	{
+		if (!ppv)
+		{
+			return E_POINTER;
+		}
+
+		if (riid == IID_IUnknown || riid == IID_IFileDialogEvents)
+		{
+			*ppv = static_cast<IFileDialogEvents*>(this);
+			AddRef();
+			return S_OK;
+		}
+
+		*ppv = nullptr;
+		return E_NOINTERFACE;
+	}
+
+	IFACEMETHODIMP_(ULONG) AddRef() override
+	{
+		return InterlockedIncrement(&m_refCount);
+	}
+
+	IFACEMETHODIMP_(ULONG) Release() override
+	{
+		auto refCount = InterlockedDecrement(&m_refCount);
+
+		if (!refCount)
+		{
+			delete this;
+		}
+
+		return refCount;
+	}
+
+	// IFileDialogEvents
+	IFACEMETHODIMP OnFolderChange(IFileDialog* dialog) override
+	{
+		// first event fired once the dialog window exists: report that to the game (so it
+		// knows the helper isn't wedged) and pull the window in front of the game (the
+		// game granted us foreground rights via AllowSetForegroundWindow before spawning)
+		InterlockedExchange(&m_response->windowCreated, 1);
+
+		if (!m_raised)
+		{
+			m_raised = true;
+
+			WRL::ComPtr<IOleWindow> oleWindow;
+
+			if (SUCCEEDED(dialog->QueryInterface(IID_PPV_ARGS(&oleWindow))))
+			{
+				HWND window = nullptr;
+
+				if (SUCCEEDED(oleWindow->GetWindow(&window)) && window)
+				{
+					// The game spawned us in the background while it holds the foreground, so a
+					// bare SetForegroundWindow is usually denied and the dialog opens behind the
+					// game - where the user's next click dismisses it (ERROR_CANCELLED). Defeat the
+					// foreground lock (same idiom as glue/ConnectToNative.cpp) and toggle topmost to
+					// force z-order to the front even if the activation grant is still refused.
+					LockSetForegroundWindow(LSFW_UNLOCK);
+
+					SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+					SetWindowPos(window, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+					BringWindowToTop(window);
+					SetForegroundWindow(window);
+				}
+			}
+		}
+
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnFolderChanging(IFileDialog*, IShellItem*) override
+	{
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnFileOk(IFileDialog*) override
+	{
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnSelectionChange(IFileDialog*) override
+	{
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnShareViolation(IFileDialog*, IShellItem*, FDE_SHAREVIOLATION_RESPONSE*) override
+	{
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnTypeChange(IFileDialog*) override
+	{
+		return S_OK;
+	}
+
+	IFACEMETHODIMP OnOverwrite(IFileDialog*, IShellItem*, FDE_OVERWRITE_RESPONSE*) override
+	{
+		return S_OK;
+	}
+
+private:
+	virtual ~FileDialogServerEvents() = default;
+
+	fdipc::Response* m_response;
+	bool m_raised = false;
+	LONG m_refCount = 1;
+};
+
+// The helper is a separate short-lived process, so launcher trace() (which targets the launcher's
+// own log) is no use for diagnosing it in the field. Append the outcome to a small dedicated file
+// next to CitizenFX.log. Narrow throughout to keep %s unambiguous (paths passed as ToNarrow()).
+static void FDLog(const char* fmt, ...)
+{
+	static FILE* f = _wfopen(MakeRelativeCitPath(L"CitizenFX_FileDialog.log").c_str(), L"a");
+
+	if (!f)
+	{
+		return;
+	}
+
+	va_list ap;
+	va_start(ap, fmt);
+	vfprintf(f, fmt, ap);
+	va_end(ap);
+
+	fflush(f);
+}
+
+static void AppendResultPath(fdipc::Response* response, IShellItem* item)
+{
+	PWSTR filePath = nullptr;
+
+	if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &filePath)) || !filePath)
+	{
+		return;
+	}
+
+	// strings are packed back to back, terminators included
+	size_t length = wcslen(filePath) + 1;
+
+	if (response->resultChars + length <= fdipc::kMaxResultChars)
+	{
+		memcpy(&response->results[response->resultChars], filePath, length * sizeof(wchar_t));
+		response->resultChars += static_cast<uint32_t>(length);
+		response->numFiles++;
+	}
+
+	CoTaskMemFree(filePath);
+}
+
+static void RunFileDialogServer(fdipc::SharedBlock* block)
+{
+	auto& request = block->request;
+	auto response = &block->response;
+
+	if (request.version != fdipc::kVersion)
+	{
+		return;
+	}
+
+	ScopedCoInitialize coInit(COINIT_APARTMENTTHREADED);
+
+	if (!coInit)
+	{
+		return;
+	}
+
+	const CLSID dialogClsid = (request.mode == fdipc::kModeSave) ? CLSID_FileSaveDialog : CLSID_FileOpenDialog;
+
+	WRL::ComPtr<IFileDialog> dialog;
+
+	if (FAILED(CoCreateInstance(dialogClsid, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dialog))))
+	{
+		return;
+	}
+
+	FILEOPENDIALOGOPTIONS options = 0;
+	dialog->GetOptions(&options);
+
+	options |= FOS_FORCEFILESYSTEM | FOS_NOCHANGEDIR;
+
+	switch (request.mode)
+	{
+		case fdipc::kModeOpen:
+			options |= FOS_FILEMUSTEXIST;
+			break;
+		case fdipc::kModeOpenMultiple:
+			options |= FOS_FILEMUSTEXIST | FOS_ALLOWMULTISELECT;
+			break;
+		case fdipc::kModeOpenFolder:
+			options |= FOS_PICKFOLDERS;
+			break;
+		case fdipc::kModeSave:
+			options |= FOS_OVERWRITEPROMPT;
+			break;
+	}
+
+	dialog->SetOptions(options);
+
+	if (request.title[0])
+	{
+		dialog->SetTitle(request.title);
+	}
+
+	// default path: split into folder (SetFolder) and file name (SetFileName)
+	if (request.defaultPath[0])
+	{
+		std::wstring normalized = request.defaultPath;
+		std::replace(normalized.begin(), normalized.end(), L'/', L'\\');
+
+		auto separator = normalized.find_last_of(L'\\');
+
+		std::wstring folder;
+		std::wstring fileName;
+
+		if (separator == std::wstring::npos)
+		{
+			fileName = normalized;
+		}
+		else
+		{
+			folder = normalized.substr(0, separator);
+			fileName = normalized.substr(separator + 1);
+		}
+
+		if (!folder.empty())
+		{
+			WRL::ComPtr<IShellItem> folderItem;
+
+			if (SUCCEEDED(SHCreateItemFromParsingName(folder.c_str(), nullptr, IID_PPV_ARGS(&folderItem))))
+			{
+				dialog->SetFolder(folderItem.Get());
+			}
+		}
+
+		if (!fileName.empty())
+		{
+			dialog->SetFileName(fileName.c_str());
+		}
+	}
+
+	if (request.numFilters > 0 && request.mode != fdipc::kModeOpenFolder)
+	{
+		uint32_t numFilters = (std::min)(request.numFilters, static_cast<uint32_t>(fdipc::kMaxFilters));
+
+		std::vector<COMDLG_FILTERSPEC> specs(numFilters);
+
+		for (uint32_t i = 0; i < numFilters; i++)
+		{
+			specs[i].pszName = request.filterNames[i];
+			specs[i].pszSpec = request.filterSpecs[i];
+		}
+
+		dialog->SetFileTypes(numFilters, specs.data());
+		dialog->SetFileTypeIndex(1);
+
+		if (request.mode == fdipc::kModeSave)
+		{
+			// first spec is "*.ext" or "*.ext;*.ext2" - take the leading extension
+			std::wstring pattern = specs[0].pszSpec;
+
+			if (auto end = pattern.find(L';'); end != std::wstring::npos)
+			{
+				pattern.resize(end);
+			}
+
+			if (auto dot = pattern.find(L'.'); dot != std::wstring::npos)
+			{
+				dialog->SetDefaultExtension(pattern.substr(dot + 1).c_str());
+			}
+		}
+	}
+
+	DWORD adviseCookie = 0;
+	WRL::ComPtr<IFileDialogEvents> events;
+	events.Attach(new FileDialogServerEvents(response));
+	dialog->Advise(events.Get(), &adviseCookie);
+
+	// unowned on purpose: an owner HWND from another process would get EnableWindow(FALSE)'d,
+	// and a disabled game window is unrecoverable from here. The events sink raises us instead.
+	const HRESULT hr = dialog->Show(nullptr);
+
+	if (adviseCookie)
+	{
+		dialog->Unadvise(adviseCookie);
+	}
+
+	if (FAILED(hr))
+	{
+		// ERROR_CANCELLED lands here - plain cancel
+		FDLog("[fd] Show hr=0x%08x (0x800704C7 = cancelled)\n", (unsigned)hr);
+		return;
+	}
+
+	if (request.mode == fdipc::kModeOpenMultiple)
+	{
+		WRL::ComPtr<IFileOpenDialog> openDialog;
+		WRL::ComPtr<IShellItemArray> items;
+
+		if (SUCCEEDED(dialog.As(&openDialog)) && SUCCEEDED(openDialog->GetResults(&items)))
+		{
+			DWORD count = 0;
+			items->GetCount(&count);
+
+			for (DWORD i = 0; i < count; i++)
+			{
+				WRL::ComPtr<IShellItem> item;
+
+				if (SUCCEEDED(items->GetItemAt(i, &item)))
+				{
+					AppendResultPath(response, item.Get());
+				}
+			}
+		}
+	}
+	else
+	{
+		WRL::ComPtr<IShellItem> item;
+
+		if (SUCCEEDED(dialog->GetResult(&item)))
+		{
+			AppendResultPath(response, item.Get());
+		}
+	}
+
+	response->succeeded = (response->numFiles > 0) ? 1 : 0;
+
+	FDLog("[fd] done succeeded=%u numFiles=%u\n", (unsigned)response->succeeded, (unsigned)response->numFiles);
+}
+}
+
+bool InitializeFileDialogServer()
+{
+	auto commandLine = GetCommandLineW();
+	auto argument = wcsstr(commandLine, L"-filedialog:");
+
+	if (!argument)
+	{
+		return false;
+	}
+
+	// -filedialog:<mappingHandle>:<eventHandle>, both inherited
+	wchar_t* next = nullptr;
+	HANDLE mapping = reinterpret_cast<HANDLE>(wcstoull(&argument[12], &next, 10));
+	HANDLE doneEvent = (next && *next == L':') ? reinterpret_cast<HANDLE>(wcstoull(next + 1, nullptr, 10)) : nullptr;
+
+	auto block = reinterpret_cast<fdipc::SharedBlock*>(MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, 0));
+
+	if (block)
+	{
+		// SEH so a crash mid-extract is diagnosed rather than silently exiting with succeeded=0
+		__try
+		{
+			RunFileDialogServer(block);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER)
+		{
+			FDLog("[fd] EXCEPTION 0x%08x during RunFileDialogServer\n", (unsigned)GetExceptionCode());
+		}
+
+		UnmapViewOfFile(block);
+	}
+
+	if (doneEvent)
+	{
+		SetEvent(doneEvent);
+	}
+
+	// handled - the process should exit without doing anything else
+	return true;
+}
 #endif

--- a/code/client/launcher/Main.cpp
+++ b/code/client/launcher/Main.cpp
@@ -41,6 +41,7 @@ std::optional<int> EnsureGamePath();
 
 extern "C" bool InitializeExceptionHandler();
 bool InitializeExceptionServer();
+bool InitializeFileDialogServer();
 
 std::map<std::string, std::string> UpdateGameCache();
 
@@ -221,6 +222,13 @@ int RealMain()
 
 		// run exception handler
 		if (InitializeExceptionServer())
+		{
+			return 0;
+		}
+
+		// file dialog helper for the game process (see nui-core/src/NUIFileDialog.cpp) -
+		// must run before any bootstrap/update work
+		if (InitializeFileDialogServer())
 		{
 			return 0;
 		}

--- a/code/client/shared/CfxSubProcess.h
+++ b/code/client/shared/CfxSubProcess.h
@@ -136,7 +136,8 @@ inline const wchar_t* MakeCfxSubProcess(const std::wstring& processType, const s
 
 	if (GetFileAttributes(outPath.c_str()) == INVALID_FILE_ATTRIBUTES)
 	{
-		if (processType != L"DumpServer")
+		// these helpers can run from the original exe just fine if the copy failed
+		if (processType != L"DumpServer" && processType != L"FileDialog.exe")
 		{
 			__debugbreak();
 		}

--- a/code/client/shared/FileDialogIPC.h
+++ b/code/client/shared/FileDialogIPC.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// Request/response block for the out-of-process file dialog helper.
+//
+// The game process cannot safely show IFileDialog itself: shell extension creation
+// deadlocks on the shell's own worker pool inside the hooked/hand-mapped game process
+// (see nui-core/src/NUIFileDialog.cpp). The dialog is therefore shown by a clean copy of
+// the main launcher exe ("FiveM_FileDialog.exe", spawned via MakeCfxSubProcess), which
+// receives this block through an inherited anonymous file mapping and signals completion
+// through an inherited anonymous event - both passed as handle integers on the command
+// line, following the -dumpserver/-switchcl convention.
+//
+// Fixed layout on purpose: no allocation, no parsing, no versioned serialization - the
+// mapping is created and consumed by binaries built from the same tree.
+
+#include <windows.h>
+#include <stdint.h>
+
+namespace fdipc
+{
+constexpr uint32_t kVersion = 1;
+
+constexpr size_t kMaxStringChars = 1024;
+constexpr size_t kMaxFilters = 24;
+constexpr size_t kMaxFilterChars = 256;
+constexpr size_t kMaxResultChars = 64 * 1024;
+
+// mirrors CefDialogHandler::FileDialogMode - kept as raw integers so the launcher side
+// needs no CEF headers
+constexpr uint32_t kModeOpen = 0;
+constexpr uint32_t kModeOpenMultiple = 1;
+constexpr uint32_t kModeOpenFolder = 2;
+constexpr uint32_t kModeSave = 3;
+
+struct Request
+{
+	uint32_t version;
+	uint32_t mode;
+
+	wchar_t title[kMaxStringChars];
+	wchar_t defaultPath[kMaxStringChars];
+
+	// pre-built COMDLG_FILTERSPEC pairs - the game side owns filter derivation (MIME map
+	// etc.), the helper just passes them through
+	uint32_t numFilters;
+	wchar_t filterNames[kMaxFilters][kMaxFilterChars];
+	wchar_t filterSpecs[kMaxFilters][kMaxFilterChars];
+};
+
+struct Response
+{
+	// set by the helper the moment the dialog window exists; the game uses it to tell
+	// "user is browsing, wait forever" from "wedged in init, kill the helper"
+	volatile LONG windowCreated;
+
+	uint32_t succeeded; // 1 = user picked file(s), 0 = cancelled or failed
+	uint32_t numFiles;
+
+	// numFiles null-terminated strings, packed back to back
+	uint32_t resultChars;
+	wchar_t results[kMaxResultChars];
+};
+
+struct SharedBlock
+{
+	Request request;
+	Response response;
+};
+}

--- a/code/components/nui-core/include/NUIClient.h
+++ b/code/components/nui-core/include/NUIClient.h
@@ -11,6 +11,7 @@
 
 #include <NUIWindow.h>
 #include <include/cef_client.h>
+#include <include/cef_dialog_handler.h>
 
 #if __has_include(<include/cef_permission_handler.h>)
 #define NUI_WITH_MEDIA_ACCESS
@@ -26,6 +27,7 @@ class NUIClient : public CefClient,
 	public CefLifeSpanHandler,
 	public CefDisplayHandler,
 	public CefContextMenuHandler,
+	public CefDialogHandler,
 	public CefLoadHandler,
 #ifdef NUI_WITH_MEDIA_ACCESS
 	public CefPermissionHandler,
@@ -100,6 +102,7 @@ protected:
 	virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override;
 	virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() override;
 	virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() override;
+	virtual CefRefPtr<CefDialogHandler> GetDialogHandler() override;
 	virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override;
 	virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override;
 	virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override;
@@ -159,6 +162,15 @@ protected:
 // CefContextMenuHandler
 protected:
 	virtual void OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefContextMenuParams> params, CefRefPtr<CefMenuModel> model) override;
+
+// CefDialogHandler
+protected:
+	virtual bool OnFileDialog(CefRefPtr<CefBrowser> browser,
+		FileDialogMode mode,
+		const CefString& title,
+		const CefString& default_file_path,
+		const std::vector<CefString>& accept_filters,
+		CefRefPtr<CefFileDialogCallback> callback) override;
 
 // CefDisplayHandler
 protected:

--- a/code/components/nui-core/src/NUIClient.cpp
+++ b/code/components/nui-core/src/NUIClient.cpp
@@ -659,6 +659,11 @@ CefRefPtr<CefContextMenuHandler> NUIClient::GetContextMenuHandler()
 	return this;
 }
 
+CefRefPtr<CefDialogHandler> NUIClient::GetDialogHandler()
+{
+	return this;
+}
+
 CefRefPtr<CefLoadHandler> NUIClient::GetLoadHandler()
 {
 	return this;

--- a/code/components/nui-core/src/NUIFileDialog.cpp
+++ b/code/components/nui-core/src/NUIFileDialog.cpp
@@ -1,0 +1,771 @@
+/*
+ * This file is part of the CitizenFX project - http://citizen.re/
+ *
+ * See LICENSE and MENTIONS in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include "StdInc.h"
+#include "NUIClient.h"
+#include "CefOverlay.h"
+
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <atlbase.h>
+#include <knownfolders.h>
+
+#include <algorithm>
+#include <atomic>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <json.hpp>
+
+#include <CfxSubProcess.h>
+#include <FileDialogIPC.h>
+
+#include "include/wrapper/cef_closure_task.h"
+#include "include/base/cef_callback_helpers.h"
+
+#include "memdbgon.h"
+
+extern nui::GameInterface* g_nuiGi;
+
+// ext -> mime, defined in NUISchemeHandler.cpp
+extern const std::map<std::string_view, std::string_view, std::less<>> g_mimeTypeMap;
+
+namespace
+{
+#define FDTRACE(seq, fmtStr, ...) trace("[filedialog][s%d] " fmtStr "\n", (seq), ##__VA_ARGS__)
+
+// If the helper never creates a dialog window within this budget, Show() is wedged inside shell
+// init and never coming back; kill the helper and resolve as cancel. A window that exists means the
+// user is browsing - left alone however long that takes.
+constexpr int kHelperNoWindowMs = 6000;
+
+struct ScopedHandle
+{
+	explicit ScopedHandle(HANDLE handle = nullptr)
+		: handle(handle)
+	{
+	}
+
+	~ScopedHandle()
+	{
+		if (handle)
+		{
+			CloseHandle(handle);
+		}
+	}
+
+	ScopedHandle(const ScopedHandle&) = delete;
+	ScopedHandle& operator=(const ScopedHandle&) = delete;
+
+	explicit operator bool() const
+	{
+		return handle != nullptr;
+	}
+
+	HANDLE handle;
+};
+
+// Tells the originating NUI frame how its file dialog resolved.
+//
+// This CEF is Chromium 103; the <input type="file"> 'cancel' event only exists from
+// Chrome 113, so without this a page cannot distinguish "picker cancelled" from "picker
+// still open". PostFrameMessage marshals onto its own worker thread and tolerates
+// not-yet-ready browsers, so this is safe to call from any thread. The page receives it
+// as a regular window 'message' event.
+//
+// NOTE: this event and the input's own 'change' event ride different queues - pages must
+// tolerate them arriving in either order.
+void EmitFileDialogResult(const std::string& frameName, int seq, int mode, bool cancelled, const std::vector<CefString>& paths)
+{
+	if (frameName.empty())
+	{
+		return;
+	}
+
+	auto files = nlohmann::json::array();
+
+	for (const auto& path : paths)
+	{
+		files.push_back(std::filesystem::path(path.ToWString()).u8string());
+	}
+
+	nui::PostFrameMessage(frameName, nlohmann::json::object({
+		{ "type", "nuiFileDialogResult" },
+		{ "seq", seq },
+		{ "mode", mode },
+		{ "cancelled", cancelled },
+		{ "files", std::move(files) },
+	}).dump());
+}
+
+// Resolves a CefFileDialogCallback exactly once, cancelling on destruction if nothing else did.
+//
+// The renderer keeps one file chooser per frame. While a request is outstanding Blink silently
+// drops every new <input type="file"> activation - no dialog, no callback, not even a cancel - so
+// an unresolved callback wedges the picker for the rest of the session. Making the resolve
+// unconditional is the entire point of this class.
+//
+// (Note: this is a renderer-side limit. CEF's own "only one pending dialog" wording in
+// cef_browser.h applies to the CefBrowserHost::RunFileDialog API, not to <input type="file">.)
+class ScopedFileDialogCallback
+{
+public:
+	ScopedFileDialogCallback(CefRefPtr<CefFileDialogCallback> callback, std::string frameName, int seq, int mode)
+		: m_callback(std::move(callback)), m_frameName(std::move(frameName)), m_seq(seq), m_mode(mode)
+	{
+	}
+
+	~ScopedFileDialogCallback()
+	{
+		Cancel();
+	}
+
+	ScopedFileDialogCallback(const ScopedFileDialogCallback&) = delete;
+	ScopedFileDialogCallback& operator=(const ScopedFileDialogCallback&) = delete;
+
+	void Continue(const std::vector<CefString>& paths)
+	{
+		auto callback = Take();
+
+		if (!callback)
+		{
+			return;
+		}
+
+		if (paths.empty())
+		{
+			CefPostTask(TID_UI, base::BindOnce(&CefFileDialogCallback::Cancel, callback));
+		}
+		else
+		{
+			CefPostTask(TID_UI, base::BindOnce(&CefFileDialogCallback::Continue, callback, paths));
+		}
+
+		// exactly-once by construction: emission only happens on the winning Take()
+		EmitFileDialogResult(m_frameName, m_seq, m_mode, paths.empty(), paths);
+	}
+
+	void Cancel()
+	{
+		if (auto callback = Take())
+		{
+			CefPostTask(TID_UI, base::BindOnce(&CefFileDialogCallback::Cancel, callback));
+
+			EmitFileDialogResult(m_frameName, m_seq, m_mode, true, {});
+		}
+	}
+
+private:
+	// Held so the handover is atomic - a request finishing normally and an escape path both racing to
+	// resolve must not double-resolve the CEF callback.
+	CefRefPtr<CefFileDialogCallback> Take()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+
+		CefRefPtr<CefFileDialogCallback> callback;
+		std::swap(callback, m_callback);
+
+		return callback;
+	}
+
+	std::mutex m_mutex;
+
+	CefRefPtr<CefFileDialogCallback> m_callback;
+
+	// for the nuiFileDialogResult page event - resolved eagerly on the CEF UI thread at
+	// request time, because the browser may be gone by resolution time
+	std::string m_frameName;
+	int m_seq;
+	int m_mode;
+};
+
+std::atomic<int> g_fileDialogSeq{ 0 };
+
+// Guards the request queue and busy flag.
+std::mutex g_dialogMutex;
+bool g_dialogBusy = false;
+
+// COMDLG_FILTERSPEC holds raw pointers, so the backing strings have to outlive it. All strings are
+// filled before any spec is built - otherwise vector reallocation dangles them.
+struct FilterSpecStorage
+{
+	std::vector<std::wstring> strings;
+	std::vector<COMDLG_FILTERSPEC> specs;
+};
+
+std::vector<std::string> SplitString(std::string_view value, char delimiter)
+{
+	std::vector<std::string> parts;
+
+	size_t start = 0;
+
+	while (start <= value.size())
+	{
+		auto end = value.find(delimiter, start);
+
+		if (end == std::string_view::npos)
+		{
+			end = value.size();
+		}
+
+		auto part = value.substr(start, end - start);
+
+		if (!part.empty())
+		{
+			parts.emplace_back(part);
+		}
+
+		start = end + 1;
+	}
+
+	return parts;
+}
+
+// ".png" or "png" -> "png"
+std::string NormalizeExtension(std::string_view extension)
+{
+	while (!extension.empty() && (extension.front() == '.' || extension.front() == '*'))
+	{
+		extension.remove_prefix(1);
+	}
+
+	std::string normalized{ extension };
+	std::transform(normalized.begin(), normalized.end(), normalized.begin(), ::tolower);
+
+	return normalized;
+}
+
+// g_mimeTypeMap is ext -> mime, so every MIME lookup is a linear reverse scan. It runs once per
+// dialog over a few hundred entries, which is not worth a reverse index.
+void CollectExtensionsForMimeType(const std::string& mimeType, std::vector<std::string>& extensions)
+{
+	const bool isWildcard = mimeType.size() > 2 && mimeType.compare(mimeType.size() - 2, 2, "/*") == 0;
+	const std::string prefix = isWildcard ? mimeType.substr(0, mimeType.size() - 1) : std::string{};
+
+	for (const auto& [extension, entryMime] : g_mimeTypeMap)
+	{
+		// the map has junk keys like "*mp3"/"*wav" that aren't real extensions
+		if (extension.empty() || extension.front() == '*')
+		{
+			continue;
+		}
+
+		const bool matches = isWildcard
+			? (entryMime.size() >= prefix.size() && entryMime.compare(0, prefix.size(), prefix) == 0)
+			: (entryMime == mimeType);
+
+		if (matches)
+		{
+			extensions.emplace_back(extension);
+		}
+	}
+}
+
+// accept_filters entries come in three forms (cef_dialog_handler.h):
+//   "Image Types|.png;.gif"  - description + extension list
+//   ".png,.jpg"              - extension list
+//   "image/*" / "image/png"  - MIME type
+void BuildFilterSpecs(const std::vector<CefString>& acceptFilters, FilterSpecStorage& storage)
+{
+	std::vector<std::pair<size_t, size_t>> pending;
+
+	for (const auto& acceptFilter : acceptFilters)
+	{
+		auto filter = acceptFilter.ToString();
+
+		if (filter.empty())
+		{
+			continue;
+		}
+
+		std::string description;
+		std::vector<std::string> extensions;
+
+		if (auto pipe = filter.find('|'); pipe != std::string::npos)
+		{
+			description = filter.substr(0, pipe);
+
+			for (const auto& part : SplitString(std::string_view{ filter }.substr(pipe + 1), ';'))
+			{
+				extensions.emplace_back(NormalizeExtension(part));
+			}
+		}
+		else if (filter.find('/') != std::string::npos)
+		{
+			CollectExtensionsForMimeType(filter, extensions);
+		}
+		else
+		{
+			for (const auto& part : SplitString(filter, ','))
+			{
+				extensions.emplace_back(NormalizeExtension(part));
+			}
+		}
+
+		extensions.erase(std::remove_if(extensions.begin(), extensions.end(), [](const std::string& extension)
+		{
+			return extension.empty();
+		}), extensions.end());
+
+		std::sort(extensions.begin(), extensions.end());
+		extensions.erase(std::unique(extensions.begin(), extensions.end()), extensions.end());
+
+		if (extensions.empty())
+		{
+			continue;
+		}
+
+		std::string pattern;
+
+		for (const auto& extension : extensions)
+		{
+			if (!pattern.empty())
+			{
+				pattern += ";";
+			}
+
+			pattern += "*." + extension;
+		}
+
+		if (description.empty())
+		{
+			description = filter + " (" + pattern + ")";
+		}
+
+		storage.strings.push_back(ToWide(description));
+		storage.strings.push_back(ToWide(pattern));
+
+		pending.emplace_back(storage.strings.size() - 2, storage.strings.size() - 1);
+	}
+
+	if (pending.empty())
+	{
+		return;
+	}
+
+	// never trap the user in a filter they can't escape
+	storage.strings.push_back(L"All Files");
+	storage.strings.push_back(L"*.*");
+
+	pending.emplace_back(storage.strings.size() - 2, storage.strings.size() - 1);
+
+	storage.specs.reserve(pending.size());
+
+	for (const auto& [descriptionIndex, patternIndex] : pending)
+	{
+		storage.specs.push_back({ storage.strings[descriptionIndex].c_str(), storage.strings[patternIndex].c_str() });
+	}
+}
+
+// Shows the file dialog OUT OF PROCESS and resolves the CEF callback with the result.
+//
+// Showing IFileDialog inside the game process deadlocks: shell-extension creation
+// (AssocCreateForClasses -> SHExtCoCreateInstanceString) parks shell's own worker-pool STAs in
+// non-pumping waits inside this hooked/hand-mapped process, so Show() blocks forever inside shell
+// init without ever creating a window, and the stuck shell workers accumulate. A clean copy of the
+// main launcher exe (see launcher/GameSelect.cpp, FileDialogIPC.h) shows the dialog instead; if THAT
+// hangs before creating a window it is simply killed - the whole point of the out-of-process design.
+//
+// Runs on the persistent dialog thread (see StartDialogThread): CEF uses
+// multi_threaded_message_loop, so OnFileDialog arrives on the CEF UI thread and blocking there would
+// stall all of CEF.
+void ShowFileDialog(int seq,
+	CefDialogHandler::FileDialogMode mode,
+	std::wstring title,
+	std::wstring defaultPath,
+	std::vector<CefString> acceptFilters,
+	std::string frameName,
+	HWND parentWindow,
+	CefRefPtr<CefBrowser> browser,
+	CefRefPtr<CefFileDialogCallback> rawCallback)
+{
+	auto callbackPtr = std::make_shared<ScopedFileDialogCallback>(rawCallback, std::move(frameName), seq, (int)mode);
+	auto& callback = *callbackPtr;
+
+	try
+	{
+		// package the request into an inheritable anonymous mapping + completion event
+		SECURITY_ATTRIBUTES inheritable = { sizeof(inheritable), nullptr, TRUE };
+
+		ScopedHandle mapping(CreateFileMappingW(INVALID_HANDLE_VALUE, &inheritable, PAGE_READWRITE,
+			0, (DWORD)sizeof(fdipc::SharedBlock), nullptr));
+
+		if (!mapping)
+		{
+			FDTRACE(seq, "CreateFileMapping failed err=%u", (unsigned)GetLastError());
+			return;
+		}
+
+		auto block = reinterpret_cast<fdipc::SharedBlock*>(MapViewOfFile(mapping.handle, FILE_MAP_ALL_ACCESS, 0, 0, 0));
+
+		if (!block)
+		{
+			FDTRACE(seq, "MapViewOfFile failed err=%u", (unsigned)GetLastError());
+			return;
+		}
+
+		std::unique_ptr<fdipc::SharedBlock, decltype(&UnmapViewOfFile)> blockGuard(block, &UnmapViewOfFile);
+
+		memset(block, 0, sizeof(*block));
+
+		auto& request = block->request;
+		request.version = fdipc::kVersion;
+		request.mode = (uint32_t)mode;
+		wcsncpy_s(request.title, title.c_str(), _TRUNCATE);
+		wcsncpy_s(request.defaultPath, defaultPath.c_str(), _TRUNCATE);
+
+		if (mode != FILE_DIALOG_OPEN_FOLDER)
+		{
+			// filter derivation (MIME map etc.) stays on this side - the helper just passes
+			// the finished COMDLG pairs through
+			FilterSpecStorage filters;
+			BuildFilterSpecs(acceptFilters, filters);
+
+			uint32_t numFilters = 0;
+
+			for (const auto& spec : filters.specs)
+			{
+				if (numFilters >= fdipc::kMaxFilters)
+				{
+					break;
+				}
+
+				wcsncpy_s(request.filterNames[numFilters], spec.pszName, _TRUNCATE);
+				wcsncpy_s(request.filterSpecs[numFilters], spec.pszSpec, _TRUNCATE);
+				numFilters++;
+			}
+
+			request.numFilters = numFilters;
+		}
+
+		ScopedHandle doneEvent(CreateEventW(&inheritable, TRUE, FALSE, nullptr));
+
+		if (!doneEvent)
+		{
+			FDTRACE(seq, "CreateEvent failed err=%u", (unsigned)GetLastError());
+			return;
+		}
+
+		auto helperPath = MakeCfxSubProcess(L"FileDialog.exe");
+
+		wchar_t commandLine[1024];
+		swprintf_s(commandLine, L"\"%s\" -filedialog:%llu:%llu", helperPath,
+			(unsigned long long)(uintptr_t)mapping.handle, (unsigned long long)(uintptr_t)doneEvent.handle);
+
+		FDTRACE(seq, "spawning dialog helper mode=%d", (int)mode);
+
+		STARTUPINFOW startupInfo = { sizeof(startupInfo) };
+		PROCESS_INFORMATION processInfo = {};
+
+		if (!CreateProcessW(helperPath, commandLine, nullptr, nullptr, TRUE, 0, nullptr, nullptr, &startupInfo, &processInfo))
+		{
+			FDTRACE(seq, "CreateProcess failed err=%u", (unsigned)GetLastError());
+			return;
+		}
+
+		ScopedHandle process(processInfo.hProcess);
+		ScopedHandle processThread(processInfo.hThread);
+
+		// let the helper raise its dialog over the game window
+		AllowSetForegroundWindow(processInfo.dwProcessId);
+
+		// Wait for the result while keeping this STA pumping: a helper that creates no window within
+		// the timeout is killed; once a window exists, the user can browse for as long as they like.
+		const HANDLE waitHandles[] = { doneEvent.handle, process.handle };
+
+		const uint64_t started = GetTickCount64();
+		bool completed = false;
+		bool killed = false;
+
+		for (;;)
+		{
+			const DWORD wait = MsgWaitForMultipleObjects(2, waitHandles, FALSE, 1000, QS_ALLINPUT);
+
+			if (wait == WAIT_OBJECT_0)
+			{
+				completed = true;
+				break;
+			}
+
+			if (wait == WAIT_OBJECT_0 + 1 || wait == WAIT_FAILED)
+			{
+				// helper exited (or the wait broke) without signalling a result
+				break;
+			}
+
+			if (wait == WAIT_OBJECT_0 + 2)
+			{
+				// service the apartment: inbound COM calls arrive as window messages
+				MSG msg;
+
+				while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+				{
+					TranslateMessage(&msg);
+					DispatchMessageW(&msg);
+				}
+			}
+
+			const uint64_t elapsed = GetTickCount64() - started;
+
+			if (!killed && !block->response.windowCreated && elapsed >= (uint64_t)kHelperNoWindowMs)
+			{
+				FDTRACE(seq, "helper made no window in %ums - killing it", (unsigned)elapsed);
+				TerminateProcess(process.handle, 1);
+				killed = true;
+				// loop continues; the process handle signals on the next pass
+			}
+		}
+
+		std::vector<CefString> paths;
+
+		if (completed && block->response.succeeded && block->response.numFiles > 0)
+		{
+			const uint32_t resultChars = (std::min)(block->response.resultChars, (uint32_t)fdipc::kMaxResultChars);
+			const wchar_t* cursor = block->response.results;
+			const wchar_t* end = block->response.results + resultChars;
+
+			for (uint32_t i = 0; i < block->response.numFiles && cursor < end; i++)
+			{
+				const size_t length = wcsnlen(cursor, end - cursor);
+				paths.emplace_back(ToNarrow(std::wstring(cursor, length)));
+				cursor += length + 1;
+			}
+		}
+
+		FDTRACE(seq, "helper result: succeeded=%u files=%u%s",
+			(unsigned)(completed ? block->response.succeeded : 0), (unsigned)paths.size(),
+			completed ? "" : (killed ? " (killed)" : " (no result)"));
+
+		// empty resolves as cancel inside the guard
+		callback.Continue(paths);
+	}
+	catch (const std::exception& e)
+	{
+		// guard cancels on unwind
+		FDTRACE(seq, "C++ EXCEPTION escaped: %s", e.what());
+	}
+	catch (...)
+	{
+		// guard cancels on unwind. note /EHsc means SEH (access violations, delay-load failures) is
+		// NOT caught here - that would reach breakpad instead
+		FDTRACE(seq, "UNKNOWN C++ EXCEPTION escaped");
+	}
+
+	// The modal took Win32 focus, but nui::HasFocus() is a script-driven flag that never changed, so
+	// the edge-triggered re-assert in CefInput.cpp won't fire and CEF stays internally unfocused -
+	// leaving the page unable to take keyboard input. Push focus back explicitly.
+	if (parentWindow)
+	{
+		SetForegroundWindow(parentWindow);
+	}
+
+	if (browser)
+	{
+		// unconditional: HasFocus() is the script-driven flag that never changed across the dialog,
+		// so gating on it would skip the re-assert in exactly the cases that need it
+		CefPostTask(TID_UI, base::BindOnce([](CefRefPtr<CefBrowser> browser)
+		{
+			browser->GetHost()->SetFocus(true);
+		},
+		browser));
+	}
+}
+
+// One request for the persistent dialog thread.
+struct DialogRequest
+{
+	int seq;
+	CefDialogHandler::FileDialogMode mode;
+	std::wstring title;
+	std::wstring defaultPath;
+	std::vector<CefString> acceptFilters;
+	std::string frameName;
+	HWND parentWindow;
+	CefRefPtr<CefBrowser> browser;
+	CefRefPtr<CefFileDialogCallback> callback;
+};
+
+std::deque<DialogRequest> g_dialogQueue;
+
+// Wakes the dialog thread when a request is queued. A Win32 auto-reset event rather than a
+// condition_variable, because the thread waits in a way that still dispatches messages - see
+// StartDialogThread.
+HANDLE g_dialogWakeEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+// false until the first request starts the dialog thread
+std::atomic<bool> g_dialogThreadStarted{ false };
+
+// A single thread serves every file dialog request, for the life of the process.
+//
+// The dialog itself runs out of process (see ShowFileDialog), so this thread's job is just to
+// serialize requests off the CEF UI thread and host the bounded wait on the helper. It stays an STA
+// with a pumping wait because the apartment exists for the thread's lifetime (combase!CoUninitialize
+// is no-op-hooked process-wide - see citicore/FileMapping.Win32.cpp) and an STA that stops
+// dispatching would block anything that ever marshals into it.
+void StartDialogThread()
+{
+	std::thread([]()
+	{
+		// deliberately never uninitialized - this thread outlives every request
+		CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+		// a thread's message queue is created lazily on the first message call - force it into
+		// existence now, so the apartment is dispatchable before anyone can marshal into it
+		MSG primer;
+		PeekMessageW(&primer, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+		while (true)
+		{
+			MsgWaitForMultipleObjects(1, &g_dialogWakeEvent, FALSE, INFINITE, QS_ALLINPUT);
+
+			// service the apartment: inbound COM calls arrive here as window messages
+			MSG msg;
+
+			while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+			{
+				TranslateMessage(&msg);
+				DispatchMessageW(&msg);
+			}
+
+			// the wake event is auto-reset, so drain rather than handling a single request - two
+			// could have landed between waits
+			while (true)
+			{
+				DialogRequest request;
+
+				{
+					std::unique_lock<std::mutex> lock(g_dialogMutex);
+
+					if (g_dialogQueue.empty())
+					{
+						break;
+					}
+
+					request = std::move(g_dialogQueue.front());
+					g_dialogQueue.pop_front();
+				}
+
+				try
+				{
+					ShowFileDialog(request.seq, request.mode, std::move(request.title), std::move(request.defaultPath),
+						std::move(request.acceptFilters), std::move(request.frameName), request.parentWindow,
+						request.browser, request.callback);
+				}
+				catch (...)
+				{
+					// ShowFileDialog handles its own exceptions, but never let one escape and leave
+					// g_dialogBusy stuck - that would lock the picker out for the session
+					FDTRACE(request.seq, "EXCEPTION escaped ShowFileDialog");
+				}
+
+				{
+					std::unique_lock<std::mutex> lock(g_dialogMutex);
+					g_dialogBusy = false;
+				}
+			}
+		}
+	}).detach();
+}
+
+// Returns false if a dialog is already up, in which case the caller must resolve the callback.
+bool QueueDialogRequest(DialogRequest&& request)
+{
+	{
+		std::unique_lock<std::mutex> lock(g_dialogMutex);
+
+		// Don't queue behind an open dialog - popping a second picker the instant the first closes
+		// is not what someone who clicked minutes ago expects. Cancelling instead frees the
+		// renderer's chooser right away, so the next click works normally.
+		if (g_dialogBusy)
+		{
+			return false;
+		}
+
+		g_dialogBusy = true;
+		g_dialogQueue.push_back(std::move(request));
+
+		if (!g_dialogThreadStarted.exchange(true))
+		{
+			StartDialogThread();
+		}
+	}
+
+	SetEvent(g_dialogWakeEvent);
+
+	return true;
+}
+}
+
+bool NUIClient::OnFileDialog(CefRefPtr<CefBrowser> browser,
+	FileDialogMode mode,
+	const CefString& title,
+	const CefString& default_file_path,
+	const std::vector<CefString>& accept_filters,
+	CefRefPtr<CefFileDialogCallback> callback)
+{
+	const int seq = ++g_fileDialogSeq;
+
+	FDTRACE(seq, "request mode=%d filters=%d", (int)mode, (int)accept_filters.size());
+
+	// The browser is windowless with a null parent (NUIWindow.cpp), so parent focus restoration
+	// targets the real game window instead.
+	HWND parentWindow = (g_nuiGi) ? g_nuiGi->GetHWND() : nullptr;
+
+	// Resolve the frame name for the nuiFileDialogResult event NOW, on the CEF UI thread,
+	// while the browser is known-live - never lazily from another thread (OnBeforeClose /
+	// ClearWindow can race a late resolution).
+	std::string frameName;
+
+	if (auto window = GetWindow())
+	{
+		frameName = window->GetName();
+
+		if (frameName.find("nui_") == 0)
+		{
+			frameName = frameName.substr(4);
+		}
+	}
+
+	DialogRequest request{
+		seq,
+		mode,
+		title.ToWString(),
+		default_file_path.ToWString(),
+		accept_filters,
+		frameName,
+		parentWindow,
+		browser,
+		callback
+	};
+
+	try
+	{
+		if (!QueueDialogRequest(std::move(request)))
+		{
+			// resolve rather than drop it, or the renderer's chooser stays outstanding and every
+			// later <input type="file"> is silently ignored
+			FDTRACE(seq, "a dialog is already open - cancelling this request");
+			callback->Cancel();
+
+			// this path bypasses ScopedFileDialogCallback, so tell the page directly
+			EmitFileDialogResult(frameName, seq, (int)mode, true, {});
+		}
+	}
+	catch (const std::system_error& e)
+	{
+		FDTRACE(seq, "QUEUE FAILED: %s (code=%d)", e.what(), (int)e.code().value());
+		callback->Cancel();
+
+		EmitFileDialogResult(frameName, seq, (int)mode, true, {});
+	}
+
+	return true;
+}


### PR DESCRIPTION
### Goal of this PR

Make `<input type="file">` work in NUI. Today the OS file picker opens once and then never again until the game restarts (citizenfx/fivem#3091).

This matters because native file upload is a real building block for FiveM resources: MDT / CAD scripts let officers attach mugshots and evidence photos, character creators and identity systems let players upload an avatar, and admin / reporting tools attach screenshots. All of these rely on `<input type="file">`, and today it is unreliable — it works once and then silently stops, so authors resort to awkward workarounds (paste-a-URL fields, external uploaders) instead of a plain file picker. Fixing it makes the standard web pattern authors already know just work inside NUI.

### How is this PR achieving the goal

NUIClient never implemented CefDialogHandler, so `<input type="file">` fell through to CEF's internal default dialog. The NUI browser is windowless with a null parent HWND, so that dialog has no owner window and strands CEF's single pending-file-chooser slot; once stuck, every later click resolves instantly as cancelled and the picker stops opening until restart.

An in-process IFileDialog does not work here: in the hooked, hand-mapped game process, shell-extension creation (`AssocCreateForClasses` -> `SHExtCoCreateInstanceString`) parks the shell's own worker-pool STAs in non-pumping waits, so `IFileDialog::Show()` blocks forever inside shell init without ever creating a window, and the stuck workers accumulate across attempts.

So the dialog is shown in a separate process: a clean copy of the main launcher exe (spawned via `MakeCfxSubProcess` as `FiveM_FileDialog.exe`) receives the request through an inherited file mapping, shows IFileDialog outside all of the game's hooks, and returns the result through the mapping plus an inherited completion event. The game waits on a pumping STA thread; a helper that never creates a window within the timeout is killed, so a wedge can no longer take the picker down. An RAII guard resolves the CEF callback exactly once on every path, so the pending-chooser slot cannot leak.

The helper defeats the foreground lock so the dialog reliably lands in front of the fullscreen game instead of opening behind it.

Because this CEF is Chromium 103 (predating the `<input type="file">` `cancel` event from Chrome 113), a `nuiFileDialogResult` message is pushed to the originating frame on every resolution (pick, cancel, busy-reject) so pages can detect a cancelled picker. It and the input's own `change` event ride different queues, so pages must tolerate either order.

Covers all four FileDialogMode values, translates `accept_filters` into `COMDLG_FILTERSPEC`, and sets `FOS_NOCHANGEDIR` so the dialog can't mutate the process-wide CWD.

Note on design: this spawns a helper process (a copy of the launcher exe via the existing `MakeCfxSubProcess`/DumpServer pattern) from the game process, using an inherit-handles `CreateProcess`. Failure modes are graceful — a `CreateProcess` failure or a helper that makes no window within the timeout both resolve as cancel, and the IPC block is fixed-layout with all reads bounds-checked. The one gap is that a fault inside the game-side wait loop escapes to breakpad rather than the C++ guard (SEH, not `catch(...)`), as noted in-code. The helper being a signed-launcher copy is the item most likely to need a maintainer's input on the release/signing pipeline.

### This PR applies to the following area(s)

FiveM, NUI

### Successfully tested on

**Game builds:** b3258

**Platforms:** Windows

Example + reproduction resource: https://github.com/frostfire575/fivem-nui-file-upload
A small resource that both demonstrates `<input type="file">` usage in NUI and reproduces #3091. Repeatedly opened single / multi-select / filtered pickers and cancels; picker now opens every time, cancels are detected via `nuiFileDialogResult`, no restart needed.

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

fixes #3091
