### PR TITLE
fix(mod-loader): support subdir streaming entries (ped head_ ydd/ytd) in mods/

### DIFF
--- a/code/components/citizen-mod-loader-five/src/ModVFSDevice.cpp
+++ b/code/components/citizen-mod-loader-five/src/ModVFSDevice.cpp
@@ -158,6 +158,9 @@ public:
 
 	bool Flush(THandle handle) override;
 
+	// 'mp_m_freemode_01/head_000_r.ydd' -> 'mp_m_freemode_01^head_000_r.ydd'
+	static std::string StreamName(std::string tgtFile);
+
 private:
 	std::string MapFileName(const std::string& fn);
 
@@ -233,8 +236,20 @@ ModVFSDevice::ModVFSDevice(const std::shared_ptr<ModPackage>& package)
 			{
 				m_entries["common/" + tgtFile] = srcFile;
 			}
+			else if (entry.archiveRoots.size() >= 2 && tgtFile.find('/') != std::string::npos)
+			{
+				// subdir entry in a streaming rpf (e.g. mp_m_freemode_01/head_000_r.ydd): the game slot
+				// is dir-prefixed, so expose it under the dir^file name the streaming loader maps back
+				m_entries["stream/" + StreamName(tgtFile)] = srcFile;
+			}
 		}
 	}
+}
+
+std::string ModVFSDevice::StreamName(std::string tgtFile)
+{
+	std::replace(tgtFile.begin(), tgtFile.end(), '/', '^');
+	return tgtFile;
 }
 
 bool ModVFSDevice::ShouldMountCommon()
@@ -423,18 +438,21 @@ void MountModStream(const std::shared_ptr<fx::ModPackage>& modPackage)
 			// if only one path is there, as well
 			auto slashCount = std::count(tgtFile.begin(), tgtFile.end(), '/');
 
-			if (slashCount == 0 || isCoreTexture)
+			// probably a streaming file
+			std::string fn = modPackage->GetRootPath() + "content/" + entry.sourceFile;
+			std::replace(fn.begin(), fn.end(), '\\', '/');
+
+			GetRagePageFlagsExtension data;
+			data.fileName = fn.c_str();
+			parentDevice->ExtensionCtl(VFS_GET_RAGE_PAGE_FLAGS, &data, sizeof(data));
+
+			if (slashCount > 0 && !isCoreTexture)
 			{
-				// probably a streaming file
-				std::string fn = modPackage->GetRootPath() + "content/" + entry.sourceFile;
-				std::replace(fn.begin(), fn.end(), '\\', '/');
-
-				GetRagePageFlagsExtension data;
-				data.fileName = fn.c_str();
-				parentDevice->ExtensionCtl(VFS_GET_RAGE_PAGE_FLAGS, &data, sizeof(data));
-
-				CfxCollection_AddStreamingFileByTag("mod_" + modPackage->GetGuidString(), fn, data.flags);
+				// subdir entry: register the dir^file name mapped by ModVFSDevice so the slot name keeps its directory
+				fn = fmt::sprintf("modVfs_%s:/stream/%s", modPackage->GetGuidString(), ModVFSDevice::StreamName(tgtFile));
 			}
+
+			CfxCollection_AddStreamingFileByTag("mod_" + modPackage->GetGuidString(), fn, data.flags);
 		}
 	}
 

--- a/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
+++ b/code/components/gta-streaming-five/src/LoadStreamingFile.cpp
@@ -1712,20 +1712,32 @@ static std::set<std::string> g_pedsToRegister;
 
 static std::unordered_set<int> g_ourIndexes;
 
