### PR TITLE
fix(scripting-core): keep resource file writes inside the resource

### DIFF
--- a/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
+++ b/code/components/citizen-scripting-core/src/FilesystemPermissions.cpp
@@ -91,6 +91,21 @@ bool ScriptingFilesystemAllowWrite(const std::string& path, fx::Resource* resour
 		return false;
 	}
 
+	// the part after the resource name has to stay inside that resource, otherwise '..' would
+	// resolve past it and the permission check below would be answering for the wrong resource
+	if (resourceFilePath.is_absolute() || resourceFilePath.has_root_name())
+	{
+		return false;
+	}
+
+	for (const auto& part : resourceFilePath)
+	{
+		if (part == "..")
+		{
+			return false;
+		}
+	}
+
 	std::string currentResourceName{};
 	fx::Resource* currentResource = nullptr;
 	if (resourceOverride != nullptr)

--- a/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
+++ b/code/components/citizen-scripting-core/src/MetadataScriptFunctions.cpp
@@ -78,6 +78,43 @@ static bool IsPathWithinResourceRoot(const std::filesystem::path& rootPath, cons
 
 	return true;
 }
+
+// Resolves a resource-relative file name against the resource root and checks that it stays
+// there. Read and write natives have to agree on this, so they share the check.
+static bool IsResourceFilePathAllowed(const std::string& rootPath, const std::string& requestedFileName)
+{
+	// an empty root path would resolve against the process working directory
+	if (rootPath.empty())
+	{
+		return false;
+	}
+
+	try
+	{
+		const std::filesystem::path resourceRoot = std::filesystem::weakly_canonical(std::filesystem::absolute(std::filesystem::u8path(rootPath)));
+
+		std::string sanitizedFileName = requestedFileName;
+		while (!sanitizedFileName.empty() && (sanitizedFileName[0] == '/' || sanitizedFileName[0] == '\\'))
+		{
+			sanitizedFileName.erase(sanitizedFileName.begin());
+		}
+
+		const std::filesystem::path requestedPath = std::filesystem::u8path(sanitizedFileName);
+
+		if (requestedPath.empty() || requestedPath.is_absolute() || requestedPath.has_root_name())
+		{
+			return false;
+		}
+
+		const std::filesystem::path absoluteRequestedPath = std::filesystem::weakly_canonical(std::filesystem::absolute(resourceRoot / requestedPath));
+
+		return IsPathWithinResourceRoot(resourceRoot, absoluteRequestedPath);
+	}
+	catch (const std::filesystem::filesystem_error&)
+	{
+		return false;
+	}
+}
 #endif
 
 static InitFunction initFunction([] ()
@@ -174,33 +211,7 @@ static InitFunction initFunction([] ()
 			return;
 		}
 #else
-		try
-		{
-			const std::filesystem::path resourceRoot = std::filesystem::weakly_canonical(std::filesystem::absolute(std::filesystem::u8path(rootPath)));
-
-			std::string sanitizedFileName = requestedFileName;
-			while (!sanitizedFileName.empty() && (sanitizedFileName[0] == '/' || sanitizedFileName[0] == '\\'))
-			{
-				sanitizedFileName.erase(sanitizedFileName.begin());
-			}
-
-			const std::filesystem::path requestedPath = std::filesystem::u8path(sanitizedFileName);
-
-			if (requestedPath.is_absolute() || requestedPath.has_root_name())
-			{
-				context.SetResult(nullptr);
-				return;
-			}
-
-			const std::filesystem::path absoluteRequestedPath = std::filesystem::weakly_canonical(std::filesystem::absolute(resourceRoot / requestedPath));
-
-			if (!IsPathWithinResourceRoot(resourceRoot, absoluteRequestedPath))
-			{
-				context.SetResult(nullptr);
-				return;
-			}
-		}
-		catch (const std::filesystem::filesystem_error&)
+		if (!IsResourceFilePathAllowed(rootPath, requestedFileName))
 		{
 			context.SetResult(nullptr);
 			return;
@@ -264,14 +275,24 @@ static InitFunction initFunction([] ()
 			return;
 		}
 
-		if (!fx::ScriptingFilesystemAllowWrite("@" + resource->GetName() + "/" + context.CheckArgument<const char*>(1)))
+		const char* requestedFileName = context.CheckArgument<const char*>(1);
+
+		// the name is joined onto the resource path further down without being resolved, so it
+		// has to be confined to the resource first. same rule LOAD_RESOURCE_FILE applies.
+		if (!IsResourceFilePathAllowed(resource->GetPath(), requestedFileName))
+		{
+			context.SetResult(nullptr);
+			return;
+		}
+
+		if (!fx::ScriptingFilesystemAllowWrite("@" + resource->GetName() + "/" + requestedFileName))
 		{
 			context.SetResult(nullptr);
 			return;
 		}
 
 		// try opening a writable file in the resource's home directory
-		const std::string filePath = resource->GetPath() + "/" + context.CheckArgument<const char*>(1);
+		const std::string filePath = resource->GetPath() + "/" + requestedFileName;
 
 		fwRefContainer<vfs::Device> device = vfs::GetDevice(filePath);
 		auto handle = device->Create(filePath);


### PR DESCRIPTION
### Goal of this PR
A server resource should not be able to write outside its own directory. On current master it can. SAVE_RESOURCE_FILE joins the requested name onto the resource path and hands that string to the device. No resolve. No check that the result still sits under the resource. ScriptingFilesystemAllowWrite sits in front of it and does not help: it splits `@name/rest` and only compares the resource name. `@myresource/../otherresource/file` looks like a write into the caller's own resource and is allowed.

LOAD_RESOURCE_FILE already refuses this. Same name, same resource, Load says no, Save writes anyway. That is the sandbox Load already protects, applied only to reads.

This is a write API, not a read. A resource can reach sibling resources, files above the resources directory, and anything else the server process can write, including server.cfg if that sits in range. There is no extra permission for that. add_filesystem_permission exists specifically so cross-resource writes have to be granted by name. Walking out with `..` skips that map.

`..` is not needed for legitimate use. Cross-resource writes already have a path: pass the other resource as the first argument and grant it with add_filesystem_permission. Subdirectories inside the resource still work. This PR does not change that.

os.remove and os.rename go through the same AllowWrite function and had no `..` check of their own. Lua io.open already rejects a path part that is exactly `..`. Writes were the hole. Reads through Load were not.

### How is this PR achieving the goal
Two changes, both server scripting-core.

1. ScriptingFilesystemAllowWrite rejects a resource-relative path that is absolute or contains `..`.

That is the same rule io.open already applies. It also covers os.remove and os.rename, which had no check of their own.

2. The path resolution LOAD_RESOURCE_FILE already does is moved into a helper. SAVE_RESOURCE_FILE uses it too.

Read and write natives now agree on what a resource-relative name may point at. If someone later changes the symlink handling, both sides move together.

Writing to another resource still works the way it was meant to. Names and subdirectories inside the resource are unaffected. A name like `data/../config.json` that would have resolved back inside the resource is now refused, because the `..` scan is lexical. io.open already refuses those.

Not in this PR: os.createdir still skips AllowWrite. OpenHostFile still joins the name raw. Both are real, both sit on different paths, and mixing them in here makes the review worse.

Related:
- LOAD_RESOURCE_FILE already has the server-side root check. This PR makes Save match it.
- #4108 and #3959 are about Load + symlinks. Separate from this hole.

### This PR applies to the following area(s)
ScRT, FXServer

### Successfully tested on
Reproduced live on FXServer artifact 35805 (Windows, txData ESXLegacy base): a resource calling SaveResourceFile(res, "../../traversal_poc_proof.txt", ...) wrote outside its directory, landing next to server.cfg in the server data folder. The permission check allowed it, exactly as described. On the same artifact, LoadResourceFile(res, "../../server.cfg") also succeeded (returned the full 3056-byte config), so the read side is not consistently protected there either.

The patched behavior was verified by mirroring the two touched functions locally against a small resource tree: subdirectories, ./name, and a leading slash still pass; every .. escape is denied; cross-resource writes through add_filesystem_permission still work and cannot walk out of the target; os.remove / os.rename through AllowWrite deny the same escapes. The sibling file on disk is untouched.

<img width="789" height="975" alt="codeinsiders_4818723" src="https://github.com/user-attachments/assets/5e690d77-cb16-490c-b152-c0a39c05b802" />
<img width="982" height="173" alt="firefox_pFEJFIyLBw" src="https://github.com/user-attachments/assets/35061d30-f198-492e-9bdc-be27d86389d1" />


### Checklist
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.