### PR TITLE
feat(server): expose performance data to scripting runtimes

### DIFF
--- a/code/components/citizen-server-impl/include/ServerPerfComponent.h
+++ b/code/components/citizen-server-impl/include/ServerPerfComponent.h
@@ -1,9 +1,30 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
 #include <prometheus/registry.h>
 
 namespace fx
 {
+struct ServerPerformanceMetric
+{
+	double currentMilliseconds = 0.0;
+	double averageMilliseconds = 0.0;
+	double maximumMilliseconds = 0.0;
+	uint64_t sampleCount = 0;
+};
+
+struct ServerPerformanceSnapshot
+{
+	ServerPerformanceMetric tick;
+	ServerPerformanceMetric script;
+};
+
 class ServerPerfComponent : public fwRefCountable
 {
 public:
@@ -17,8 +38,76 @@ public:
 		return m_registry;
 	}
 
+	inline void ObserveServerTick(std::chrono::steady_clock::duration duration)
+	{
+		std::lock_guard lock(m_metricsMutex);
+		m_tickMetrics.Append(duration);
+	}
+
+	inline void ObserveScriptTick(std::chrono::steady_clock::duration duration)
+	{
+		std::lock_guard lock(m_metricsMutex);
+		m_scriptMetrics.Append(duration);
+	}
+
+	inline ServerPerformanceSnapshot GetPerformanceSnapshot() const
+	{
+		std::lock_guard lock(m_metricsMutex);
+		return { m_tickMetrics.GetSnapshot(), m_scriptMetrics.GetSnapshot() };
+	}
+
 private:
+	static constexpr size_t SampleWindow = 64;
+
+	struct RollingMetrics
+	{
+		void Append(std::chrono::steady_clock::duration duration)
+		{
+			const double milliseconds = std::chrono::duration<double, std::milli>(duration).count();
+
+			if (size == SampleWindow)
+			{
+				sum -= samples[next];
+			}
+			else
+			{
+				++size;
+			}
+
+			samples[next] = milliseconds;
+			sum += milliseconds;
+			next = (next + 1) % SampleWindow;
+			current = milliseconds;
+			++count;
+		}
+
+		ServerPerformanceMetric GetSnapshot() const
+		{
+			if (size == 0)
+			{
+				return {};
+			}
+
+			return {
+				current,
+				sum / size,
+				*std::max_element(samples.begin(), samples.begin() + size),
+				count
+			};
+		}
+
+		std::array<double, SampleWindow> samples {};
+		size_t next = 0;
+		size_t size = 0;
+		double current = 0.0;
+		double sum = 0.0;
+		uint64_t count = 0;
+	};
+
 	std::shared_ptr<prometheus::Registry> m_registry;
+	mutable std::mutex m_metricsMutex;
+	RollingMetrics m_tickMetrics;
+	RollingMetrics m_scriptMetrics;
 };
 }
 

--- a/code/components/citizen-server-impl/src/GameServer.cpp
+++ b/code/components/citizen-server-impl/src/GameServer.cpp
@@ -204,6 +204,7 @@ namespace fx
 					auto frameTime = 1000 / 20;
 
 					auto mpd = mainData.get();
+					auto serverPerf = m_instance->GetComponent<ServerPerfComponent>();
 
 					static auto& collector = prometheus::BuildHistogram()
 						.Name("tickTime")
@@ -214,9 +215,10 @@ namespace fx
 						});
 
 					uv_timer_init(loop, &mainData->tickTimer);
