### PR TITLE
fix(gta-streaming-five): save_gta_cache crashing since b2802

### DIFF
--- a/code/components/gta-streaming-five/src/CacheLoader.cpp
+++ b/code/components/gta-streaming-five/src/CacheLoader.cpp
@@ -59,10 +59,12 @@ struct
 {
 	struct
 	{
-		void(*loadCache)();
-		void(*saveCache)();
-		char name[48];
-		int size;
+		bool(*loadCache)(const void* entry, void* debugTextStream);
+		void(*saveCache)(void* debugTextStream);
+		char name[32];
+		char* headerPos;
+		char* footerPos;
+		int entrySize;
 	} fields[6];
 
 	uint32_t numModules;
@@ -316,7 +318,7 @@ static InitFunction initFunction([]()
 			};
 
 			fileData << "<module>\n" << g_cacheMgr->fields[i].name << "\n";
-			g_cacheMgr->fields[i].saveCache();
+			g_cacheMgr->fields[i].saveCache(nullptr);
 
 			// cache is prefixed with size
 			std::string cacheStr = cacheData.str();


### PR DESCRIPTION
### Goal of this PR

Make `save_gta_cache` work again. It currently crashes the client, or writes a
258 byte file with three empty module sections when something catches the
exception.

### How is this PR achieving the goal

b2802 added an extra parameter to the `strCacheLoader` module save callback.
Calling it without one left whatever happened to be in `rcx` to be used as the
stream, which faulted in the flush before the cache append was ever reached.
Declare the parameter and pass `nullptr`; builds below b2802 ignore it.

### This PR applies to the following area(s)

FiveM

### Successfully tested on

Game builds: **3258 (FiveM)**
Platforms: **Windows**

Checked every build from 1604 to
3751 for the signature change: 1604-2699 take no argument, 2802-3751 do.

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code is properly formatted and follows the existing style.
- [x] Commit message is clear and follows the project conventions.
- [x] This PR introduces no new compilation warnings.