-static std::string GetBaseName(const std::string& name)
+static bool IsModTag(const std::string& tag)
+{
+	return tag.find("mod_") == 0 || tag.find("faux_pack") == 0;
+}
+
+// isMod: local mods/ content gets subdir mapping without the server policy (there is no server at startup)
+static std::string GetBaseName(const std::string& name, bool isMod = false)
 {
 	std::string retval = name;
 
 	std::string policyVal;
 
-	if (Instance<ICoreGameInit>::Get()->GetData("policy", &policyVal))
+	bool allowSubdir = isMod;
+
+	if (!allowSubdir && Instance<ICoreGameInit>::Get()->GetData("policy", &policyVal))
 	{
 #ifndef _DEBUG
-		if (policyVal.find("[subdir_file_mapping]") != std::string::npos)
+		allowSubdir = policyVal.find("[subdir_file_mapping]") != std::string::npos;
+#else
+		allowSubdir = true;
 #endif
-		{
-			std::replace(retval.begin(), retval.end(), '^', '/');
-		}
+	}
+
+	if (allowSubdir)
+	{
+		std::replace(retval.begin(), retval.end(), '^', '/');
 	}
 
 	// is this trying to override a file extant in platform:/textures/?
@@ -1774,7 +1786,7 @@ static void LoadStreamingFiles(LoadType loadType)
 	{
 		auto [file, tag] = *it;
 
-		bool isMod = tag.find("mod_") == 0 || tag.find("faux_pack") == 0;
+		bool isMod = IsModTag(tag);
 
 		if (loadType == LoadType::Startup || loadType == LoadType::BeforeMapLoad || loadType == LoadType::AfterSessionEarlyStage)
 		{
@@ -1802,7 +1814,7 @@ static void LoadStreamingFiles(LoadType loadType)
 			continue;
 		}
 
-		auto baseName = GetBaseName(std::string(slashPos + 1));
+		auto baseName = GetBaseName(std::string(slashPos + 1), isMod);
 		auto nameWithoutExt = baseName.substr(0, baseName.find_last_of('.'));
 
 #ifdef GTA_FIVE
@@ -2530,7 +2542,7 @@ void DLL_EXPORT CfxCollection_AddStreamingFileByTag(const std::string& tag, cons
 		start = it + 1;
 	}
 
-	auto baseName = GetBaseName(fileName.substr(start));
+	auto baseName = GetBaseName(fileName.substr(start), IsModTag(tag));
 
 	if (baseName.find(".ymf") == baseName.length() - 4)
 	{
@@ -2581,7 +2593,7 @@ void DLL_EXPORT CfxCollection_RemoveStreamingTag(const std::string& tag)
 			start = it + 1;
 		}
 
-		auto baseName = GetBaseName(file.substr(start));
+		auto baseName = GetBaseName(file.substr(start), IsModTag(tag));
 		auto nameWithoutExt = baseName.substr(0, baseName.find_last_of('.'));
 
 		// get dot position and skip if no dot


### PR DESCRIPTION
### Goal of this PR
Make OpenIV-style mod packages in `mods/` able to replace ped component files that live in a subdirectory of a streaming rpf — most notably `head_*.ydd` / `head_diff_*.ytd` in `x64v.rpf/models/cdimages/streamedpeds_mp.rpf/mp_m_freemode_01/` (and `streamedpeds_players.rpf/player_zero/`). Today such entries are silently dropped.

### How is this PR achieving the goal
The game registers these assets under a directory-prefixed slot name (`mp_m_freemode_01/head_000_r`), which is why resource `stream/` uses the `dir^file` convention. The mod loader lost that directory at three points:

1. `ModVFSDevice` only mapped entries whose last archive is `update.rpf`, a top-level `x64N.rpf`, or `common.rpf`; nested archives fell through.
2. `MountModStream` required `slashCount == 0`, so `mp_m_freemode_01/head_000_r.ydd` was never registered as a streaming file.
3. The `^` → `/` subdir mapping in `LoadStreamingFile.cpp` is gated on the server policy `[subdir_file_mapping]`, which doesn't exist at `OnInitialMount` (no server yet).

Changes:
- **gta-streaming-five**: `GetBaseName()` takes an `isMod` flag; `mod_` / `faux_pack` tags get subdir mapping without the server policy. Resource behaviour is unchanged. Small `IsModTag()` helper replaces the inline check.
- **citizen-mod-loader-five**: nested-archive entries with a subdirectory target are exposed by `ModVFSDevice` as `stream/<dir>^<file>` and registered from `MountModStream` as `modVfs_<guid>:/stream/<dir>^<file>`, so the streaming slot keeps its directory. Flat entries and `textures/` overrides register exactly as before.

Not covered: a whole `streamedpeds_*.rpf` dropped in as an `.rpf` target (`MountFauxStreamingRpf` is non-recursive, and a packfile can't serve a `^` name).

### This PR applies to the following area(s)
FiveM

### Successfully tested on
Compiles (Release x64, no new warnings). **Not yet tested in-game** — will update once verified.

**Game builds:** ..

**Platforms:** Windows

### Checklist
- [ ] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.

### Fixes issues
None.