-					uv_timer_start(&mainData->tickTimer, UvPersistentCallback(&mainData->tickTimer, [this, mpd](uv_timer_t*)
+					uv_timer_start(&mainData->tickTimer, UvPersistentCallback(&mainData->tickTimer, [this, mpd, serverPerf](uv_timer_t*)
 					{
 						auto now = msec();
+						auto tickStart = std::chrono::steady_clock::now();
 						auto thisTime = now - mpd->lastTime;
 						mpd->lastTime = now;
 
@@ -227,6 +229,7 @@ namespace fx
 						}
 
 						ProcessServerFrame(thisTime.count());
+						serverPerf->ObserveServerTick(std::chrono::steady_clock::now() - tickStart);
 
 						auto atEnd = msec();
 						collector.Observe((atEnd - now).count() / 1000.0);

--- a/code/components/citizen-server-impl/src/ServerPerformanceScriptFunctions.cpp
+++ b/code/components/citizen-server-impl/src/ServerPerformanceScriptFunctions.cpp
@@ -1,0 +1,39 @@
+#include "StdInc.h"
+
+#include <ResourceManager.h>
+#include <ScriptEngine.h>
+#include <ScriptSerialization.h>
+#include <ServerInstanceBaseRef.h>
+#include <ServerPerfComponent.h>
+
+namespace
+{
+struct ServerPerformanceData
+{
+	double tickTime;
+	double tickTimeAverage;
+	double tickTimeMax;
+	double scriptTime;
+	uint64_t frameCount;
+
+	MSGPACK_DEFINE_MAP(tickTime, tickTimeAverage, tickTimeMax, scriptTime, frameCount);
+};
+}
+
+static InitFunction initFunction([]()
+{
+	fx::ScriptEngine::RegisterNativeHandler("GET_SERVER_PERFORMANCE_DATA", [](fx::ScriptContext& context)
+	{
+		auto resourceManager = fx::ResourceManager::GetCurrent();
+		auto instance = resourceManager->GetComponent<fx::ServerInstanceBaseRef>()->Get();
+		auto snapshot = instance->GetComponent<fx::ServerPerfComponent>()->GetPerformanceSnapshot();
+
+		context.SetResult(fx::SerializeObject(ServerPerformanceData{
+			snapshot.tick.currentMilliseconds,
+			snapshot.tick.averageMilliseconds,
+			snapshot.tick.maximumMilliseconds,
+			snapshot.script.currentMilliseconds,
+			snapshot.tick.sampleCount
+		}));
+	});
+});

--- a/code/components/citizen-server-impl/src/ServerResources.cpp
+++ b/code/components/citizen-server-impl/src/ServerResources.cpp
@@ -10,6 +10,7 @@
 
 #include <ServerInstanceBase.h>
 #include <ServerInstanceBaseRef.h>
+#include <ServerPerfComponent.h>
 
 #include "ServerResourceList.h"
 
@@ -840,10 +841,13 @@ static InitFunction initFunction([]()
 		});
 
 		auto gameServer = instance->GetComponent<fx::GameServer>();
+		auto serverPerf = instance->GetComponent<fx::ServerPerfComponent>();
 
-		gameServer->OnTick.Connect([=]()
+		gameServer->OnTick.Connect([resman, serverPerf]()
 		{
+			auto tickStart = std::chrono::steady_clock::now();
 			resman->Tick();
+			serverPerf->ObserveScriptTick(std::chrono::steady_clock::now() - tickStart);
 		});
 	}, 50);
 });

--- a/code/tests/server/TestServerPerfComponent.cpp
+++ b/code/tests/server/TestServerPerfComponent.cpp
@@ -1,0 +1,58 @@
+#include <StdInc.h>
+
+#include <catch_amalgamated.hpp>
+
+#include <ServerPerfComponent.h>
+
+using namespace std::chrono_literals;
+
+TEST_CASE("Server performance metrics track a rolling window")
+{
+	fx::ServerPerfComponent component;
+
+	SECTION("an empty component returns zero values")
+	{
+		auto snapshot = component.GetPerformanceSnapshot();
+
+		REQUIRE(snapshot.tick.currentMilliseconds == 0.0);
+		REQUIRE(snapshot.tick.averageMilliseconds == 0.0);
+		REQUIRE(snapshot.tick.maximumMilliseconds == 0.0);
+		REQUIRE(snapshot.tick.sampleCount == 0);
+		REQUIRE(snapshot.script.sampleCount == 0);
+	}
+
+	SECTION("tick metrics retain the latest 64 samples")
+	{
+		for (int milliseconds = 1; milliseconds <= 64; ++milliseconds)
+		{
+			component.ObserveServerTick(std::chrono::milliseconds(milliseconds));
+		}
+
+		auto snapshot = component.GetPerformanceSnapshot();
+		REQUIRE(snapshot.tick.currentMilliseconds == 64.0);
+		REQUIRE(snapshot.tick.averageMilliseconds == 32.5);
+		REQUIRE(snapshot.tick.maximumMilliseconds == 64.0);
+		REQUIRE(snapshot.tick.sampleCount == 64);
+
+		component.ObserveServerTick(100ms);
+		snapshot = component.GetPerformanceSnapshot();
+
+		REQUIRE(snapshot.tick.currentMilliseconds == 100.0);
+		REQUIRE(snapshot.tick.averageMilliseconds == Catch::Approx(34.046875));
+		REQUIRE(snapshot.tick.maximumMilliseconds == 100.0);
+		REQUIRE(snapshot.tick.sampleCount == 65);
+	}
+
+	SECTION("script metrics are tracked independently")
+	{
+		component.ObserveServerTick(4ms);
+		component.ObserveScriptTick(1500us);
+
+		auto snapshot = component.GetPerformanceSnapshot();
+		REQUIRE(snapshot.tick.currentMilliseconds == 4.0);
+		REQUIRE(snapshot.script.currentMilliseconds == 1.5);
+		REQUIRE(snapshot.script.averageMilliseconds == 1.5);
+		REQUIRE(snapshot.script.maximumMilliseconds == 1.5);
+		REQUIRE(snapshot.script.sampleCount == 1);
+	}
+}

