### PR TITLE
fix(devtools): replace the interiors timecycle when editing inside an MLO

### DIFF
--- a/code/components/devtools-five/include/TimecycleEditor.h
+++ b/code/components/devtools-five/include/TimecycleEditor.h
@@ -41,6 +41,7 @@ private:
 	char m_detailDropDownBuffer[kMaxBufferSize]{};
 
 	bool m_applySelectedTimecycle = false;
+	bool m_replaceInteriorTimecycle = true;
 	tinyxml2::XMLPrinter g_timecycleXmlOutput;
 
 public:

--- a/code/components/devtools-five/src/TimecycleEditor.cpp
+++ b/code/components/devtools-five/src/TimecycleEditor.cpp
@@ -220,6 +220,10 @@ void TimecycleEditor::Draw()
 
 			if (auto scriptData = TimecycleManager::GetScriptData())
 			{
+				auto selected = m_selectedModifier.GetModifier();
+				int selectedIndex = selected ? TheTimecycleManager->GetTimecycleIndex(*selected) : -1;
+				int interiorIndex = m_replaceInteriorTimecycle ? selectedIndex : -1;
+
 				if (scriptData->m_primaryModifierIndex != -1)
 				{
 					auto modifier = TheTimecycleManager->GetTimecycleByIndex(scriptData->m_primaryModifierIndex);
@@ -233,6 +237,7 @@ void TimecycleEditor::Draw()
 					if (ImGui::Button("Clear"))
 					{
 						scriptData->m_primaryModifierIndex = -1;
+						m_applySelectedTimecycle = false;
 					}
 				}
 				else
@@ -286,16 +291,59 @@ void TimecycleEditor::Draw()
 
 				ImGui::Separator();
 
+				if (interiorIndex != -1)
+				{
+					auto modifier = TheTimecycleManager->GetTimecycleByIndex(interiorIndex);
+					auto tcName = modifier ? TheTimecycleManager->GetTimecycleName(*modifier).c_str() : "INVALID";
+					ImGui::Text("Interior modifier: %s", tcName);
+				}
+				else
+				{
+					ImGui::Text("Interior modifier: NONE");
+				}
+
+				ImGui::Separator();
+
 				if (ImGui::Checkbox("Apply selected", &m_applySelectedTimecycle))
 				{
 					if (m_applySelectedTimecycle)
 					{
-						if (auto modifier = m_selectedModifier.GetModifier())
-						{
-							scriptData->m_primaryModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
-						}
+						m_replaceInteriorTimecycle = false;
+					}
+					else
+					{
+						scriptData->m_primaryModifierIndex = -1;
 					}
 				}
+
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::SetTooltip("Applies the selected timecycle globally, the way a script would.\n"
+									  "Inside an MLO this stacks on top of the interiors own timecycle.");
+				}
+
+				if (m_applySelectedTimecycle && selectedIndex != -1)
+				{
+					scriptData->m_primaryModifierIndex = selectedIndex;
+				}
+
+				if (ImGui::Checkbox("Replace interior timecycle", &m_replaceInteriorTimecycle))
+				{
+					if (m_replaceInteriorTimecycle)
+					{
+						m_applySelectedTimecycle = false;
+						scriptData->m_primaryModifierIndex = -1;
+					}
+				}
+
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::SetTooltip("Makes the room you are standing in use the selected timecycle instead of its\n"
+									  "own, so you see it on its own rather than stacked on the interiors.\n"
+									  "Only does anything while you are inside an MLO.");
+				}
+
+				TheTimecycleManager->SetInteriorModifierOverride(m_replaceInteriorTimecycle ? selectedIndex : -1);
 			}
 
 			if (ImGui::BeginChild("list", ImVec2(-1.0f, -1.0f), false))
@@ -330,17 +378,6 @@ void TimecycleEditor::Draw()
 							TheTimecycleManager->EnsureTimecycleBackup(*modifier);
 							m_selectedModifier.SetModifier(modifier);
 							strcpy(m_detailNameBuffer, modifierName.c_str());
-
-							if (m_applySelectedTimecycle)
-							{
-								auto modifier = m_selectedModifier.GetModifier();
-								auto scriptData = TimecycleManager::GetScriptData();
-
-								if (scriptData != nullptr && modifier != nullptr)
-								{
-									scriptData->m_primaryModifierIndex = TheTimecycleManager->GetTimecycleIndex(*modifier);
-								}
-							}
 						}
 
 						ImGui::TreePop();
@@ -831,6 +868,8 @@ void TimecycleEditor::Reset()
 
 	m_editorEnabled = false;
 	m_applySelectedTimecycle = false;
+	m_replaceInteriorTimecycle = true;
+	TheTimecycleManager->SetInteriorModifierOverride(-1);
 	g_timecycleXmlOutput.ClearBuffer();
 	m_searchCache.clear();
 }

