### PR TITLE
feat(extra-natives-five): add curb boost control native

### DIFF
--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -322,6 +322,39 @@ static int WheelPowerOffset;
 static int WheelHealthOffset; // = 0x1E8; // 75 24 F3 0F 10 81 ? ? ? ? F3 0F
 static int WheelSurfaceMaterialOffset;
 static int WheelFlagsOffset;
+// GTA V uses bits 0-25 of this 32-bit field. Reserve bit 30 for a Cfx-only
+// override so the physics hook can remain allocation-free.
+static constexpr uint32_t CfxCurbBoostDisabledWheelFlag = 0x40000000;
+
+static void SetVehicleCurbBoostEnabledForWheels(fwEntity* vehicle, bool enabled)
+{
+	const unsigned char numWheels = readValue<unsigned char>(vehicle, NumWheelsOffset);
+	const uintptr_t wheelsAddress = readValue<uintptr_t>(vehicle, WheelsPtrOffset);
+
+	if (!wheelsAddress)
+	{
+		return;
+	}
+
+	for (unsigned char wheelIndex = 0; wheelIndex < numWheels; ++wheelIndex)
+	{
+		const uintptr_t wheelAddress = *reinterpret_cast<uintptr_t*>(wheelsAddress + (sizeof(uintptr_t) * wheelIndex));
+		if (!wheelAddress)
+		{
+			continue;
+		}
+
+		auto& wheelFlags = *reinterpret_cast<uint32_t*>(wheelAddress + WheelFlagsOffset);
+		if (enabled)
+		{
+			wheelFlags &= ~CfxCurbBoostDisabledWheelFlag;
+		}
+		else
+		{
+			wheelFlags |= CfxCurbBoostDisabledWheelFlag;
+		}
+	}
+}
 
 static char* VehicleTopSpeedModifierPtr;
 static int VehicleCheatPowerIncreaseOffset;
@@ -759,6 +792,54 @@ static HookFunction initFunction([]()
 		auto location = hook::get_pattern<char>("75 11 48 8B 01 8B 88");
 
 		WheelFlagsOffset = *(uint32_t*)(location + 7);
+	}
+
+	{
+		auto curbBoostLocation = hook::get_pattern<char>("0F 2E BB 4C 01 00 00 75 ? 44 38 2D ? ? ? ? F3 0F 10 05 ? ? ? ? 74 ? 48 8B 83 20 01 00 00 0F 2F 40 14");
+		auto curbBoostSkipTarget = curbBoostLocation + 9 + *(int8_t*)(curbBoostLocation + 8);
+
+		static struct : jitasm::Frontend
+		{
+			int32_t skipDelta{ 0 };
+			int32_t wheelFlagsOffset{ 0 };
+
+			void SetOffsets(int32_t delta, int32_t flagsOffset)
+			{
+				skipDelta = delta;
+				wheelFlagsOffset = flagsOffset;
+			}
+
+			void RedirectReturnAddress()
+			{
+				push(rax);
+				mov(rax, qword_ptr[rsp + 8]);
+				add(rax, skipDelta);
+				mov(qword_ptr[rsp + 8], rax);
+				pop(rax);
+				ret();
+			}
+
+			virtual void InternalMain() override
+			{
+				// Preserve the game's Open Wheel/suspension-raise condition.
+				ucomiss(xmm7, dword_ptr[rbx + 0x14C]);
+				jne("skipLongSlipSmoothing");
+
+				// The native marks the wheel directly, avoiding a helper call in the physics loop.
+				test(dword_ptr[rbx + wheelFlagsOffset], CfxCurbBoostDisabledWheelFlag);
+				jne("skipLongSlipSmoothing");
+				ret();
+
+				L("skipLongSlipSmoothing");
+				RedirectReturnAddress();
+			}
+		} curbBoostStub;
+
+		curbBoostStub.SetOffsets(
+			(int32_t)(curbBoostSkipTarget - (curbBoostLocation + 5)),
+			WheelFlagsOffset);
+		hook::nop(curbBoostLocation, 9);
+		hook::call(curbBoostLocation, curbBoostStub.GetCode());
 	}
 
 	{
@@ -1786,6 +1867,14 @@ static HookFunction initFunction([]()
 			{
 				g_skipRepairVehicles.erase(entity);
 			}	
+		}
+	});
+
+	fx::ScriptEngine::RegisterNativeHandler("SET_VEHICLE_CURB_BOOST_ENABLED", [](fx::ScriptContext& context)
+	{
+		if (fwEntity* entity = getAndCheckVehicle(context, "SET_VEHICLE_CURB_BOOST_ENABLED"))
+		{
+			SetVehicleCurbBoostEnabledForWheels(entity, context.GetArgument<bool>(1));
 		}
 	});
 

--- a/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
+++ b/code/components/extra-natives-five/src/VehicleExtraNatives.cpp
@@ -795,51 +795,63 @@ static HookFunction initFunction([]()
 	}
 
 	{
-		auto curbBoostLocation = hook::get_pattern<char>("0F 2E BB 4C 01 00 00 75 ? 44 38 2D ? ? ? ? F3 0F 10 05 ? ? ? ? 74 ? 48 8B 83 20 01 00 00 0F 2F 40 14");
-		auto curbBoostSkipTarget = curbBoostLocation + 9 + *(int8_t*)(curbBoostLocation + 8);
+		auto curbBoostLocation = hook::get_pattern<char>("0F 2E BB 4C 01 00 00");
 
-		static struct : jitasm::Frontend
+		const uint8_t curbBoostJumpOpcode = *(uint8_t*)(curbBoostLocation + 7);
+		const bool curbBoostNearJump = curbBoostJumpOpcode == 0x0F && *(uint8_t*)(curbBoostLocation + 8) == 0x85;
+
+		if (curbBoostJumpOpcode != 0x75 && !curbBoostNearJump)
 		{
-			int32_t skipDelta{ 0 };
-			int32_t wheelFlagsOffset{ 0 };
+			trace("Unrecognized jump after the curb boost gate, leaving it unpatched.\n");
+		}
+		else
+		{
+			const size_t curbBoostGateSize = curbBoostNearJump ? 13 : 9;
+			auto curbBoostSkipTarget = curbBoostLocation + curbBoostGateSize + (curbBoostNearJump
+				? *(int32_t*)(curbBoostLocation + 9)
+				: *(int8_t*)(curbBoostLocation + 8));
 
-			void SetOffsets(int32_t delta, int32_t flagsOffset)
+			static struct : jitasm::Frontend
 			{
-				skipDelta = delta;
-				wheelFlagsOffset = flagsOffset;
-			}
+				int32_t skipDelta{ 0 };
+				int32_t wheelFlagsOffset{ 0 };
 
-			void RedirectReturnAddress()
-			{
-				push(rax);
-				mov(rax, qword_ptr[rsp + 8]);
-				add(rax, skipDelta);
-				mov(qword_ptr[rsp + 8], rax);
-				pop(rax);
-				ret();
-			}
+				void SetOffsets(int32_t delta, int32_t flagsOffset)
+				{
+					skipDelta = delta;
+					wheelFlagsOffset = flagsOffset;
+				}
 
-			virtual void InternalMain() override
-			{
-				// Preserve the game's Open Wheel/suspension-raise condition.
-				ucomiss(xmm7, dword_ptr[rbx + 0x14C]);
-				jne("skipLongSlipSmoothing");
+				void RedirectReturnAddress()
+				{
+					push(rax);
+					mov(rax, qword_ptr[rsp + 8]);
+					add(rax, skipDelta);
+					mov(qword_ptr[rsp + 8], rax);
+					pop(rax);
+					ret();
+				}
 
-				// The native marks the wheel directly, avoiding a helper call in the physics loop.
-				test(dword_ptr[rbx + wheelFlagsOffset], CfxCurbBoostDisabledWheelFlag);
-				jne("skipLongSlipSmoothing");
-				ret();
+				virtual void InternalMain() override
+				{
+					// Preserve the game's Open Wheel/suspension-raise condition.
+					ucomiss(xmm7, dword_ptr[rbx + 0x14C]);
+					jne("skipLongSlipSmoothing");
 
-				L("skipLongSlipSmoothing");
-				RedirectReturnAddress();
-			}
-		} curbBoostStub;
+					// The native marks the wheel directly, avoiding a helper call in the physics loop.
+					test(dword_ptr[rbx + wheelFlagsOffset], CfxCurbBoostDisabledWheelFlag);
+					jne("skipLongSlipSmoothing");
+					ret();
 
-		curbBoostStub.SetOffsets(
-			(int32_t)(curbBoostSkipTarget - (curbBoostLocation + 5)),
-			WheelFlagsOffset);
-		hook::nop(curbBoostLocation, 9);
-		hook::call(curbBoostLocation, curbBoostStub.GetCode());
+					L("skipLongSlipSmoothing");
+					RedirectReturnAddress();
+				}
+			} curbBoostStub;
+
+			curbBoostStub.SetOffsets((int32_t)(curbBoostSkipTarget - (curbBoostLocation + 5)), WheelFlagsOffset);
+			hook::nop(curbBoostLocation, curbBoostGateSize);
+			hook::call(curbBoostLocation, curbBoostStub.GetCode());
+		}
 	}
 
 	{

--- a/ext/native-decls/SetVehicleCurbBoostEnabled.md
+++ b/ext/native-decls/SetVehicleCurbBoostEnabled.md
@@ -1,0 +1,27 @@
+---
+ns: CFX
+apiset: client
+game: gta5
+---
+## SET_VEHICLE_CURB_BOOST_ENABLED
+
+```c
+void SET_VEHICLE_CURB_BOOST_ENABLED(Vehicle vehicle, BOOL enabled);
+```
+
+Controls the longitudinal tyre-slip smoothing that can make a vehicle gain speed from kerbs and similar bumps.
+
+Unlike enabling the `CF_USE_DOWNFORCE_BIAS` advanced handling flag, disabling curb boost with this native does not enable the Open Wheel suspension raise, downforce bias, or drag behavior.
+
+This is a client-local setting. It remains active until the vehicle's wheel objects are recreated, the entity is deleted, or this native is called with `enabled` set to `true`. Reapply it after an ownership migration or other event that recreates the vehicle locally.
+
+## Parameters
+
+* **vehicle**: The vehicle to configure.
+* **enabled**: Set to `false` to prevent curb boosting, or `true` to restore vanilla behavior.
+
+## Examples
+
+```lua
+SetVehicleCurbBoostEnabled(vehicle, false)
+```


### PR DESCRIPTION
### Goal of this PR

Add `SET_VEHICLE_CURB_BOOST_ENABLED`, allowing resources to disable curb-induced speed boosting on individual vehicles without enabling the unrelated suspension, downforce, and drag behavior associated with `CF_USE_DOWNFORCE_BIAS`.

### How is this PR achieving the goal

The new client native applies a Cfx-only marker to the vehicle's current wheel objects.

An allocation free hook in the longitudinal tyre-slip update checks this marker and skips the relevant smoothing operation when curb boosting is disabled. The game's original suspension-raise condition remains unchanged.

A native declaration and usage documentation are included.

### This PR applies to the following area(s)

FiveM, Natives

### Successfully tested on

**Game builds:** 3095, 3570

**Platforms:** Windows

Testing included:

- Debug x64 compilation of `extra-natives-five`
- Disabling curb boosting with `SET_VEHICLE_CURB_BOOST_ENABLED`
- Driving repeatedly over a large bump
- Confirming the vehicle no longer gained speed from the bump
- Confirming no crash occurred during the test

### Checklist

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues

None.