### PR TITLE
fix(rdr3): allocate third AMV buffer

### DIFF
--- a/code/components/gta-core-rdr3/src/PatchAMV.cpp
+++ b/code/components/gta-core-rdr3/src/PatchAMV.cpp
@@ -29,9 +29,14 @@ static HookFunction hookFunction([]()
 	constexpr size_t BitsetNumBlocks = BitsetPresentCopyNumIterations * 32 + 28;
 	constexpr size_t BitsetNumBytes = BitsetNumBlocks * sizeof(uint32_t);
 
-	// x2 because the bitset is double-buffered, one for render thread and another one for update thread
-	uint32_t* amvEnabledBitsetReplacement =  reinterpret_cast<uint32_t*>(hook::AllocateStubMemory(BitsetNumBytes * 2));
-	memset(amvEnabledBitsetReplacement, 0, BitsetNumBytes * 2);
+	// AMVPresentBuffer can address a third BitsetNumBytes-sized buffer.
+	// Allocate space for all three buffers so the third copy does not overwrite
+	// subsequent allocations from the shared stub-memory arena.
+	constexpr size_t BitsetBufferCount = 3;
+	constexpr size_t BitsetAllocationBytes = BitsetNumBytes * BitsetBufferCount;
+
+	uint32_t* amvEnabledBitsetReplacement = reinterpret_cast<uint32_t*>(hook::AllocateStubMemory(BitsetAllocationBytes));
+	memset(amvEnabledBitsetReplacement, 0, BitsetAllocationBytes);
 
 	// AMVInit
 	{


### PR DESCRIPTION
### Goal of this PR

Fix a RedM crash when disconnecting from a server and reconnecting again without restarting the client.

### How is this PR achieving the goal

**AMVPresentBuffer** can access a 3rd **BitsetNumBytes**-sized buffer, but the replacement AMV bitset only allocated space for two.

This could overwrite future allocations in the shared stub memory area, including hook stubs used during reload.

Allocate space for all three AMV buffers to prevent the out-of-bounds write.

### This PR applies to the following area(s)

RedM

### Successfully tested on

**Game builds:**
1491

**Platforms:**
Windows

### Checklist

* [x] Code compiles and has been tested successfully.
* [x] Code explains itself well and/or is documented.
* [x] My commit message explains what the changes do and what they are for.
* [x] No extra compilation warnings are added by these changes.

### Fixes issues

Tested with around 15 disconnect/reconnects without restarting RedM. The crash reproduced consistently before this change and did not reproduce after it.

Follow-up to #3145. This allocates space for the third AMV buffer without changing the original bitset sizing.