--- a/code/components/gta-game-five/include/Timecycle.h
+++ b/code/components/gta-game-five/include/Timecycle.h
@@ -107,6 +107,7 @@ class GAME_COMPONENT_EXPORT TimecycleManager
 {
 private:
 	bool m_activateEditor; // hack...
+	int m_interiorModifierOverride = -1; // modifier the room the player is in should use instead of its own
 	std::map<uint32_t, std::string> m_originalNames; // names that were gathered from data files
 	std::map<uint32_t, std::string> m_customNames; // names of custom timecycles that were created in code
 	std::map<uint32_t, rage::tcModifier*> m_modifiersBackup; // backups of original modifiers
@@ -142,6 +143,8 @@ public:
 	void HandleTimecycleUnloaded(uint32_t hash);
 	void SetActivateEditor(bool flag);
 	bool ShouldActivateEditor();
+	void SetInteriorModifierOverride(int index);
+	int GetInteriorModifierOverride();
 
 	static rage::tcManager* GetGameManager(); // get pointer to instance of RAGE timecycle manager
 	static TimecycleScriptData* GetScriptData(); // get "script" data, seems to be struct that is used in natives

--- a/code/components/gta-game-five/src/Timecycle.cpp
+++ b/code/components/gta-game-five/src/Timecycle.cpp
@@ -515,6 +515,16 @@ bool TimecycleManager::ShouldActivateEditor()
 	return m_activateEditor;
 }
 
+void TimecycleManager::SetInteriorModifierOverride(int index)
+{
+	m_interiorModifierOverride = index;
+}
+
+int TimecycleManager::GetInteriorModifierOverride()
+{
+	return m_interiorModifierOverride;
+}
+
 #if IS_RDR3
 void TimecycleManager::StoreVarInfoName(const std::string& name)
 {
@@ -761,6 +771,45 @@ static uint32_t TimecycleComputeHashLoad(int ns, char* name)
 	return hash;
 }
 
+#if GTA_FIVE
+struct CPortalModifierData
+{
+	float portalBoundSphere[4]; // rage::spdSphere
+	float strength;
+	int mainModifier;
+	int secondaryModifier;
+	float blendWeight;
+};
+
+struct CPortalModifierQueryResults
+{
+	CPortalModifierData m_entries[20];
+	int m_count;
+};
+
+static void (*g_origFindModifiersForInteriors)(const void*, void*, uint32_t, CPortalModifierQueryResults*);
+static void FindModifiersForInteriors(const void* viewport, void* interiorInst, uint32_t roomId, CPortalModifierQueryResults* results)
+{
+	g_origFindModifiersForInteriors(viewport, interiorInst, roomId, results);
+
+	int index = TCManager.GetInteriorModifierOverride();
+	if (index < 0)
+	{
+		return;
+	}
+
+	for (int i = 0; i < results->m_count; i++)
+	{
+		// -1 entries are portals looking out of the interior, they should stay exterior
+		if (results->m_entries[i].mainModifier != -1)
+		{
+			results->m_entries[i].mainModifier = index;
+			results->m_entries[i].secondaryModifier = -1;
+		}
+	}
+}
+#endif
+
 static uint32_t (*g_origTimecycleComputeHashUnload)(int, char*);
 static uint32_t TimecycleComputeHashUnload(int ns, char* name)
 {
@@ -792,6 +841,7 @@ static HookFunction hookFunction([]()
 	OnKillNetworkDone.Connect([=]()
 	{
 		TCManager.SetActivateEditor(false);
+		TCManager.SetInteriorModifierOverride(-1);
 		TCManager.RevertChanges();
 	});
 
@@ -853,6 +903,15 @@ static HookFunction hookFunction([]()
 		hook::set_call(&g_origTimecycleComputeHashUnload, location);
 		hook::call(location, TimecycleComputeHashUnload);
 	}
+
+#if GTA_FIVE
+	{
+		auto location = hook::get_pattern("4C 8D 0D ? ? ? ? 44 8B ? 48 8B ? 48 8B ? E8 ? ? ? ? 8B 05", 16);
+
+		hook::set_call(&g_origFindModifiersForInteriors, location);
+		hook::call(location, FindModifiersForInteriors);
+	}
+#endif
 
 #if IS_RDR3
 	// RDR3 doesn't store variable names inside rage::tcVarInfo anymore, so hacking around to get bring names back.


### PR DESCRIPTION
### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
Previously, the timecycle editor would apply the timecycle like how it would be applied using scripting natives, but this would cause issues when editing a timecycle inside an interior, as the timecycle modifiers would sort of stack on top of each other making editing them pretty inaccurate
...


### How is this PR achieving the goal
replace the interior modifier index for the room with ours, so a previewed timecycle renders through the interior and not as a script applied modifier.
...


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM
...


### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 
3095, 3258
**Platforms:** Windows, Linux
Windows

### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


