### PR TITLE
Fix/minimap overlay reconnect crash

### DIFF
--- a/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
+++ b/code/components/citizen-resources-gta/src/TextChangingFunctions.cpp
@@ -178,6 +178,11 @@ static InitFunction initFunction([] ()
 		context.SetResult(overlayIdx);
 	});
 
+	fx::ScriptEngine::RegisterNativeHandler("REMOVE_MINIMAP_OVERLAY", [](fx::ScriptContext& context)
+	{
+		sf::RemoveMinimapOverlay(context.GetArgument<int>(0));
+	});
+
 	fx::ScriptEngine::RegisterNativeHandler("HAS_MINIMAP_OVERLAY_LOADED", [](fx::ScriptContext& context)
 	{
 		context.SetResult(sf::HasMinimapLoaded(context.GetArgument<int>(0)));

--- a/code/components/gta-streaming-five/include/sfDefinitions.h
+++ b/code/components/gta-streaming-five/include/sfDefinitions.h
@@ -282,6 +282,18 @@ public:
 		}
 	}
 
+	inline bool HasObjectInterface() const
+	{
+		return pObjectInterface != nullptr;
+	}
+
+	inline void Detach()
+	{
+		pObjectInterface = nullptr;
+		Type = VT_Undefined;
+		mValue.pData = nullptr;
+	}
+
 	inline ValueType GetType() const
 	{
 		return ValueType(Type & VTC_TypeMask);

--- a/code/components/gta-streaming-five/src/ScaleformHacks.cpp
+++ b/code/components/gta-streaming-five/src/ScaleformHacks.cpp
@@ -6,6 +6,7 @@
 #include <sfDefinitions.h>
 
 #include <CoreConsole.h>
+#include <GameInit.h>
 #include <Streaming.h>
 #include <CrossBuildRuntime.h>
 
@@ -106,6 +107,16 @@ static hook::cdecl_stub<GFxMovieRoot*(uint32_t movie)> _getScaleformMovie([]()
 
 static std::map<int, std::shared_ptr<GFxValue>> g_overlayClips;
 
+static void DetachMinimapOverlayClips()
+{
+	for (const auto& [swfId, clip] : g_overlayClips)
+	{
+		clip->Detach();
+	}
+
+	g_overlayClips.clear();
+}
+
 class OverlayMethodFunctionHandler : public GFxFunctionHandler
 {
 public:
@@ -118,15 +129,15 @@ public:
 
 		int movieId = static_cast<int>(params.pArgs[0].GetNumber());
 
-		auto& clipVal = g_overlayClips[movieId];
+		auto clipIt = g_overlayClips.find(movieId);
 
-		if (clipVal)
+		if (clipIt != g_overlayClips.end())
 		{
 			const char* fn = params.pArgs[1].GetString();
 
 			GFxValue pTimeline;
 
-			if (clipVal->GetMember("TIMELINE", &pTimeline))
+			if (clipIt->second->GetMember("TIMELINE", &pTimeline))
 			{
 				pTimeline.Invoke(va("%s", fn), params.pRetVal, &params.pArgs[2], params.ArgCount - 2);
 			}
@@ -143,8 +154,10 @@ static uint32_t* g_gfxId;
 static void SetupTerritories()
 {
 	g_origSetupTerritories();
-	
-	overlayRootClip = {};
+
+	DetachMinimapOverlayClips();
+
+	overlayRootClip.Detach();
 
 	g_foregroundOverlay3D->CreateEmptyMovieClip(&overlayRootClip, "asTestClip3D", -1);
 
@@ -167,6 +180,16 @@ struct MinimapOverlayLoadRequest
 static std::map<std::string, MinimapOverlayLoadRequest> g_minimapOverlayLoadQueue;
 static std::set<int> g_minimapOverlayRemoveQueue;
 static int g_minimapOverlaySwfId;
+
+static void ResetMinimapOverlayState()
+{
+	DetachMinimapOverlayClips();
+
+	overlayRootClip.Detach();
+
+	g_minimapOverlayLoadQueue.clear();
+	g_minimapOverlayRemoveQueue.clear();
+}
 
 static hook::cdecl_stub<void(const char*, bool)> _gfxPushString([]()
 {
@@ -218,9 +241,9 @@ namespace sf
 
 	void SetMinimapOverlayDisplay(int minimap, float x, float y, float xScale, float yScale, float alpha)
 	{
-		auto& clip = g_overlayClips[minimap];
+		auto clipIt = g_overlayClips.find(minimap);
 
-		if (clip)
+		if (clipIt != g_overlayClips.end())
 		{
 			GFxValue::DisplayInfo dispInfo;
 			dispInfo.VarsSet = 0x1 | 0x2 | 0x8 | 0x10 | 0x20; // x, y, xscale, yscale, alpha
@@ -230,7 +253,7 @@ namespace sf
 			dispInfo.YScale = yScale;
 			dispInfo.Alpha = alpha;
 
-			clip->SetDisplayInfo(dispInfo);
+			clipIt->second->SetDisplayInfo(dispInfo);
 		}
 	}
 }
@@ -279,42 +302,55 @@ static HookFunction hookFunction([]()
 {
 	OnMainGameFrame.Connect([]()
 	{
-		std::set<std::string> toRemoveFromMinimapOverlayLoadQueue;
-
-		auto cstreaming = streaming::Manager::GetInstance();
-
-		for (const auto& [gfxFileName, request] : g_minimapOverlayLoadQueue)
+		if (overlayRootClip.HasObjectInterface())
 		{
-			auto swf = std::make_shared<GFxValue>();
+			std::set<std::string> toRemoveFromMinimapOverlayLoadQueue;
 
-			auto instanceName = va("id%d", request.sfwId);
+			for (const auto& [gfxFileName, request] : g_minimapOverlayLoadQueue)
+			{
+				auto swf = std::make_shared<GFxValue>();
 
-			overlayRootClip.CreateEmptyMovieClip(swf.get(), instanceName, request.depth);
+				auto instanceName = va("id%d", request.sfwId);
 
-			GFxValue result;
-			GFxValue args(gfxFileName.c_str());
+				overlayRootClip.CreateEmptyMovieClip(swf.get(), instanceName, request.depth);
 
-			swf->Invoke("loadMovie", &result, &args, 1);
+				GFxValue result;
+				GFxValue args(gfxFileName.c_str());
 
-			g_overlayClips[request.sfwId] = swf;
+				swf->Invoke("loadMovie", &result, &args, 1);
 
-			toRemoveFromMinimapOverlayLoadQueue.insert(gfxFileName);
-		}
+				g_overlayClips[request.sfwId] = swf;
 
-		for (const auto& gfxFileName : toRemoveFromMinimapOverlayLoadQueue)
-		{
-			g_minimapOverlayLoadQueue.erase(gfxFileName);
+				toRemoveFromMinimapOverlayLoadQueue.insert(gfxFileName);
+			}
+
+			for (const auto& gfxFileName : toRemoveFromMinimapOverlayLoadQueue)
+			{
+				g_minimapOverlayLoadQueue.erase(gfxFileName);
+			}
 		}
 
 		for (int swfId : g_minimapOverlayRemoveQueue)
 		{
-			if (auto swf = g_overlayClips[swfId]; swf)
+			for (auto it = g_minimapOverlayLoadQueue.begin(); it != g_minimapOverlayLoadQueue.end();)
 			{
-				swf->Invoke("removeMovieClip", nullptr, nullptr, 0);
+				it = (it->second.sfwId == swfId) ? g_minimapOverlayLoadQueue.erase(it) : std::next(it);
+			}
+
+			if (auto clipIt = g_overlayClips.find(swfId); clipIt != g_overlayClips.end())
+			{
+				clipIt->second->Invoke("removeMovieClip", nullptr, nullptr, 0);
+
+				g_overlayClips.erase(clipIt);
 			}
 		}
 
 		g_minimapOverlayRemoveQueue.clear();
+	});
+
+	OnKillNetworkDone.Connect([]()
+	{
+		ResetMinimapOverlayState();
 	});
 
 	{

--- a/ext/native-decls/RemoveMinimapOverlay.md
+++ b/ext/native-decls/RemoveMinimapOverlay.md
@@ -1,0 +1,20 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## REMOVE_MINIMAP_OVERLAY
+
+```c
+void REMOVE_MINIMAP_OVERLAY(int miniMap);
+```
+
+Removes a minimap overlay added with [`ADD_MINIMAP_OVERLAY`](#_0x4AFD2499) or
+[`ADD_MINIMAP_OVERLAY_WITH_DEPTH`](#_0xED0935B5).
+
+Overlays are removed automatically when the resource that added them stops, so this is only needed
+to remove one before that. Passing an ID that is unknown, or that has already been removed, does
+nothing.
+
+## Parameters
+* **miniMap**: The minimap overlay ID.


### PR DESCRIPTION
### Goal of this PR

Resources using `ADD_MINIMAP_OVERLAY` or `ADD_MINIMAP_OVERLAY_WITH_DEPTH` can crash the client after disconnecting and reconnecting within the same game process.

Minimap overlay `GFxValue` handles are kept in process-lifetime state and were not cleared when the session ended. Once the minimap movie is destroyed, these handles become invalid and can be accessed during the next session.

This PR fixes the lifetime handling and exposes `REMOVE_MINIMAP_OVERLAY` so resources can explicitly remove overlays.

Repro: have a resource call `AddMinimapOverlay("something.gfx")` on start, join a server, disconnect, then reconnect. The client can crash in `gta-streaming-five.dll`.

### How is this PR achieving the goal

First commit, `fix(gta-streaming-five): don't carry minimap overlay handles across sessions`:

* Adds `GFxValue::Detach()` to safely discard managed values without accessing an object interface that may already be invalid.
* Clears overlay handles and pending queues when the network session ends, preventing stale state from carrying into the next session.
* Drops old overlay handles when `SetupTerritories()` replaces the minimap root clip.
* Adds `GFxValue::HasObjectInterface()` so queued overlays wait until the minimap is available before being loaded.
* Avoids inserting entries for unknown overlay IDs and erases removed overlays from `g_overlayClips`.
* Removes an unused `cstreaming` local, clearing an existing C4189 warning.

Second commit, `feat(gta-streaming-five): add REMOVE_MINIMAP_OVERLAY native`:

Registers the existing `sf::RemoveMinimapOverlay` functionality as a native, allowing resources to remove overlays without stopping.

No new `hook::get_pattern` calls are introduced, so these changes are not game-build specific.

### This PR applies to the following area(s)

FiveM, Natives

### Successfully tested on

**Game builds:** 3889

**Platforms:** Windows

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues