### PR TITLE
feat(gta-streaming-five): add ped metadata data file mounters

### DIFF
--- a/code/components/gta-core-five/include/RageParser.h
+++ b/code/components/gta-core-five/include/RageParser.h
@@ -185,6 +185,8 @@ namespace rage
 	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(const char* structType);
 
 	COMPONENT_EXPORT(GTA_CORE_TARGET) rage::parStructure* GetStructureDefinition(uint32_t structHash);
+
+	COMPONENT_EXPORT(GTA_CORE_TARGET) bool LoadFromStructure(const char* fileName, const char* ext, rage::parStructure* parStruct, void* target, bool typeChecks, void* unk);
 }
 
 #undef GTA_CORE_TARGET

--- a/code/components/gta-core-five/src/RageParser.cpp
+++ b/code/components/gta-core-five/src/RageParser.cpp
@@ -2,11 +2,18 @@
 #include <Hooking.h>
 #include <RageParser.h>
 
+#include "Hooking.Stubs.h"
+
 static void** g_parser;
 
 static hook::cdecl_stub<rage::parStructure* (void* parser, uint32_t)> _parser_getStructure([]()
 {
 	return hook::get_call(hook::get_pattern("8B 10 E8 ? ? ? ? 4C 8D 5C 24", 2));
+});
+
+static hook::cdecl_stub<bool (void* parser, const char*, const char*, rage::parStructure*, void*, bool, void*)> _parser_loadFromStructure([]()
+{
+	return hook::get_call(hook::get_pattern("E8 ? ? ? ? 0F B7 7D 10"));
 });
 
 namespace rage
@@ -19,6 +26,11 @@ namespace rage
 	DLL_EXPORT rage::parStructure* GetStructureDefinition(uint32_t structHash)
 	{
 		return _parser_getStructure(*g_parser, structHash);
+	}
+
+	DLL_EXPORT bool LoadFromStructure(const char* fileName, const char* ext, rage::parStructure* parStruct, void* target, bool typeChecks, void* unk)
+	{
+		return _parser_loadFromStructure(*g_parser, fileName, ext, parStruct, target, typeChecks, unk);
 	}
 }
 

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1559,6 +1559,148 @@ public:
 
 static CfxPedFacialOverlaysMounter g_pedFacialOverlaysMounter;
 
+// layout per the game's parser definition: three component arrays at 0, then four byte
+// arrays at 48/64/80/96, 112 bytes in total
+struct CPedSkinTonesStore
+{
+	atArray<uint32_t> comps[3];
+
+	// males/females/uniqueMales/uniqueFemales - indices into the file's own ordering, so
+	// appending them would need remapping; only read to report that they were ignored
+	atArray<uint8_t> genderIndices[4];
+};
+
+// these stores load from a run of near-identical call sites and the path operand cannot
+// anchor them, so each match is validated against the shape CPedSkinTones has to have
+static CPedSkinTonesStore* GetPedSkinTonesStore()
+{
+	static CPedSkinTonesStore* store = ([]() -> CPedSkinTonesStore*
+	{
+		auto matches = hook::pattern("48 8B 0D ? ? ? ? 48 8D 05 ? ? ? ? 48 8D 15 ? ? ? ? 4C 8B C3");
+		matches.count_hint(8);
+
+		if (matches.empty())
+		{
+			trace("CFX_PED_SKIN_TONES: no candidate call sites found\n");
+			return nullptr;
+		}
+
+		for (size_t i = 0; i < matches.size(); i++)
+		{
+			// the store is the operand of the second instruction in the run
+			auto candidate = hook::get_address<CPedSkinTonesStore*>(matches.get(i).get<void>(7), 3, 7);
+			if (!candidate)
+			{
+				continue;
+			}
+
+			if (candidate->comps[0].GetCount() == 0 || candidate->comps[0].GetCount() > 64)
+			{
+				continue;
+			}
+
+			// all three components carry the same number of tones in every shipped build
+			if (candidate->comps[1].GetCount() != candidate->comps[0].GetCount() ||
+				candidate->comps[2].GetCount() != candidate->comps[0].GetCount())
+			{
+				continue;
+			}
+
+			trace("CFX_PED_SKIN_TONES: store at %p (%d tones per component)\n",
+				(void*)candidate, (int)candidate->comps[0].GetCount());
+			return candidate;
+		}
+
+		trace("CFX_PED_SKIN_TONES: no call site resolved to a usable store\n");
+		return nullptr;
+	})();
+
+	return store;
+}
+
+class CfxPedSkinTonesMounter : public CDataFileMountInterface
+{
+private:
+	std::map<std::string, std::array<uint16_t, 3>> m_added;
+
+public:
+	virtual bool LoadDataFile(CDataFileMgr::DataFile* entry) override
+	{
+		auto store = GetPedSkinTonesStore();
+		auto def = rage::GetStructureDefinition("CPedSkinTones");
+
+		if (!store || !def || !def->m_new || !def->m_delete)
+		{
+			trace("CFX_PED_SKIN_TONES: store or parser structure unavailable\n");
+			return false;
+		}
+
+		void* scratch = def->m_new();
+		if (!scratch)
+		{
+			return false;
+		}
+
+		std::string fileName = entry->name;
+		auto basePath = fileName.substr(0, fileName.find_last_of('.'));
+
+		if (!rage::LoadFromStructure(basePath.c_str(), "meta", def, scratch, true, nullptr))
+		{
+			def->m_delete(scratch);
+			return false;
+		}
+
+		auto loaded = (CPedSkinTonesStore*)scratch;
+		std::array<uint16_t, 3> added{};
+
+		for (int i = 0; i < 3; i++)
+		{
+			auto& dst = store->comps[i];
+			auto& src = loaded->comps[i];
+
+			added[i] = AppendUniqueHashes(dst, src);
+		}
+
+		m_added[entry->name] = added;
+
+		uint16_t ignored = 0;
+		for (size_t i = 0; i < 4; i++)
+		{
+			ignored += loaded->genderIndices[i].GetCount();
+		}
+
+		def->m_delete(scratch);
+
+		trace("CFX_PED_SKIN_TONES: appended %d/%d/%d\n", added[0], added[1], added[2]);
+
+		if (ignored > 0)
+		{
+			trace("CFX_PED_SKIN_TONES: ignored %d entries in males/females/uniqueMales/uniqueFemales\n", ignored);
+		}
+		return true;
+	}
+
+	virtual void UnloadDataFile(CDataFileMgr::DataFile* entry) override
+	{
+		auto store = GetPedSkinTonesStore();
+		auto it = m_added.find(entry->name);
+
+		if (!store || it == m_added.end())
+		{
+			return;
+		}
+
+		for (int i = 0; i < 3; i++)
+		{
+			TrimAppendedHashes(store->comps[i], it->second[i]);
+		}
+
+		m_added.erase(it);
+	}
+};
+
+static CfxPedSkinTonesMounter g_pedSkinTonesMounter;
+
 
 
 
@@ -1665,6 +1807,11 @@ static CDataFileMountInterface* LookupDataFileMounter(const std::string& type)
 	}
 
 #if GTA_FIVE
+	if (type == "CFX_PED_SKIN_TONES")
+	{
+		return &g_pedSkinTonesMounter;
+	}
+
 	if (type == "CFX_PED_FACIAL_OVERLAYS")
 	{
 		return &g_pedFacialOverlaysMounter;

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1399,6 +1399,172 @@ struct CInteriorProxy
 };
 
 #ifdef GTA_FIVE
