### PR TITLE
feat(server): add SET_PLAYER_NAME native and onPlayerNameChanged event

### DIFF
--- a/code/components/citizen-playernames-five/src/HookPlayerNameHandling.cpp
+++ b/code/components/citizen-playernames-five/src/HookPlayerNameHandling.cpp
@@ -123,6 +123,31 @@ static InitFunction initFunction([] ()
 		{
 			eventComponent->OnTriggerEvent.Connect([] (const std::string& eventName, const std::string& eventPayload, const std::string& eventSource, bool* eventCanceled)
 			{
+				// a rename only needs the name map updated
+				if (eventName == "onPlayerNameChanged")
+				{
+					try
+					{
+						msgpack::unpacked msg;
+						msgpack::unpack(msg, eventPayload.c_str(), eventPayload.size());
+
+						std::vector<msgpack::object> arguments;
+						msg.get().convert(arguments);
+
+						// netId, oldName, newName, resourceName
+						if (arguments.size() >= 3)
+						{
+							g_netIdToNames[arguments[0].as<int>()] = arguments[2].as<std::string>();
+						}
+					}
+					catch (std::runtime_error& e)
+					{
+						trace("Failed to unpack onPlayerNameChanged event: %s\n", e.what());
+					}
+
+					return;
+				}
+
 				// if this is the event 'we' handle...
 				if (eventName == "onPlayerJoining" || eventName == "onPlayerDropped")
 				{

--- a/code/components/citizen-playernames-rdr3/src/HookPlayerNameHandling.cpp
+++ b/code/components/citizen-playernames-rdr3/src/HookPlayerNameHandling.cpp
@@ -68,6 +68,31 @@ static InitFunction initFunction([]()
 		{
 			eventComponent->OnTriggerEvent.Connect([](const std::string& eventName, const std::string& eventPayload, const std::string& eventSource, bool* eventCanceled)
 			{
+				// a rename only needs the name map updated
+				if (eventName == "onPlayerNameChanged")
+				{
+					try
+					{
+						msgpack::unpacked msg;
+						msgpack::unpack(msg, eventPayload.c_str(), eventPayload.size());
+
+						std::vector<msgpack::object> arguments;
+						msg.get().convert(arguments);
+
+						// netId, oldName, newName, resourceName
+						if (arguments.size() >= 3)
+						{
+							g_netIdToNames[arguments[0].as<int>()] = arguments[2].as<std::string>();
+						}
+					}
+					catch (std::runtime_error& e)
+					{
+						trace("Failed to unpack onPlayerNameChanged event: %s\n", e.what());
+					}
+
+					return;
+				}
+
 				// if this is the event 'we' handle...
 				if (eventName == "onPlayerJoining" || eventName == "onPlayerDropped")
 				{

--- a/code/components/citizen-server-impl/include/PlayerName.h
+++ b/code/components/citizen-server-impl/include/PlayerName.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include <utf8.h>
+
+namespace fx
+{
+static constexpr size_t kMaxPlayerNameLength = 200;
+
+// Limits a name to kMaxPlayerNameLength bytes and replaces invalid UTF-8 in it.
+inline bool NormalizePlayerName(std::string& name)
+{
+	if (name.length() >= kMaxPlayerNameLength)
+	{
+		name = name.substr(0, kMaxPlayerNameLength);
+	}
+
+	std::string validName;
+
+	try
+	{
+		utf8::replace_invalid(name.begin(), name.end(), std::back_inserter(validName));
+	}
+	catch (std::exception&)
+	{
+		return false;
+	}
+
+	name = std::move(validName);
+
+	return true;
+}
+}

--- a/code/components/citizen-server-impl/src/InitConnectMethod.cpp
+++ b/code/components/citizen-server-impl/src/InitConnectMethod.cpp
@@ -49,6 +49,8 @@
 
 #include <utf8.h>
 
+#include <PlayerName.h>
+
 #include "NetBitVersion.h"
 
 #include <HttpClient.h>
@@ -611,27 +613,11 @@ static InitFunction initFunction([]()
 				return;
 			}
 
-			// limit name length
-			if (name.length() >= 200)
+			// limit name length and replace invalid UTF8 sequences in name
+			if (!fx::NormalizePlayerName(name))
 			{
-				name = name.substr(0, 200);
-			}
-
-			// replace invalid UTF8 sequences in name
-			{
-				std::string validName;
-
-				try
-				{
-					utf8::replace_invalid(name.begin(), name.end(), std::back_inserter(validName));
-				}
-				catch (std::exception& e)
-				{
-					sendError("Parsing name failed.");
-					return;
-				}
-
-				name = validName;
+				sendError("Parsing name failed.");
+				return;
 			}
 
 			TicketData ticketData;

--- a/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/PlayerScriptFunctions.cpp
@@ -7,6 +7,11 @@
 #include <ClientRegistry.h>
 #include <ServerInstanceBaseRef.h>
 
+#include <ResourceEventComponent.h>
+#include <ServerEventComponent.h>
+
+#include <PlayerName.h>
+
 #include <ScriptEngine.h>
 
 #include <se/Security.h>
@@ -30,6 +35,63 @@ static void CreatePlayerCommands()
 	fx::ScriptEngine::RegisterNativeHandler("GET_PLAYER_NAME", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
 	{
 		return client->GetName().c_str();
+	}));
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_PLAYER_NAME", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)
+	{
+		std::string name = context.CheckArgument<const char*>(1);
+
+		if (!fx::NormalizePlayerName(name) || name.empty())
+		{
+			return false;
+		}
+
+		std::string oldName = client->GetName();
+
+		if (oldName == name)
+		{
+			return false;
+		}
+
+		client->SetName(name);
+
+		std::string resourceName;
+
+		fx::OMPtr<IScriptRuntime> runtime;
+		if (FX_SUCCEEDED(fx::GetCurrentScriptRuntime(&runtime)))
+		{
+			fx::Resource* resource = reinterpret_cast<fx::Resource*>(runtime->GetParentObject());
+
+			if (resource)
+			{
+				resourceName = resource->GetName();
+			}
+		}
+
+		auto resourceManager = fx::ResourceManager::GetCurrent();
+
+		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+
+		// joining clients get their name as part of onPlayerJoining
+		if (client->HasConnected())
+		{
+			instance->GetComponent<fx::ServerEventComponent>()->TriggerClientEvent("onPlayerNameChanged", std::optional<std::string_view>(), client->GetNetId(), oldName, name, resourceName);
+		}
+
+		/*NETEV onPlayerNameChanged SERVER
+		/#*
+		 * A server-side event that is triggered when a player's name is changed using SET_PLAYER_NAME.
+		 *
+		 * @param source - The player's NetID (a number in Lua/JS), **not a real argument, use [FromSource] or source**.
+		 * @param oldName - The name the player had before the change.
+		 * @param newName - The name the player has after the change, as normalized by the server.
+		 * @param resourceName - The name of the resource that changed the name, or an empty string if it wasn't changed by a resource.
+		 #/
+		declare function onPlayerNameChanged(source: string, oldName: string, newName: string, resourceName: string): void;
+		*/
+		resourceManager->GetComponent<fx::ResourceEventManagerComponent>()->QueueEvent2("onPlayerNameChanged", { fmt::sprintf("internal-net:%d", client->GetNetId()) }, oldName, name, resourceName);
+
+		return true;
 	}));
 
 	fx::ScriptEngine::RegisterNativeHandler("DOES_PLAYER_EXIST", MakeClientFunction([](fx::ScriptContext& context, const fx::ClientSharedPtr& client)

--- a/ext/native-decls/SetPlayerName.md
+++ b/ext/native-decls/SetPlayerName.md
@@ -1,0 +1,26 @@
+---
+ns: CFX
+apiset: server
+---
+## SET_PLAYER_NAME
+
+```c
+BOOL SET_PLAYER_NAME(char* playerSrc, char* name);
+```
+
+Changes the name of a player, both for the server (`GET_PLAYER_NAME`, player lists) and for other
+clients in-game.
+
+The name gets normalized the same way names sent on connection are: it is limited to 200 bytes and
+invalid UTF-8 sequences get replaced.
+
+This can be used during `playerConnecting` as well as afterwards. Changing the name triggers the
+`onPlayerNameChanged` server event.
+
+## Parameters
+* **playerSrc**: The player to change the name of.
+* **name**: The new name for the player.
+
+## Return value
+`true` if the name was changed, `false` if the player didn't exist, the name was empty/invalid, or
+the player already had this name.


### PR DESCRIPTION
### Goal of this PR

Make the enhanced `SET_PLAYER_NAME` native and the `onPlayerNameChanged` event available on
legacy GTA5 and RedM.

### How is this PR achieving the goal

The native sets the name on `fx::Client`, so `GET_PLAYER_NAME` and everything built on it change
immediately. Names are normalized exactly like connection-time names are (200 byte limit, invalid
UTF-8 replaced), factored out of `initConnect` into `fx::NormalizePlayerName` and shared by both
paths.

Clients keep their own netId-to-name map that the game's name lookup is hooked into, so the rename
is broadcast as `onPlayerNameChanged` and `citizen-playernames-five` / `-rdr3` update just that
name. Re-sending `onPlayerJoining` would also recreate the physical player, hence the separate
event.

Server-side scripts get `onPlayerNameChanged(source, oldName, newName, resourceName)`. Native name,
event name and arguments match the enhanced API.

### This PR applies to the following area(s)

FiveM, RedM, Natives, FxServer

### Successfully tested on

Game builds: **3258 (FiveM)**, **1491 (RedM)**, **FxServer**
Platforms: **Windows**

Tested thoroughly on both games, client and server, with the test resource attached below: renaming
during `playerConnecting` and after joining, all return values, the length limit, invalid UTF-8, the
event arguments, and the client-side name matching the server in the player list and overhead tags.
No issues found.

[setplayername_test.zip](https://github.com/user-attachments/files/31048045/setplayername_test.zip)


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.
