### PR TITLE
fix(mono): keep RELAX_DELEGATE, drop RELAX_REFLECTION

### DIFF
--- a/code/components/citizen-scripting-mono/component.lua
+++ b/code/components/citizen-scripting-mono/component.lua
@@ -6,6 +6,8 @@ return function()
 	add_dependencies { 'vendor:eastl' }
 
 	if os.istarget('windows') then
+		add_dependencies { 'vendor:minhook' }
+
 		filter 'architecture:x64'
 			links { "mono-2.0-sgen" }
 	

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -9,11 +9,17 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/mono-gc.h>
+#include <mono/metadata/image.h>
 
 #ifndef IS_FXSERVER
 extern "C" {
 #include <mono/metadata/security-core-clr.h>
 }
+#endif
+
+#if !defined(IS_FXSERVER) && defined(_WIN32)
+#include <cerrno>
+#include <MinHook.h>
 #endif
 
 #ifdef _WIN32
@@ -65,6 +71,126 @@ extern "C" void mono_handle_native_crash_nop(const char* signal, void* sigctx, v
 }
 #endif
 
+#if !defined(IS_FXSERVER) && defined(_WIN32)
+// Keep this rule in sync with audit/path_gate.py.
+// Resolve the path, then prefix-match. Do not stat or open the target.
+static bool IsAllowedClientAssemblyPath(const char* fname)
+{
+	if (!fname || !fname[0])
+	{
+		return false;
+	}
+
+	wchar_t fullPath[MAX_PATH];
+	if (GetFullPathNameW(ToWide(fname).c_str(), _countof(fullPath), fullPath, nullptr) == 0)
+	{
+		return false;
+	}
+
+	std::wstring root = GetAbsoluteCitPath();
+	if (root.empty())
+	{
+		return false;
+	}
+
+	if (root.back() != L'\\' && root.back() != L'/')
+	{
+		root.push_back(L'\\');
+	}
+
+	return _wcsnicmp(fullPath, root.c_str(), root.size()) == 0;
+}
+
+static void DenyAssemblyPath(MonoImageOpenStatus* status)
+{
+	if (status)
+	{
+		*status = MONO_IMAGE_ERROR_ERRNO;
+	}
+
+	errno = ENOENT;
+}
+
+static MonoImage* (*g_origImageOpen)(const char*, MonoImageOpenStatus*);
+static MonoImage* (*g_origImageOpenFull)(const char*, MonoImageOpenStatus*, mono_bool);
+static MonoImage* (*g_origPeFileOpen)(const char*, MonoImageOpenStatus*);
+static MonoAssembly* (*g_origAssemblyOpen)(const char*, MonoImageOpenStatus*);
+static MonoAssembly* (*g_origAssemblyOpenFull)(const char*, MonoImageOpenStatus*, mono_bool);
+
+static MonoImage* GateImageOpen(const char* fname, MonoImageOpenStatus* status)
+{
+	if (!IsAllowedClientAssemblyPath(fname))
+	{
+		DenyAssemblyPath(status);
+		return nullptr;
+	}
+
+	return g_origImageOpen(fname, status);
+}
+
+static MonoImage* GateImageOpenFull(const char* fname, MonoImageOpenStatus* status, mono_bool refonly)
+{
+	if (!IsAllowedClientAssemblyPath(fname))
+	{
+		DenyAssemblyPath(status);
+		return nullptr;
+	}
+
+	return g_origImageOpenFull(fname, status, refonly);
+}
+
+static MonoImage* GatePeFileOpen(const char* fname, MonoImageOpenStatus* status)
+{
+	if (!IsAllowedClientAssemblyPath(fname))
+	{
+		DenyAssemblyPath(status);
+		return nullptr;
+	}
+
+	return g_origPeFileOpen(fname, status);
+}
+
+static MonoAssembly* GateAssemblyOpen(const char* fname, MonoImageOpenStatus* status)
+{
+	if (!IsAllowedClientAssemblyPath(fname))
+	{
+		DenyAssemblyPath(status);
+		return nullptr;
+	}
+
+	return g_origAssemblyOpen(fname, status);
+}
+
+static MonoAssembly* GateAssemblyOpenFull(const char* fname, MonoImageOpenStatus* status, mono_bool refonly)
+{
+	if (!IsAllowedClientAssemblyPath(fname))
+	{
+		DenyAssemblyPath(status);
+		return nullptr;
+	}
+
+	return g_origAssemblyOpenFull(fname, status, refonly);
+}
+
+static void InstallClientAssemblyPathGate()
+{
+	static bool installed = false;
+	if (installed)
+	{
+		return;
+	}
+
+	installed = true;
+	MH_Initialize();
+	MH_CreateHook(reinterpret_cast<void*>(mono_image_open), reinterpret_cast<void*>(GateImageOpen), reinterpret_cast<void**>(&g_origImageOpen));
+	MH_CreateHook(reinterpret_cast<void*>(mono_image_open_full), reinterpret_cast<void*>(GateImageOpenFull), reinterpret_cast<void**>(&g_origImageOpenFull));
+	MH_CreateHook(reinterpret_cast<void*>(mono_pe_file_open), reinterpret_cast<void*>(GatePeFileOpen), reinterpret_cast<void**>(&g_origPeFileOpen));
+	MH_CreateHook(reinterpret_cast<void*>(mono_assembly_open), reinterpret_cast<void*>(GateAssemblyOpen), reinterpret_cast<void**>(&g_origAssemblyOpen));
+	MH_CreateHook(reinterpret_cast<void*>(mono_assembly_open_full), reinterpret_cast<void*>(GateAssemblyOpenFull), reinterpret_cast<void**>(&g_origAssemblyOpenFull));
+	MH_EnableHook(MH_ALL_HOOKS);
+}
+#endif
+
 void MonoComponentHostShared::Initialize()
 {
 	// TODO: remove this particular mutex lock
@@ -100,11 +226,14 @@ void MonoComponentHostShared::Initialize()
 		mono_security_enable_core_clr();
 		// RELAX_DELEGATE stays. BaseScript [Tick]/events and Newtonsoft need CreateDelegate.
 		// Taking it out is what broke scripts in #3138.
-		// RELAX_REFLECTION does not. It lets transparent resource scripts invoke
-		// SecurityCritical APIs (for example Assembly.LoadFrom) and that is enough
-		// for a server to probe files on a connecting player's machine.
+		// RELAX_REFLECTION is extra attack surface for other Critical APIs. It is not
+		// what makes Assembly.LoadFrom callable; that method is SecuritySafeCritical
+		// in the shipped mscorlib. The path gate below is what stops the disk probe.
 		mono_security_core_clr_set_options((MonoSecurityCoreCLROptions)(MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_DELEGATE));
 		mono_security_set_core_clr_platform_callback(CoreCLRIsTrustedCode);
+#ifdef _WIN32
+		InstallClientAssemblyPathGate();
+#endif
 
 		mono_profiler_install(&s_monoProfiler, ProfilerShutDown);
 		mono_profiler_install_gc(gc_event, gc_resize);

--- a/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
+++ b/code/components/citizen-scripting-mono/src/MonoComponentHostShared.cpp
@@ -98,7 +98,12 @@ void MonoComponentHostShared::Initialize()
 
 #ifndef IS_FXSERVER
 		mono_security_enable_core_clr();
-		mono_security_core_clr_set_options((MonoSecurityCoreCLROptions)(MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_DELEGATE | MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_REFLECTION));
+		// RELAX_DELEGATE stays. BaseScript [Tick]/events and Newtonsoft need CreateDelegate.
+		// Taking it out is what broke scripts in #3138.
+		// RELAX_REFLECTION does not. It lets transparent resource scripts invoke
+		// SecurityCritical APIs (for example Assembly.LoadFrom) and that is enough
+		// for a server to probe files on a connecting player's machine.
+		mono_security_core_clr_set_options((MonoSecurityCoreCLROptions)(MONO_SECURITY_CORE_CLR_OPTIONS_RELAX_DELEGATE));
 		mono_security_set_core_clr_platform_callback(CoreCLRIsTrustedCode);
 
 		mono_profiler_install(&s_monoProfiler, ProfilerShutDown);


### PR DESCRIPTION
### Goal of this PR
A player who joins a server should not have their local disk queried by that server's C# client resource. On current master they do. This started as a duplicate of #3987. That PR dropped RELAX_REFLECTION and was closed by pointing at #3138. Closing it did not change the code. The option is still set. The hole is still there.

This matters because the trust boundary is backwards. The server is untrusted. The filesystem belongs to the player. CoreCLR is turned on specifically so resource scripts stay on the transparent side of that line. No prompt. No permission. No way for the player to refuse it without leaving the server.

A remote resource only needs a path it already knows. Common install locations, launchers, tools, known cheat filenames. The answer comes back as an exception type. That is a software inventory of the player's machine, taken from anyone who clicks Join. You do not need to list a directory and you do not need to brute-force names. A wordlist of well-known paths is enough, and it can be repeated on every connect.

People have already treated this as "it only tells you exist / not exist, so it is fine." That is the wrong bar. Existence of a path is still data the player did not hand over.

I also checked the mechanism before sending this. RELAX_REFLECTION is not what makes Assembly.LoadFrom callable. In the shipped client mscorlib that method is SecuritySafeCritical. Transparent code can call it with the flag on or off. I embedded the repo's client Mono (4.9.1). Present non-assembly path: BadImageFormatException. Missing path: FileNotFoundException. Same result for flags 3 (master), 2 (delegate only), and 0. File.ReadAllText stays SecurityException. So #3987 named the right problem and locked the wrong door. Leaving RELAX_REFLECTION on is still extra surface for other Critical APIs. It is not the LoadFrom channel.

This has already shown up in real client resources. Filing it once and walking away did not make it unused.

### How is this PR achieving the goal
Two changes, both client Mono.

1. Keep RELAX_DELEGATE, drop RELAX_REFLECTION.

BaseScript wires [Tick] and events with CreateDelegate. Newtonsoft.Json does the same when it reads private members. That is what #3138 actually was. Taking RELAX_DELEGATE out broke live servers and got reverted in cc97bd6. This PR does not touch that flag.

RELAX_REFLECTION is the other switch. It relaxes the CoreCLR reflection access check. #3987 already proposed this split and was closed as if it would repeat #3138. Please read those stacks before doing that again. They are all CreateDelegate. That is RELAX_DELEGATE.

2. Stop path-based assembly opens from leaving the FiveM app directory.

That is the LoadFrom channel. Resource scripts are loaded from bytes (OpenHostFile + Assembly.Load), so they do not need arbitrary filesystem LoadFrom. This hooks the Mono open-from-filename APIs and allows only paths under GetAbsoluteCitPath() (Citizen and cache). Anything else returns MONO_IMAGE_ERROR_ERRNO / ENOENT. The target file is not opened. Present and missing look the same.

#3987 is the duplicate of the flag half. This PR is that half plus the path gate that actually closes the disk probe.

Related / duplicates:
- #3987 (flag-only, closed, nothing landed)
- #3138 (different flag; that regression is why the flag half keeps getting waved off)

### This PR applies to the following area(s)
ScRT: C#, FiveM (client)

### Successfully tested on
Not a full live client. The shipped client Mono was run in a separate process with the same CoreCLR platform callback. Critical APIs from transparent code are refused. LoadFrom still reaches disk unless the path gate is applied.

The path rule was checked against the repo client tree: platform mscorlib is allowed, including a .. form that still resolves inside the tree. Audit fixtures and C:\Windows are denied. Present and missing get the same deny. Resource assemblies loaded from bytes are not on this path.

### Checklist
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.