### PR TITLE
feat(gta-streaming-five): increase ymt limit to 256

### DIFF
--- a/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
+++ b/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
@@ -200,7 +200,12 @@ static int GetDependencies(void* self, uint32_t localIndex, uint32_t* outIndices
 static HookFunction hookFunction([]
 {
 	g_origSetPedMetaDataFile = hook::trampoline(hook::get_pattern("83 FA FF 74 ? 53 48 83 EC 20 8B DA 48 81 C1 E0 00 00 00 BA 01 00 00 00 E8"), SetPedMetaDataFile);
-	g_origGetDependencies = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 44 89 48 ? 89 50 ? 48 89 48"), GetDependencies);
+
+	auto vtable = hook::get_address<uintptr_t*>(hook::get_pattern("48 8D 05 ? ? ? ? 48 8D 0D ? ? ? ? 48 89 05 ? ? ? ? E8 ? ? ? ? 48 8D 15 ? ? ? ? 48 8D 0D ? ? ? ? E8", 3));
+	auto slot = *reinterpret_cast<uint32_t*>(hook::get_pattern("FF 90 ? ? ? ? 33 D2 4C 63 C0 85 C0", 2)) / 8;
+
+	g_origGetDependencies = reinterpret_cast<decltype(g_origGetDependencies)>(vtable[slot]);
+	hook::putVP(&vtable[slot], reinterpret_cast<uintptr_t>(GetDependencies));
 
 	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]
 	{

--- a/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
+++ b/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
@@ -6,7 +6,6 @@
 #include <ICoreGameInit.h>
 #include <Streaming.h>
 
-#include <algorithm>
 #include <mutex>
 #include <unordered_set>
 
@@ -108,23 +107,14 @@ static void SetPedMetaDataFile(void* self, uint32_t localIndex)
 	}
 }
 
-static int GetDependencies(void* self, uint32_t localIndex, uint32_t* outIndices, int count)
+static int __declspec(noinline) FilterDependencies(const uint32_t* dependencies, int total, uint32_t* outIndices, int count)
 {
 	auto manager = streaming::Manager::GetInstance();
 
-	if (count <= 0 || static_cast<size_t>(count) >= kExtendedDependencyCount || !manager || !manager->Entries)
+	if (!manager || !manager->Entries)
 	{
-		return g_origGetDependencies(self, localIndex, outIndices, count);
-	}
-
-	uint32_t dependencies[kExtendedDependencyCount];
-
-	int total = std::clamp(g_origGetDependencies(self, localIndex, dependencies, kExtendedDependencyCount), 0, static_cast<int>(kExtendedDependencyCount));
-
-	if (total <= count)
-	{
-		memcpy(outIndices, dependencies, total * sizeof(uint32_t));
-		return total;
+		memcpy(outIndices, dependencies, static_cast<size_t>(count) * sizeof(uint32_t));
+		return count;
 	}
 
 	uint32_t rearm[kExtendedDependencyCount];
@@ -169,6 +159,42 @@ static int GetDependencies(void* self, uint32_t localIndex, uint32_t* outIndices
 	}
 
 	return written;
+}
+
+static int GetDependencies(void* self, uint32_t localIndex, uint32_t* outIndices, int count)
+{
+	if (count <= 0 || static_cast<size_t>(count) >= kExtendedDependencyCount)
+	{
+		return g_origGetDependencies(self, localIndex, outIndices, count);
+	}
+
+	uint32_t dependencies[kExtendedDependencyCount];
+
+	int total = g_origGetDependencies(self, localIndex, dependencies, static_cast<int>(kExtendedDependencyCount));
+
+	if (total == 1)
+	{
+		outIndices[0] = dependencies[0];
+		return 1;
+	}
+
+	if (total <= 0)
+	{
+		return 0;
+	}
+
+	if (static_cast<size_t>(total) > kExtendedDependencyCount)
+	{
+		total = static_cast<int>(kExtendedDependencyCount);
+	}
+
+	if (total > count)
+	{
+		return FilterDependencies(dependencies, total, outIndices, count);
+	}
+
+	memcpy(outIndices, dependencies, static_cast<size_t>(total) * sizeof(uint32_t));
+	return total;
 }
 
 static HookFunction hookFunction([]

--- a/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
+++ b/code/components/gta-streaming-five/src/PedMetaDataLimits.cpp
@@ -1,0 +1,183 @@
+#include <StdInc.h>
+
+#include <Hooking.h>
+#include <Hooking.Stubs.h>
+
+#include <ICoreGameInit.h>
+#include <Streaming.h>
+
+#include <algorithm>
+#include <mutex>
+#include <unordered_set>
+
+constexpr size_t kExtendedDependencyCount = 256;
+constexpr int kResidentStreamingFlags = 7;
+
+constexpr uint32_t kStatusMask = 3;
+constexpr uint32_t kStatusLoaded = 1;
+constexpr uint32_t kRequiredFlagsMask = 0x00F10000;
+
+static void (*g_origSetPedMetaDataFile)(void*, uint32_t);
+static int (*g_origGetDependencies)(void*, uint32_t, uint32_t*, int);
+
+static streaming::strStreamingModule* g_metaDataStore;
+
+static std::mutex g_residentMutex;
+static std::unordered_set<uint32_t> g_residentIndices;
+
+static streaming::strStreamingModule* GetMetaDataStore()
+{
+	if (!g_metaDataStore)
+	{
+		if (auto manager = streaming::Manager::GetInstance())
+		{
+			g_metaDataStore = manager->moduleMgr.GetStreamingModule("ymt");
+		}
+	}
+
+	return g_metaDataStore;
+}
+
+static uint32_t GetEntryFlags(streaming::Manager* manager, uint32_t globalIndex)
+{
+	return (globalIndex < static_cast<uint32_t>(manager->numEntries)) ? manager->Entries[globalIndex].flags : 0;
+}
+
+static void EnsureObjectResident(uint32_t globalIndex)
+{
+	auto manager = streaming::Manager::GetInstance();
+
+	if (!manager || !manager->Entries || globalIndex >= static_cast<uint32_t>(manager->numEntries))
+	{
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(g_residentMutex);
+		g_residentIndices.insert(globalIndex);
+	}
+
+	if ((GetEntryFlags(manager, globalIndex) & kRequiredFlagsMask) == 0)
+	{
+		manager->RequestObject(globalIndex, kResidentStreamingFlags);
+	}
+}
+
+static void ReleaseResidentObjects()
+{
+	std::unordered_set<uint32_t> indices;
+
+	{
+		std::lock_guard<std::mutex> lock(g_residentMutex);
+		indices.swap(g_residentIndices);
+	}
+
+	auto manager = streaming::Manager::GetInstance();
+
+	if (!manager || !manager->Entries)
+	{
+		return;
+	}
+
+	for (uint32_t index : indices)
+	{
+		if (index >= static_cast<uint32_t>(manager->numEntries))
+		{
+			continue;
+		}
+
+		if ((manager->Entries[index].flags & kRequiredFlagsMask) == 0)
+		{
+			manager->RequestObject(index, kResidentStreamingFlags);
+		}
+
+		manager->ReleaseObject(index, kResidentStreamingFlags);
+	}
+}
+
+static void SetPedMetaDataFile(void* self, uint32_t localIndex)
+{
+	g_origSetPedMetaDataFile(self, localIndex);
+
+	if (localIndex != -1)
+	{
+		if (auto store = GetMetaDataStore())
+		{
+			EnsureObjectResident(store->baseIdx + localIndex);
+		}
+	}
+}
+
+static int GetDependencies(void* self, uint32_t localIndex, uint32_t* outIndices, int count)
+{
+	auto manager = streaming::Manager::GetInstance();
+
+	if (count <= 0 || static_cast<size_t>(count) >= kExtendedDependencyCount || !manager || !manager->Entries)
+	{
+		return g_origGetDependencies(self, localIndex, outIndices, count);
+	}
+
+	uint32_t dependencies[kExtendedDependencyCount];
+
+	int total = std::clamp(g_origGetDependencies(self, localIndex, dependencies, kExtendedDependencyCount), 0, static_cast<int>(kExtendedDependencyCount));
+
+	if (total <= count)
+	{
+		memcpy(outIndices, dependencies, total * sizeof(uint32_t));
+		return total;
+	}
+
+	uint32_t rearm[kExtendedDependencyCount];
+	int rearmCount = 0;
+	int written = 0;
+	int index = 0;
+
+	{
+		std::lock_guard<std::mutex> lock(g_residentMutex);
+
+		for (; index < total && written < count; index++)
+		{
+			uint32_t dependency = dependencies[index];
+
+			if (g_residentIndices.find(dependency) != g_residentIndices.end())
+			{
+				uint32_t flags = GetEntryFlags(manager, dependency);
+
+				if ((flags & kRequiredFlagsMask) == 0)
+				{
+					rearm[rearmCount++] = dependency;
+				}
+
+				if ((flags & kStatusMask) == kStatusLoaded)
+				{
+					continue;
+				}
+			}
+
+			outIndices[written++] = dependency;
+		}
+	}
+
+	for (int i = 0; i < rearmCount; i++)
+	{
+		manager->RequestObject(rearm[i], kResidentStreamingFlags);
+	}
+
+	for (; index < total; index++)
+	{
+		EnsureObjectResident(dependencies[index]);
+	}
+
+	return written;
+}
+
+static HookFunction hookFunction([]
+{
+	g_origSetPedMetaDataFile = hook::trampoline(hook::get_pattern("83 FA FF 74 ? 53 48 83 EC 20 8B DA 48 81 C1 E0 00 00 00 BA 01 00 00 00 E8"), SetPedMetaDataFile);
+	g_origGetDependencies = hook::trampoline(hook::get_pattern("48 8B C4 48 89 58 ? 44 89 48 ? 89 50 ? 48 89 48"), GetDependencies);
+
+	Instance<ICoreGameInit>::Get()->OnShutdownSession.Connect([]
+	{
+		ReleaseResidentObjects();
+	}, -10000);
+});


### PR DESCRIPTION
### Goal of this PR

Increase the limit of YMT (ped metadata) files that a freemode ped model can have. It's the same problem as #3444: clothing packs that add new YMT files end up reaching the limit of the game build and the game crashes on `SetPlayerModel`. Each build has a different amount of free slots depending on the dlc being used.

**Feature Branch:** `specific/feature/experimental-ymt-extension`

### How is this PR achieving the goal

Instead of growing the array I move the ownership of the overflow. The hook calls the original into my own 256 entry buffer, if the result fits I pass it through untouched, and if it doesn't I skip the entries that I have pinned resident and that are already loaded, then pin whatever is left over. The only job of a dependency slot is "load this and keep it alive", and for those entries I already did both.

I've tested two clothing packs that without this patch were crashing due to reaching the described limit. Thanks to @marcelo-fervi and @spacevx for sharing and providing a server to test this patch.

### This PR applies to the following area(s)
FiveM


### Successfully tested on
**Game builds:** 3258
**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
fixes #2938 
