### PR TITLE
Fix/weapon archetype limit

### DIFF
--- a/code/components/gta-core-five/src/CrashFixes.cpp
+++ b/code/components/gta-core-five/src/CrashFixes.cpp
@@ -489,10 +489,15 @@ void ShiftWeaponInfoBlobsDown(CWeaponInfoBlob* pArray[], uint16_t startIndex)
 {
 	uint16_t lastItemIndex = *g_weaponInfoArrayCount - 1;
 
+	uint16_t arraySize = g_weaponInfoArrayCount[1];
+
 	g_origShiftWeaponInfoBlobsDown(pArray, startIndex);
 
-	// Only clear if a shift occured
-	if (startIndex < lastItemIndex)
+	// Only clear if a shift occured, and only while the entry past the last one is still part of the
+	// allocation: a completely full array has no spare constructed blob to copy from, and reading one
+	// would be an out-of-bounds read of sizeof(CWeaponInfoBlob) bytes. This also covers an empty array,
+	// where lastItemIndex underflows to 0xFFFF.
+	if (startIndex < lastItemIndex && (lastItemIndex + 1) < arraySize)
 	{
 		// Copy the next empty weapon info into this unused one to reset it
 		(*pArray)[lastItemIndex] = (*pArray)[lastItemIndex + 1];

--- a/code/components/gta-streaming-five/include/Local.h
+++ b/code/components/gta-streaming-five/include/Local.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr int kNumWeaponInfoBlobs = 512;
+constexpr int kNumWeaponInfoBlobs = 1024;

--- a/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
+++ b/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
@@ -1,0 +1,62 @@
+#include "StdInc.h"
+
+#include <Hooking.h>
+
+#include <Error.h>
+#include <MinHook.h>
+
+struct atArrayHeader
+{
+	void* m_offset;
+	uint16_t m_count;
+	uint16_t m_size;
+};
+
+static void* g_weaponArchetypeStore;
+static atArrayHeader* (*g_getWeaponArchetypeArray)(void* store, uint32_t storeKey);
+static void* (*g_origAllocateWeaponArchetype)(void* definition, bool registerModel, uint32_t storeKey);
+
+static void* AllocateWeaponArchetypeStub(void* definition, bool registerModel, uint32_t storeKey)
+{
+	if (auto array = g_getWeaponArchetypeArray(g_weaponArchetypeStore, storeKey))
+	{
+		// a zero m_size means this isn't an array we understand - stay out of the way
+		if (array->m_size != 0 && array->m_count >= array->m_size)
+		{
+			AddCrashometry("weapon_archetype_limit", "%d", (int)array->m_size);
+
+			FatalError(
+				"Ran out of weapon archetype slots: all %d of them (MaxExtraWeaponModelInfos) are in use.\n"
+				"\n"
+				"Every add-on weapon registers one CWeaponModelInfo for each model it ships - the weapon itself "
+				"plus every one of its component models - so this limit is hit long before the number of weapons "
+				"looks suspicious, and the weaponarchetypes.meta being loaded when this happened (see the line "
+				"right above this one in CitizenFX.log) is only the file that crossed the limit, not the file at "
+				"fault.\n"
+				"\n"
+				"Load fewer add-on weapons, or raise MaxExtraWeaponModelInfos in gameconfig.xml.",
+				(int)array->m_size);
+		}
+	}
+
+	return g_origAllocateWeaponArchetype(definition, registerModel, storeKey);
+}
+
+static HookFunction hookFunction([]()
+{
+	auto allocPattern = hook::pattern("48 48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 81 EC A0 00 00 00 48 8B E9 8A DA 48 8D 0D");
+
+	if (allocPattern.size() != 1)
+	{
+		return;
+	}
+
+	auto location = allocPattern.get(0).get<char>(0);
+
+	g_weaponArchetypeStore = hook::get_address<void*>(location + 0x20);
+	g_getWeaponArchetypeArray = (decltype(g_getWeaponArchetypeArray))hook::get_call(location + 0x2A);
+
+	MH_Initialize();
+	MH_CreateHook(location, AllocateWeaponArchetypeStub, (void**)&g_origAllocateWeaponArchetype);
+	MH_EnableHook(MH_ALL_HOOKS);
+});

--- a/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
+++ b/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
@@ -1,9 +1,9 @@
 #include "StdInc.h"
 
 #include <Hooking.h>
+#include <Hooking.Stubs.h>
 
 #include <Error.h>
-#include <MinHook.h>
 
 struct atArrayHeader
 {
@@ -56,16 +56,5 @@ static HookFunction hookFunction([]()
 	g_weaponArchetypeStore = hook::get_address<void*>(location + 0x20);
 	g_getWeaponArchetypeArray = (decltype(g_getWeaponArchetypeArray))hook::get_call(location + 0x2A);
 
-	// the prologue opens with a redundant REX prefix (48 48 89 5C 24 08), which MinHook's
-	// disassembler rejects outright, so hook a byte in where the stream decodes cleanly - a call
-	// landing on the prefix still reaches the jump, as a REX prefix on E9 has no effect.
-	MH_Initialize();
-
-	if (auto status = MH_CreateHook(location + 1, AllocateWeaponArchetypeStub, (void**)&g_origAllocateWeaponArchetype); status != MH_OK)
-	{
-		trace("Couldn't hook the weapon archetype allocator (MinHook error %d) - running out of archetype slots will crash instead of erroring.\n", (int)status);
-		return;
-	}
-
-	MH_EnableHook(MH_ALL_HOOKS);
+	g_origAllocateWeaponArchetype = hook::trampoline(location + 1, AllocateWeaponArchetypeStub);
 });

--- a/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
+++ b/code/components/gta-streaming-five/src/PatchWeaponArchetypeLimit.cpp
@@ -56,7 +56,16 @@ static HookFunction hookFunction([]()
 	g_weaponArchetypeStore = hook::get_address<void*>(location + 0x20);
 	g_getWeaponArchetypeArray = (decltype(g_getWeaponArchetypeArray))hook::get_call(location + 0x2A);
 
+	// the prologue opens with a redundant REX prefix (48 48 89 5C 24 08), which MinHook's
+	// disassembler rejects outright, so hook a byte in where the stream decodes cleanly - a call
+	// landing on the prefix still reaches the jump, as a REX prefix on E9 has no effect.
 	MH_Initialize();
-	MH_CreateHook(location, AllocateWeaponArchetypeStub, (void**)&g_origAllocateWeaponArchetype);
+
+	if (auto status = MH_CreateHook(location + 1, AllocateWeaponArchetypeStub, (void**)&g_origAllocateWeaponArchetype); status != MH_OK)
+	{
+		trace("Couldn't hook the weapon archetype allocator (MinHook error %d) - running out of archetype slots will crash instead of erroring.\n", (int)status);
+		return;
+	}
+
 	MH_EnableHook(MH_ALL_HOOKS);
 });

--- a/code/components/gta-streaming-five/src/PatchWeaponLimits.cpp
+++ b/code/components/gta-streaming-five/src/PatchWeaponLimits.cpp
@@ -40,7 +40,7 @@ struct PatternPair
 };
 
 // should be synced with CWeaponComponentInfo in gameconfig.xml
