### PR TITLE
tweak(gta-streaming-five): Cut connect time in half on asset heavy servers

### DIFF
--- a/code/components/citizen-resources-client/include/ResourceCacheDeviceV2.h
+++ b/code/components/citizen-resources-client/include/ResourceCacheDeviceV2.h
@@ -167,6 +167,8 @@ public:
 
 	virtual std::shared_ptr<RcdBulkStream> OpenBulkStream(const std::string& fileName, uint64_t* ptr) override;
 
+	virtual uint32_t GetAttributes(const std::string& fileName) override;
+
 	virtual bool ExtensionCtl(int controlIdx, void* controlData, size_t controlSize) override;
 
 	virtual size_t GetLength(const std::string& fileName) override;

--- a/code/components/citizen-resources-client/src/ResourceCacheDeviceV2.cpp
+++ b/code/components/citizen-resources-client/src/ResourceCacheDeviceV2.cpp
@@ -300,6 +300,11 @@ size_t ResourceCacheDeviceV2::GetRealSize(const ResourceCacheEntryList::Entry& e
 	return realSize;
 }
 
+uint32_t ResourceCacheDeviceV2::GetAttributes(const std::string& fileName)
+{
+	return GetEntryForFileName(fileName) ? 0 : -1;
+}
+
 bool ResourceCacheDeviceV2::ExistsOnDisk(const std::string& fileName)
 {
 	auto entry = GetEntryForFileName(fileName);
@@ -670,8 +675,31 @@ void ResourceCacheDeviceV2::SetRequestWeight(const std::string& hash, int newWei
 	}
 }
 
+std::atomic<uint64_t> g_rcdEntryGeneration{ 0 };
+
 std::optional<std::reference_wrapper<const ResourceCacheEntryList::Entry>> ResourceCacheDeviceV2::GetEntryForFileName(std::string_view fileName)
 {
+	// The streaming load path asks for the same file two or three times in a row
+	// (existence, resource version, open), and each resolution walks the resource
+	// manager and two maps. Remember the last answer per thread.
+	struct LastEntry
+	{
+		uint64_t generation = UINT64_MAX;
+		const void* device = nullptr;
+		std::string fileName;
+		const ResourceCacheEntryList::Entry* entry = nullptr;
+		fwRefContainer<ResourceCacheEntryList> owner;
+	};
+
+	static thread_local LastEntry last;
+
+	const uint64_t generation = g_rcdEntryGeneration.load(std::memory_order_relaxed);
+
+	if (last.entry && last.generation == generation && last.device == this && last.fileName == fileName)
+	{
+		return *last.entry;
+	}
+
 	// strip the path prefix
 	std::string_view relativeName = fileName.substr(m_pathPrefix.length());
 
@@ -700,6 +728,12 @@ std::optional<std::reference_wrapper<const ResourceCacheEntryList::Entry>> Resou
 	{
 		return {};
 	}
+
+	last.generation = generation;
+	last.device = this;
+	last.fileName.assign(fileName);
+	last.entry = &entry->get();
+	last.owner = entryList;
 
 	return entry;
 }
@@ -1008,4 +1042,19 @@ void MountResourceCacheDeviceV2(std::shared_ptr<ResourceCache> cache)
 static InitFunction initFunction([]
 {
 	resources::g_downloadBackoff = new ConVar<int>("cl_rcdFailureBackoff", ConVar_None, 500);
+
+	fx::Resource::OnInitializeInstance.Connect([](fx::Resource* resource)
+	{
+		resource->OnStart.Connect([]()
+		{
+			resources::g_rcdEntryGeneration.fetch_add(1, std::memory_order_relaxed);
+		},
+		INT32_MIN);
+
+		resource->OnStop.Connect([]()
+		{
+			resources::g_rcdEntryGeneration.fetch_add(1, std::memory_order_relaxed);
+		},
+		INT32_MIN);
+	});
 });

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -33,6 +33,7 @@
 
 #include <CustomRtti.h>
 
+
 #if __has_include(<StatusText.h>)
 #include <StatusText.h>
 #include <nutsnbolts.h>
