### PR TITLE
feat(server): add onPedHealthChanged and onPedDeath events

### DIFF
--- a/code/components/citizen-resources-core/include/ResourceEventComponent.h
+++ b/code/components/citizen-resources-core/include/ResourceEventComponent.h
@@ -119,6 +119,13 @@ public:
 	void AddResourceHandledEvent(const std::string& resourceName, const std::string& eventName);
 
 	//
+	// An event to observe which events resources subscribe to, so that expensive event sources
+	// can cache whether producing an event is worth it.
+	// Arguments: eventName, resourceName
+	//
+	fwEvent<const std::string&, const std::string&> OnResourceHandledEvent;
+
+	//
 	// An event to handle event execution externally.
 	// Arguments: eventName, eventPayload, eventSource, eventCanceled
 	//

--- a/code/components/citizen-resources-core/src/ResourceEventComponent.cpp
+++ b/code/components/citizen-resources-core/src/ResourceEventComponent.cpp
@@ -177,7 +177,10 @@ void ResourceEventManagerComponent::AddResourceHandledEvent(const std::string& r
 	}
 
 	m_eventResources.emplace(eventName, resourceName);
+
+	OnResourceHandledEvent(eventName, resourceName);
 }
+
 
 bool ResourceEventManagerComponent::TriggerEvent(const std::string& eventName, const std::string& eventPayload, const std::string& eventSource /* = std::string() */, ResourceEventComponent* filter /* = nullptr*/)
 {

--- a/code/components/citizen-server-impl/include/state/ServerGameState.h
+++ b/code/components/citizen-server-impl/include/state/ServerGameState.h
@@ -1569,6 +1569,8 @@ private:
 
 	bool ValidateEntity(EntityLockdownMode entityLockdownMode, const fx::sync::SyncEntityPtr& entity);
 
+	void HandlePedHealthUpdate(const fx::sync::SyncEntityPtr& entity, fx::sync::CPedHealthNodeData* healthNode, int oldHealth, int oldArmour);
+
 public:
 	std::unordered_set<uint32_t> blockedEvents;
 	std::shared_mutex blockedEventsMutex;
@@ -1587,6 +1589,16 @@ public:
 
 private:
 	fx::ServerInstanceBase* m_instance;
+
+	enum PedEventFlags : uint32_t
+	{
+		PedEventHealthChanged = 1 << 0,
+		PedEventDeath = 1 << 1,
+	};
+
+	// updated when a resource registers a handler, so the sync parse path only needs an
+	// atomic read instead of a lookup in the event registry
+	std::atomic<uint32_t> m_pedEventFlags{ 0 };
 
 #ifdef USE_ASYNC_SCL_POSTING
 	std::unique_ptr<ThreadPool> m_tg;

--- a/code/components/citizen-server-impl/src/state/ServerGameState.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState.cpp
@@ -3518,9 +3518,23 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 		{
 			if (parsingType == 2)
 			{
+				auto healthNode = (entity->type == sync::NetObjEntityType::Ped || entity->type == sync::NetObjEntityType::Player)
+					? syncTree->GetPedHealth()
+					: nullptr;
+
+				// maxHealth is only 0 until the node was parsed for the first time
+				bool hadHealth = healthNode && healthNode->maxHealth != 0;
+				int oldHealth = hadHealth ? healthNode->health : 0;
+				int oldArmour = hadHealth ? healthNode->armour : 0;
+
 				syncTree->ParseSync(state);
 
 				entity->hasSynced = true;
+
+				if (hadHealth)
+				{
+					HandlePedHealthUpdate(entity, healthNode, oldHealth, oldArmour);
+				}
 			}
 			else if (parsingType == 1)
 			{
@@ -3706,6 +3720,83 @@ bool ServerGameState::ProcessClonePacket(const fx::ClientSharedPtr& client, rl::
 	}
 
 	return true;
+}
+
+void ServerGameState::HandlePedHealthUpdate(const fx::sync::SyncEntityPtr& entity, fx::sync::CPedHealthNodeData* healthNode, int oldHealth, int oldArmour)
+{
+	int health = healthNode->health;
+	int armour = healthNode->armour;
+
+	if (health == oldHealth && armour == oldArmour)
+	{
+		return;
+	}
+
+	bool died = oldHealth > 0 && health <= 0;
+
+	uint32_t flags = m_pedEventFlags.load(std::memory_order_relaxed);
+	bool wantsHealthChanged = (flags & PedEventHealthChanged) != 0;
+	bool wantsDeath = died && (flags & PedEventDeath) != 0;
+
+	// don't pay for events nobody is listening to
+	if (!wantsHealthChanged && !wantsDeath)
+	{
+		return;
+	}
+
+	// the node may be parsed again before the callback runs, so pass values, not the node
+	uint32_t weaponHash = healthNode->causeOfDeath;
+	int sourceOfDamage = healthNode->sourceOfDamage;
+
+	gscomms_execute_callback_on_main_thread([this, entity, wantsHealthChanged, wantsDeath, oldHealth, health, oldArmour, armour, sourceOfDamage, weaponHash]()
+	{
+		auto evComponent = m_instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::ResourceEventManagerComponent>();
+		auto ped = MakeScriptHandle(entity);
+
+		uint32_t attacker = 0;
+
+		if (sourceOfDamage != 0)
+		{
+			if (auto attackerEntity = GetEntity(0, sourceOfDamage))
+			{
+				attacker = MakeScriptHandle(attackerEntity);
+			}
+		}
+
+		if (wantsHealthChanged)
+		{
+			/*NETEV onPedHealthChanged SERVER
+			/#*
+			 * Triggered when the health or armour of a ped changed.
+			 *
+			 * @param ped - The handle of the ped whose health or armour changed.
+			 * @param oldHealth - The health the ped had before the change.
+			 * @param health - The health the ped has after the change.
+			 * @param oldArmour - The armour the ped had before the change.
+			 * @param armour - The armour the ped has after the change.
+			 * @param attacker - The handle of the entity that caused the damage, or 0 if unknown.
+			 * @param weaponHash - The hash of the weapon that caused the damage, or 0 if unknown.
+			 #/
+			declare function onPedHealthChanged(ped: number, oldHealth: number, health: number, oldArmour: number, armour: number, attacker: number, weaponHash: number): void;
+			*/
+			evComponent->TriggerEvent2("onPedHealthChanged", {}, ped, oldHealth, health, oldArmour, armour, attacker, weaponHash);
+		}
+
+		if (wantsDeath)
+		{
+			/*NETEV onPedDeath SERVER
+			/#*
+			 * Triggered when a ped died.
+			 *
+			 * @param ped - The handle of the ped that died.
+			 * @param attacker - The handle of the entity that killed the ped, or 0 if unknown.
+			 * @param weaponHash - The hash of the weapon that killed the ped, or 0 if unknown.
+			 #/
+			declare function onPedDeath(ped: number, attacker: number, weaponHash: number): void;
+			*/
+			evComponent->TriggerEvent2("onPedDeath", {}, ped, attacker, weaponHash);
+		}
+	});
 }
 
 bool ServerGameState::ValidateEntity(EntityLockdownMode entityLockdownMode, const fx::sync::SyncEntityPtr& entity)
@@ -4570,6 +4661,29 @@ auto ServerGameState::GetEntityLockdownMode(const fx::ClientSharedPtr& client) -
 void ServerGameState::AttachToObject(fx::ServerInstanceBase* instance)
 {
 	m_instance = instance;
+
+	instance->GetComponent<fx::ResourceManager>()->GetComponent<fx::ResourceEventManagerComponent>()->OnResourceHandledEvent.Connect([this](const std::string& eventName, const std::string&)
+	{
+		uint32_t flags = 0;
+
+		if (eventName == "onPedHealthChanged")
+		{
+			flags = PedEventHealthChanged;
+		}
+		else if (eventName == "onPedDeath")
+		{
+			flags = PedEventDeath;
+		}
+		else if (eventName == "*")
+		{
+			flags = PedEventHealthChanged | PedEventDeath;
+		}
+
+		if (flags)
+		{
+			m_pedEventFlags.fetch_or(flags, std::memory_order_relaxed);
+		}
+	});
 
 	m_lockdownModeVar = instance->AddVariable<fx::EntityLockdownMode>("sv_entityLockdown", ConVar_None, m_entityLockdownMode, &m_entityLockdownMode);
 	m_stateBagStrictModeVar = instance->AddVariable<bool>("sv_stateBagStrictMode", ConVar_None, m_stateBagStrictMode, &m_stateBagStrictMode);


### PR DESCRIPTION
### Goal of this PR

Make the enhanced `onPedHealthChanged` and `onPedDeath` server events available on legacy GTA5.

### How is this PR achieving the goal

A ped only sends its health node when the game changed health, armour or damage state, so parsing it
is the detector: the clone sync path reads health and armour off the node before `ParseSync`, compares
them to what the node holds afterwards, and turns a difference into events. No state is added to the
node, nothing is polled, and the event rate can never exceed the sync rate.

`onPedDeath` fires on the transition to dead only, so a ped that stays dead does not report a second
death while a revived ped that dies again does.

Both events are only raised when a resource registered a handler for them. `ResourceEventManagerComponent`
gained an `OnResourceHandledEvent` notification that fires when a resource subscribes to an event
name; the game state caches its interest in an atomic bitmask from it, so the parse path costs a
relaxed atomic load and never touches the event registry.

Arguments match the enhanced API:

```
onPedHealthChanged(ped, oldHealth, health, oldArmour, armour, attacker, weaponHash)
onPedDeath(ped, attacker, weaponHash)
```

`ped` and `attacker` are server-side entity handles, as in `entityCreated`. RedM needs the ped
health node in its sync tree first (see https://github.com/citizenfx/fivem/pull/3508), after which
these events work there unchanged, minus armour, attacker and weapon.

### This PR applies to the following area(s)

FiveM, FxServer

### Successfully tested on

Game builds: **3258**, **FxServer**
Platforms: **Windows**

Tested thoroughly with the test resource attached below, which runs a scripted damage protocol:
armour, damage, healing, death firing exactly once, damage on a corpse not repeating it, revival,
dying again, an idle server staying silent, and weapon damage reporting the attacker and weapon —
for players and for non-player peds. No issues found.
[pedevents_test.zip](https://github.com/user-attachments/files/31048039/pedevents_test.zip)

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.
