### PR TITLE
fix(core/rdr3): missing comma in pool entries table

### DIFF
--- a/code/components/gta-core-rdr3/src/PoolManagement.cpp
+++ b/code/components/gta-core-rdr3/src/PoolManagement.cpp
@@ -212,7 +212,7 @@ static const char* poolEntriesTable[] = {
 	"CNetObjDraftVehicle",
 	"CNetObjGroupScenario",
 	"CNetObjGuardZone",
-	"CNetObjHorse"
+	"CNetObjHorse",
 	"CNetObjHerd",
 	"CNetObjIncident",
 	"CNetObjObject",


### PR DESCRIPTION
### Goal of this PR

Fix two pool names being merged ("CNetObjHorseCNetObjHerd")

### How is this PR achieving the goal

Adds a missing comma in rdr3 core pool entries table

### This PR applies to the following area(s)

RedM / rdr3 core

### Successfully tested on

**Game builds:** 1491 

**Platforms:** Windows


### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
N/A