@@ -1087,7 +1088,6 @@ static void ReloadMapStore()
 
 	auto mgr = streaming::Manager::GetInstance();
 
-
 	// Find collision files that need reloading
 	ForAllStreamingFiles([&](const std::string& file)
 	{
@@ -1126,7 +1126,6 @@ static void ReloadMapStore()
 			trace("Skipped %s - it's cached! (id %d)\n", file.c_str(), relId);
 		}
 	});
-
 
 	static constexpr uint8_t batchSize = 4;
 
@@ -1540,7 +1539,7 @@ static void HandleDataFile(const std::pair<std::string, std::string>& dataFile, 
 
 	std::tie(typeName, fileName) = dataFile;
 
-	trace("%s %s %s.\n", op, typeName, fileName);
+	console::DPrintf("gta:streaming", "%s %s %s.\n", op, typeName, fileName);
 
 	CDataFileMountInterface* mounter = LookupDataFileMounter(typeName);
 
@@ -1552,7 +1551,18 @@ static void HandleDataFile(const std::pair<std::string, std::string>& dataFile, 
 
 	if (mounter)
 	{
-		std::string className = SearchTypeName(mounter);
+		// the name depends only on the mounter's vtable, and there are far fewer
+		// mounters than data files
+		static std::unordered_map<CDataFileMountInterface*, std::string> classNameCache;
+
+		auto classNameIt = classNameCache.find(mounter);
+
+		if (classNameIt == classNameCache.end())
+		{
+			classNameIt = classNameCache.emplace(mounter, SearchTypeName(mounter)).first;
+		}
+
+		const std::string& className = classNameIt->second;
 
 		CDataFileMgr::DataFile entry;
 		memset(&entry, 0, sizeof(entry));
@@ -1566,7 +1576,7 @@ static void HandleDataFile(const std::pair<std::string, std::string>& dataFile, 
 
 		if (result)
 		{
-			trace("done %s %s in data file mounter %s.\n", op, fileName, className);
+			console::DPrintf("gta:streaming", "done %s %s in data file mounter %s.\n", op, fileName, className);
 		}
 		else
 		{
@@ -1712,6 +1722,54 @@ static std::set<std::string> g_pedsToRegister;
 
 static std::unordered_set<int> g_ourIndexes;
 
+#ifdef GTA_FIVE
+struct PlatformTextureIndex
+{
+	std::unordered_set<std::string> names;
+	bool hasSubdirectories = false;
+};
+
+static const PlatformTextureIndex& GetPlatformTextureIndex()
+{
+	static const PlatformTextureIndex index = []
+	{
+		PlatformTextureIndex result;
+
+		auto device = rage::fiDevice::GetDevice("platform:/textures/", true);
+
+		if (device)
+		{
+			rage::fiFindData fd;
+			auto handle = device->FindFirst("platform:/textures/", &fd);
+
+			if (handle != static_cast<uint64_t>(-1))
+			{
+				do
+				{
+					if (fd.fileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+					{
+						if (strcmp(fd.fileName, ".") != 0 && strcmp(fd.fileName, "..") != 0)
+						{
+							result.hasSubdirectories = true;
+						}
+					}
+					else
+					{
+						result.names.insert(boost::algorithm::to_lower_copy(std::string(fd.fileName)));
+					}
+				} while (device->FindNext(handle, &fd));
+
+				device->FindClose(handle);
+			}
+		}
+
+		return result;
+	}();
+
+	return index;
+}
+#endif
+
 static std::string GetBaseName(const std::string& name)
 {
 	std::string retval = name;
@@ -1729,12 +1787,31 @@ static std::string GetBaseName(const std::string& name)
 	}
 
 	// is this trying to override a file extant in platform:/textures/?
-	auto texturesName = fmt::sprintf("platform:/textures/%s", retval);
+#ifdef GTA_FIVE
+	// enumerating platform:/textures/ is not safe on RDR3 at the point streaming
+	// files are first registered, so only five takes the indexed path
+	const auto& index = GetPlatformTextureIndex();
 
-	if (auto device = rage::fiDevice::GetDevice(texturesName.c_str(), true); device && device->GetFileAttributes(texturesName.c_str()) != -1)
+	// subdir_file_mapping turns '^' into '/', and a nested name can only resolve
+	// if platform:/textures/ actually has subdirectories
+	const bool nested = retval.find('/') != std::string::npos;
+
+	if (index.names.empty() || (nested && index.hasSubdirectories))
+#endif
 	{
-		retval = texturesName;
+		auto texturesName = fmt::sprintf("platform:/textures/%s", retval);
+
+		if (auto device = rage::fiDevice::GetDevice(texturesName.c_str(), true); device && device->GetFileAttributes(texturesName.c_str()) != -1)
+		{
+			retval = texturesName;
+		}
 	}
+#ifdef GTA_FIVE
+	else if (!nested && index.names.find(boost::algorithm::to_lower_copy(retval)) != index.names.end())
+	{
+		retval = "platform:/textures/" + retval;
+	}
+#endif
 
 	return retval;
 }
@@ -1764,10 +1841,13 @@ static void (*g_assetOverridesCb)(uint32_t, const char*) = nullptr;
 
 static void (*g_assetOverridesRemovalCb)(uint32_t) = nullptr;
 
+
 static void LoadStreamingFiles(LoadType loadType)
 {
+
 	auto cstreaming = streaming::Manager::GetInstance();
 	std::vector<std::tuple<int, std::string>> newGfx;
+	std::map<std::string, size_t> unregisterableByTag;
 
 	// register any custom streaming assets
 	for (auto it = g_customStreamingFiles.begin(); it != g_customStreamingFiles.end(); )
@@ -1872,13 +1952,11 @@ static void LoadStreamingFiles(LoadType loadType)
 		it = g_customStreamingFiles.erase(it);
 
 		// check if the file even exists
-		{
-			auto holderDevice = rage::fiDevice::GetDevice(file.c_str(), true);
+		auto fileDevice = rage::fiDevice::GetDevice(file.c_str(), true);
 
-			if (holderDevice->GetFileAttributes(file.c_str()) == INVALID_FILE_ATTRIBUTES)
-			{
-				continue;
-			}
+		if (!fileDevice || fileDevice->GetFileAttributes(file.c_str()) == INVALID_FILE_ATTRIBUTES)
+		{
+			continue;
 		}
 
 		auto strModule = cstreaming->moduleMgr.GetStreamingModule(ext.c_str());
@@ -1988,7 +2066,8 @@ static void LoadStreamingFiles(LoadType loadType)
 			// verify whether the file is a zlib'd file from a real backing RPF7
 			// (length and resource value mismatching)
 #ifdef GTA_FIVE
-			auto device = rage::fiDevice::GetDevice(file.c_str(), true);
+
+			auto device = fileDevice;
 
 			if (device && fileId != -1)
 			{
@@ -2019,7 +2098,9 @@ static void LoadStreamingFiles(LoadType loadType)
 		}
 		else if (ext != "ymf")
 		{
-			trace("can't register %s: no streaming module (does this file even belong in stream?)\n", file);
+			console::DPrintf("gta:streaming", "can't register %s: no streaming module (does this file even belong in stream?)\n", file);
+
+			unregisterableByTag[tag]++;
 		}
 
 #ifdef GTA_FIVE
@@ -2029,6 +2110,26 @@ static void LoadStreamingFiles(LoadType loadType)
 			g_pedsToRegister.insert(baseName.substr(0, baseName.find('/')));
 		}
 #endif
+	}
+
+	if (!unregisterableByTag.empty())
+	{
+		size_t total = 0;
+		std::string resourceList;
+
+		for (const auto& [resourceTag, count] : unregisterableByTag)
+		{
+			total += count;
+
+			if (!resourceList.empty())
+			{
+				resourceList += ", ";
+			}
+
+			resourceList += fmt::sprintf("%s (%d)", resourceTag, count);
+		}
+
+		trace("^3%d file(s) in stream/ have no streaming module and were skipped: %s. Set `developer 1` to list them individually.^7\n", total, resourceList);
 	}
 
 #ifdef GTA_FIVE
@@ -2450,7 +2551,22 @@ static void LoadDataFiles()
 	HandleDataFileList(g_dataFiles, [](CDataFileMountInterface* mounter, CDataFileMgr::DataFile& entry)
 	{
 #if __has_include(<StatusText.h>)
-		OnLookAliveFrame();
+		{
+			// this drives a Scaleform frame advance and a streaming progress scan;
+			// once per data file is far more often than a spinner needs
+			static ConVar<int> frameIntervalVar("game_loadDataFileFrameInterval", ConVar_Archive | ConVar_UserPref, 33);
+			static uint64_t lastLookAlive = 0;
+
+			const uint64_t now = GetTickCount64();
+			const int interval = frameIntervalVar.GetValue();
+
+			if (interval <= 0 || (now - lastLookAlive) >= static_cast<uint64_t>(interval))
+			{
+				lastLookAlive = now;
+
+				OnLookAliveFrame();
+			}
+		}
 #endif
 
 		return mounter->LoadDataFile(&entry);
@@ -3788,7 +3904,6 @@ static HookFunction hookFunction([]()
 #elif IS_RDR3
 	hook::jump(hook::get_pattern("4D 63 C1 81 E2 FF 03 00 00 48 C1 E8 0A 48 8B 84 C1 B0 05 00 00", -8), pgRawStreamer__GetEntryNameToBuffer);
 #endif
-
 
 	{
 		// mapdatastore/maptypesstore 'should async place'


### PR DESCRIPTION
### Goal of this PR

Cut the time it takes to connect to an asset-heavy server roughly in half:
**67s -> 34s (1.98x)**, measured from the first init function to spawning in on a
95,480 file / 36.9 GB streaming set.

The asset load itself, which is the part this PR touches, goes from **42.5s to
16.0s (2.66x)**. The game's own init work inside that window measures ~10s on my machine and is untouched

### How is this PR achieving the goal

- `ResourceCacheDeviceV2::GetEntryForFileName` now remembers the last file it
  resolved. The load path asks for the same file two or three times in a row -
  existence, resource version, open - and each resolution walked the resource
  manager and two maps. Invalidated on resource start/stop.
- `ResourceCacheDeviceV2` gains a `GetAttributes` override, which
  `ResourceCacheDevice` already had. Without it the base implementation opens and
  closes the file, allocating a stream object and a handle per call.
- `GetBaseName` probed the packfile index for every streaming file to check for a
  `platform:/textures/` override, on both the registration and the load path.
  That directory is now enumerated once (134us -> 0.2us per call). Nested names
  still fall back to a probe, but only when the directory has subdirectories -
  `subdir_file_mapping` rewrites `^` to `/`, which most asset-pack files contain.
- The existence check and the size fixup resolved the same path twice; the device
  pointer is reused.
- `SearchTypeName` is cached per mounter; the name depends only on the vtable.
- The per-file `loading`/`done`/`can't register` traces become `DPrintf`, since
  print listeners run inline on the calling thread. The skipped-file diagnostic
  becomes one summary line per pass naming the resources and counts.
- The `LoadDataFiles` frame pump ran once per data file and drives a Scaleform
  frame advance plus a streaming progress scan. `game_loadDataFileFrameInterval`
  defaults to 33ms; `0` restores per-file.

Which assets get registered is unchanged.

### This PR applies to the following area(s)

FiveM, RedM

### Successfully tested on

Game builds: **3258 (FiveM)**
Platforms: **Windows**

95,480 streaming files / 36.9 GB, both builds alternating which one runs first:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 103.6s | 64.8s | 67.0s | **67.0s** |
| after | 42.8s | 33.8s | 33.7s | **33.8s** |

Note: the 103.6s is a cold start / empty cache, so is 42.8s

Faster in every round. Verified after each step with a test resource that
requests vehicle models, the freemode ped and addon clothing and reports
pass/fail - all load, registration unchanged. 

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.

Note: I did NOT test this in RedM as I don't really have enough streaming assets to test with