### PR TITLE
tweak(citizen-server-impl): cut server startup time by a third

### DIFF
--- a/code/components/citizen-server-impl/src/ResourceFileDatabase.cpp
+++ b/code/components/citizen-server-impl/src/ResourceFileDatabase.cpp
@@ -174,15 +174,27 @@ auto ResourceFileDatabase::GetEntry(const std::string& file) -> Entry
 
 		if (handle != INVALID_DEVICE_HANDLE)
 		{
-			entry.mtime = device->GetModifiedTime(file);
-			entry.size = device->GetLength(handle);
-			
-			vfs::GetFileIdExtension idExt;
-			idExt.handle = handle;
+			vfs::GetFileInfoExtension infoExt;
+			infoExt.handle = handle;
 
-			device->ExtensionCtl(VFS_GET_FILE_ID, &idExt, sizeof(idExt));
+			if (device->ExtensionCtl(VFS_GET_FILE_INFO, &infoExt, sizeof(infoExt)))
+			{
+				entry.mtime = infoExt.mtime;
+				entry.size = infoExt.size;
+				entry.fileId = infoExt.fileId;
+			}
+			else
+			{
+				entry.mtime = device->GetModifiedTime(file);
+				entry.size = device->GetLength(handle);
 
-			entry.fileId = idExt.fileId;
+				vfs::GetFileIdExtension idExt;
+				idExt.handle = handle;
+
+				device->ExtensionCtl(VFS_GET_FILE_ID, &idExt, sizeof(idExt));
+
+				entry.fileId = idExt.fileId;
+			}
 
 			// very important, close the file
 			device->Close(handle);

--- a/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
+++ b/code/components/citizen-server-impl/src/ResourceStreamComponent.cpp
@@ -127,7 +127,9 @@ namespace fx
 
 			for (auto& entry : entries)
 			{
-				if (!vfs::OpenRead(entry.onDiskPath).GetRef())
+				auto entryDevice = vfs::GetDevice(entry.onDiskPath);
+
+				if (!entryDevice.GetRef() || entryDevice->GetAttributes(entry.onDiskPath) == -1)
 				{
 					return true;
 				}
@@ -137,7 +139,7 @@ namespace fx
 		return false;
 	}
 
-	static void MakeSymLink(const std::string& cacheRoot, ResourceStreamComponent::RuntimeEntry* file)
+	static void EnsureCacheRoot(const std::string& cacheRoot)
 	{
 		auto device = vfs::GetDevice(cacheRoot);
 		device->CreateDirectory(cacheRoot);
@@ -148,6 +150,11 @@ namespace fx
 		{
 			device->Close(h);
 		}
+	}
+
+	static void MakeSymLink(const std::string& cacheRoot, ResourceStreamComponent::RuntimeEntry* file)
+	{
+		auto device = vfs::GetDevice(cacheRoot);
 
 		vfs::MakeHardLinkExtension cd;
 		cd.existingPath = file->onDiskPath;
@@ -185,6 +192,8 @@ namespace fx
 
 		// look at files
 		std::vector<std::string> files;
+
+		EnsureCacheRoot(cacheRoot);
 
 		IterateRecursively(fmt::sprintf("%s/stream/", m_resource->GetPath()), [this, device, &cacheRoot, &files](const std::string& fullPath)
 		{
@@ -504,6 +513,8 @@ namespace fx
 					{
 						std::vector<Entry> entries(numEntries);
 						stream->Read(&entries[0], entries.size() * sizeof(Entry));
+
+						EnsureCacheRoot(cacheRoot);
 
 						for (auto& entry : entries)
 						{

--- a/code/components/vfs-core/include/VFSDevice.h
+++ b/code/components/vfs-core/include/VFSDevice.h
@@ -115,4 +115,17 @@ struct GetFileIdExtension
 	// out
 	FileId fileId;
 };
+
+#define VFS_GET_FILE_INFO 0x10004
+
+struct GetFileInfoExtension
+{
+	// in
+	Device::THandle handle;
+
+	// out
+	std::time_t mtime;
+	uint64_t size;
+	FileId fileId;
+};
 }

--- a/code/components/vfs-impl-server/src/PlatformDevice.Win32.cpp
+++ b/code/components/vfs-impl-server/src/PlatformDevice.Win32.cpp
@@ -368,6 +368,53 @@ bool LocalDevice::ExtensionCtl(int controlIdx, void* controlData, size_t control
 			}
 		}
 	}
+	else if (controlIdx == VFS_GET_FILE_INFO && controlSize == sizeof(GetFileInfoExtension))
+	{
+		auto data = reinterpret_cast<GetFileInfoExtension*>(controlData);
+
+		BY_HANDLE_FILE_INFORMATION info;
+
+		if (!GetFileInformationByHandle(reinterpret_cast<HANDLE>(data->handle), &info))
+		{
+			return false;
+		}
+
+		ULARGE_INTEGER li;
+		li.HighPart = info.ftLastWriteTime.dwHighDateTime;
+		li.LowPart = info.ftLastWriteTime.dwLowDateTime;
+		data->mtime = li.QuadPart / 10000000ULL - 11644473600ULL;
+
+		ULARGE_INTEGER size;
+		size.HighPart = info.nFileSizeHigh;
+		size.LowPart = info.nFileSizeLow;
+		data->size = size.QuadPart;
+
+		data->fileId = vfs::FileId{};
+
+		if (IsWindows8OrGreater())
+		{
+			FILE_ID_INFO idInfo;
+
+			if (GetFileInformationByHandleEx(reinterpret_cast<HANDLE>(data->handle), FileIdInfo, &idInfo, sizeof(idInfo)))
+			{
+				memcpy(data->fileId.data(), &idInfo.FileId.Identifier, std::min(sizeof(idInfo.FileId.Identifier), data->fileId.size()));
+			}
+			else
+			{
+				return false;
+			}
+		}
+		else
+		{
+			ULARGE_INTEGER fileInt;
+			fileInt.LowPart = info.nFileIndexLow;
+			fileInt.HighPart = info.nFileIndexHigh;
+
+			memcpy(data->fileId.data(), &fileInt, std::min(sizeof(fileInt), data->fileId.size()));
+		}
+
+		return true;
+	}
 	else if (controlIdx == VFS_MAKE_HARDLINK && controlSize == sizeof(MakeHardLinkExtension))
 	{
 		auto data = reinterpret_cast<MakeHardLinkExtension*>(controlData);


### PR DESCRIPTION
### Goal of this PR

Cut server startup on asset-heavy servers by a third: **62s -> 41s (1.5x)** on a
95,480 file / 36.9 GB streaming set, by removing redundant filesystem calls from
the per-file scan that runs every time a resource starts.

### How is this PR achieving the goal

- `ResourceFileDatabase::GetEntry` opened every file twice, because
  `GetModifiedTime` is path-based and opens it again. New `VFS_GET_FILE_INFO`
  extension returns modified time, size and file id from one
  `GetFileInformationByHandle`, falling back to the old sequence otherwise.
- `ShouldUpdateSet` checked `.sfl` entries with `vfs::OpenRead` (stream object +
  file handle per entry); `GetAttributes` answers the same question with one stat.
- `MakeSymLink` created the cache-root directory and readme once per streaming
  file instead of once per resource.

What the scan concludes is unchanged.

### This PR applies to the following area(s)

FxServer

### Successfully tested on

Game builds: **3258 (FiveM)**, **FxServer**
Platforms: **Windows**

95,480 streaming files / 36.9 GB, 77 resources, release build, both builds
alternating which one runs first:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 210.9s | 62.2s | 61.5s | **62.2s** |
| after | 41.8s | 41.0s | 30.6s | **41.0s** |

Faster in every round. The 210.9s is the first server start of the session, where
the files are read from disk rather than from the page cache; Verified afterwards by connecting a
client and confirming vehicles, ped and addon clothing still stream correctly.

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.