--- a/ext/native-decls/GetServerPerformanceData.md
+++ b/ext/native-decls/GetServerPerformanceData.md
@@ -1,0 +1,50 @@
+---
+ns: CFX
+apiset: server
+---
+## GET_SERVER_PERFORMANCE_DATA
+
+```c
+object GET_SERVER_PERFORMANCE_DATA();
+```
+
+Returns timing data for the server's main tick and resource execution. All durations are in milliseconds.
+
+The data returned has the following layout:
+
+```json
+{
+  "tickTime": 2.41,
+  "tickTimeAverage": 2.73,
+  "tickTimeMax": 8.91,
+  "scriptTime": 1.52,
+  "frameCount": 123456
+}
+```
+
+`tickTime` is the duration of the last completed `svMain` tick. `tickTimeAverage` and `tickTimeMax` are calculated over up to 64 completed ticks. `scriptTime` is the duration of the last completed resource manager tick, including resource script execution. `frameCount` is the total number of observed `svMain` ticks since the server started.
+
+Before the first server tick completes, all fields are zero.
+
+## Return value
+An object containing the latest server performance data.
+
+## Examples
+
+```lua
+local performance = GetServerPerformanceData()
+
+print(('Tick: %.2f ms (avg %.2f ms, max %.2f ms)'):format(
+    performance.tickTime,
+    performance.tickTimeAverage,
+    performance.tickTimeMax
+))
+print(('Scripts: %.2f ms'):format(performance.scriptTime))
+```
+
+```js
+const performance = GetServerPerformanceData();
+
+console.log(`Tick: ${performance.tickTime.toFixed(2)} ms`);
+console.log(`Scripts: ${performance.scriptTime.toFixed(2)} ms`);
+```


### PR DESCRIPTION
### Goal of this PR

Expose lightweight, structured FXServer performance metrics to server-side scripting runtimes on both FiveM and RedM, without relying on the Windows-only server GUI.

The new `GET_SERVER_PERFORMANCE_DATA` native returns the latest main tick duration, a rolling average and maximum, the latest resource manager tick duration, and the total observed frame count.

### How is this PR achieving the goal

- Extends `ServerPerfComponent` with a thread-safe 64-sample rolling metrics window.
- Measures completed `svMain` frames around `ProcessServerFrame` using `std::chrono::steady_clock`.
- Measures resource execution around `ResourceManager::Tick`.
- Exposes the snapshot as a structured object through `GET_SERVER_PERFORMANCE_DATA`.
- Adds native documentation with Lua and JavaScript examples.
- Adds unit coverage for empty values, rolling-window replacement, average/maximum calculation, sample counts, and independent script metrics.

The existing Prometheus collectors and their behavior are unchanged.

### This PR applies to the following area(s)

FiveM, RedM, Server, Natives, ScRT: Lua, ScRT: JS

### Successfully tested on

**Game builds:** FXServer

**Platforms:** Windows x64 (Visual Studio 2022)

The native declaration was also processed successfully by the native documentation generator.

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

N/A