### PR TITLE
feat(nui): expose per-frame game state to NUI via getGameState()

### DIFF
--- a/code/client/citicore/NuiGameState.h
+++ b/code/client/citicore/NuiGameState.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifndef IS_FXSERVER
+#include <atomic>
+#include <cstdint>
+
+struct NuiGameStateData
+{
+	float pedPos[3]{};
+
+	float camPos[3]{};
+
+	float camRot[3]{};
+
+	float camForward[3]{};
+	float camUp[3]{};
+
+	float camFov = 0.0f;
+};
+
+struct NuiGameState
+{
+	// seqlock: the writer makes this odd for the duration of a write, and it changes on
+	// every write, so a reader that sees the same even value before and after copying
+	// `data` knows it did not observe a half-written frame. 0 means 'never written'.
+	std::atomic<uint32_t> sequence{ 0 };
+
+	NuiGameStateData data;
+};
+#endif

--- a/code/components/extra-natives-five/src/NuiGameState.cpp
+++ b/code/components/extra-natives-five/src/NuiGameState.cpp
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the Cfx project - https://cfx.re/
+ *
+ * See LICENSE in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include <StdInc.h>
+
+#include <GamePrimitives.h>
+#include <HostSharedData.h>
+#include <Hooking.h>
+#include <ICoreGameInit.h>
+#include <NuiGameState.h>
+#include <nutsnbolts.h>
+
+static constexpr float kRadToDeg = 57.29577951308232f;
+
+static float* g_actorPos;
+
+static HostSharedData<NuiGameState> g_nuiGameState("CfxNuiGameState");
+
+static void StoreVector(float (&out)[3], float x, float y, float z)
+{
+	out[0] = x;
+	out[1] = y;
+	out[2] = z;
+}
+
+static void StoreEulerFromBasis(float (&out)[3], const float (&right)[3], const float (&forward)[3], const float (&up)[3])
+{
+	auto pitch = std::asin(std::clamp(forward[2], -1.0f, 1.0f));
+	float yaw, roll;
+
+	if (std::abs(forward[2]) > 0.99999f)
+	{
+		yaw = std::atan2(right[1], right[0]);
+		roll = 0.0f;
+	}
+	else
+	{
+		yaw = std::atan2(-forward[0], forward[1]);
+		roll = std::atan2(-right[2], up[2]);
+	}
+
+	StoreVector(out, pitch * kRadToDeg, roll * kRadToDeg, yaw * kRadToDeg);
+}
+
+static void NuiGameState_RunFrame()
+{
+	if (!Instance<ICoreGameInit>::Get()->HasVariable("gameSettled"))
+	{
+		return;
+	}
+
+	if (!g_actorPos || !g_viewportGame || !*g_viewportGame)
+	{
+		return;
+	}
+
+	auto& state = *g_nuiGameState;
+
+	// take the seqlock: an odd sequence tells readers this frame is mid-write
+	auto sequence = state.sequence.load(std::memory_order_relaxed);
+	state.sequence.store(sequence + 1, std::memory_order_relaxed);
+
+	std::atomic_thread_fence(std::memory_order_release);
+
+	auto& data = state.data;
+
+	const auto& viewport = (*g_viewportGame)->viewport;
+	const auto& camMatrix = viewport.m_inverseView;
+
+	float right[3] = { camMatrix[0], camMatrix[1], camMatrix[2] };
+	float up[3] = { camMatrix[4], camMatrix[5], camMatrix[6] };
+	float forward[3] = { -camMatrix[8], -camMatrix[9], -camMatrix[10] };
+
+	StoreVector(data.camPos, camMatrix[12], camMatrix[13], camMatrix[14]);
+	StoreVector(data.camForward, forward[0], forward[1], forward[2]);
+	StoreVector(data.camUp, up[0], up[1], up[2]);
+	StoreEulerFromBasis(data.camRot, right, forward, up);
+
+	data.camFov = (viewport.m_projection[5] > 0.0f)
+		? 2.0f * std::atan(1.0f / viewport.m_projection[5]) * kRadToDeg
+		: 0.0f;
+
+	StoreVector(data.pedPos, g_actorPos[0], g_actorPos[1], g_actorPos[2]);
+
+	// release the seqlock, back to an even (and different) sequence
+	state.sequence.store(sequence + 2, std::memory_order_release);
+}
+
+static HookFunction hookFunction([]()
+{
+#ifdef GTA_FIVE
+	g_actorPos = hook::get_address<float*>(hook::get_pattern("BB 00 00 40 00 48 89 7D F8 89 1D", -4)) + 12;
+#elif IS_RDR3
+	g_actorPos = hook::get_address<float*>(hook::get_pattern("45 33 C9 48 89 5D E0 8D 53 01", 63)) + 16;
+#endif
+});
+
+static InitFunction initFunction([]()
+{
+	OnMainGameFrame.Connect([]()
+	{
+		NuiGameState_RunFrame();
+	});
+
+	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]()
+	{
+		g_nuiGameState->sequence.store(0, std::memory_order_release);
+	});
+});