+#include <RageParser.h>
+
+struct CPedFacialOverlays
+{
+	atArray<uint32_t> m_blemishes;
+	atArray<uint32_t> m_facialHair;
+	atArray<uint32_t> m_eyebrow;
+	atArray<uint32_t> m_aging;
+	atArray<uint32_t> m_makeup;
+	atArray<uint32_t> m_blusher;
+	atArray<uint32_t> m_damage;
+	atArray<uint32_t> m_baseDetail;
+	atArray<uint32_t> m_skinDetail1;
+	atArray<uint32_t> m_skinDetail2;
+	atArray<uint32_t> m_bodyOverlay1;
+	atArray<uint32_t> m_bodyOverlay2;
+	atArray<uint32_t> m_bodyOverlay3;
+
+	bool LoadFromFile(const char* filePath);
+};
+
+bool CPedFacialOverlays::LoadFromFile(const char* filePath)
+{
+	auto parserStruct = rage::GetStructureDefinition("CPedFacialOverlays");
+	
+	return LoadFromStructure(filePath, "meta", parserStruct, this, true, nullptr);
+}
+
+static CPedFacialOverlays* g_pedFacialOverlaysStore;
+
+// appends hashes dst does not have yet, returning the count so unload can trim it back
+// again - skipping duplicates lets a file be a full replacement or only its own additions
+static uint16_t AppendUniqueHashes(atArray<uint32_t>& dst, atArray<uint32_t>& src)
+{
+	uint16_t srcCount = src.GetCount();
+	if (srcCount == 0)
+	{
+		return 0;
+	}
+
+	// reserve for the worst case, where none of the entries are already present
+	if (dst.GetCount() + srcCount > dst.GetSize())
+	{
+		dst.Expand(dst.GetCount() + srcCount);
+	}
+
+	uint16_t appended = 0;
+
+	for (uint16_t i = 0; i < srcCount; i++)
+	{
+		uint32_t value = src.Get(i);
+		bool exists = false;
+
+		for (uint16_t k = 0; k < dst.GetCount(); k++)
+		{
+			if (dst.Get(k) == value)
+			{
+				exists = true;
+				break;
+			}
+		}
+
+		if (exists)
+		{
+			continue;
+		}
+
+		dst.Get(dst.GetCount()) = value;
+		dst.m_count = dst.GetCount() + 1;
+		appended++;
+	}
+
+	return appended;
+}
+
+// removes what we appended, always the tail - by value could delete a base game entry
+static void TrimAppendedHashes(atArray<uint32_t>& arr, uint16_t count)
+{
+	if (count > 0 && arr.GetCount() >= count)
+	{
+		arr.m_count = arr.GetCount() - count;
+	}
+}
+
+class CfxPedFacialOverlaysMounter : public CDataFileMountInterface
+{
+private:
+	static constexpr size_t kOverlayCount = 13;
+
+	// how many entries this mounter appended to each overlay array, keyed by data file
+	std::map<std::string, std::array<uint16_t, kOverlayCount>> m_added;
+
+public:
+	virtual bool LoadDataFile(CDataFileMgr::DataFile* entry) override
+	{
+		auto def = rage::GetStructureDefinition("CPedFacialOverlays");
+
+		if (!g_pedFacialOverlaysStore || !def || !def->m_new || !def->m_delete)
+		{
+			trace("CFX_PED_FACIAL_OVERLAYS: store or parser structure unavailable\n");
+			return false;
+		}
+
+		void* scratch = def->m_new();
+		if (!scratch)
+		{
+			return false;
+		}
+
+		std::string fileName = entry->name;
+		auto basePath = fileName.substr(0, fileName.find_last_of('.'));
+
+		if (!rage::LoadFromStructure(basePath.c_str(), "meta", def, scratch, true, nullptr))
+		{
+			def->m_delete(scratch);
+			return false;
+		}
+
+		// the 13 members are consecutive atArray<uint32_t> at 16 byte intervals
+		auto dst = reinterpret_cast<atArray<uint32_t>*>(g_pedFacialOverlaysStore);
+		auto src = reinterpret_cast<atArray<uint32_t>*>(scratch);
+
+		std::array<uint16_t, kOverlayCount> added{};
+		uint16_t total = 0;
+
+		for (size_t i = 0; i < kOverlayCount; i++)
+		{
+			added[i] = AppendUniqueHashes(dst[i], src[i]);
+			total += added[i];
+		}
+
+		m_added[entry->name] = added;
+		def->m_delete(scratch);
+
+		trace("CFX_PED_FACIAL_OVERLAYS: appended %d entries from %s\n", total, fileName);
+		return true;
+	}
+
+	virtual void UnloadDataFile(CDataFileMgr::DataFile* entry) override
+	{
+		auto it = m_added.find(entry->name);
+
+		if (!g_pedFacialOverlaysStore || it == m_added.end())
+		{
+			return;
+		}
+
+		auto dst = reinterpret_cast<atArray<uint32_t>*>(g_pedFacialOverlaysStore);
+
+		for (size_t i = 0; i < kOverlayCount; i++)
+		{
+			TrimAppendedHashes(dst[i], it->second[i]);
+		}
+
+		m_added.erase(it);
+	}
+};
+
+static CfxPedFacialOverlaysMounter g_pedFacialOverlaysMounter;
+
+
+
+
+#endif
+
+#ifdef GTA_FIVE
 static hook::thiscall_stub<int(void* store, int* out, uint32_t* inHash)> _getIndexByKey([]()
 {
 	return hook::get_pattern("39 1C 91 74 4F 44 8B 4C 91 08 45 3B", -0x34);
@@ -1497,6 +1663,13 @@ static CDataFileMountInterface* LookupDataFileMounter(const std::string& type)
 	{
 		return &g_staticCacheMounter;
 	}
+
+#if GTA_FIVE
+	if (type == "CFX_PED_FACIAL_OVERLAYS")
+	{
+		return &g_pedFacialOverlaysMounter;
+	}
+#endif
 
 	int fileType = LookupDataFileType(type);
 
@@ -3313,6 +3486,8 @@ void* chunkyArrayAppend(hook::FlexStruct* self)
 	return g_chunkyArrayAppend(self);
 }
 
+#endif
+
 static ConsoleCommand pgRawStreamer_AssetsCountCmd("assetscount", []()
 {
 	std::stringstream ss;
@@ -3333,8 +3508,6 @@ const rage::chunkyArray<rage::fiCollection::RawEntry, 1024, 64>& rage::GetPgRawS
 {
 	return g_GetRawStreamer()->m_entries;
 }
-
-#endif
 
 static void CleanupStreaming()
 {
@@ -3508,6 +3681,7 @@ static HookFunction hookFunction([]()
 #endif
 
 #ifdef GTA_FIVE
+	g_pedFacialOverlaysStore = hook::get_address<decltype(g_pedFacialOverlaysStore)>(hook::get_pattern<char>("48 8D 05 ? ? ? ? 48 8D 1D ? ? ? ? 48 8D 15", 3));
 
 	loadChangeSet = hook::get_pattern<char>("48 81 EC 50 03 00 00 49 8B F0 4C", -0x18);
 

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1439,6 +1439,13 @@ static uint16_t AppendUniqueHashes(atArray<uint32_t>& dst, atArray<uint32_t>& sr
 		return 0;
 	}
 
+	uint16_t headroom = static_cast<uint16_t>(UINT16_MAX - dst.GetCount());
+
+	if (srcCount > headroom)
+	{
+		srcCount = headroom;
+	}
+
 	// reserve for the worst case, where none of the entries are already present
 	if (dst.GetCount() + srcCount > dst.GetSize())
 	{


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

`facial_overlays.meta` and `ped_skin_tones.meta` are loaded once from fixed paths during startup and are not present in the game's data file type table. Because of this, resources cannot add custom makeup, facial hair, eyebrows, or skin tones.

Requested in #2188.


### How is this PR achieving the goal

Adds two Cfx-side data file types, resolved before the game enum lookup:

```lua
data_file 'CFX_PED_FACIAL_OVERLAYS' 'facial_overlays.meta'
data_file 'CFX_PED_SKIN_TONES'      'ped_skin_tones.meta'
```

Both mounters use the game's parser to load the file into a game-allocated instance and append its entries to the live store.

Duplicate entries are skipped, so resources can include either the full file or only their additions. On unload, only the entries appended by that resource are removed.

Also exposes `rage::LoadFromStructure`, which is used by both mounters.

Tested with a resource containing 141 overlay textures and a `ped_skin_tones.meta` containing the 12 default entries plus 4 additional entries:

| Component | Before | After |
|---|---:|---:|
| Facial hair | 29 | 87 |
| Eyebrows | 34 | 68 |
| Skin tones per component | 12 | 16 |

`GetPedHeadOverlayNum` returns the new counts, and the added overlays render correctly on freemode peds. This was also tested in multiplayer with the overlays synchronized between players.

Test: https://www.youtube.com/watch?v=NW949uSiLDY&feature=youtu.be
A client without these changes logs both data file types as invalid, as expected.

`CPedSkinTones` also contains `males`, `females`, `uniqueMales`, and `uniqueFemales`. These are indices based on the ordering of the loaded file and cannot be appended without remapping them against the component offsets. They are ignored for now, and the ignored entry count is logged.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 3258, 3751

**Platforms:** Windows

**Multiplayer:** Tested successfully with multiple clients


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

Closes #2188