-constexpr int kNumWeaponComponentInfos = 2048;
+constexpr int kNumWeaponComponentInfos = 4096;
 
 static CWeaponComponentInfo** weaponComponentInfoCollection;
 

--- a/data/client/citizen/common/data/gameconfig.xml
+++ b/data/client/citizen/common/data/gameconfig.xml
@@ -386,7 +386,7 @@
 						</Item>
 						<Item>
 							<PoolName>CWeaponComponentInfo</PoolName>
-							<PoolSize value="2048"/>
+							<PoolSize value="4096"/>
 						</Item>
 						<Item>
 							<PoolName>phInstGta</PoolName>
@@ -902,7 +902,7 @@
 					<MaxWeaponModelInfos value="115"/>
 					<MaxExtraPedModelInfos value="1044"/>
 					<MaxExtraVehicleModelInfos value="2068"/>
-					<MaxExtraWeaponModelInfos value="2048"/>
+					<MaxExtraWeaponModelInfos value="4096"/>
 				</ConfigModelInfo>
 
 				<ConfigExtensions>


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->

Let servers load more add-on weapons without the client crashing with `c0000005` while mounting a `weaponarchetypes.meta`.


### How is this PR achieving the goal

The crash comes from the limit on weapon archetypes.

Every entry from `weaponarchetypes.meta` is added to the same `atArray<CWeaponModelInfo>`. The size of this array is set when the server starts, based on `MaxExtraWeaponModelInfos`. The problem is that the allocator doesn't check if the array is already full. It keeps increasing `m_count`, calculates the next address with `m_offset + idx * 0x190`, and then calls the object at that address.
Once we go past the allocated space, we're basically reading random data from the heap as if it was a valid object. The vtable is no longer valid, which eventually causes the crash.
On b3258, the crash dump shows the count reaching `0x800` (2048), which is exactly the current value of `MaxExtraWeaponModelInfos`.
Add-on weapons also use more than one archetype. A weapon usually needs one for the weapon itself and one for each of its component models, around 6 entries per weapon on average. This is why the limit is reached at roughly 250 weapons. The specific weapon file reported in the crash isn't necessarily the actual cause; depending on the order things are loaded, any weapon can end up being the one that triggers it.
`MaxExtraWeaponModelInfos` was already increased back in 2021 to address the same issue, so this is essentially the same limitation coming back with larger weapon packs.
This PR increases the limit from 2048 to 4096. It also increases `CWeaponInfoBlob` from 512 to 1024 and adjusts `CWeaponComponentInfo` as well (including its pool and relocated array), so we don't just hit the exact same problem somewhere else after increasing the weapon limit.
A bounds check is also added so that if the limit is reached, we get an actual error explaining which limit was hit instead of continuing into invalid memory and corrupting the heap.

Finally, this also fixes an existing out-of-bounds read in `ShiftWeaponInfoBlobsDown` that can happen when the array is completely full.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->

FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** 

Game builds: 3258
Platforms: Windows

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [X] Code explains itself well and/or is documented.
- [X] My commit message explains what the changes do and what they are for.
- [X] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->

fixes #3624 fixes #2992