--- a/code/components/extra-natives-rdr3/component.lua
+++ b/code/components/extra-natives-rdr3/component.lua
@@ -17,6 +17,7 @@ return function()
 		'components/extra-natives-five/src/PoolTraversalNatives.cpp',
 		'components/extra-natives-five/src/RadioDSP.cpp',
 		'components/extra-natives-five/src/NuiAudioSink.cpp',
+		'components/extra-natives-five/src/NuiGameState.cpp',
 		'components/extra-natives-five/src/InputNatives.cpp',
 		'components/gta-core-five/include/GameAudioState.h',
 		'components/extra-natives-five/include/audDspEffect.h',

--- a/code/components/nui-core/src/NUIApp.cpp
+++ b/code/components/nui-core/src/NUIApp.cpp
@@ -111,6 +111,7 @@ void NUIApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 	}
 
 	window->SetValue("invokeNative", CefV8Value::CreateFunction("invokeNative", this), V8_PROPERTY_ATTRIBUTE_READONLY);
+	window->SetValue("getGameState", CefV8Value::CreateFunction("getGameState", this), V8_PROPERTY_ATTRIBUTE_READONLY);
 	window->SetValue("nuiSetAudioCategory", CefV8Value::CreateFunction("nuiSetAudioCategory", this), V8_PROPERTY_ATTRIBUTE_READONLY);
 	window->SetValue("nuiTargetGame", CefV8Value::CreateString(
 #ifdef IS_LAUNCHER

--- a/code/components/nui-core/src/NUICallbacks_GameState.cpp
+++ b/code/components/nui-core/src/NUICallbacks_GameState.cpp
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Cfx project - https://cfx.re/
+ *
+ * See LICENSE in the root of the source tree for information
+ * regarding licensing.
+ */
+
+#include "StdInc.h"
+#include "NUIApp.h"
+
+#include <HostSharedData.h>
+#include <NuiGameState.h>
+
+#include "memdbgon.h"
+
+static bool ReadGameState(NuiGameStateData& out)
+{
+	static HostSharedData<NuiGameState> gameState("CfxNuiGameState");
+
+	for (int i = 0; i < 16; i++)
+	{
+		auto sequence = gameState->sequence.load(std::memory_order_acquire);
+
+		// odd: a write is in progress
+		if (sequence & 1)
+		{
+			continue;
+		}
+
+		out = gameState->data;
+
+		std::atomic_thread_fence(std::memory_order_acquire);
+
+		if (gameState->sequence.load(std::memory_order_relaxed) == sequence)
+		{
+			// 0 means the game process never wrote a frame
+			return sequence != 0;
+		}
+	}
+
+	return false;
+}
+
+static CefRefPtr<CefV8Value> CreateVector(const float (&value)[3])
+{
+	auto object = CefV8Value::CreateObject(nullptr, nullptr);
+
+	object->SetValue("x", CefV8Value::CreateDouble(value[0]), V8_PROPERTY_ATTRIBUTE_NONE);
+	object->SetValue("y", CefV8Value::CreateDouble(value[1]), V8_PROPERTY_ATTRIBUTE_NONE);
+	object->SetValue("z", CefV8Value::CreateDouble(value[2]), V8_PROPERTY_ATTRIBUTE_NONE);
+
+	return object;
+}
+
+static InitFunction initFunction([]()
+{
+	auto nuiApp = Instance<NUIApp>::Get();
+
+	nuiApp->AddV8Handler("getGameState", [](const CefV8ValueList& arguments, CefString& exception) -> CefRefPtr<CefV8Value>
+	{
+		NuiGameStateData data;
+
+		if (!ReadGameState(data))
+		{
+			return CefV8Value::CreateNull();
+		}
+
+		auto ped = CefV8Value::CreateObject(nullptr, nullptr);
+		ped->SetValue("position", CreateVector(data.pedPos), V8_PROPERTY_ATTRIBUTE_NONE);
+
+		auto camera = CefV8Value::CreateObject(nullptr, nullptr);
+		camera->SetValue("position", CreateVector(data.camPos), V8_PROPERTY_ATTRIBUTE_NONE);
+		camera->SetValue("rotation", CreateVector(data.camRot), V8_PROPERTY_ATTRIBUTE_NONE);
+		camera->SetValue("forward", CreateVector(data.camForward), V8_PROPERTY_ATTRIBUTE_NONE);
+		camera->SetValue("up", CreateVector(data.camUp), V8_PROPERTY_ATTRIBUTE_NONE);
+		camera->SetValue("fov", CefV8Value::CreateDouble(data.camFov), V8_PROPERTY_ATTRIBUTE_NONE);
+
+		auto state = CefV8Value::CreateObject(nullptr, nullptr);
+		state->SetValue("ped", ped, V8_PROPERTY_ATTRIBUTE_NONE);
+		state->SetValue("camera", camera, V8_PROPERTY_ATTRIBUTE_NONE);
+
+		return state;
+	});
+}, 1);


### PR DESCRIPTION
### Goal of this PR
Expose data that needs frequent updates to NUI

### How is this PR achieving the goal
Expose data to the window function getGameState() using better data fetching than native (like mumble component) and avoiding NUI message payloads

### This PR applies to the following area(s)
NUI API for FiveM/RedM

### Successfully tested on
Only tested with FiveM canary

**Game builds:** 3889

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.