### PR TITLE
feat(extra-natives/rdr3): bring SET_ENTITY_MATRIX in RedM to parity with FiveM

### DIFF
--- a/code/components/extra-natives-rdr3/src/EntityNatives.cpp
+++ b/code/components/extra-natives-rdr3/src/EntityNatives.cpp
@@ -61,6 +61,37 @@ static bool CanProcessPendingAttachment(hook::FlexStruct* self, void* currentAtt
 
 static HookFunction hookFunction([]()
 {
+	fx::ScriptEngine::RegisterNativeHandler("SET_ENTITY_MATRIX", [](fx::ScriptContext& context)
+	{
+		fwEntity* entity = rage::fwScriptGuid::GetBaseFromGuid(context.GetArgument<int>(0));
+		if (!entity)
+		{
+			return;
+		}
+
+		const float forwardX = context.GetArgument<float>(1);
+		const float forwardY = context.GetArgument<float>(2);
+		const float forwardZ = context.GetArgument<float>(3);
+		const float rightX = context.GetArgument<float>(4);
+		const float rightY = context.GetArgument<float>(5);
+		const float rightZ = context.GetArgument<float>(6);
+		const float upX = context.GetArgument<float>(7);
+		const float upY = context.GetArgument<float>(8);
+		const float upZ = context.GetArgument<float>(9);
+		const float atX = context.GetArgument<float>(10);
+		const float atY = context.GetArgument<float>(11);
+		const float atZ = context.GetArgument<float>(12);
+
+		DirectX::XMMATRIX matrix(
+			DirectX::XMVectorSet(rightX, rightY, rightZ, 0.0f),
+			DirectX::XMVectorSet(forwardX, forwardY, forwardZ, 0.0f),
+			DirectX::XMVectorSet(upX, upY, upZ, 0.0f),
+			DirectX::XMVectorSet(atX, atY, atZ, 1.0f)
+		);
+
+		entity->SetMatrix(matrix, true);
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITIES_IN_RADIUS", [](fx::ScriptContext& context)
 	{
 		float checkX = context.GetArgument<float>(0);

--- a/code/components/gta-streaming-rdr3/include/EntitySystem.h
+++ b/code/components/gta-streaming-rdr3/include/EntitySystem.h
@@ -130,6 +130,11 @@ public:
 	return (this->*(get_member<TFn>(vtbl[(offset / 8)])))(__VA_ARGS__);
 
 public:
+	inline void SetMatrix(const DirectX::XMMATRIX& matrix, bool updateScene, bool moreUpdate = false, bool evenMoreUpdate = false)
+	{
+		FORWARD_FUNC(SetMatrix, 0x658, matrix, updateScene, moreUpdate, evenMoreUpdate);
+	}
+
 	inline float GetRadius()
 	{
 		FORWARD_FUNC(GetRadius, 0x200);

--- a/ext/native-decls/sdk/SetEntityMatrix.md
+++ b/ext/native-decls/sdk/SetEntityMatrix.md
@@ -1,7 +1,6 @@
 ---
 ns: CFX
 apiset: client
-game: gta5
 ---
 ## SET_ENTITY_MATRIX
 


### PR DESCRIPTION
### Goal of this PR

Add RedM support for the existing `SET_ENTITY_MATRIX` CFX client native so scripts can update an entity's full transform matrix, matching the API already available in FiveM.


### How is this PR achieving the goal

- Registers `SET_ENTITY_MATRIX` in `extra-natives-rdr3`.
- Resolves the RedM entity from its script GUID and constructs the engine matrix using the documented forward, right, up, and position argument order.
- Forwards the matrix through `rage::fwEntity::SetMatrix`.
- Makes the shared native declaration available to RedM.

The `fwEntity::SetMatrix` vtable entry was verified against RedM 1491.50 symbols and runtime vtable data.


### This PR applies to the following area(s)

RedM, Natives, ScRT: Lua, ScRT: JS, ScRT: C#


### Successfully tested on

**Game builds:** RedM 1491.50

**Platforms:** Windows

Built `gta-streaming-rdr3` and `extra-natives-rdr3` in Debug, then runtime-tested with `p_hitchingpost01x` by applying a 2x basis matrix and a 1-unit position offset. All three basis vector lengths changed from 1.0 to 2.0 and the position delta matched the requested value.

Video : https://youtu.be/Goe1Gy1mGw0

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues

N/A